### PR TITLE
[3.1] Fix failure to sync on startup

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1162,11 +1162,10 @@ namespace eosio {
             }
             return;
          } else if( latest_blk_time > 0 ) {
-            const tstamp timeout = std::max(hb_timeout*2, 2*std::chrono::milliseconds(config::block_interval_ms).count());
+            const tstamp timeout = std::max(hb_timeout/2, 2*std::chrono::milliseconds(config::block_interval_ms).count());
             if ( current_time > latest_blk_time + timeout ) {
-               no_retry = benign_other;
-               peer_wlog(this, "block timeout");
-               close();
+               send_handshake();
+               return;
             }
          }
       }

--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -165,8 +165,15 @@ try:
         numBlocksToCatchup=(lastLibNum-lastCatchupLibNum-1)+twoRounds
         waitForBlock(catchupNode, lastLibNum, timeout=twoRoundsTimeout, blockType=BlockType.lib)
 
+        catchupHead=head(catchupNode)
         Print("Shutdown catchup node and validate exit code")
         catchupNode.interruptAndVerifyExitStatus(60)
+
+        # every other catchup make a lib catchup
+        if catchup_num % 2 == 0:
+            Print(f"Wait for producer to advance lib past head of catchup {catchupHead}")
+            # catchupHead+5 to allow for advancement of head during shutdown of catchupNode
+            waitForBlock(node0, catchupHead+5, timeout=twoRoundsTimeout*2, blockType=BlockType.lib)
 
         Print("Restart catchup node")
         catchupNode.relaunch(cachePopen=True)


### PR DESCRIPTION
3.1.0-rc3 included https://github.com/eosnetworkfoundation/mandel/pull/627 which attempted to fix a producer stuck in a coma state. However, the fix was a bit too aggressive and introduced a race-condition on startup syncing.

This PR reverts the aggressive reset of syncing from LIB instead of HEAD for every call to `start_sync`. Instead it restarts syncing from LIB only when unlinkable blocks causes a connection to be closed. This should still fix the issue of https://github.com/eosnetworkfoundation/mandel/issues/623 without causing the problem seen in #49.

Resolves #49