### PR TITLE
remove boost::thread usage, fixing pinned builds

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -5,7 +5,6 @@
 #include <stdint.h>
 
 #include <boost/asio.hpp>
-#include <boost/thread.hpp>
 
 #include <eosio/chain/block_header.hpp>
 #include <eosio/chain/exceptions.hpp>
@@ -156,11 +155,8 @@ class state_history_log {
    ~state_history_log() {
       // complete execution before possible vacuuming
       if (thr.joinable()) {
-         try  { 
-            work_guard.reset();
-            thr.join(); 
-         }
-         catch (const boost::thread_interrupted&) {/* suppressed */}
+         work_guard.reset();
+         thr.join();
       }     
 
       //nothing to do if log is empty or we aren't pruning


### PR DESCRIPTION
The ancient boost version in pinned builds has a broken boost::thread when building on Ubuntu 22.04. This is not terribly surprising, we've seen such problems before and it's why we've tried to move away from some of these boost libraries.

Remove the boost thread header; it's not being used except for the `catch(boost::thread_interrupted)` which is unnecessary since we're using std::thread here anyways.

Resolves #32 