### PR TITLE
[3.2] Cleanup regression python test handling of CalledProcessError

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -624,7 +624,7 @@ class Cluster(object):
             verStr=m.group(1)
             return verStr
         except subprocess.CalledProcessError as ex:
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             Utils.Print("ERROR: Exception during client version query. %s" % (msg))
             raise
 
@@ -666,7 +666,7 @@ class Cluster(object):
                 if Utils.Debug: Utils.Print("name: %s, key(owner): ['%s', '%s], key(active): ['%s', '%s']" % (name, ownerPublic, ownerPrivate, activePublic, activePrivate))
 
             except subprocess.CalledProcessError as ex:
-                msg=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
                 Utils.Print("ERROR: Exception during key creation. %s" % (msg))
                 break
 
@@ -1353,7 +1353,7 @@ class Cluster(object):
                 psOut=Utils.checkOutput(cmd.split())
                 return psOut
             except subprocess.CalledProcessError as ex:
-                msg=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
                 Utils.Print("ERROR: call of \"%s\" failed. %s" % (cmd, msg))
                 return None
             return None

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -794,9 +794,7 @@ class Node(object):
                 retMap["returncode"]=ex.returncode
                 retMap["cmd"]=ex.cmd
                 retMap["output"]=ex.output
-                # commented below as they are available only in Python3.5 and above
-                # retMap["stdout"]=ex.stdout
-                # retMap["stderr"]=ex.stderr
+                retMap["stderr"]=ex.stderr
                 return retMap
 
         if shouldFail:

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -177,7 +177,7 @@ class Node(object):
             outs,errs=popen.communicate(input=subcommand.encode("utf-8"))
             ret=popen.wait()
         except subprocess.CalledProcessError as ex:
-            msg=ex.output
+            msg=ex.stderr
             return (ex.returncode, msg, None)
 
         return (ret, outs, errs)
