### PR TITLE
[3.2] always run the long running tests, including for pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,10 +7,6 @@ on:
       - "release/*"
   pull_request:
   workflow_dispatch:
-    inputs:
-      run-lr-tests:
-        description: 'Run long running tests'
-        type: boolean
 
 permissions:
   packages: read
@@ -176,7 +172,7 @@ jobs:
   lr-tests:
     name: LR Tests
     needs: [d, Build]
-    if: always() && needs.Build.result == 'success' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || inputs.run-lr-tests)
+    if: always() && needs.Build.result == 'success'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Currently we only run LR tests for merges to main or release branches, as well as when manually requested. Due to our usage of the "All Required Tests Passed" test as a branch protect rule we can go ahead and enable these LR tests to always run and still not block merging should a PR be approved and need to merge before LR tests complete.

Based on some experimentation:
* If the PR is approved before "All Required Tests Passed" completes successfully, the merge button remains disabled (with an admin override option for some of us).
* If a PR is approved before or after "All Required Tests Passed" completes successfully, but before LR tests complete, the merge button is "white" -- this still allows merging.
* Once LR tests complete successfully the merge button additionally goes green.
* If a LR test fails, the merge button will remain white.

The last scenario is a bit unfortunate. Still, this change would seem to provide more information (more test feedback) in the times we don't need to rush a PR in within ~10 minutes, but still allow anyone to merge PRs quickly before LR tests complete when they feel its appropriate.