### PR TITLE
[PH] Added early termination status

### DIFF
--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import subprocess
 
 harnessPath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(harnessPath)
@@ -106,6 +107,7 @@ try:
                             f'--trx-gen-duration {testGenerationDurationSec} '
                             f'--target-tps {targetTps}'
                          )
+
     # Get stats after transaction generation stops
     data.ceaseBlock = waitForEmptyBlocks(validationNode) - emptyBlockGoal + 1
     log_reader.scrapeLog(data, "var/lib/node_01/stderr.txt")
@@ -124,6 +126,8 @@ try:
     assert transactionsSent == data.totalTransactions , f"Error: Transactions received: {data.totalTransactions} did not match expected total: {transactionsSent}"
 
     testSuccessful = True
+except subprocess.CalledProcessError as err:
+    print(f"trx_generator return error code: {err.returncode}.  Test aborted.")
 finally:
     TestHelper.shutdown(
         cluster,

--- a/tests/trx_generator/main.cpp
+++ b/tests/trx_generator/main.cpp
@@ -12,6 +12,7 @@ using namespace eosio::chain;
 using namespace eosio;
 
 enum return_codes {
+   TERMINATED_EARLY = -3,
    OTHER_FAIL = -2,
    INITIALIZE_FAIL = -1,
    SUCCESS = 0,
@@ -168,6 +169,10 @@ int main(int argc, char** argv) {
       return OTHER_FAIL;
    }
 
+   if (monitor->terminated_early()) {
+      return TERMINATED_EARLY;
+   }
+   
    return SUCCESS;
 
 }

--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -98,6 +98,7 @@ namespace eosio::testing {
                     ("sent", stats.trxs_sent)
                     ("per_off", per_off)
                     ("vstart", _violation_start_time));
+               _terminated_early = true;
                return false;
            }
          } else {

--- a/tests/trx_generator/trx_provider.hpp
+++ b/tests/trx_generator/trx_provider.hpp
@@ -65,17 +65,18 @@ namespace eosio::testing {
    };
 
    struct tps_performance_monitor {
-      fc::microseconds     _spin_up_time;
-      uint32_t             _max_lag_per;
-      fc::microseconds     _max_lag_duration_us;
-
+      fc::microseconds                    _spin_up_time;
+      uint32_t                            _max_lag_per;
+      fc::microseconds                    _max_lag_duration_us;
+      bool                                _terminated_early;
       std::optional<fc::time_point>       _violation_start_time;
 
       tps_performance_monitor(int64_t spin_up_time=default_spin_up_time_us, uint32_t max_lag_per=default_max_lag_per,
                               int64_t max_lag_duration_us=default_max_lag_duration_us) : _spin_up_time(spin_up_time),
-                              _max_lag_per(max_lag_per), _max_lag_duration_us(max_lag_duration_us) {}
+                              _max_lag_per(max_lag_per), _max_lag_duration_us(max_lag_duration_us), _terminated_early(false) {}
 
       bool monitor_test(const tps_test_stats& stats);
+      bool terminated_early() {return _terminated_early;}
    };
 
    template<typename G, typename M>


### PR DESCRIPTION
Added a new return value (TERMINATED_EARLY -3) for trx_generator to indicate that the test terminated early.