### PR TITLE
[3.1] Remove #pragma(s) to ignore warnings

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -56,7 +56,6 @@ void apply_context::exec_one()
 
    digest_type act_digest;
 
-   const auto& cfg = control.get_global_properties().configuration;
    const account_metadata_object* receiver_account = nullptr;
 
    auto handle_exception = [&](const auto& e)

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1066,11 +1066,12 @@ struct controller_impl {
                                                                              active_permission.id,
                                                                              active_producers_authority,
                                                                              genesis.initial_timestamp );
-      const auto& minority_permission     = authorization.create_permission( config::producers_account_name,
+                                            authorization.create_permission( config::producers_account_name,
                                                                              config::minority_producers_permission_name,
                                                                              majority_permission.id,
                                                                              active_producers_authority,
                                                                              genesis.initial_timestamp );
+
    }
 
    // The returned scoped_exit should not exceed the lifetime of the pending which existed when make_block_restore_point was called.

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -93,7 +93,7 @@ void apply_eosio_newaccount(apply_context& context) {
               "Cannot create account named ${name}, as that name is already taken",
               ("name", create.name));
 
-   const auto& new_account = db.create<account_object>([&](auto& a) {
+   db.create<account_object>([&](auto& a) {
       a.name = create.name;
       a.creation_date = context.control.pending_block_time();
    });
@@ -127,8 +127,6 @@ void apply_eosio_newaccount(apply_context& context) {
 } FC_CAPTURE_AND_RETHROW( (create) ) }
 
 void apply_eosio_setcode(apply_context& context) {
-   const auto& cfg = context.control.get_global_properties().configuration;
-
    auto& db = context.db;
    auto  act = context.get_action().data_as<setcode>();
    context.require_authorization(act.account);

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -283,8 +283,6 @@ namespace eosio { namespace chain {
    }
 
    block_header_state_ptr fork_database::get_block_header( const block_id_type& id )const {
-      const auto& by_id_idx = my->index.get<by_block_id>();
-
       if( my->root->id == id ) {
          return my->root;
       }

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -3,8 +3,6 @@
 #include <fc/time.hpp>
 #include <fc/utility.hpp>
 
-#pragma GCC diagnostic ignored "-Wunused-variable"
-
 namespace eosio { namespace chain { namespace config {
 
 typedef __uint128_t uint128_t;

--- a/libraries/chain/webassembly/softfloat.cpp
+++ b/libraries/chain/webassembly/softfloat.cpp
@@ -276,7 +276,6 @@ namespace eosio { namespace chain { namespace webassembly {
       float64_t ret;
       int e = a.v >> 52 & 0x7FF;
       float64_t y;
-      double de = 1/DBL_EPSILON;
       if ( a.v == 0x8000000000000000) {
          return af;
       }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -554,8 +554,6 @@ protocol_feature_set initialize_protocol_features( const fc::path& p, bool popul
    }
 
    auto output_protocol_feature = [&p]( const builtin_protocol_feature& f, const digest_type& feature_digest ) {
-      static constexpr int max_tries = 10;
-
       string filename( "BUILTIN-" );
       filename += builtin_protocol_feature_codename( f.get_codename() );
       filename += ".json";
@@ -1678,8 +1676,6 @@ string get_table_type( const abi_def& abi, const name& table_name ) {
 
 read_only::get_table_rows_result read_only::get_table_rows( const read_only::get_table_rows_params& p )const {
    const abi_def abi = eosio::chain_apis::get_abi( db, p.code );
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
    bool primary = false;
    auto table_with_index = get_table_index_name( p, primary );
    if( primary ) {
@@ -1739,7 +1735,6 @@ read_only::get_table_rows_result read_only::get_table_rows( const read_only::get
       }
       EOS_ASSERT(false, chain::contract_table_query_exception,  "Unsupported secondary index type: ${t}", ("t", p.key_type));
    }
-#pragma GCC diagnostic pop
 }
 
 read_only::get_table_by_scope_result read_only::get_table_by_scope( const read_only::get_table_by_scope_params& p )const {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1708,18 +1708,22 @@ read_only::get_table_rows_result read_only::get_table_rows( const read_only::get
       }
       else if (p.key_type == chain_apis::float64) {
          return get_table_rows_by_seckey<index_double_index, double>(p, abi, [](double v)->float64_t {
-            float64_t f = *(float64_t *)&v;
+            float64_t f;
+            double_to_float64(v, f);
             return f;
          });
       }
       else if (p.key_type == chain_apis::float128) {
          if ( p.encode_type == chain_apis::hex) {
             return get_table_rows_by_seckey<index_long_double_index, uint128_t>(p, abi, [](uint128_t v)->float128_t{
-               return *reinterpret_cast<float128_t *>(&v);
+               float128_t f;
+               uint128_to_float128(v, f);
+               return f;
             });
          }
          return get_table_rows_by_seckey<index_long_double_index, double>(p, abi, [](double v)->float128_t{
-            float64_t f = *(float64_t *)&v;
+            float64_t f;
+            double_to_float64(v, f);
             float128_t f128;
             f64_to_f128M(f, &f128);
             return f128;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -416,6 +416,8 @@ namespace eosio {
     *  If there is a change to network protocol or behavior, increment net version to identify
     *  the need for compatibility hooks
     */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
    constexpr uint16_t proto_base = 0;
    constexpr uint16_t proto_explicit_sync = 1;       // version at time of eosio 1.0
    constexpr uint16_t proto_block_id_notify = 2;     // reserved. feature was removed. next net_version should be 3
@@ -424,6 +426,7 @@ namespace eosio {
    constexpr uint16_t proto_dup_goaway_resolution = 5;     // eosio 2.1: support peer address based duplicate connection resolution
    constexpr uint16_t proto_dup_node_id_goaway = 6;        // eosio 2.1: support peer node_id based duplicate connection resolution
    constexpr uint16_t proto_leap_initial = 7;            // leap client, needed because none of the 2.1 versions are supported
+#pragma GCC diagnostic pop
 
    constexpr uint16_t net_version_max = proto_leap_initial;
 
@@ -2672,7 +2675,6 @@ namespace eosio {
       const unsigned long trx_in_progress_sz = this->trx_in_progress_size.load();
 
       auto ds = pending_message_buffer.create_datastream();
-      const auto buff_size_start = pending_message_buffer.bytes_to_read();
       unsigned_int which{};
       fc::raw::unpack( ds, which );
       shared_ptr<packed_transaction> ptr = std::make_shared<packed_transaction>();
@@ -3348,7 +3350,6 @@ namespace eosio {
    // called from application thread
    void net_plugin_impl::on_accepted_block(const block_state_ptr& bs) {
       update_chain_info();
-      controller& cc = chain_plug->chain();
       dispatcher->strand.post( [this, bs]() {
          fc_dlog( logger, "signaled accepted_block, blk num = ${num}, id = ${id}", ("num", bs->block_num)("id", bs->id) );
 
@@ -3475,7 +3476,6 @@ namespace eosio {
    bool connection::populate_handshake( handshake_message& hello ) {
       namespace sc = std::chrono;
       hello.network_version = net_version_base + net_version;
-      const auto prev_head_id = hello.head_id;
       uint32_t lib, head;
       std::tie( lib, std::ignore, head,
                 hello.last_irreversible_block_id, std::ignore, hello.head_id ) = my_impl->get_chain_info();

--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -74,7 +74,7 @@ namespace eosio::trace_api {
    get_block_t store_provider::get_block(uint32_t block_height, const yield_function& yield) {
       std::optional<uint64_t> trace_offset;
       bool irreversible = false;
-      uint64_t offset = scan_metadata_log_from(block_height, 0, [&block_height, &trace_offset, &irreversible](const metadata_log_entry& e) -> bool {
+      scan_metadata_log_from(block_height, 0, [&block_height, &trace_offset, &irreversible](const metadata_log_entry& e) -> bool {
          if (std::holds_alternative<block_entry_v0>(e)) {
             const auto& block = std::get<block_entry_v0>(e);
             if (block.number == block_height) {

--- a/plugins/trace_api_plugin/test/test_extraction.cpp
+++ b/plugins/trace_api_plugin/test/test_extraction.cpp
@@ -122,9 +122,7 @@ struct extraction_test_fixture {
       }
 
       void append_trx_ids(const block_trxs_entry& tt){
-         for (const auto& id : tt.ids) {
-             fixture.id_log[tt.block_num] = tt.ids;
-         }
+         fixture.id_log[tt.block_num] = tt.ids;
       }
 
       extraction_test_fixture& fixture;
@@ -175,8 +173,6 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
             { chain::packed_transaction(ptrx1) } );
       signal_accepted_block( bsp1 );
       
-      const uint32_t expected_lib = 0;
-
       const std::vector<action_trace_v1> expected_action_traces {
          {
             {
@@ -268,8 +264,6 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
       auto bsp1 = make_block_state( chain::block_id_type(), 1, 1, "bp.one"_n,
             { chain::packed_transaction(ptrx1), chain::packed_transaction(ptrx2), chain::packed_transaction(ptrx3) } );
       signal_accepted_block( bsp1 );
-
-      const uint32_t expected_lib = 0;
 
       const std::vector<action_trace_v1> expected_action_trace1 {
          {
@@ -382,8 +376,6 @@ BOOST_AUTO_TEST_SUITE(block_extraction)
       auto bsp1 = make_block_state( chain::block_id_type(), 1, 1, "bp.one"_n,
             { chain::packed_transaction(transfer_trx) } );
       signal_accepted_block( bsp1 );
-
-      const uint32_t expected_lib = 0;
 
       const std::vector<action_trace_v1> expected_action_trace {
          {

--- a/plugins/trace_api_plugin/test/test_trace_file.cpp
+++ b/plugins/trace_api_plugin/test/test_trace_file.cpp
@@ -498,7 +498,6 @@ BOOST_AUTO_TEST_SUITE(slice_tests)
       const auto be1_size = data.size();
       BOOST_REQUIRE_EQUAL(header_size + be1_size, slice.tellp());
       BOOST_REQUIRE_EQUAL(bfs::file_size(fp), slice.tellp());
-      uint64_t index_file_size = bfs::file_size(fp);
       slice.close();
 
       found = sd.find_or_create_index_slice(1, open_state::read, slice);

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -360,7 +360,6 @@ struct trace_api_plugin_impl {
    :common(common) {}
 
    static void set_program_options(appbase::options_description& cli, appbase::options_description& cfg) {
-      auto cfg_options = cfg.add_options();
    }
 
    void plugin_initialize(const appbase::variables_map& options) {

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -291,7 +291,6 @@ struct txn_test_gen_plugin_impl {
 
       running = true;
 
-      controller& cc = app().get_plugin<chain_plugin>().chain();
       auto abi_serializer_max_time = app().get_plugin<chain_plugin>().get_abi_serializer_max_time();
       abi_serializer eosio_token_serializer{fc::json::from_string(contracts::eosio_token_abi().data()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time )};
       //create the actions here

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3122,7 +3122,7 @@ int main( int argc, char** argv ) {
                      // ->required();
    contractSubcommand->add_option("wasm-file", wasmPath, localized("The file containing the contract WASM relative to contract-dir"));
 //                     ->check(CLI::ExistingFile);
-   auto abi = contractSubcommand->add_option("abi-file,-a,--abi", abiPath, localized("The ABI for the contract relative to contract-dir"));
+   contractSubcommand->add_option("abi-file,-a,--abi", abiPath, localized("The ABI for the contract relative to contract-dir"));
 //                                ->check(CLI::ExistingFile);
    contractSubcommand->add_flag( "-c,--clear", contract_clear, localized("Remove contract on an account"));
    contractSubcommand->add_flag( "--suppress-duplicate-check", suppress_duplicate_check, localized("Don't check for duplicate"));
@@ -3818,13 +3818,11 @@ int main( int argc, char** argv ) {
             const auto& approvals_object = rows2[0].get_object();
 
             for( const auto& ra : approvals_object["requested_approvals"].get_array() ) {
-               const auto& ra_obj = ra.get_object();
                auto pl = ra["level"].as<permission_level>();
                all_approvals.emplace( pl, std::make_pair(ra["time"].as<fc::time_point>(), approval_status::unapproved) );
             }
 
             for( const auto& pa : approvals_object["provided_approvals"].get_array() ) {
-               const auto& pa_obj = pa.get_object();
                auto pl = pa["level"].as<permission_level>();
                auto res = all_approvals.emplace( pl, std::make_pair(pa["time"].as<fc::time_point>(), approval_status::approved) );
                provided_approvers[pl.actor].second.push_back( res.first );

--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -362,7 +362,6 @@ string producer_names::producer_name(unsigned int producer_number, bool shared_p
    }
 
    prod_name[total_chars] = '\0';
-   const auto original_producer_number = producer_number;
    for (int current_char_loc = total_chars - 1; current_char_loc >= 0; --current_char_loc) {
       const unsigned int slot_value = static_cast<char>(producer_number % valid_char_range);
       producer_number /= valid_char_range;
@@ -1866,7 +1865,6 @@ launcher_def::ignite() {
       string script("bash " + start_script);
       bp::child c(script);
       try {
-         boost::system::error_code ec;
          cerr << "waiting for script completion\n";
          c.wait();
       } catch (bfs::filesystem_error &ex) {

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -2054,8 +2054,7 @@ BOOST_AUTO_TEST_CASE(abi_account_name_in_eosio_abi)
    }
    )=====";
 
-   auto abi = eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
-   auto is_type_exception = [](fc::assert_exception const & e) -> bool { return e.to_detail_string().find("abi.types.size") != std::string::npos; };
+   eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
 
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -333,7 +333,7 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
                      != result->action_traces[0].receipt->auth_sequence.end() );
    auto base_global_sequence_num = result->action_traces[0].receipt->global_sequence;
    auto base_system_recv_seq_num = result->action_traces[0].receipt->recv_sequence;
-   auto base_system_auth_seq_num = result->action_traces[0].receipt->auth_sequence[config::system_account_name];
+                                   result->action_traces[0].receipt->auth_sequence[config::system_account_name];
    auto base_system_code_seq_num = result->action_traces[0].receipt->code_sequence.value;
    auto base_system_abi_seq_num  = result->action_traces[0].receipt->abi_sequence.value;
 

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -341,7 +341,6 @@ BOOST_AUTO_TEST_CASE( any_auth ) { try {
 
    const auto spending_priv_key = chain.get_private_key(name("alice"), "spending");
    const auto spending_pub_key = spending_priv_key.get_public_key();
-   //const auto bob_spending_priv_key = chain.get_private_key(name("bob"), "spending");
    const auto bob_spending_pub_key = spending_priv_key.get_public_key();
 
    chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("active"));

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE( any_auth ) { try {
 
    const auto spending_priv_key = chain.get_private_key(name("alice"), "spending");
    const auto spending_pub_key = spending_priv_key.get_public_key();
-   const auto bob_spending_priv_key = chain.get_private_key(name("bob"), "spending");
+   //const auto bob_spending_priv_key = chain.get_private_key(name("bob"), "spending");
    const auto bob_spending_pub_key = spending_priv_key.get_public_key();
 
    chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("active"));

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -325,7 +325,7 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         claim_rewards("runnerup1"_n);
         BOOST_TEST(get_balance("runnerup1"_n).get_amount() > 0);
 
-        const auto first_june_2018 = fc::seconds(1527811200); // 2018-06-01
+        //const auto first_june_2018 = fc::seconds(1527811200); // 2018-06-01
         const auto first_june_2028 = fc::seconds(1843430400); // 2028-06-01
         // Ensure that now is yet 10 years after 2018-06-01 yet
         BOOST_REQUIRE(control->head_block_time().time_since_epoch() < first_june_2028);

--- a/unittests/deep_mind_tests.cpp
+++ b/unittests/deep_mind_tests.cpp
@@ -328,7 +328,7 @@ void merge(const std::string& input_filename, const std::string& pattern_filenam
          for(std::ptrdiff_t i = 0; i < std::min(line_end - line_iter, pattern_end - pattern_iter); ++i)
          {
             tab.emplace_back();
-            for(std::ptrdiff_t j = 0, j_end; j < i; ++j)
+            for(std::ptrdiff_t j = 0; j < i; ++j)
             {
                tab[i].push_back(add_point(i, j));
                if(tab[i][j].unmodified >= resync_threshold)

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -1621,8 +1621,6 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
 BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
    TESTER chain;
 
-   const auto& tester_account = "tester"_n;
-
    chain.produce_blocks();
    chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -23,7 +23,7 @@ chainbase::bfs::path get_parent_path(chainbase::bfs::path blocks_dir, int ordina
       blocks_dir = blocks_dir.parent_path();
       leaf_dir = blocks_dir.filename();
       try {
-         auto ordinal_for_config = boost::lexical_cast<int>(leaf_dir.generic_string());
+         boost::lexical_cast<int>(leaf_dir.generic_string());
          blocks_dir = blocks_dir.parent_path();
       }
       catch(const boost::bad_lexical_cast& ) {

--- a/unittests/wasm_config_tests.cpp
+++ b/unittests/wasm_config_tests.cpp
@@ -158,7 +158,7 @@ static const char many_exports_wast[] = R"=====(
   (func (export "apply") (param i64 i64 i64))
 )
 )=====";
-static const char one_export[] =  "(export \"fn${N}\" (func 0))";
+//static const char one_export[] =  "(export \"fn${N}\" (func 0))";
 
 static const char many_elem_wast[] = R"=====(
 (module

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -239,7 +239,7 @@ BOOST_FIXTURE_TEST_CASE( f32_tests, TESTER ) try {
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
-      const auto& receipt = get_transaction_receipt(trx.id());
+      get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
 BOOST_FIXTURE_TEST_CASE( f32_test_bitwise, TESTER ) try {
@@ -262,7 +262,7 @@ BOOST_FIXTURE_TEST_CASE( f32_test_bitwise, TESTER ) try {
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
-      const auto& receipt = get_transaction_receipt(trx.id());
+      get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
 BOOST_FIXTURE_TEST_CASE( f32_test_cmp, TESTER ) try {
@@ -285,7 +285,7 @@ BOOST_FIXTURE_TEST_CASE( f32_test_cmp, TESTER ) try {
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
-      const auto& receipt = get_transaction_receipt(trx.id());
+      get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
 
@@ -310,7 +310,7 @@ BOOST_FIXTURE_TEST_CASE( f64_tests, TESTER ) try {
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
-      const auto& receipt = get_transaction_receipt(trx.id());
+      get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
 BOOST_FIXTURE_TEST_CASE( f64_test_bitwise, TESTER ) try {
@@ -333,7 +333,7 @@ BOOST_FIXTURE_TEST_CASE( f64_test_bitwise, TESTER ) try {
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
-      const auto& receipt = get_transaction_receipt(trx.id());
+      get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
 BOOST_FIXTURE_TEST_CASE( f64_test_cmp, TESTER ) try {
@@ -356,7 +356,7 @@ BOOST_FIXTURE_TEST_CASE( f64_test_cmp, TESTER ) try {
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
-      const auto& receipt = get_transaction_receipt(trx.id());
+      get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
 
@@ -382,7 +382,7 @@ BOOST_FIXTURE_TEST_CASE( f32_f64_conversion_tests, tester ) try {
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
-      const auto& receipt = get_transaction_receipt(trx.id());
+      get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
 
@@ -413,7 +413,7 @@ BOOST_FIXTURE_TEST_CASE( f32_f64_overflow_tests, tester ) try {
          push_transaction(trx);
          produce_blocks(1);
          BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
-         const auto& receipt = get_transaction_receipt(trx.id());
+         get_transaction_receipt(trx.id());
          return true;
       } catch (eosio::chain::wasm_execution_error &) {
          return false;


### PR DESCRIPTION
- Most of the changes are from the removal of ignoring unused-variables from `chain/config.hpp`
- Removed pragma to ignore `strict-aliasing` from `chain_plugin` which is the main reason for the changes.
  - Didn't need any code changes as this did not generate any warnings (at least on clang).
    - [ Will see what GCC does with it in cicd. ]

Resolves #229 