### PR TITLE
[3.1] patch pinned build's boost 1.70 to fix websocket defect

### DIFF
--- a/scripts/0001-beast-fix-moved-from-executor.patch
+++ b/scripts/0001-beast-fix-moved-from-executor.patch
@@ -1,0 +1,89 @@
+diff -Naur a/boost/beast/websocket/impl/ping.hpp b/boost/beast/websocket/impl/ping.hpp
+--- a/boost/beast/websocket/impl/ping.hpp	2019-05-06 22:01:43.435117251 -0400
++++ b/boost/beast/websocket/impl/ping.hpp	2019-05-06 22:02:37.949433556 -0400
+@@ -176,7 +176,8 @@
+                 impl.op_idle_ping.emplace(std::move(*this));
+                 impl.wr_block.lock(this);
+                 BOOST_ASIO_CORO_YIELD
+-                net::post(this->get(), std::move(*this));
++                net::post(
++                    this->get_executor(), std::move(*this));
+                 BOOST_ASSERT(impl.wr_block.is_locked(this));
+             }
+             if(impl.check_stop_now(ec))
+diff -Naur a/libs/beast/CHANGELOG.md b/libs/beast/CHANGELOG.md
+--- a/libs/beast/CHANGELOG.md	2019-05-06 22:02:54.332528615 -0400
++++ b/libs/beast/CHANGELOG.md	2019-05-06 22:03:05.896595711 -0400
+@@ -1,3 +1,10 @@
++Version 248-hf1:
++
++* Add idle ping suspend test
++* Fix moved-from executor in idle ping timeout
++
++--------------------------------------------------------------------------------
++
+ Version 248:
+ 
+ * Don't use a moved-from handler
+diff -Naur a/libs/beast/test/beast/websocket/ping.cpp b/libs/beast/test/beast/websocket/ping.cpp
+--- a/libs/beast/test/beast/websocket/ping.cpp	2019-05-06 22:02:54.342528673 -0400
++++ b/libs/beast/test/beast/websocket/ping.cpp	2019-05-06 22:03:05.908595781 -0400
+@@ -10,8 +10,11 @@
+ // Test that header file is self-contained.
+ #include <boost/beast/websocket/stream.hpp>
+ 
++#include <boost/beast/_experimental/test/tcp.hpp>
++
+ #include "test.hpp"
+ 
++#include <boost/asio/ip/tcp.hpp>
+ #include <boost/asio/io_context.hpp>
+ #include <boost/asio/strand.hpp>
+ 
+@@ -366,6 +369,46 @@
+             BEAST_EXPECT(count == 3);
+         });
+ 
++        // suspend idle ping
++        {
++            using socket_type =
++                net::basic_stream_socket<
++                    net::ip::tcp,
++                    net::executor>;
++            net::io_context ioc;
++            stream<socket_type> ws1(ioc);
++            stream<socket_type> ws2(ioc);
++            ws1.set_option(stream_base::timeout{
++                stream_base::none(),
++                std::chrono::seconds(0),
++                true});
++            test::connect(
++                ws1.next_layer(),
++                ws2.next_layer());
++            ws1.async_handshake("localhost", "/",
++                [](error_code){});
++            ws2.async_accept([](error_code){});
++            ioc.run();
++            ioc.restart();
++            flat_buffer b1;
++            auto mb = b1.prepare(65536);
++            std::memset(mb.data(), 0, mb.size());
++            b1.commit(65536);
++            ws1.async_write(b1.data(),
++                [&](error_code, std::size_t){});
++            BEAST_EXPECT(
++                ws1.impl_->wr_block.is_locked());
++            ws1.async_read_some(net::mutable_buffer{},
++                [&](error_code, std::size_t){});
++            ioc.run();
++            ioc.restart();
++            flat_buffer b2;
++            ws2.async_read(b2,
++                [&](error_code, std::size_t){});
++            ioc.run();
++        }
++        //);
++
+         {
+             echo_server es{log, kind::async};
+             net::io_context ioc;

--- a/scripts/pinned_build.sh
+++ b/scripts/pinned_build.sh
@@ -106,8 +106,9 @@ install_boost() {
    if [ ! -d "${BOOST_DIR}" ]; then
       echo "Installing Boost ${BOOST_VER} @ ${BOOST_DIR}"
       try wget https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VER}/source/boost_${BOOST_VER//\./_}.tar.gz
-      try tar -xvzf boost_${BOOST_VER//\./_}.tar.gz -C ${DEP_DIR}
+      try tar --transform="s:^boost_${BOOST_VER//\./_}:boost_${BOOST_VER//\./_}patched:" -xvzf boost_${BOOST_VER//\./_}.tar.gz -C ${DEP_DIR}
       pushdir ${BOOST_DIR}
+      patch -p1 < "${SCRIPT_DIR}/0001-beast-fix-moved-from-executor.patch"
       try ./bootstrap.sh -with-toolset=clang --prefix=${BOOST_DIR}/bin
       ./b2 toolset=clang cxxflags='-stdlib=libc++ -D__STRICT_ANSI__ -nostdinc++ -I${CLANG_DIR}/include/c++/v1 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE' linkflags='-stdlib=libc++ -pie' link=static threading=multi --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -q -j${JOBS} install
       popdir ${DEP_DIR}
@@ -120,7 +121,7 @@ pushdir ${DEP_DIR}
 
 install_clang ${DEP_DIR}/clang-${CLANG_VER}
 install_llvm ${DEP_DIR}/llvm-${LLVM_VER}
-install_boost ${DEP_DIR}/boost_${BOOST_VER//\./_}
+install_boost ${DEP_DIR}/boost_${BOOST_VER//\./_}patched
 
 # go back to the directory where the script starts
 popdir ${START_DIR}


### PR DESCRIPTION
Our pinned builds will use boost 1.70 for the entirety of 3.x's lifecycle. boost 1.70 shipped with a defect in beast's websocket implementation that can lead to crashes. Can read more here,
```
https://github.com/boostorg/beast/issues/1599
```
The patch included with this PR to fix the issue is linked directly from boost's release notes for 1.70 so it seems to be a well supported fix
https://www.boost.org/users/history/version_1_70_0.html

The only component in Leap that uses websockets is the state history plugin and we caution users to only expose that websocket endpoint to internal trusted clients, so this fix isn't being fast tracked.

Resolves eosnetworkfoundation/mandel#816