### PR TITLE
[3.2] updated schema references to eosnetwork host

### DIFF
--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -37,14 +37,14 @@ paths:
                 - account_name
               properties:
                 account_name:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: "https://eosio.github.io/schemata/v2.0/oas/Account.yaml"
+                $ref: "https://docs.eosnetwork.com/openapi/v2.0/Account.yaml"
   /get_block:
     post:
       description: Returns an object containing various details about a specific block on the blockchain.
@@ -66,7 +66,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "https://eosio.github.io/schemata/v2.0/oas/Block.yaml"
+                $ref: "https://docs.eosnetwork.com/openapi/v2.0/Block.yaml"
   /get_block_info:
     post:
       description: Similar to `get_block` but returns a fixed-size smaller subset of the block data.
@@ -100,7 +100,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "https://eosio.github.io/schemata/v2.0/oas/Info.yaml"
+                $ref: "https://docs.eosnetwork.com/openapi/v2.0/Info.yaml"
 
   /push_transaction:
     post:
@@ -116,7 +116,7 @@ paths:
                   type: array
                   description: array of signatures required to authorize transaction
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Signature.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Signature.yaml"
                 compression:
                   type: boolean
                   description: Compression used, usually false
@@ -148,7 +148,7 @@ paths:
                   type: array
                   description: array of signatures required to authorize transaction
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Signature.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Signature.yaml"
                 compression:
                   type: boolean
                   description: Compression used, usually false
@@ -177,7 +177,7 @@ paths:
             schema:
               type: array
               items:
-                $ref: "https://eosio.github.io/schemata/v2.0/oas/Transaction.yaml"
+                $ref: "https://docs.eosnetwork.com/openapi/v2.0/Transaction.yaml"
       responses:
         "200":
           description: OK
@@ -208,7 +208,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "https://eosio.github.io/schemata/v2.0/oas/BlockHeaderState.yaml"
+                $ref: "https://docs.eosnetwork.com/openapi/v2.0/BlockHeaderState.yaml"
 
   /get_abi:
     post:
@@ -223,14 +223,14 @@ paths:
                 - account_name
               properties:
                 account_name:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: "https://eosio.github.io/schemata/v2.0/oas/Abi.yaml"
+                $ref: "https://docs.eosnetwork.com/openapi/v2.0/Abi.yaml"
   /get_currency_balance:
     post:
       description: Retrieves the current balance
@@ -246,11 +246,11 @@ paths:
                 - symbol
               properties:
                 code:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 account:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 symbol:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Symbol.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Symbol.yaml"
 
       responses:
         "200":
@@ -260,7 +260,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Symbol.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Symbol.yaml"
 
   /get_currency_stats:
     post:
@@ -273,9 +273,9 @@ paths:
               type: object
               properties:
                 code:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 symbol:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Symbol.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Symbol.yaml"
 
       responses:
         "200":
@@ -299,12 +299,12 @@ paths:
                 - available_keys
               properties:
                 transaction:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Transaction.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Transaction.yaml"
                 available_keys:
                   type: array
                   description: Provide the available keys
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/PublicKey.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/PublicKey.yaml"
       responses:
         "200":
           description: OK
@@ -356,17 +356,17 @@ paths:
                     type: array
                     nullable: true
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/ProducerSchedule.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/ProducerSchedule.yaml"
                   pending:
                     type: array
                     nullable: true
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/ProducerSchedule.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/ProducerSchedule.yaml"
                   proposed:
                     type: array
                     nullable: true
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/ProducerSchedule.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/ProducerSchedule.yaml"
 
 
   /get_raw_code_and_abi:
@@ -382,7 +382,7 @@ paths:
                 - account_name
               properties:
                 account_name:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
 
       responses:
         "200":
@@ -393,7 +393,7 @@ paths:
                 type: object
                 properties:
                   account_name:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   wasm:
                     type: string
                     description: base64 encoded wasm
@@ -412,7 +412,7 @@ paths:
               type: object
               properties:
                 lower_bound:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/DateTimeSeconds.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/DateTimeSeconds.yaml"
                 limit:
                   description: The maximum number of transactions to return
                   type: integer
@@ -430,7 +430,7 @@ paths:
                   transactions:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Transaction.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Transaction.yaml"
 
 
   /get_table_by_scope:
@@ -481,9 +481,9 @@ paths:
                   rows:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/TableScope.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/TableScope.yaml"
                   more:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
 
   /get_table_rows:
     post:
@@ -563,9 +563,9 @@ paths:
                 - args
               properties:
                 code:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 action:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 args:
                   type: object
                   description: json object of the action parameters that will be serialized.
@@ -579,7 +579,7 @@ paths:
                 type: object
                 properties:
                   binargs:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Hex.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Hex.yaml"
 
   /abi_bin_to_json:
     post:
@@ -597,11 +597,11 @@ paths:
                 - binargs
               properties:
                 code:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 action:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 binargs:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Hex.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Hex.yaml"
       responses:
         "200":
           description: OK
