### PR TITLE
[3.2] Do not apply 3-strike rule when subjective billing is disabled

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1980,7 +1980,8 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
             fc_dlog( _trx_failed_trace_log, "Failed ${c} trx, auth: ${a}, prev billed: ${p}us, ran: ${r}us, id: ${id}",
                      ("c", failure_code)("a", first_auth)("p", prev_billed_cpu_time_us)
                      ( "r", end - start )( "id", trx->id() ) );
-            _account_fails.add( first_auth, failure_code );
+            if( !disable_subjective_enforcement )
+               _account_fails.add( first_auth, failure_code );
          }
          if( next ) {
             if( return_failure_trace ) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1915,8 +1915,12 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
 {
    auto start = fc::time_point::now();
 
+   bool disable_subjective_enforcement = (persist_until_expired && _disable_subjective_api_billing)
+                                         || (!persist_until_expired && _disable_subjective_p2p_billing)
+                                         || trx->read_only;
+
    auto first_auth = trx->packed_trx()->get_transaction().first_authorizer();
-   if( _account_fails.failure_limit( first_auth ) ) {
+   if( !disable_subjective_enforcement && _account_fails.failure_limit( first_auth ) ) {
       if( next ) {
          auto except_ptr = std::static_pointer_cast<fc::exception>( std::make_shared<tx_cpu_usage_exceeded>(
                FC_LOG_MESSAGE( error, "transaction ${id} exceeded failure limit for account ${a}",
@@ -1933,9 +1937,7 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
    if( max_trx_time.count() < 0 ) max_trx_time = fc::microseconds::maximum();
 
    bool disable_subjective_billing = ( _pending_block_mode == pending_block_mode::producing )
-                                     || ( persist_until_expired && _disable_subjective_api_billing )
-                                     || ( !persist_until_expired && _disable_subjective_p2p_billing )
-                                     || trx->read_only;
+                                     || disable_subjective_enforcement;
 
    int64_t sub_bill = 0;
    if( !disable_subjective_billing )


### PR DESCRIPTION
#151 Added 3-strike rule to subjective blocks. However, the 3-strike rule is supposed to be disabled for read-only transactions and when subjective billing is disabled. 

Disable 3-strike rule when subjective billing is disabled or if transaction is read-only.

Resolves #174 