### PR TITLE
[3.1 -> main] pinned_build.sh: make relative path work

### DIFF
--- a/scripts/pinned_build.sh
+++ b/scripts/pinned_build.sh
@@ -25,7 +25,8 @@ if [ $# -eq 0 ] || [ -z "$1" ]
 fi
 
 CORE_SYM=EOS
-DEP_DIR=$1
+# CMAKE_C_COMPILER requires absolute path
+DEP_DIR=`realpath $1`
 LEAP_DIR=$2
 JOBS=$3
 CLANG_VER=11.0.1
@@ -49,7 +50,8 @@ popdir() {
    echo ${D}
    D=`eval echo $D | head -n1 | cut -d " " -f1`
 
-   if [[ ${D} != ${EXPECTED} ]]; then
+   # -ef compares absolute paths
+   if ! [[ ${D} -ef ${EXPECTED} ]]; then
      echo "Directory is not where expected EXPECTED=${EXPECTED} at ${D}"
      exit 1 
    fi


### PR DESCRIPTION
`main` branch merge of https://github.com/AntelopeIO/leap/pull/179.
Resolve https://github.com/AntelopeIO/leap/issues/130.

Two issues prevents relative paths from working:

1. `if [[ ${D} != ${EXPECTED} ]]; then` does string comparison. `../lib` != `/home/lib` even though they refer to the same directory.
2. After the first problem was fixed, a second error occurred in `cmake`:
```
 The CMAKE_C_COMPILER:
    ../lib/clang-11.0.1/bin/clang
  is not a full path and was not found in the PATH.
```
After the fix, 

`./scripts/pinned_build.sh ../lib ./build 6` produces
```
...
CPackDeb: - Generating dependency list
 .----------------.  .----------------.  .----------------.  .----------------.
| .--------------. || .--------------. || .--------------. || .--------------. |
| |   _____      | || |  _________   | || |      __      | || |   ______     | |
| |  |_   _|     | || | |_   ___  |  | || |     /  \     | || |  |_   __ \   | |
| |    | |       | || |   | |_  \_|  | || |    / /\ \    | || |    | |__) |  | |
| |    | |   _   | || |   |  _|  _   | || |   / ____ \   | || |    |  ___/   | |
| |   _| |__/ |  | || |  _| |___/ |  | || | _/ /    \ \_ | || |   _| |_      | |
| |  |________|  | || | |_________|  | || ||____|  |____|| || |  |_____|     | |
| |              | || |              | || |              | || |              | |
| '--------------' || '--------------' || '--------------' || '--------------' |
Leap has successfully built and constructed its packages.  You should be able to find the packages at ./build.  Enjoy!!!

```