### PR TITLE
[3.2] add missing incoming_persisted in unapplied transaction queue's get_trx_type

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1470,6 +1470,8 @@ producer_plugin::get_unapplied_transactions( const get_unapplied_transactions_pa
             return "forked";
          case trx_enum_type::aborted:
             return "aborted";
+         case trx_enum_type::incoming_persisted:
+            return "incoming_persisted";
          case trx_enum_type::incoming:
             return "incoming";
       }


### PR DESCRIPTION
This was generating a compiler warning that a value was not handled.