### PR TITLE
[3.2] http-max-bytes-in-flight-mb fixes

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -217,7 +217,7 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
          std::optional<eosio::chain::named_thread_pool>   thread_pool;
          std::atomic<size_t>                         bytes_in_flight{0};
          std::atomic<int32_t>                        requests_in_flight{0};
-         size_t                                      max_bytes_in_flight = 0;
+         uint64_t                                    max_bytes_in_flight = 0;
          int32_t                                     max_requests_in_flight = -1;
          fc::microseconds                            max_response_time{30*1000};
 
@@ -750,8 +750,8 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
              "Specify if Access-Control-Allow-Credentials: true should be returned on each request.")
             ("max-body-size", bpo::value<uint32_t>()->default_value(my->max_body_size),
              "The maximum body size in bytes allowed for incoming RPC requests")
-            ("http-max-bytes-in-flight-mb", bpo::value<uint32_t>()->default_value(500),
-             "Maximum size in megabytes http_plugin should use for processing http requests. 429 error response when exceeded." )
+            ("http-max-bytes-in-flight-mb", bpo::value<int64_t>()->default_value(500),
+             "Maximum size in megabytes http_plugin should use for processing http requests. -1 for unlimited. 429 error response when exceeded." )
             ("http-max-in-flight-requests", bpo::value<int32_t>()->default_value(-1),
              "Maximum number of requests http_plugin should use for processing http requests. 429 error response when exceeded." )
             ("http-max-response-time-ms", bpo::value<uint32_t>()->default_value(30),
@@ -776,7 +776,16 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
          EOS_ASSERT( my->thread_pool_size > 0, chain::plugin_config_exception,
                      "http-threads ${num} must be greater than 0", ("num", my->thread_pool_size));
 
-         my->max_bytes_in_flight = options.at( "http-max-bytes-in-flight-mb" ).as<uint32_t>() * 1024 * 1024;
+         // http-max-bytes-in-flight-mb is allowed to be -1,
+         // that's why int64_t is used
+         auto max_bytes_mb = options.at( "http-max-bytes-in-flight-mb" ).as<int64_t>();
+         EOS_ASSERT( max_bytes_mb == -1 || (max_bytes_mb >= 0 && max_bytes_mb < std::numeric_limits<int64_t>::max() / (1024 * 1024)), chain::plugin_config_exception,
+                     "http-max-bytes-in-flight-mb ${max_bytes_mb} must be equal to or greater than 0 and less than ${max}, or -1", ("max_bytes_mb", max_bytes_mb) ("max", std::numeric_limits<int64_t>::max() / (1024 * 1024)) );
+         if ( max_bytes_mb == -1 ) {
+            my->max_bytes_in_flight = std::numeric_limits<uint64_t>::max();
+         } else {
+            my->max_bytes_in_flight = max_bytes_mb * 1024 * 1024;
+         }
          my->max_requests_in_flight = options.at( "http-max-in-flight-requests" ).as<int32_t>();
          my->max_response_time = fc::microseconds( options.at("http-max-response-time-ms").as<uint32_t>() * 1000 );
          


### PR DESCRIPTION
Resolve https://github.com/AntelopeIO/leap/issues/48

- allow http-max-bytes-in-flight-mb bigger than 4GB
- make -1 indicate unlimited
- add range check