### PR TITLE
[3.2] replace git commands from nodeos' & launcher's cmake with libversion usage

### DIFF
--- a/libraries/version/include/eosio/version/version.hpp
+++ b/libraries/version/include/eosio/version/version.hpp
@@ -10,4 +10,6 @@ namespace eosio { namespace version {
    ///< Grab the full version information of the client; example:  `v1.8.0-rc1-7de458254[-dirty]`
    const std::string& version_full();
 
+   ///< Grab the full git hash hex string; example:  `f3b24a2118df7d98659511897cfde6de0e4a375b`
+   const std::string& version_hash();
 } }

--- a/libraries/version/src/version.cpp
+++ b/libraries/version/src/version.cpp
@@ -12,4 +12,9 @@ namespace eosio { namespace version {
       return version;
    }
 
+   const std::string& version_hash() {
+      static const std::string vhash{_version_hash()};
+      return vhash;
+   }
+
 } }

--- a/libraries/version/src/version_impl.cpp.in
+++ b/libraries/version/src/version_impl.cpp.in
@@ -37,4 +37,8 @@ namespace eosio { namespace version {
       }
    }
 
+   std::string _version_hash() {
+      return version_hash;
+   }
+
 } }

--- a/libraries/version/src/version_impl.hpp
+++ b/libraries/version/src/version_impl.hpp
@@ -10,4 +10,7 @@ namespace eosio { namespace version {
    ///< Helper function for `version_full()`
    std::string _version_full();
 
+   ///< Helper function for `version_hash()`
+   std::string _version_hash();
+
 } }

--- a/programs/eosio-launcher/CMakeLists.txt
+++ b/programs/eosio-launcher/CMakeLists.txt
@@ -3,27 +3,12 @@ if( UNIX AND NOT APPLE )
   set(rt_library rt )
 endif()
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../.git)
-  find_package(Git)
-  if(GIT_FOUND)
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --short=8 HEAD
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
-      OUTPUT_VARIABLE "launcher_BUILD_VERSION"
-      ERROR_QUIET
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    message(STATUS "Git commit revision: ${launcher_BUILD_VERSION}")
-  else()
-    set(launcher_BUILD_VERSION 0)
-  endif()
-endif()
-
 configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
 
 target_include_directories(eosio-launcher PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries(eosio-launcher
-                      PRIVATE eosio_chain fc Boost::program_options ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+                      PRIVATE eosio_chain version fc Boost::program_options ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 
 install( TARGETS
    eosio-launcher

--- a/programs/eosio-launcher/config.hpp.in
+++ b/programs/eosio-launcher/config.hpp.in
@@ -7,7 +7,6 @@
 #define CONFIG_HPP_IN
 
 namespace eosio { namespace launcher { namespace config {
-  constexpr char version_str[] = "${launcher_BUILD_VERSION}";
   constexpr char node_executable_name[] = "${NODE_EXECUTABLE_NAME}";
 }}}
 

--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -30,6 +30,7 @@
 #include <netinet/in.h>
 #include <net/if.h>
 #include <eosio/chain/genesis_state.hpp>
+#include <eosio/version/version.hpp>
 
 #include "config.hpp"
 
@@ -2026,7 +2027,7 @@ int main (int argc, char *argv[]) {
       return 0;
     }
     if (vmap.count("version") > 0) {
-      cout << eosio::launcher::config::version_str << endl;
+      cout << eosio::version::version_full() << endl;
       return 0;
     }
 

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -4,23 +4,6 @@ if( UNIX AND NOT APPLE )
   set(rt_library rt )
 endif()
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../.git)
-  find_package(Git)
-  if(GIT_FOUND)
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --short=8 HEAD
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
-      OUTPUT_VARIABLE "nodeos_BUILD_VERSION"
-      ERROR_QUIET
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    message(STATUS "Git commit revision: ${nodeos_BUILD_VERSION}")
-  else()
-    set(nodeos_BUILD_VERSION 0)
-  endif()
-else()
-  set(nodeos_BUILD_VERSION 0)
-endif()
-
 configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
 
 target_include_directories(${NODE_EXECUTABLE_NAME} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})

--- a/programs/nodeos/config.hpp.in
+++ b/programs/nodeos/config.hpp.in
@@ -7,7 +7,6 @@
 #define CONFIG_HPP_IN
 
 namespace eosio { namespace nodeos { namespace config {
-  constexpr uint64_t version = 0x${nodeos_BUILD_VERSION};
   const string node_executable_name = "${NODE_EXECUTABLE_NAME}";
 }}}
 

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -108,7 +108,10 @@ enum return_codes {
 int main(int argc, char** argv)
 {
    try {
-      app().set_version(eosio::nodeos::config::version);
+      uint32_t short_hash = 0;
+      fc::from_hex(eosio::version::version_hash(), (char*)&short_hash, sizeof(short_hash));
+
+      app().set_version(htonl(short_hash));
       app().set_version_string(eosio::version::version_client());
       app().set_full_version_string(eosio::version::version_full());
 


### PR DESCRIPTION
libversion is the canonical method by which components should be retrieving the build version. But both nodeos' & eosio-launcher's CMakeLists were running git to retrieve a version. Remove that and replace with libversion usage instead. libversion needed a method added to retrieve the git hash as nodeos' get_info server_version returns the first 4 bytes of the git hash.