### PR TITLE
[3.1] net_plugin fix startup issue when peer does not have requested blocks

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1161,7 +1161,7 @@ namespace eosio {
                close(false);
             }
             return;
-         } else if( latest_blk_time > 0 ) {
+         } else {
             const tstamp timeout = std::max(hb_timeout/2, 2*std::chrono::milliseconds(config::block_interval_ms).count());
             if ( current_time > latest_blk_time + timeout ) {
                send_handshake();


### PR DESCRIPTION
Test failure of #115 caused by peer not requesting blocks when no blocks where received from the sync source peer.

Two things contributed to this.
1. The node was expecting blocks from a different source than the tracked `sync_source` because the `sync_source` was set to a different connection but no new request was sent. When the connection was closed that this node was expecting blocks from it did not request from a different connection because the `sync_source` indicated it was already syncing from a different connection. This caused it not to try a different connection on the close of the sync source connection.
2. This should have timed out, but since no blocks were ever received it never sent a new handshake.

Changed to keep `sync_source` up to date with with the connection actually syncing from. This is done by only updating `sync_source` when a request to sync from a peer is made.
Also changed to always send a handshake on a block heart beat timeout since there is no harm in sending an extra handshake. 

Resolves #115 