### PR TITLE
[3.2] Remove initial_chain_id in genesis.json as it is not supported.

### DIFF
--- a/tutorials/bios-boot-tutorial/genesis.json
+++ b/tutorials/bios-boot-tutorial/genesis.json
@@ -19,6 +19,5 @@
     "max_inline_action_size": 4096,
     "max_inline_action_depth": 4,
     "max_authority_depth": 6
-  },
-  "initial_chain_id": "0000000000000000000000000000000000000000000000000000000000000000"
+  }
 }


### PR DESCRIPTION
`initial_chain_id` is a remnant of long ago...