### PR TITLE
[3.1] when uploading failure logs, ignore missing files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,7 +150,7 @@ jobs:
           ctest --output-on-failure -L "nonparallelizable_tests"
       - name: Bundle logs from failed tests
         if: failure()
-        run: tar -czf ${{matrix.platform}}-serial-logs.tar.gz build/var build/etc build/leap-ignition-wd
+        run: tar --ignore-failed-read -czf ${{matrix.platform}}-serial-logs.tar.gz build/var build/etc build/leap-ignition-wd
       - name: Upload logs from failed tests  
         uses: actions/upload-artifact@v3
         if: failure()
@@ -183,7 +183,7 @@ jobs:
           ctest --output-on-failure -R ${{matrix.test-name}}
       - name: Bundle logs from failed tests
         if: failure()
-        run: tar -czf ${{matrix.platform}}-${{matrix.test-name}}-logs.tar.gz build/var build/etc build/leap-ignition-wd
+        run: tar --ignore-failed-read -czf ${{matrix.platform}}-${{matrix.test-name}}-logs.tar.gz build/var build/etc build/leap-ignition-wd
       - name: Upload logs from failed tests  
         uses: actions/upload-artifact@v3
         if: failure()


### PR DESCRIPTION
https://github.com/AntelopeIO/leap/actions/runs/3107049183/jobs/5034762683 mentioned in #210 didn't upload failure logs because one of the files listed on tar's command line wasn't created in that particular test. `tar --ignore-failed-read` to fix this case and ensure all the other existing files do get uploaded.