@@ -580,7 +580,7 @@ class Node(object):
                 self.trackCmdTransaction(trans, reportStatus=reportStatus)
         except subprocess.CalledProcessError as ex:
             end=time.perf_counter()
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             Utils.Print("ERROR: Exception during funds transfer.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
             if exitOnError:
                 Utils.cmdError("could not transfer \"%s\" from %s to %s" % (amountStr, source, destination))
@@ -604,7 +604,7 @@ class Node(object):
                 Utils.Print("cmd Duration: %.3f sec" % (end-start))
         except subprocess.CalledProcessError as ex:
             end=time.perf_counter()
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             Utils.Print("ERROR: Exception during spawn of funds transfer.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
             if exitOnError:
                 Utils.cmdError("could not transfer \"%s\" from %s to %s" % (amountStr, source, destination))
@@ -764,7 +764,7 @@ class Node(object):
             return m.group(1)
         except subprocess.CalledProcessError as ex:
             end=time.perf_counter()
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             Utils.Print("ERROR: Exception during code hash retrieval.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
             return None
 
@@ -786,7 +786,7 @@ class Node(object):
         except subprocess.CalledProcessError as ex:
             if not shouldFail:
                 end=time.perf_counter()
-                msg=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
                 Utils.Print("ERROR: Exception during set contract.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
                 return None
             else:
@@ -865,7 +865,7 @@ class Node(object):
                 Utils.Print("cmd Duration: %.3f sec" % (end-start))
             return (Node.getTransStatus(retTrans) == 'executed', retTrans)
         except subprocess.CalledProcessError as ex:
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             if not silentErrors:
                 end=time.perf_counter()
                 Utils.Print("ERROR: Exception during push transaction.  cmd Duration=%.3f sec.  %s" % (end - start, msg))
@@ -893,7 +893,7 @@ class Node(object):
                 Utils.Print("cmd Duration: %.3f sec" % (end-start))
             return (Node.getTransStatus(trans) == 'executed' if expectTrxTrace else True, trans)
         except subprocess.CalledProcessError as ex:
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             if not silentErrors:
                 end=time.perf_counter()
                 Utils.Print("ERROR: Exception during push message.  cmd Duration=%.3f sec.  %s" % (end - start, msg))
@@ -994,7 +994,7 @@ class Node(object):
         except subprocess.CalledProcessError as ex:
             if not silentErrors:
                 end=time.perf_counter()
-                msg=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
                 errorMsg="Exception during \"%s\". Exception message: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, end-start, exitMsg)
                 if exitOnError:
                     Utils.cmdError(errorMsg)
@@ -1040,7 +1040,7 @@ class Node(object):
         except subprocess.CalledProcessError as ex:
             if not silentErrors:
                 end=time.perf_counter()
-                msg=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
                 errorMsg="Exception during \"%s\". %s.  cmd Duration=%.3f sec." % (cmd, msg, end-start)
                 if exitOnError:
                     Utils.cmdError(errorMsg)

--- a/tests/TestHarness/WalletMgr.py
+++ b/tests/TestHarness/WalletMgr.py
@@ -95,6 +95,8 @@ class WalletMgr(object):
             psOut=Utils.checkOutput(pgrepCmd.split())
             if Utils.Debug: Utils.Print("Launched %s. {%s}" % (Utils.EosWalletName, psOut))
         except subprocess.CalledProcessError as ex:
+            Utils.Print(f"STDOUT: {ex.output}")
+            Utils.Print(f"STDERR: {ex.stderr}")
             Utils.errorExit("Failed to launch the wallet manager")
 
         return True
@@ -131,7 +133,7 @@ class WalletMgr(object):
                     time.sleep(delay)
                     continue
 
-                msg=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
                 errorMsg="ERROR: Failed to create wallet - %s. %s" % (name, msg)
                 if exitOnError:
                     Utils.errorExit("%s" % (errorMsg))
@@ -170,7 +172,7 @@ class WalletMgr(object):
         try:
             Utils.checkOutput(cmd.split())
         except subprocess.CalledProcessError as ex:
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             if warningMsg in msg:
                 if not ignoreDupKeyWarning:
                     Utils.Print("WARNING: This key is already imported into the wallet.")
@@ -187,7 +189,7 @@ class WalletMgr(object):
             try:
                 Utils.checkOutput(cmd.split())
             except subprocess.CalledProcessError as ex:
-                msg=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
                 if warningMsg in msg:
                     if not ignoreDupKeyWarning:
                         Utils.Print("WARNING: This key is already imported into the wallet.")
@@ -237,7 +239,7 @@ class WalletMgr(object):
         try:
             retStr=Utils.checkOutput(cmd.split())
         except subprocess.CalledProcessError as ex:
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             Utils.Print("ERROR: Failed to open wallets. %s" % (msg))
             return False
 
@@ -259,7 +261,7 @@ class WalletMgr(object):
         try:
             retStr=Utils.checkOutput(cmd.split())
         except subprocess.CalledProcessError as ex:
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             Utils.Print("ERROR: Failed to get keys. %s" % (msg))
             return False
         m=p.findall(retStr)

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -204,7 +204,6 @@ class Utils:
         (output,error)=popen.communicate()
         Utils.checkOutputFileWrite(start, cmd, output, error)
         if popen.returncode != 0 and not ignoreError:
-            # for now just include both stderr and stdout in output, python 3.5+ supports both a stdout and stderr attributes
             raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=output, stderr=error)
         return output.decode("utf-8")
 

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -204,9 +204,8 @@ class Utils:
         (output,error)=popen.communicate()
         Utils.checkOutputFileWrite(start, cmd, output, error)
         if popen.returncode != 0 and not ignoreError:
-            Utils.Print("ERROR: %s" % error)
             # for now just include both stderr and stdout in output, python 3.5+ supports both a stdout and stderr attributes
-            raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=error+bytes(" ", 'utf-8')+output)
+            raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=output, stderr=error)
         return output.decode("utf-8")
 
     @staticmethod
@@ -397,7 +396,7 @@ class Utils:
             if throwException:
                 raise
             if not silentErrors:
-                msg=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
                 errorMsg="Exception during \"%s\". %s" % (cmd, msg)
                 if exitOnError:
                     Utils.cmdError(errorMsg)

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -119,7 +119,8 @@ def cleos_sign_test():
         outs,errs=popen.communicate()
         popen.wait()
     except subprocess.CalledProcessError as ex:
-        print(ex.output)
+        print(f"STDOUT: {ex.output}")
+        print(f"STDERR: {ex.stderr}")
     # make sure fields are unpacked
     assert(b'"expiration": "2019-08-01T07:15:49"' in errs)
     assert(b'"ref_block_num": 34881' in errs)
@@ -145,7 +146,8 @@ def processCleosCommand(cmd):
         outs, errs = popen.communicate()
         popen.wait()
     except subprocess.CalledProcessError as ex:
-        print(ex.output)
+        print(f"STDOUT: {ex.output}")
+        print(f"STDERR: {ex.stderr}")
     return outs, errs
 
 def cleos_abi_file_test():


### PR DESCRIPTION
Use Python 3.5+ feature of capturing stderr in CalledProcessError.
Also remove "debug" ERROR print statement which was causing log spam.

Cleanup related to #139