@@ -624,7 +624,7 @@ paths:
                 - code_as_wasm
               properties:
                 account_name:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 code_as_wasm:
                   type: integer
                   default: 1
@@ -639,15 +639,15 @@ paths:
                 title: GetCodeResponse.yaml
                 properties:
                   name:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   code_hash:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                   wast:
                     type: string
                   wasm:
                     type: string
                   abi:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Abi.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Abi.yaml"
 
   /get_raw_abi:
     post:
@@ -662,7 +662,7 @@ paths:
                 - account_name
               properties:
                 account_name:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
       responses:
         "200":
           description: OK
@@ -672,12 +672,12 @@ paths:
                 type: object
                 properties:
                   account_name:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   code_hash:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                   abi_hash:
                     allOf:
-                      - $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                      - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                   abi:
                     type: string
 
@@ -741,13 +741,13 @@ paths:
                   description: List of authorizing accounts and/or actor/permissions
                   items:
                     anyOf:
-                      - $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-                      - $ref: "https://eosio.github.io/schemata/v2.0/oas/Authority.yaml"
+                      - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                      - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Authority.yaml"
                 keys:
                   type: array
                   description: List of authorizing keys
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/PublicKey.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/PublicKey.yaml"
       responses:
         "200":
           description: OK
@@ -773,13 +773,13 @@ paths:
                         - threshold
                       properties:
                         account_name:
-                          $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                         permission_name:
-                          $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                         authorizer:
                           oneOf:
-                            - $ref: "https://eosio.github.io/schemata/v2.0/oas/PublicKey.yaml"
-                            - $ref: "https://eosio.github.io/schemata/v2.0/oas/Authority.yaml"
+                            - $ref: "https://docs.eosnetwork.com/openapi/v2.0/PublicKey.yaml"
+                            - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Authority.yaml"
                         weight:
                           type: "integer"
                           description: the weight that this authorizer adds to satisfy the permission

--- a/plugins/net_api_plugin/net.swagger.yaml
+++ b/plugins/net_api_plugin/net.swagger.yaml
@@ -61,17 +61,17 @@ paths:
                           description: Incremental value above a computed base
                           type: integer
                         chain_id:
-                          $ref: 'https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml'
+                          $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml'
                         node_id:
-                          $ref: 'https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml'
+                          $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml'
                         key:
-                          $ref: 'https://eosio.github.io/schemata/v2.0/oas/PublicKey.yaml'
+                          $ref: 'https://docs.eosnetwork.com/openapi/v2.0/PublicKey.yaml'
                         time:
-                          $ref: 'https://eosio.github.io/schemata/v2.0/oas/DateTimeSeconds.yaml'
+                          $ref: 'https://docs.eosnetwork.com/openapi/v2.0/DateTimeSeconds.yaml'
                         token:
-                          $ref: 'https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml'
+                          $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml'
                         sig:
-                          $ref: 'https://eosio.github.io/schemata/v2.0/oas/Signature.yaml'
+                          $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Signature.yaml'
                         p2p_address:
                           description: IP address or URL of the peer
                           type: string
@@ -79,12 +79,12 @@ paths:
                           description: Last irreversible block number
                           type: integer
                         last_irreversible_block_id:
-                          $ref: 'https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml'
+                          $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml'
                         head_num:
                           description: Head number
                           type: integer
                         head_id:
-                          $ref: 'https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml'
+                          $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml'
                         os:
                           description: Operating system name
                           type: string
@@ -190,17 +190,17 @@ paths:
                         description: Incremental value above a computed base
                         type: integer
                       chain_id:
-                        $ref: 'https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml'
+                        $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml'
                       node_id:
-                        $ref: 'https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml'
+                        $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml'
                       key:
-                        $ref: 'https://eosio.github.io/schemata/v2.0/oas/PublicKey.yaml'
+                        $ref: 'https://docs.eosnetwork.com/openapi/v2.0/PublicKey.yaml'
                       time:
-                        $ref: 'https://eosio.github.io/schemata/v2.0/oas/DateTimeSeconds.yaml'
+                        $ref: 'https://docs.eosnetwork.com/openapi/v2.0/DateTimeSeconds.yaml'
                       token:
-                        $ref: 'https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml'
+                        $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml'
                       sig:
-                        $ref: 'https://eosio.github.io/schemata/v2.0/oas/Signature.yaml'
+                        $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Signature.yaml'
                       p2p_address:
                         description: IP address or URL of the peer
                         type: string
@@ -208,12 +208,12 @@ paths:
                         description: Last irreversible block number
                         type: integer
                       last_irreversible_block_id:
-                        $ref: 'https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml'
+                        $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml'
                       head_num:
                         description: Head number
                         type: integer
                       head_id:
