### PR TITLE
[3.2] fix ship_client test on boost 1.67-1.69

### DIFF
--- a/tests/ship_client.cpp
+++ b/tests/ship_client.cpp
@@ -21,6 +21,17 @@ namespace ws = boost::beast::websocket;
 
 namespace bpo = boost::program_options;
 
+/* Prior to boost 1.70, if socket type is not boost::asio::ip::tcp::socket nor boost::asio::ssl::stream beast requires
+   an overload of async_/teardown. This has been improved in 1.70+ to support any basic_stream_socket<> out of the box
+   which includes unix sockets. */
+#if BOOST_VERSION < 107000
+namespace boost::beast::websocket {
+void teardown(role_type, unixs::socket& sock, error_code& ec) {
+   sock.close(ec);
+}
+}
+#endif
+
 int main(int argc, char* argv[]) {
    boost::asio::io_context ctx;
    boost::asio::ip::tcp::resolver resolver(ctx);


### PR DESCRIPTION
Similar tweak to what already exists in state_history_plugin