### PR TITLE
[3.1] updated trace_api openapi documentation

### DIFF
--- a/plugins/trace_api_plugin/trace_api.swagger.yaml
+++ b/plugins/trace_api_plugin/trace_api.swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Trace API
-  description: This plubing must specifiy one option `trace-rpc-abi` or `no-trace-abis`. These options are provided at nodeos startup on the command line or in config.ini file. Configuration option `trace-rpc-abi` There must be at least one ABI specified OR the flag trace-no-abis must be used. ABIs are specified as "Key=Value" pairs in the form <account-name>=<abi-def> Where <abi-def> can be an absolute path to a file containing a valid JSON-encoded ABI a relative path from `data-dir` to a file containing a valid JSON-encoded ABI. Configuration option `trace-no-abis` use to indicate that the RPC responses
+  description: See developer documentation at https://docs.eosnetwork.com for information on enabling this plugin.
   version: 1.0.0
   license:
     name: MIT
@@ -47,7 +47,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/component/schema/BLOCK_TRACE"
+                oneOf:
+                  - $ref: "https://docs.eosnetwork.com/openapi/v2.0/BlockTraceV0.yaml"
+                  - $ref: "https://docs.eosnetwork.com/openapi/v2.0/BlockTraceV1.yaml"
+                  - $ref: "https://docs.eosnetwork.com/openapi/v2.0/BlockTraceV2.yaml"
         "400":
           description: Error - requested block number is invalid (not a number, larger than max int)
           content:
@@ -115,7 +118,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/component/schema/TRANSACTION_TRACE"
+                oneOf:
+                  - $ref: "https://docs.eosnetwork.com/openapi/v2.0/TransactionTraceV0.yaml"
+                  - $ref: "https://docs.eosnetwork.com/openapi/v2.0/TransactionTraceV1.yaml"
+                  - $ref: "https://docs.eosnetwork.com/openapi/v2.0/TransactionTraceV2.yaml"
+                  - $ref: "https://docs.eosnetwork.com/openapi/v2.0/TransactionTraceV3.yaml"
         "400":
           description: Error - requested block number is invalid (not a number, larger than max int)
           content:
@@ -210,114 +217,6 @@ component:
             memo:
               type: string
               example: "first transfer"
-    TRANSACTION_HEADER:
-      type: object
-      properties:
-        expiration:
-          type: string
-          example: "2019-06-18T00:00:00"
-        ref_block_num:
-          type: integer
-          example: 25
-        ref_block_prefix:
-          type: integer
-          example: 61809694
-        max_net_usage_words:
-          type: integer
-          example: 0
-        max_cpu_usage_ms:
-          type: integer
-          example: 0
-        delay_sec:
-          type: integer
-          example: 0
-    TRANSACTION_TRACE:
-      type: object
-      properties:
-        id:
-          type: string
-          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
-        block_num:
-          type: integer
-          example: 31
-        block_time:
-          type: string
-          example: "2019-06-18T00:00:00"
-        producer_block_id:
-          type: string
-          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
-        actions:
-          type: array
-          items:
-            $ref: "#/component/schema/TRACE"
-        status:
-          type: string
-          example: executed
-        cpu_usage_us:
-          type: integer
-          example: 669
-        net_usage_words:
-          type: integer
-          example: 6
-        signatures:
-          type: array
-          items:
-            $ref: "https://docs.eosnetwork.com/openapi/v2.0/CppSignature.yaml"
-        transaction_header:
-          type: object
-          $ref: "#/component/schema/TRANSACTION_HEADER"
-    BLOCK_TRACE:
-      type: object
-      properties:
-        id:
-          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
-        number:
-          type: integer
-          example: 31
-        previous_id:
-          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
-        status:
-          type: string
-          enum:
-            - "irreversible"
-            - "executed"
-            - "pending"
-          example: executed
-        timestamp:
-          type: string
-          example: "2019-06-18T00:00:00"
-        producer:
-          type: string
-          example: myproducer
-        transaction_mroot:
-          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
-        action_mroot:
-          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
-        schedule_version:
-          type: integer
-          example: 1
-        transactions:
-          type: array
-          items:
-            type: object
-            properties:
-              id:
-                $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
-              block_num:
-                type: integer
-                example: 31
-              block_time:
-                type: string
-                example: "2019-06-18T00:00:00"
-              producer_block_id:
-                $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
-              actions:
-                type: array
-                items:
-                  $ref: "#/component/schema/TRACE"
-              transaction_header:
-                type: object
-                $ref: "#/component/schema/TRANSACTION_HEADER"
     ERROR_DETAILS:
       type: object
       properties:

--- a/plugins/trace_api_plugin/trace_api.swagger.yaml
+++ b/plugins/trace_api_plugin/trace_api.swagger.yaml
@@ -1,12 +1,13 @@
 openapi: 3.0.0
 info:
   title: Trace API
+  description: This plubing must specifiy one option `trace-rpc-abi` or `no-trace-abis`. These options are provided at nodeos startup on the command line or in config.ini file. Configuration option `trace-rpc-abi` There must be at least one ABI specified OR the flag trace-no-abis must be used. ABIs are specified as "Key=Value" pairs in the form <account-name>=<abi-def> Where <abi-def> can be an absolute path to a file containing a valid JSON-encoded ABI a relative path from `data-dir` to a file containing a valid JSON-encoded ABI. Configuration option `trace-no-abis` use to indicate that the RPC responses
   version: 1.0.0
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT
   contact:
-    url: https://eos.io
+    url: https://eosnetwork.com
 servers:
   - url: '{protocol}://{host}:{port}/v1/'
     variables:
@@ -21,9 +22,12 @@ servers:
         default: "8080"
 components:
   schemas: {}
+security:
+  - {}
 paths:
   /trace_api/get_block:
     post:
