### PR TITLE
[3.1 -> main] Fix python format issue that caused test to fail

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,7 +150,7 @@ jobs:
           ctest --output-on-failure -L "nonparallelizable_tests"
       - name: Bundle logs from failed tests
         if: failure()
-        run: tar -czf ${{matrix.platform}}-serial-logs.tar.gz build/var build/etc
+        run: tar -czf ${{matrix.platform}}-serial-logs.tar.gz build/var build/etc build/leap-ignition-wd
       - name: Upload logs from failed tests  
         uses: actions/upload-artifact@v3
         if: failure()
@@ -183,7 +183,7 @@ jobs:
           ctest --output-on-failure -R ${{matrix.test-name}}
       - name: Bundle logs from failed tests
         if: failure()
-        run: tar -czf ${{matrix.platform}}-${{matrix.test-name}}-logs.tar.gz build/var build/etc
+        run: tar -czf ${{matrix.platform}}-${{matrix.test-name}}-logs.tar.gz build/var build/etc build/leap-ignition-wd
       - name: Upload logs from failed tests  
         uses: actions/upload-artifact@v3
         if: failure()

--- a/testnet.template
+++ b/testnet.template
@@ -24,7 +24,7 @@ if [ -z "$bioscurrencysymbol" ]; then
     bioscurrencysymbol="SYS"
 fi
 
-wddir=eosio-ignition-wd
+wddir=leap-ignition-wd
 wdaddr=localhost:8899
 wdurl=http://$wdaddr
 # Manual deployers, add a line below this block that looks like:

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -77,7 +77,7 @@ class Cluster(object):
     __BiosHost="localhost"
     __BiosPort=8788
     __LauncherCmdArr=[]
-    __bootlog="eosio-ignition-wd/bootlog.txt"
+    __bootlog="leap-ignition-wd/bootlog.txt"
 
     # pylint: disable=too-many-arguments
     # walletd [True|False] Is keosd running. If not load the wallet plugin

--- a/tests/TestHarness/WalletMgr.py
+++ b/tests/TestHarness/WalletMgr.py
@@ -12,9 +12,9 @@ from .testUtils import Utils
 Wallet=namedtuple("Wallet", "name password host port")
 # pylint: disable=too-many-instance-attributes
 class WalletMgr(object):
-    __walletLogOutFile="test_keosd_out.log"
-    __walletLogErrFile="test_keosd_err.log"
-    __walletDataDir="test_wallet_0"
+    __walletLogOutFile="var/test_keosd_out.log"
+    __walletLogErrFile="var/test_keosd_err.log"
+    __walletDataDir="var/test_wallet_0"
     __MaxPort=9999
 
     # pylint: disable=too-many-arguments
@@ -127,7 +127,7 @@ class WalletMgr(object):
                             portStatus="AVAILABLE"
                         else:
                             portStatus="NOT AVAILABLE"
-                    if Utils.Debug: Utils.Print("%s was not accepted, delaying for %d seconds and trying again. port %d is %s. %s - {%s}" % (cmdDesc, delay, self.port, pgrepCmd, psOut))
+                    if Utils.Debug: Utils.Print("%s was not accepted, delaying for %d seconds and trying again. port %d is %s. %s - {%s}" % (cmdDesc, delay, self.port, pgrepCmd, psOut, portStatus))
                     time.sleep(delay)
                     continue
 


### PR DESCRIPTION
Python regression test failed because a debug log statement caused a python exception. The debug log statement format string was malformed. 

Also include some better capturing of test log output to more easily debug test failures in the future. 
* Rename `eosio-ignition-wd` to `leap-ignition-wd` directory used by tests.
* Add `leap-ignition-wd` directory to captured log directories on test failures. 
* Move `keosd` test logs into `var/` directory so they are captured on test failures.

Resolves #62 