### PR TITLE
[3.2] Fix documentation for get_scheduled_transactions in plugins/chain_api_plugin/chain.swagger.yaml

### DIFF
--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -401,10 +401,10 @@ paths:
                     type: string
                     description: base64 encoded ABI
 
-  /get_scheduled_transaction:
+  /get_scheduled_transactions:
     post:
-      description: Retrieves the scheduled transaction
-      operationId: get_scheduled_transaction
+      description: Retrieves scheduled transactions
+      operationId: get_scheduled_transactions
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Rename `get_scheduled_transaction` to `get_scheduled_transactions` (notice the trailing "s") as `get_scheduled_transaction` does not exist.

Also fix the description.