### PR TITLE
[3.1 -> main] Test fix: wait for system init to be in block

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -1337,6 +1337,11 @@ class Cluster(object):
             data="{\"version\":0,\"core\":\"4,%s\"}" % (CORE_SYMBOL)
             opts="--permission %s@active" % (eosioAccount.name)
             trans=biosNode.pushMessage(eosioAccount.name, action, data, opts)
+            transId=Node.getTransId(trans[1])
+            Utils.Print("Wait for system init transaction to be in a block.")
+            if not biosNode.waitForTransInBlock(transId):
+                Utils.Print("ERROR: Failed to validate transaction %s in block on server port %d." % (transId, biosNode.port))
+                return None
 
         Utils.Print("Cluster bootstrap done.")
 

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -107,7 +107,7 @@ try:
         errorExit("Failed to kill the seed node")
 
 finally:
-    TestHelper.shutdown(cluster, walletMgr, testSuccessful=True, killEosInstances=True, killWallet=True, keepLogs=True, cleanRun=True, dumpErrorDetails=True)
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=True, killWallet=True, keepLogs=True, cleanRun=True, dumpErrorDetails=True)
 
 errorCode = 0 if testSuccessful else 1
 exit(errorCode)


### PR DESCRIPTION
Test failure due to attempt to use system contract to create an account before the system contract `init` transaction executed. Add a wait to the test for the system `init` contract to make it into a block before continuing the test.

Also fix `nodeos_contrl_c_test.py` to not log "Test succeeded" when the test fails.

Resolves #223 
Merges #226 into `main`.