### PR TITLE
[3.1 -> main] Validate set whitelist blacklist input main

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1129,6 +1129,8 @@ producer_plugin::runtime_options producer_plugin::get_runtime_options() const {
 }
 
 void producer_plugin::add_greylist_accounts(const greylist_params& params) {
+   EOS_ASSERT(params.accounts.size() > 0, chain::invalid_http_request, "At least one account is required");
+
    chain::controller& chain = my->chain_plug->chain();
    for (auto &acc : params.accounts) {
       chain.add_resource_greylist(acc);
@@ -1136,6 +1138,8 @@ void producer_plugin::add_greylist_accounts(const greylist_params& params) {
 }
 
 void producer_plugin::remove_greylist_accounts(const greylist_params& params) {
+   EOS_ASSERT(params.accounts.size() > 0, chain::invalid_http_request, "At least one account is required");
+
    chain::controller& chain = my->chain_plug->chain();
    for (auto &acc : params.accounts) {
       chain.remove_resource_greylist(acc);
@@ -1166,6 +1170,11 @@ producer_plugin::whitelist_blacklist producer_plugin::get_whitelist_blacklist() 
 }
 
 void producer_plugin::set_whitelist_blacklist(const producer_plugin::whitelist_blacklist& params) {
+   EOS_ASSERT(params.actor_whitelist || params.actor_blacklist || params.contract_whitelist || params.contract_blacklist || params.action_blacklist || params.key_blacklist,
+              chain::invalid_http_request,
+              "At least one of actor_whitelist, actor_blacklist, contract_whitelist, contract_blacklist, action_blacklist, and key_blacklist is required"
+             );
+
    chain::controller& chain = my->chain_plug->chain();
    if(params.actor_whitelist) chain.set_actor_whitelist(*params.actor_whitelist);
    if(params.actor_blacklist) chain.set_actor_blacklist(*params.actor_blacklist);


### PR DESCRIPTION
Resolve https://github.com/AntelopeIO/leap/issues/86
Merge https://github.com/AntelopeIO/leap/pull/113 from `release/3.1` to `main`

Add input validation for `set_whitelist_blacklist`, `add_greylist_accounts` and `remove_greylist_accounts` by ensuring at least one optional parameter is present in a RPC call.

Previously,
```
curl -d '{"foo":["bar"]}' http://127.0.0.1:8888/v1/producer/set_whitelist_blacklist
{"result":"ok"}
```

Now,
```
curl -d '{"foo":["bar"]}' http://127.0.0.1:8888/v1/producer/set_whitelist_blacklist
{"code":400,"message":"Invalid Request","error":{"code":3200006,"name":"invalid_http_request","what":"invalid http request","details":[{"message":"At least one of actor_whitelist, actor_blacklist, contract_whitelist, contract_blacklist, action_blacklist, and key_blacklist is required","file":"producer_plugin.cpp","line_number":1382,"method":"set_whitelist_blacklist"}]}}~/work/validate_input_3_1/plugins
```

```
curl -d '{"accounts":[]}' http://127.0.0.1:8888/v1/producer/add_greylist_accounts
{"code":400,"message":"Invalid Request","error":{"code":3200006,"name":"invalid_http_request","what":"invalid http request","details":[{"message":"At least one account is required","file":"producer_plugin.cpp","line_number":1338,"method":"add_greylist_accounts"}]}}
```

```
curl -d '{"accounts":[]}' http://127.0.0.1:8888/v1/producer/remove_greylist_accounts
{"code":400,"message":"Invalid Request","error":{"code":3200006,"name":"invalid_http_request","what":"invalid http request","details":[{"message":"At least one account is required","file":"producer_plugin.cpp","line_number":1347,"method":"remove_greylist_accounts"}]}}
```