### PR TITLE
[3.2] label new issues with 'triage' label and add them to the Team Backlog project as Todo

### DIFF
--- a/.github/workflows/label_new_issues.yaml
+++ b/.github/workflows/label_new_issues.yaml
@@ -1,0 +1,17 @@
+name: Label New Issue
+
+on:
+  issues:
+    types: opened
+
+jobs:
+  label_new_issue:
+    uses: AntelopeIO/issue-project-labeler-workflow/.github/workflows/issue-project-labeler.yaml@v1
+    with:
+      issue-id: ${{github.event.issue.node_id}}
+      label: triage
+      org-project: 'Team Backlog'
+      project-field: Status=Todo
+    secrets:
+      token: ${{secrets.ENFCIBOT_REPO_AND_PROJECTS}}
+


### PR DESCRIPTION
Make use of a new reusable workflow to label all new issues with the _triage_ label, and add them to the _Team Backlog_ project with the _Status_ field set to _Todo_.

The one aspect that I'm not too happy with here is that modifying the project requires a token with rather broad permissions (`repo` & `project` scopes). Remember that PRs from forks don't have access to secrets, and this workflow doesn't consume any user controlled input, so in general this secret ought to be well protected against any abuse.