### PR TITLE
[3.1 -> main] Update cleos to return an error code on failed trx processing

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -479,7 +479,7 @@ public:
    get_scheduled_transactions_result get_scheduled_transactions( const get_scheduled_transactions_params& params, const fc::time_point& deadline ) const;
    struct compute_transaction_results {
        chain::transaction_id_type  transaction_id;
-       fc::variant                 processed;
+       fc::variant                 processed; // "processed" is expected JSON for trxs in cleos
     };
 
    struct compute_transaction_params {
@@ -738,7 +738,7 @@ public:
    using push_transaction_params = fc::variant_object;
    struct push_transaction_results {
       chain::transaction_id_type  transaction_id;
-      fc::variant                 processed;
+      fc::variant                 processed; // "processed" is expected JSON for trxs in cleos
    };
    void push_transaction(const push_transaction_params& params, chain::plugin_interface::next_function<push_transaction_results> next);
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -181,6 +181,7 @@ bool   print_request = false;
 bool   print_response = false;
 bool   no_auto_keosd = false;
 bool   verbose = false;
+int    return_code = 0;
 
 uint8_t  tx_max_cpu_usage = 0;
 uint32_t tx_max_net_usage = 0;
@@ -622,6 +623,32 @@ void print_action_tree( const fc::variant& action ) {
    }
 }
 
+int get_return_code( const fc::variant& result ) {
+   // if a trx with a processed, then check to see if it failed execution for return value
+   int r = 0;
+   if (result.is_object() && result.get_object().contains("processed")) {
+      const auto& processed = result["processed"];
+      if( processed.is_object() && processed.get_object().contains( "except" ) ) {
+         const auto& except = processed["except"];
+         if( except.is_object() ) {
+            try {
+               auto soft_except = except.as<fc::exception>();
+               auto code = soft_except.code();
+               if( code > std::numeric_limits<int>::max() ) {
+                  r = 1;
+               } else {
+                  r = static_cast<int>( code );
+               }
+               if( r == 0 ) r = 1;
+            } catch( ... ) {
+               r = 1;
+            }
+         }
+      }
+   }
+   return r;
+}
+
 void print_result( const fc::variant& result ) { try {
       if (result.is_object() && result.get_object().contains("processed")) {
          const auto& processed = result["processed"];
@@ -685,6 +712,7 @@ void send_actions(std::vector<chain::action>&& actions, const std::vector<public
       out << jsonstr;
       out.close();
    }
+   return_code = get_return_code( result );
    if( tx_print_json ) {
       if (jsonstr.length() == 0) {
          jsonstr = fc::json::to_pretty_string( result );
@@ -4436,14 +4464,16 @@ int main( int argc, char** argv ) {
       }
       return 1;
    } catch ( const std::bad_alloc& ) {
-     elog("bad alloc");
+      elog("bad alloc");
+      return 1;
    } catch( const boost::interprocess::bad_alloc& ) {
-     elog("bad alloc");
+      elog("bad alloc");
+      return 1;
    } catch (const fc::exception& e) {
-     return handle_error(e);
+      return handle_error(e);
    } catch (const std::exception& e) {
-      return handle_error(fc::std_exception_wrapper::from_current_exception(e)); 
+      return handle_error(fc::std_exception_wrapper::from_current_exception(e));
    }
 
-   return 0;
+   return return_code;
 }

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -802,7 +802,7 @@ class Node(object):
         if shouldFail:
             if trans["processed"]["except"] != None:
                 retMap={}
-                retMap["returncode"]=0
+                retMap["returncode"]=1
                 retMap["cmd"]=cmd
                 retMap["output"]=bytes(str(trans),'utf-8')
                 return retMap

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -205,7 +205,8 @@ class Utils:
         Utils.checkOutputFileWrite(start, cmd, output, error)
         if popen.returncode != 0 and not ignoreError:
             Utils.Print("ERROR: %s" % error)
-            raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=error)
+            # for now just include both stderr and stdout in output, python 3.5+ supports both a stdout and stderr attributes
+            raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=error+bytes(" ", 'utf-8')+output)
         return output.decode("utf-8")
 
     @staticmethod

--- a/tests/prod_preactivation_test.py
+++ b/tests/prod_preactivation_test.py
@@ -107,8 +107,9 @@ try:
     Print("publish a new bios contract %s should fails because env.is_feature_activated unresolveable" % (contractDir))
     retMap = node0.publishContract(cluster.eosioAccount, contractDir, wasmFile, abiFile, True, shouldFail=True)
 
-    if retMap["output"].decode("utf-8").find("unresolveable") < 0:
-        errorExit("bios contract not result in expected unresolveable error")
+    outPut = retMap["output"].decode("utf-8")
+    if outPut.find("unresolveable") < 0:
+        errorExit(f"bios contract not result in expected unresolveable error: {outPut}")
 
     secwait = 30
     Print("Wait for node 1 to produce...")


### PR DESCRIPTION
Leap 3.1 returns transaction failure traces by default. `EOSIO/eos 2.0` would instead throw an exception. 
The [3.1 release notes](https://github.com/AntelopeIO/leap/releases/tag/v3.1.0) included the following:

> New command line options for cleos:
> - `--use-old-send-rpc`
>   - "Use old RPC `/v1/chain/send_transaction`, rather than new RPC `/v1/chain/send_transaction2`"
> - `-t,--return-failure-trace` defaults to `true` use `-t false` for previous behavior
>   - "Return partial traces on failed transactions"
>   - Note: Automation which depends on `cleos` to return a non-zero value on transaction failure will instead need to parse the traces or use option `-t false`.

This PR addresses the cleos non-zero return values for failed transaction execution. With this PR, cleos will parse the returned transaction traces and return a non-zero return value for transactions that failed to speculatively execute.

Before:
```
$ ./cleos  push action  eosio.token transfer '{"from":"eosio","to":"testera11111","quantity":"0.0001 SYS","memo":"hi"}'
failed transaction: d19173082af2e0dee7d11a638adabc646f55b81364b923b71c6d467fbff30b76  <unknown> bytes  <unknown> us
error 2022-09-21T15:20:49.283 cleos     main.cpp:601                  print_result         ] soft_except->to_detail_string(): 3040003 tx_no_auths: Transaction should have at least one required authority
transaction must have at least one authorization
    {}
    nodeos  transaction_context.cpp:753 validate_referenced_accounts

$ echo $?
0
```

After:
```
$ ./cleos  push action  eosio.token transfer '{"from":"eosio","to":"testera11111","quantity":"0.0001 SYS","memo":"hi"}'
failed transaction: 1488c901f8d1952eae4fddd509758a639cabf5f1ea86967bf6215580c264f519  <unknown> bytes  <unknown> us
error 2022-09-21T15:20:42.847 cleos.3.1 main.cpp:575                  print_result         ] soft_except->to_detail_string(): 3040003 tx_no_auths: Transaction should have at least one required authority
transaction must have at least one authorization
    {}
    nodeos  transaction_context.cpp:753 validate_referenced_accounts

$ echo $?
3
```

Resolves #139 
Merges #199 into `main`.