### PR TITLE
[3.1] [CI] tweak name of dev package artifiact for consistency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,7 @@ jobs:
           if: matrix.platform == 'ubuntu20'
           uses: actions/upload-artifact@v3
           with:
-            name: leap_dev_amd64
+            name: leap-dev-ubuntu20-amd64
             path: build/leap-dev*.deb
   tests:
     name: Tests


### PR DESCRIPTION
This just tweaks the name of an internal (not public) artifact name for the leap-dev package for increased consistency: include name of platform and use `-` instead of `_`