### PR TITLE
[3.2] switch parallel tests to new runner type

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,7 +126,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu20]
-    runs-on: ["self-hosted", "enf-x86-beefy"]
+    runs-on: ["self-hosted", "enf-x86-hightier"]
     container: ${{fromJSON(needs.d.outputs.p)[matrix.platform].image}}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This is a cost/efficiency change in preparation for more tests to be run in CI shortly (such as pinned builds & ARM builds). The parallel tests will now run on the lesser "hightier" runner which doesn't slow down total test time at all because even with the reduced number of CPUs we have to wait around for the `test_monitor_loop` test which is a minute longer than anything else.

The current configuration, always subject to change if need be,
* **beefy**: 224 "CPUs", 896GB¹
* **hightier**: 96 "CPUs", 48GB
* **midtier**: 16 "CPUs", 24GB
* **lowtier**: 8 "CPUs", 16GB

1: This was 224GB until very recently. Last couple days started to see some runs exhaust memory so was bumped up.