### PR TITLE
[3.2] avoid redefining _mm_crc32_u64 which can lead to compile errors

### DIFF
--- a/libraries/libfc/src/crypto/city.cpp
+++ b/libraries/libfc/src/crypto/city.cpp
@@ -38,8 +38,10 @@
 
 #if defined(__SSE4_2__) && defined(__x86_64__)
 #include <nmmintrin.h>
+#define MM_CRC32_U64I _mm_crc32_u64
 #else
-uint64_t _mm_crc32_u64(uint64_t a, uint64_t b );
+uint64_t mm_crc32_u64(uint64_t a, uint64_t b );
+#define MM_CRC32_U64I mm_crc32_u64
 #endif
 
 namespace fc {
@@ -578,9 +580,9 @@ static void CityHashCrc256Long(const char *s, size_t len,
     g += e;                                     \
     e += z;                                     \
     g += x;                                     \
-    z = _mm_crc32_u64(z, b + g);                \
-    y = _mm_crc32_u64(y, e + h);                \
-    x = _mm_crc32_u64(x, f + a);                \
+    z = MM_CRC32_U64I(z, b + g);                \
+    y = MM_CRC32_U64I(y, e + h);                \
+    x = MM_CRC32_U64I(x, f + a);                \
     e = Rotate(e, r);                           \
     c += e;                                     \
     s += 40

--- a/libraries/libfc/src/crypto/crc.cpp
+++ b/libraries/libfc/src/crypto/crc.cpp
@@ -604,7 +604,7 @@ static const uint32_t crc_c[256] = {
 #if !defined __SSE4_2__ || (defined __SSE4_2__ && !defined __x86_64__)
 
 
-uint64_t _mm_crc32_u64(uint64_t a, uint64_t b )
+uint64_t mm_crc32_u64(uint64_t a, uint64_t b )
 {
     return crc32cSlicingBy8(a, (unsigned char*)&b, sizeof(b)); 
 }
@@ -617,7 +617,7 @@ int main( int argc, char** argv )
 {
     uint64_t f = 0x1234;
     uint64_t a = 0x5678;
-    uint32_t f1 = _mm_crc32_u64(f, a); 
+    uint32_t f1 = mm_crc32_u64(f, a);
     uint32_t f4  = crc32cSlicingBy8(f, (unsigned char*)&a, sizeof(a)); 
     std::cout<<std::hex<<f1<<"\n"<<f2<<"\n"<<f3<<"\n"<<f4<<"\n";
     return 0;


### PR DESCRIPTION
Defining our own `_mm_crc32_u64` implementation can clash with some compilers. Not too surprising since that's a reserved name in global scope. In particular, AppleClang will give an error:
```
error: always_inline function '_mm_crc32_u64' requires target feature 'sse4.2', but would be inlined into function 'CityHashCrc256Long' that is compiled without support for 'sse4.2'
```

Rename our impl to just `mm_crc32_u64` and redirect to either `mm_crc32_u64` or `_mm_crc32_u64` via a new macro.