### PR TITLE
[3.1 -> main] Fix nodeos_retry_transaction_test.py

### DIFF
--- a/tests/nodeos_retry_transaction_test.py
+++ b/tests/nodeos_retry_transaction_test.py
@@ -175,7 +175,7 @@ try:
     overdrawTransferAmount = "1001.0000 {0}".format(CORE_SYMBOL)
     Print("Transfer funds %s from account %s to %s" % (overdrawTransferAmount, overdrawAccount.name, cluster.eosioAccount.name))
     overdrawtrans = node.transferFunds(overdrawAccount, cluster.eosioAccount, overdrawTransferAmount, "test overdraw transfer", exitOnError=False, reportStatus=False, retry=1)
-    assert "overdrawn balance" in str(overdrawtrans), "ERROR: Overdraw transaction attempt should have failed with overdrawn balance."
+    assert overdrawtrans is None, f"ERROR: Overdraw transaction attempt should have failed with overdrawn balance: {overdrawtrans}"
 
     def cacheTransIdInBlock(transId, transToBlock, node):
         global lastIrreversibleBlockNum


### PR DESCRIPTION
`nodeos_retry_transaction_test.py` was created after default of `--return-failure-trace=true`. PR #212 changed `cleos` to return an error now when a transaction trace has an exception indicating the trx failed. Update test to expect this `cleos` error return code.

Also remove a debug `ERROR:` print that was causing confusing output in the tests.

Run of test here: https://github.com/AntelopeIO/leap/actions/runs/3113504045

Resolves #217 
Merges #218 into `main`.