### PR TITLE
[3.1] add a final job that passes if all tests pass making it easier to branch protect on checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -190,3 +190,10 @@ jobs:
         with:
           name: ${{matrix.platform}}-${{matrix.test-name}}-logs
           path: ${{matrix.platform}}-${{matrix.test-name}}-logs.tar.gz
+
+  all-passing:
+    name: All Required Tests Passed
+    needs: [tests, lr-tests, np-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - run: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -194,6 +194,8 @@ jobs:
   all-passing:
     name: All Required Tests Passed
     needs: [tests, np-tests]
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - if: needs.tests.result != 'success' || needs.np-tests.result != 'success'
+        run: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -193,7 +193,7 @@ jobs:
 
   all-passing:
     name: All Required Tests Passed
-    needs: [tests, lr-tests, np-tests]
+    needs: [tests, np-tests]
     runs-on: ubuntu-latest
     steps:
       - run: true


### PR DESCRIPTION
Currently PRs can't be merged because they aren't satisfying branch protection rules. Turns out that a branch protection rule specifying, for example, "Tests" doesn't satisfy the matrix of tests such as "Tests (ubuntu18)", "Tests (ubuntu20)", etc

Making the branch protection rule specify all matrix'ed jobs is too brittle: the names of jobs will change overtime as we add and remove new tests, such as an upcoming test that checks the native contract unit tests.

Instead, let's create a final job in the workflow that only passes if all dependent jobs pass -- where all dependent jobs are all the test jobs. That way the branch protection rule can simply check that "All Required Tests Passed" passed and the workflow can evolve over time without needing to touch the branch protection rule.