+      summary: get block
       description: Returns a block trace object containing retired actions and related metadata.
       operationId: get_block
       requestBody:
@@ -43,12 +47,288 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "https://eosio.github.io/schemata/v2.0/oas/BlockTraceV0.yaml"
-                  - $ref: "https://eosio.github.io/schemata/v2.0/oas/BlockTraceV1.yaml"
+                $ref: "#/component/schema/BLOCK_TRACE"
         "400":
           description: Error - requested block number is invalid (not a number, larger than max int)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 400
+                  message:
+                    type: string
+                    example: "bad or missing block_num"
+                  error:
+                    $ref: "#/component/schema/ERROR_DETAILS"
         "404":
           description: Error - requested data not present on node
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 400
+                  message:
+                    type: string
+                    example: "bad or missing block_num"
+                  error:
+                    $ref: "#/component/schema/ERROR_DETAILS"
         "500":
           description: Error - exceptional condition while processing get_block; e.g. corrupt files
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  message:
+                    type: string
+                    example: "Trace API encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process"
+                  error:
+                    $ref: "#/component/schema/ERROR_DETAILS"
+
+  /trace_api/get_transaction_trace:
+    post:
+      summary: transaction trace
+      description: Does a scan of the trace files looking for the transaction
+      optionationId: get_transaction_trace
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+              properties:
+                id:
+                  type: integer
+                  description: Proviade a transaction id
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/component/schema/TRANSACTION_TRACE"
+        "400":
+          description: Error - requested block number is invalid (not a number, larger than max int)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 400
+                  message:
+                    type: string
+                    example: "bad or missing block_num"
+                  error:
+                    $ref: "#/component/schema/ERROR_DETAILS"
+        "404":
+          description: Error - requested data not present on node
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 400
+                  message:
+                    type: string
+                    example: "bad or missing block_num"
+                  error:
+                    $ref: "#/component/schema/ERROR_DETAILS"
+        "500":
+          description: Error - exceptional condition while processing get_block; e.g. corrupt files
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  message:
+                    type: string
+                    example: "Trace API encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process"
+                  error:
+                    $ref: "#/component/schema/ERROR_DETAILS"
+component:
+  schema:
+    TRACE:
+      type: object
+      properties:
+        global_squence:
+          type: integer
+          example: 669
+        receiver:
+          type: string
+          example: myproducer
+        account:
+          type: string
+          example: esio.token
+        action:
+          type: string
+          example: transfer
+        authorization:
+          type: array
+          items:
+            type: object
+            properties:
+              account:
+                type: string
+                example: myaccount
+              permission:
+                type: string
+                example: active
+        data:
+          type: string
+          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+        return_value:
+          type: string
+          example: ""
+        params:
+          type: object
+          properties:
+            from:
+              type: string
+              example: eosio
+            to:
+              type: string
+              example: myproducer
+            quantity:
+              type: string
+              example: "10.000 SYS"
+            memo:
+              type: string
+              example: "first transfer"
+    TRANSACTION_HEADER:
+      type: object
+      properties:
+        expiration:
+          type: string
+          example: "2019-06-18T00:00:00"
+        ref_block_num:
+          type: integer
+          example: 25
+        ref_block_prefix:
+          type: integer
+          example: 61809694
+        max_net_usage_words:
+          type: integer
+          example: 0
+        max_cpu_usage_ms:
+          type: integer
+          example: 0
+        delay_sec:
+          type: integer
+          example: 0
+    TRANSACTION_TRACE:
+      type: object
+      properties:
+        id:
+          type: string
+          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+        block_num:
+          type: integer
+          example: 31
+        block_time:
+          type: string
+          example: "2019-06-18T00:00:00"
+        producer_block_id:
+          type: string
+          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+        actions:
+          type: array
+          items:
+            $ref: "#/component/schema/TRACE"
+        status:
+          type: string
+          example: executed
+        cpu_usage_us:
+          type: integer
+          example: 669
+        net_usage_words:
+          type: integer
+          example: 6
+        signatures:
+          type: array
+          items:
+            $ref: "https://docs.eosnetwork.com/openapi/v2.0/CppSignature.yaml"
+        transaction_header:
+          type: object
+          $ref: "#/component/schema/TRANSACTION_HEADER"
+    BLOCK_TRACE:
+      type: object
+      properties:
+        id:
+          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+        number:
+          type: integer
+          example: 31
+        previous_id:
+          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+        status:
+          type: string
+          enum:
+            - "irreversible"
+            - "executed"
+            - "pending"
+          example: executed
+        timestamp:
+          type: string
+          example: "2019-06-18T00:00:00"
+        producer:
+          type: string
+          example: myproducer
+        transaction_mroot:
+          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+        action_mroot:
+          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+        schedule_version:
+          type: integer
+          example: 1
+        transactions:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+              block_num:
+                type: integer
+                example: 31
+              block_time:
+                type: string
+                example: "2019-06-18T00:00:00"
+              producer_block_id:
+                $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+              actions:
+                type: array
+                items:
+                  $ref: "#/component/schema/TRACE"
+              transaction_header:
+                type: object
+                $ref: "#/component/schema/TRANSACTION_HEADER"
+    ERROR_DETAILS:
+      type: object
+      properties:
+        code:
+          type: integer
+          example: 0
+        name:
+          type: string
+        what:
+          type: string
+        details:
+          type: array
+        items:
+          type: string


### PR DESCRIPTION
- added trace_transcation method
- updated return schema for both get_block and get_transaction_trace
     - New v2 schema for BLockTrace added to options for returned schema
     - New v2 and v3 schema for TransactionTrace added to options for returned schema
     - New sub-schemas ActionTraceV2 and BlockTRaceV2
- added new component types
   - ERROR_DETAILS
