### PR TITLE
Added tps_performance_monitor

### DIFF
--- a/tests/trx_generator/CMakeLists.txt
+++ b/tests/trx_generator/CMakeLists.txt
@@ -5,7 +5,7 @@ target_include_directories(trx_generator PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CM
 target_link_libraries( trx_generator
                        PRIVATE eosio_chain fc chain_plugin eosio_testing_contracts ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 
-add_executable(trx_generator_tests trx_generator_tests.cpp)
+add_executable(trx_generator_tests trx_generator_tests.cpp trx_provider.cpp)
 target_link_libraries( trx_generator_tests
         PRIVATE eosio_chain fc chain_plugin eosio_testing_contracts ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 target_include_directories(trx_generator_tests PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/trx_generator/trx_generator_tests.cpp
+++ b/tests/trx_generator/trx_generator_tests.cpp
@@ -283,6 +283,15 @@ BOOST_AUTO_TEST_CASE(tps_performance_monitor_outside_spin_up_within_limit)
    // behind, but within limit, out of spin up window
    stats.last_run =  fc::time_point{fc::microseconds{6600000}};
    BOOST_REQUIRE(monitor.monitor_test(stats));
+
+   stats.expected_sent = 150;
+   // outside of limit again, out of spin up window
+   stats.last_run =  fc::time_point{fc::microseconds{7000000}};
+   BOOST_REQUIRE(monitor.monitor_test(stats));
+
+   // outside of limit for too long
+   stats.last_run =  fc::time_point{fc::microseconds{8100000}};
+   BOOST_REQUIRE(!monitor.monitor_test(stats));
 }
 
 BOOST_AUTO_TEST_CASE(tps_cant_keep_up_monitored)

--- a/tests/trx_generator/trx_generator_tests.cpp
+++ b/tests/trx_generator/trx_generator_tests.cpp
@@ -223,5 +223,93 @@ BOOST_AUTO_TEST_CASE(tps_med_run_med_tps_30us_delay)
            ("rt", runtime_us.count())("mx", maximum_runtime_us ) );
       BOOST_REQUIRE_LT(monitor->_calls.back().time_to_next_trx_us, 0);
    }
+
+}
+
+BOOST_AUTO_TEST_CASE(tps_performance_monitor_during_spin_up)
+{
+   tps_test_stats stats;
+   tps_performance_monitor monitor{std::chrono::microseconds(5s).count()};
+   stats.total_trxs = 1000;
+   stats.start_time = fc::time_point{fc::microseconds{0}};
+   stats.expected_sent = 100;
+   stats.trxs_sent = 90;
+
+   // behind, but still within spin up window
+   stats.last_run =  fc::time_point{fc::microseconds{100000}};
+   BOOST_REQUIRE(monitor.monitor_test(stats));
+
+   // violation, but still within spin up window
+   stats.last_run =  fc::time_point{fc::microseconds{1100000}};
+   BOOST_REQUIRE(monitor.monitor_test(stats));
+}
+
+BOOST_AUTO_TEST_CASE(tps_performance_monitor_outside_spin_up)
+{
+   tps_test_stats stats;
+   tps_performance_monitor monitor{std::chrono::microseconds(5s).count()};
+   stats.total_trxs = 1000;
+   stats.start_time = fc::time_point{fc::microseconds{0}};
+   stats.expected_sent = 100;
+   stats.trxs_sent = 90;
+
+   // behind, out of spin up window
+   stats.last_run =  fc::time_point{fc::microseconds{5500000}};
+   BOOST_REQUIRE(monitor.monitor_test(stats));
+
+   // violation, out of spin up window
+   stats.last_run =  fc::time_point{fc::microseconds{6600000}};
+   BOOST_REQUIRE(!monitor.monitor_test(stats));
+}
+
+BOOST_AUTO_TEST_CASE(tps_performance_monitor_outside_spin_up_within_limit)
+{
+   tps_test_stats stats;
+   tps_performance_monitor monitor{std::chrono::microseconds(5s).count()};
+   stats.total_trxs = 1000;
+   stats.start_time = fc::time_point{fc::microseconds{0}};
+   stats.expected_sent = 100;
+   stats.trxs_sent = 90;
+
+   // outside of limit,  out of spin up window
+   stats.last_run =  fc::time_point{fc::microseconds{5500000}};
+   BOOST_REQUIRE(monitor.monitor_test(stats));
+
+   // outside of limit, less than max violation duration
+   stats.last_run =  fc::time_point{fc::microseconds{6000000}};
+   BOOST_REQUIRE(monitor.monitor_test(stats));
+
+   stats.trxs_sent = 98;
+   // behind, but within limit, out of spin up window
+   stats.last_run =  fc::time_point{fc::microseconds{6600000}};
+   BOOST_REQUIRE(monitor.monitor_test(stats));
+}
+
+BOOST_AUTO_TEST_CASE(tps_cant_keep_up_monitored)
+{
+   constexpr uint32_t test_duration_s = 5;
+   constexpr uint32_t test_tps = 100000;
+   constexpr uint32_t trx_delay_us = 10;
+   constexpr uint32_t expected_trxs = test_duration_s * test_tps;
+   constexpr uint64_t expected_runtime_us = test_duration_s * 1000000;
+   constexpr uint64_t allowable_runtime_deviation_per = 20;
+   constexpr uint64_t allowable_runtime_deviation_us = expected_runtime_us / allowable_runtime_deviation_per;
+   constexpr uint64_t minimum_runtime_us = expected_runtime_us - allowable_runtime_deviation_us;
+   constexpr uint64_t maximum_runtime_us = expected_runtime_us + allowable_runtime_deviation_us;
+
+   std::shared_ptr<mock_trx_generator> generator = std::make_shared<mock_trx_generator>(expected_trxs, trx_delay_us);
+   std::shared_ptr<tps_performance_monitor> monitor = std::make_shared<tps_performance_monitor>();
+
+
+   trx_tps_tester<mock_trx_generator, tps_performance_monitor> t1(generator, monitor, test_duration_s, test_tps);
+
+   fc::time_point start = fc::time_point::now();
+   t1.run();
+   fc::time_point end = fc::time_point::now();
+   fc::microseconds runtime_us = end.time_since_epoch() - start.time_since_epoch() ;
+
+   BOOST_REQUIRE_LT(runtime_us.count(), expected_runtime_us);
+   BOOST_REQUIRE_LT(generator->_calls.size(), expected_trxs);
+
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Added a tps_performance_monitor that shutdowns the test if the sent transactions falls below a specified threshold for a specified amount of time.  A spin up time can also be specified.