### PR TITLE
fix package CONFLICTS

### DIFF
--- a/package.cmake
+++ b/package.cmake
@@ -33,8 +33,8 @@ set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/AntelopeIO/leap")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_DEBIAN_BASE_PACKAGE_SECTION "utils")
 
-set(CPACK_DEBIAN_PACKAGE_CONFLICTS "eosio" "mandel")
-set(CPACK_RPM_PACKAGE_CONFLICTS "eosio" "mandel")
+set(CPACK_DEBIAN_PACKAGE_CONFLICTS "eosio, mandel")
+set(CPACK_RPM_PACKAGE_CONFLICTS "eosio, mandel")
 
 #only consider "base" and "dev" components for per-component packages
 get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)


### PR DESCRIPTION
it appears these package CONFLICTS get sent directly to the control/spec file. change the format appropriately

```
dpkg: error processing archive /tmp/apt-dpkg-install-Yv0icg/243-leap-dev-3.1.0-rc3-ubuntu20.04-x86_64.deb (--unpack):
 parsing file '/var/lib/dpkg/tmp.ci/control' near line 2:
 'Conflicts' field, invalid package name 'eosio;mandel': character ';' not allowed (only letters, digits and characters '-+._')
```