### PR TITLE
[3.1] Fix crash on startup if port already in use

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3743,8 +3743,10 @@ namespace eosio {
                my->acceptor->bind(listen_endpoint);
                my->acceptor->listen();
             } catch (const std::exception& e) {
-               elog( "net_plugin::plugin_startup failed to bind to port ${port}", ("port", listen_endpoint.port()) );
-               throw e;
+               elog( "net_plugin::plugin_startup failed to bind to port ${port}, ${what}",
+                     ("port", listen_endpoint.port())("what", e.what()) );
+               app().quit();
+               return;
             }
             fc_ilog( logger, "starting listener, max clients is ${mc}",("mc",my->max_client_count) );
             my->start_listen_loop();


### PR DESCRIPTION
Do not throw exception in posted lambdas to main thread as this causes non-joined threads to terminate. Instead report error and quit the application.

```
error 2022-08-30T13:15:52.885 nodeos    net_plugin.cpp:3747           operator()           ] net_plugin::plugin_startup failed to bind to port 9876, bind: Address already in use
info  2022-08-30T13:15:52.885 nodeos    resource_monitor_plugi:122    plugin_shutdown      ] shutdown...
info  2022-08-30T13:15:52.885 nodeos    resource_monitor_plugi:129    plugin_shutdown      ] exit shutdown
info  2022-08-30T13:15:52.885 nodeos    net_plugin.cpp:3776           plugin_shutdown      ] shutdown..
info  2022-08-30T13:15:52.885 nodeos    net_plugin.cpp:3793           plugin_shutdown      ] close 0 connections
info  2022-08-30T13:15:52.885 nodeos    net_plugin.cpp:3813           plugin_shutdown      ] exit shutdown
info  2022-08-30T13:15:52.887 nodeos    main.cpp:181                  main                 ] nodeos successfully exiting
```

Resolves #60 