### PR TITLE
[3.1 -> main] net_plugin fix startup issue when peer does not have requested blocks

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1161,7 +1161,7 @@ namespace eosio {
                close(false);
             }
             return;
-         } else if( latest_blk_time > 0 ) {
+         } else {
             const tstamp timeout = std::max(hb_timeout/2, 2*std::chrono::milliseconds(config::block_interval_ms).count());
             if ( current_time > latest_blk_time + timeout ) {
                send_handshake();
@@ -1618,28 +1618,29 @@ namespace eosio {
        * otherwise select the next available from the list, round-robin style.
        */
 
+      connection_ptr new_sync_source = sync_source;
       if (conn && conn->current() ) {
-         sync_source = conn;
+         new_sync_source = conn;
       } else {
          std::shared_lock<std::shared_mutex> g( my_impl->connections_mtx );
          if( my_impl->connections.size() == 0 ) {
-            sync_source.reset();
+            new_sync_source.reset();
          } else if( my_impl->connections.size() == 1 ) {
-            if (!sync_source) {
-               sync_source = *my_impl->connections.begin();
+            if (!new_sync_source) {
+               new_sync_source = *my_impl->connections.begin();
             }
          } else {
             // init to a linear array search
             auto cptr = my_impl->connections.begin();
             auto cend = my_impl->connections.end();
             // do we remember the previous source?
-            if (sync_source) {
+            if (new_sync_source) {
                //try to find it in the list
-               cptr = my_impl->connections.find( sync_source );
+               cptr = my_impl->connections.find( new_sync_source );
                cend = cptr;
                if( cptr == my_impl->connections.end() ) {
                   //not there - must have been closed! cend is now connections.end, so just flatten the ring.
-                  sync_source.reset();
+                  new_sync_source.reset();
                   cptr = my_impl->connections.begin();
                } else {
                   //was found - advance the start to the next. cend is the old source.
@@ -1657,7 +1658,7 @@ namespace eosio {
                   if( !(*cptr)->is_transactions_only_connection() && (*cptr)->current() ) {
                      std::lock_guard<std::mutex> g_conn( (*cptr)->conn_mtx );
                      if( (*cptr)->last_handshake_recv.last_irreversible_block_num >= sync_known_lib_num ) {
-                        sync_source = *cptr;
+                        new_sync_source = *cptr;
                         break;
                      }
                   }
@@ -1670,8 +1671,9 @@ namespace eosio {
       }
 
       // verify there is an available source
-      if( !sync_source || !sync_source->current() || sync_source->is_transactions_only_connection() ) {
+      if( !new_sync_source || !new_sync_source->current() || new_sync_source->is_transactions_only_connection() ) {
          fc_elog( logger, "Unable to continue syncing at this time");
+         if( !new_sync_source ) sync_source.reset();
          sync_known_lib_num = lib_block_num;
          reset_last_requested_num(g_sync);
          set_state( in_sync ); // probably not, but we can't do anything else
@@ -1686,12 +1688,12 @@ namespace eosio {
             end = sync_known_lib_num;
          if( end > 0 && end >= start ) {
             sync_last_requested_num = end;
-            connection_ptr c = sync_source;
+            sync_source = new_sync_source;
             g_sync.unlock();
             request_sent = true;
-            c->strand.post( [c, start, end]() {
-               peer_ilog( c, "requesting range ${s} to ${e}", ("s", start)("e", end) );
-               c->request_sync_blocks( start, end );
+            new_sync_source->strand.post( [new_sync_source, start, end]() {
+               peer_ilog( new_sync_source, "requesting range ${s} to ${e}", ("s", start)("e", end) );
+               new_sync_source->request_sync_blocks( start, end );
             } );
          }
       }


### PR DESCRIPTION
Test failure of #115 caused by peer not requesting blocks when no blocks where received from the sync source peer.

Two things contributed to this.
1. The node was expecting blocks from a different source than the tracked `sync_source` because the `sync_source` was set to a different connection but no new request was sent. When the connection was closed that this node was expecting blocks from it did not request from a different connection because the `sync_source` indicated it was already syncing from a different connection. This caused it not to try a different connection on the close of the sync source connection.
2. This should have timed out, but since no blocks were ever received it never sent a new handshake.

Changed to keep `sync_source` up to date with with the connection actually syncing from. This is done by only updating `sync_source` when a request to sync from a peer is made.
Also changed to always send a handshake on a block heart beat timeout since there is no harm in sending an extra handshake. 

Merges #135 to `main`.
Resolves #115 
