### PR TITLE
[3.2] remove elog when ship thread exits normally

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -141,7 +141,6 @@ class state_history_log {
             eptr                       = std::current_exception();
             write_thread_has_exception = true;
          }
-         elog("${name} thread ended", ("name", this->name));
       });
    }
 


### PR DESCRIPTION
This `elog` is resulting in red error log prints during the course of normal shut down. It def shouldn't be an error, but I'm not seeing much utility in logging it at all?