### PR TITLE
[3.1] trx_finality_status_forked_test fix

### DIFF
--- a/tests/trx_finality_status_forked_test.py
+++ b/tests/trx_finality_status_forked_test.py
@@ -245,13 +245,13 @@ try:
         "ERROR: The way the test is designed, the transaction should be added to a block that has a higher number than it was in originally before it was forked out." + \
        f"\n\noriginal in block state: {json.dumps(originalInBlockState, indent=1)}\n\nafter fork in block state: {json.dumps(afterForkInBlockState, indent=1)}"
 
-    assert prodNodes[1].waitForBlock(afterForkInBlockState["block_number"], blockType=BlockType.lib), \
+    assert prodNodes[1].waitForBlock(afterForkInBlockState["block_number"], timeout=120, blockType=BlockType.lib), \
         f"ERROR: Block never finalized.\n\nprod 0 info: {json.dumps(prodNodes[0].getInfo(), indent=1)}\n\nprod 1 info: {json.dumps(prodNodes[1].getInfo(), indent=1)}" + \
         f"\n\nafter fork in block state: {json.dumps(afterForkInBlockState, indent=1)}"
 
     retStatus = prodNodes[1].getTransactionStatus(transId)
     if afterForkBlockId != retStatus["block_id"]: # might have been forked out, if so wait for new block to become LIB
-        assert prodNodes[1].waitForBlock(retStatus["block_number"], blockType=BlockType.lib), \
+        assert prodNodes[1].waitForBlock(retStatus["block_number"], timeout=120, blockType=BlockType.lib), \
             f"ERROR: Block never finalized.\n\nprod 0 info: {json.dumps(prodNodes[0].getInfo(), indent=1)}\n\nprod 1 info: {json.dumps(prodNodes[1].getInfo(), indent=1)}" + \
             f"\n\nafter fork in block state: {json.dumps(afterForkInBlockState, indent=1)}"
 


### PR DESCRIPTION
Test failed #178 because the fork took longer to resolve than the default 60 seconds on the test run. Increase timeout for fork resolution to 120 seconds.

Resolves #178 