### PR TITLE
[3.1 -> main] Allow for larger subjective CPU billing amounts

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1481,7 +1481,7 @@ struct controller_impl {
                                            fc::microseconds max_transaction_time,
                                            uint32_t billed_cpu_time_us,
                                            bool explicit_billed_cpu_time,
-                                           uint32_t subjective_cpu_bill_us )
+                                           int64_t subjective_cpu_bill_us )
    {
       EOS_ASSERT(block_deadline != fc::time_point(), transaction_exception, "deadline cannot be uninitialized");
 
@@ -2879,7 +2879,7 @@ void controller::push_block( controller::block_report& br,
 transaction_trace_ptr controller::push_transaction( const transaction_metadata_ptr& trx,
                                                     fc::time_point block_deadline, fc::microseconds max_transaction_time,
                                                     uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time,
-                                                    uint32_t subjective_cpu_bill_us ) {
+                                                    int64_t subjective_cpu_bill_us ) {
    validate_db_available_size();
    EOS_ASSERT( get_read_mode() != db_read_mode::IRREVERSIBLE, transaction_type_exception, "push transaction not allowed in irreversible mode" );
    EOS_ASSERT( trx && !trx->implicit && !trx->scheduled, transaction_type_exception, "Implicit/Scheduled transaction not allowed" );

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -154,7 +154,7 @@ namespace eosio { namespace chain {
          transaction_trace_ptr push_transaction( const transaction_metadata_ptr& trx,
                                                  fc::time_point deadline, fc::microseconds max_transaction_time,
                                                  uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time,
-                                                 uint32_t subjective_cpu_bill_us );
+                                                 int64_t subjective_cpu_bill_us );
 
          /**
           * Attempt to execute a specific transaction in our deferred trx database

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -144,7 +144,7 @@ namespace eosio { namespace chain {
          fc::time_point                block_deadline = fc::time_point::maximum();
          fc::microseconds              leeway = fc::microseconds( config::default_subjective_cpu_leeway_us );
          int64_t                       billed_cpu_time_us = 0;
-         uint32_t                      subjective_cpu_bill_us = 0;
+         int64_t                       subjective_cpu_bill_us = 0;
          bool                          explicit_billed_cpu_time = false;
 
          transaction_checktime_timer   transaction_timer;

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -84,7 +84,7 @@ public:
 
    bool                   is_producer_key(const chain::public_key_type& key) const;
    chain::signature_type  sign_compact(const chain::public_key_type& key, const fc::sha256& digest) const;
-   uint32_t get_subjective_bill( const account_name& first_auth, const fc::time_point& now ) const;
+   int64_t get_subjective_bill( const account_name& first_auth, const fc::time_point& now ) const;
 
    virtual void plugin_initialize(const boost::program_options::variables_map& options);
    virtual void plugin_startup();

--- a/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
@@ -28,7 +28,7 @@ private:
    struct trx_cache_entry {
       transaction_id_type     trx_id;
       account_name            account;
-      uint32_t                subjective_cpu_bill;
+      int64_t                 subjective_cpu_bill;
       fc::time_point          expiry;
    };
    struct by_id;
@@ -121,7 +121,7 @@ public:
                          const fc::microseconds& elapsed, bool in_pending_block )
    {
       if( !_disabled && !_disabled_accounts.count( first_auth ) ) {
-         uint32_t bill = std::max<int64_t>( 0, elapsed.count() );
+         int64_t bill = std::max<int64_t>( 0, elapsed.count() );
          auto p = _trx_cache_index.emplace(
                trx_cache_entry{id,
                                first_auth,
@@ -139,13 +139,13 @@ public:
    void subjective_bill_failure( const account_name& first_auth, const fc::microseconds& elapsed, const fc::time_point& now )
    {
       if( !_disabled && !_disabled_accounts.count( first_auth ) ) {
-         uint32_t bill = std::max<int64_t>( 0, elapsed.count() );
+         int64_t bill = std::max<int64_t>( 0, elapsed.count() );
          const auto time_ordinal = time_ordinal_for(now);
          _account_subjective_bill_cache[first_auth].expired_accumulator.add(bill, time_ordinal, _expired_accumulator_average_window);
       }
    }
 
-   uint32_t get_subjective_bill( const account_name& first_auth, const fc::time_point& now ) const {
+   int64_t get_subjective_bill( const account_name& first_auth, const fc::time_point& now ) const {
       if( _disabled || _disabled_accounts.count( first_auth ) ) return 0;
       const auto time_ordinal = time_ordinal_for(now);
       const subjective_billing_info* sub_bill_info = nullptr;
@@ -161,7 +161,7 @@ public:
 
       if (sub_bill_info) {
          EOS_ASSERT(sub_bill_info->pending_cpu_us >= in_block_pending_cpu_us, chain::tx_resource_exhaustion, "Logic error subjective billing ${a}", ("a", first_auth) );
-         uint32_t sub_bill = sub_bill_info->pending_cpu_us - in_block_pending_cpu_us + sub_bill_info->expired_accumulator.value_at(time_ordinal, _expired_accumulator_average_window );
+         int64_t sub_bill = sub_bill_info->pending_cpu_us - in_block_pending_cpu_us + sub_bill_info->expired_accumulator.value_at(time_ordinal, _expired_accumulator_average_window );
          return sub_bill;
       } else {
          return 0;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -743,7 +743,7 @@ bool producer_plugin::is_producer_key(const chain::public_key_type& key) const
   return false;
 }
 
-uint32_t producer_plugin::get_subjective_bill( const account_name& first_auth, const fc::time_point& now ) const
+int64_t producer_plugin::get_subjective_bill( const account_name& first_auth, const fc::time_point& now ) const
 {
    return my->_subjective_billing.get_subjective_bill( first_auth, now );
 }
@@ -1896,7 +1896,7 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
                                      || ( !persist_until_expired && _disable_subjective_p2p_billing )
                                      || trx->read_only;
 
-   uint32_t sub_bill = 0;
+   int64_t sub_bill = 0;
    if( !disable_subjective_billing )
       sub_bill = _subjective_billing.get_subjective_bill( first_auth, fc::time_point::now() );
 


### PR DESCRIPTION
`uint32_t` for microseconds of subjective billing only allows for 1.2hrs before wrapping. Use `int64_t` instead which matches type used for objective billing.

Resolves #123 
Merges #124 into `main`.