### PR TITLE
[3.1 -> main] use a temp dir for release-build test as it can leak creation of config.ini in to default location

### DIFF
--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -11,7 +11,11 @@ echo 'nodeos from source should perform a "release build" which excludes asserts
 echo 'debugging symbols, and performs compiler optimizations.'
 echo ''
 
-NODEOS_DEBUG=$(programs/nodeos/nodeos --extract-build-info >(python3 -c 'import json,sys; print(str(json.load(sys.stdin)["debug"]).lower());') &> /dev/null)
+TDIR=$(mktemp -d || exit 1)
+NODEOS_DEBUG=$(programs/nodeos/nodeos --config-dir "${TDIR}" --data-dir "${TDIR}" --extract-build-info >(python3 -c 'import json,sys; print(str(json.load(sys.stdin)["debug"]).lower());') &> /dev/null)
+#avoiding an rm -rf out of paranoia, but with the tradeoff this could change somehow in the future
+rm "${TDIR}/config.ini" || exit 1
+rmdir "${TDIR}" || exit 1
 if [[ "${NODEOS_DEBUG}" == 'false' ]]; then
     echo 'PASS: Debug flag is not set.'
     echo ''


### PR DESCRIPTION
main merge of #165 that resolves #157. Makes release-build test use a tempdir so it doesn't pollute (and potentially conflict) with default nodeos' config location