### PR TITLE
[3.2] cleos: only unpack action data when explicitly asked

### DIFF
--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -573,10 +573,11 @@ try:
     if actual != expected:
         errorExit("FAILURE - Wrong currency1111 balance (expected=%s, actual=%s)" % (str(expected), str(actual)), raw=True)
 
-    Print("push transfer action to currency1111 contract with sign skipping option enabled")
+    # Test skip sign with unpacked action data
+    Print("push transfer action to currency1111 contract with sign skipping and unpack action data options enabled")
     data="{\"from\":\"currency1111\",\"to\":\"defproducera\",\"quantity\":"
     data +="\"00.0001 CUR\",\"memo\":\"test\"}"
-    opts="-s -d --permission currency1111@active"
+    opts="-s -d -u --permission currency1111@active"
     trans=node.pushMessage(contract, action, data, opts, expectTrxTrace=False)
 
     try:
@@ -602,6 +603,37 @@ try:
     actual=amountStr
     if actual != expected:
         errorExit("FAILURE - Wrong currency1111 balance (expectedgma=%s, actual=%s)" % (str(expected), str(actual)), raw=True)
+
+    # Test skip sign with packed action data
+    Print("push transfer action to currency1111 contract with sign skipping option enabled")
+    data="{\"from\":\"currency1111\",\"to\":\"defproducera\",\"quantity\":"
+    data +="\"00.0002 CUR\",\"memo\":\"test packed\"}"
+    opts="-s -d --permission currency1111@active"
+    trans=node.pushMessage(contract, action, data, opts, expectTrxTrace=False)
+
+    try:
+        assert(not trans[1]["signatures"])
+    except (AssertionError, KeyError) as _:
+        Print("ERROR: Expected signatures array to be empty due to skipping option enabled.")
+        raise
+
+    try:
+        data = trans[1]["actions"][0]["data"]
+        Print(f"Action data: {data}")
+        assert data == "1042081e4d75af4660ae423ad15b974a020000000000000004435552000000000b74657374207061636b6564"
+    except (AssertionError, KeyError) as _:
+        Print("ERROR: Expecting packed data on push transfer action json result.")
+        raise
+
+    result=node.pushTransaction(trans[1], None)
+
+    amountStr=node.getTableAccountBalance("currency1111", currencyAccount.name)
+
+    expected="99999.9997 CUR"
+    actual=amountStr
+    if actual != expected:
+        errorExit("FAILURE - Wrong currency1111 balance (expectedgma=%s, actual=%s)" % (str(expected), str(actual)), raw=True)
+
 
     Print("---- Test for signing transaction ----")
     testeraAccountAmountBeforeTrx=node.getAccountEosBalanceStr(testeraAccount.name)


### PR DESCRIPTION
Backport of https://github.com/EOSIO/eos/pull/8676 via https://github.com/eosnetworkfoundation/mandel/pull/580 causes issue with action data of `eosio.msig`. See #118 for details.

Added new `cleos` option `-u, --unpack-action-data` which can be used with `--dont-broadcast` for expanding transaction action data section of JSON. The default now produces the same format as v3.1.0 which is what is expected by `eosio.msig` contract.

Resolves #118 