### PR TITLE
[3.1] promote ship log recovery logging from dlog to ilog

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -296,7 +296,7 @@ class state_history_log {
             break;
          pos = pos + state_history_log_header_serial_size + header.payload_size + sizeof(suffix);
          if (!(++num_found % 10000)) {
-            dlog("${num_found} blocks found, log pos = ${pos}", ("num_found", num_found)("pos", pos));
+            ilog("${num_found} blocks found, log pos = ${pos}", ("num_found", num_found)("pos", pos));
          }
       }
       log.flush();
@@ -390,7 +390,7 @@ class state_history_log {
             index.skip(-sizeof(uint64_t));
 
             if (!(remaining % 10000))
-               dlog("${remaining} blocks remaining, log pos = ${pos}", ("num_found", remaining)("pos", pos));
+               ilog("${remaining} blocks remaining, log pos = ${pos}", ("num_found", remaining)("pos", pos));
          }
       }
 


### PR DESCRIPTION
Recovering the logs is a very time intensive operation, but `dlog` isn't enabled by default. Promote these to `ilog`