### PR TITLE
[3.1] Fix nodeos_retry_transaction_test.py

### DIFF
--- a/tests/nodeos_retry_transaction_test.py
+++ b/tests/nodeos_retry_transaction_test.py
@@ -181,7 +181,7 @@ try:
     overdrawTransferAmount = "1001.0000 {0}".format(CORE_SYMBOL)
     Print("Transfer funds %s from account %s to %s" % (overdrawTransferAmount, overdrawAccount.name, cluster.eosioAccount.name))
     overdrawtrans = node.transferFunds(overdrawAccount, cluster.eosioAccount, overdrawTransferAmount, "test overdraw transfer", exitOnError=False, reportStatus=False, retry=1)
-    assert "overdrawn balance" in str(overdrawtrans), "ERROR: Overdraw transaction attempt should have failed with overdrawn balance."
+    assert overdrawtrans is None, f"ERROR: Overdraw transaction attempt should have failed with overdrawn balance: {overdrawtrans}"
 
     def cacheTransIdInBlock(transId, transToBlock, node):
         global lastIrreversibleBlockNum

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -204,7 +204,6 @@ class Utils:
         (output,error)=popen.communicate()
         Utils.checkOutputFileWrite(start, cmd, output, error)
         if popen.returncode != 0 and not ignoreError:
-            Utils.Print("ERROR: %s" % error)
             # for now just include both stderr and stdout in output, python 3.5+ supports both a stdout and stderr attributes
             raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=error+bytes(" ", 'utf-8')+output)
         return output.decode("utf-8")


### PR DESCRIPTION
`nodeos_retry_transaction_test.py` was created after default of `--return-failure-trace=true`. PR #139 changed `cleos` to return an error now when a transaction trace has an exception indicating the trx failed. Update test to expect this `cleos` error return code.

Also remove a debug `ERROR:` print that was causing confusing output in the tests.

Run of test here: https://github.com/AntelopeIO/leap/actions/runs/3112753652

Resolves #217 