### PR TITLE
[PH] Migrate numpy to ubuntu pkg

### DIFF
--- a/.cicd/platforms/ubuntu18.Dockerfile
+++ b/.cicd/platforms/ubuntu18.Dockerfile
@@ -15,13 +15,13 @@ RUN apt-get update && apt-get upgrade -y && \
                                                       ninja-build                 \
                                                       pkg-config                  \
                                                       python3                     \
+                                                      python3-numpy               \
                                                       python3-pip                 \
                                                       software-properties-common  \
                                                       zlib1g-dev                  \
                                                       zstd
 
-RUN python3 -m pip install dataclasses     \
-                           numpy
+RUN python3 -m pip install dataclasses
 
 # GitHub's actions/checkout requires git 2.18+ but Ubuntu 18 only provides 2.17
 RUN add-apt-repository ppa:git-core/ppa && apt update && apt install -y git

--- a/.cicd/platforms/ubuntu20.Dockerfile
+++ b/.cicd/platforms/ubuntu20.Dockerfile
@@ -14,7 +14,5 @@ RUN apt-get update && apt-get upgrade -y && \
                                                       llvm-11-dev          \
                                                       ninja-build          \
                                                       pkg-config           \
-                                                      python3-pip          \
+                                                      python3-numpy        \
                                                       zstd
-
-RUN python3 -m pip install numpy

--- a/.cicd/platforms/ubuntu22.Dockerfile
+++ b/.cicd/platforms/ubuntu22.Dockerfile
@@ -14,7 +14,5 @@ RUN apt-get update && apt-get upgrade -y && \
                                                       llvm-11-dev          \
                                                       ninja-build          \
                                                       pkg-config           \
-                                                      python3-pip          \
+                                                      python3-numpy        \
                                                       zstd
-
-RUN python3 -m pip install numpy


### PR DESCRIPTION
Use Ubuntu python3-numpy package instead of installing through pip