### PR TITLE
[3.1] explictly reference llvm11 in README's build documentation cmake command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ and perform the build:
 git submodule update --init --recursive
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/llvm-11 ..
 make -j $(nproc) package
 ```
 </details>


### PR DESCRIPTION
When a user has more than one LLVM installed, cmake picks the version.. somehow :shrug:.. maybe highest version? This ends up being a problem on Ubuntu 22.04 where if a user
```
apt-get install llvm-dev llvm-11-dev
```
they end up with both 11 & 14 installed and Leap's cmake without any hints finds LLVM 14 thus fails configuration.

In the README instructions, let's adjust the command for cmake to explicitly search the llvm-11 directory first. This allows building properly when LLVM 11 & 14 are installed.