-                        $ref: 'https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml'
+                        $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml'
                       os:
                         description: Operating system name
                         type: string

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -111,7 +111,7 @@ paths:
                     type: array
                     description: Array of account names stored in the greylist
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
 
   /producer/add_greylist_accounts:
     post:
@@ -128,7 +128,7 @@ paths:
                     type: array
                     description: List of account names to add
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
 
       responses:
         "201":
@@ -158,7 +158,7 @@ paths:
                   type: array
                   description: List of account names to remove
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
 
       responses:
         "201":
@@ -190,19 +190,19 @@ paths:
                   actor_whitelist:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   actor_blacklist:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   contract_whitelist:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   contract_blacklist:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   action_blacklist:
                     type: array
                     items:
@@ -210,12 +210,12 @@ paths:
                       description: Array of two string values, the account name as the first and action name as the second
                       items:
                         allOf:
-                          - $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-                          - $ref: "https://eosio.github.io/schemata/v2.0/oas/CppSignature.yaml"
+                          - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                          - $ref: "https://docs.eosnetwork.com/openapi/v2.0/CppSignature.yaml"
                   key_blacklist:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/KeyType.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/KeyType.yaml"
 
   /producer/set_whitelist_blacklist:
     post:
@@ -232,19 +232,19 @@ paths:
                 actor_whitelist:
                   type: array
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 actor_blacklist:
                   type: array
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 contract_whitelist:
                   type: array
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 contract_blacklist:
                   type: array
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                 action_blacklist:
                   type: array
                   items:
@@ -252,12 +252,12 @@ paths:
                     description: Array of two string values, the account name as the first and action name as the second
                     items:
                       anyOf:
-                        - $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-                        - $ref: "https://eosio.github.io/schemata/v2.0/oas/CppSignature.yaml"
+                        - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                        - $ref: "https://docs.eosnetwork.com/openapi/v2.0/CppSignature.yaml"
                 key_blacklist:
                   type: array
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/KeyType.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/KeyType.yaml"
       responses:
         "201":
           description: OK
@@ -287,7 +287,7 @@ paths:
                 type: object
                 properties:
                   head_block_id:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                   head_block_num:
                     type: integer
                     descripiton: Highest block number on the chain
@@ -327,9 +327,9 @@ paths:
                 description: Defines the integrity hash information details
                 properties:
                   head_block_id:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                   integrity_hash:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
 
   /producer/schedule_protocol_feature_activations:
     post:
@@ -346,7 +346,7 @@ paths:
                   type: array
                   description: List of protocol features to activate
                   items:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
       responses:
         "201":
           description: OK
@@ -391,7 +391,7 @@ paths:
                   type: object
                   properties:
                     feature_digest:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                     subjective_restrictions:
                       type: object
                       properties:
@@ -405,11 +405,11 @@ paths:
                           type: string
                           example: "1970-01-01T00:00:00.000"
                         description_digest:
-                          $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                         dependancies:
                           type: array
                           items:
-                            $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                            $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                         protocol_feature_type:
                           type: string
                           example: "builtin"
@@ -478,7 +478,7 @@ paths:
                   description: number of transactions to return, defaults to 4,294,967,295
                   example: 2
                 lower_bound:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                 time_limit_ms:
                   type: int
                   description: defaults to 10ms
@@ -503,7 +503,7 @@ paths:
                       type: object
                       properties:
                         trx_id:
-                          $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                         expiration:
                           type: string
                           example: "2022-09-17T16:30:16"
@@ -529,7 +529,7 @@ paths:
                           type: integer
                           example: 934
                   more:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
         "400":
           description: client error
           content:

--- a/plugins/test_control_api_plugin/test_control.swagger.yaml
+++ b/plugins/test_control_api_plugin/test_control.swagger.yaml
@@ -44,7 +44,7 @@ paths:
                   type: object
                   properties:
                     producer:
-                      $ref: 'https://eosio.github.io/schemata/v2.0/oas/Name.yaml'
+                      $ref: 'https://docs.eosnetwork.com/openapi/v2.0/Name.yaml'
                     where_in_sequence:
                       type: integer
                     based_on_lib:

--- a/plugins/trace_api_plugin/trace_api.swagger.yaml
+++ b/plugins/trace_api_plugin/trace_api.swagger.yaml
@@ -44,8 +44,8 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: "https://eosio.github.io/schemata/v2.0/oas/BlockTraceV0.yaml"
-                  - $ref: "https://eosio.github.io/schemata/v2.0/oas/BlockTraceV1.yaml"
+                  - $ref: "https://docs.eosnetwork.com/openapi/v2.0/BlockTraceV0.yaml"
+                  - $ref: "https://docs.eosnetwork.com/openapi/v2.0/BlockTraceV1.yaml"
         "400":
           description: Error - requested block number is invalid (not a number, larger than max int)
         "404":


### PR DESCRIPTION
The OpenAPI files had http references to an out of date location for schema items. Updated to use new host name/path.

Example of updated path
https://eosio.github.io/schemata/v2.1/oas/BlockInfo.yaml