### PR TITLE
remove nonworking Secure Enclave support from signature_provider_plugin

### DIFF
--- a/plugins/signature_provider_plugin/CMakeLists.txt
+++ b/plugins/signature_provider_plugin/CMakeLists.txt
@@ -5,6 +5,3 @@ add_library( signature_provider_plugin
 
 target_link_libraries( signature_provider_plugin appbase fc http_client_plugin )
 target_include_directories( signature_provider_plugin PUBLIC include )
-if(APPLE)
-   target_link_libraries( signature_provider_plugin se-helpers )
-endif()


### PR DESCRIPTION
This came along for the ride on eosnetworkfoundation/mandel#541. But it relies on `se-helpers` library which was never ported from 2.1. Remove it.