### PR TITLE
[3.2] manually set PKG_CONFIG_PATH for openssl on macOS

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -31,6 +31,12 @@ if(eos-vm IN_LIST EOSIO_WASM_RUNTIMES OR eos-vm-jit IN_LIST EOSIO_WASM_RUNTIMES)
 add_subdirectory( eos-vm )
 endif()
 
+#yubihsm's openssl discovery is via pkg-config instead of find_package. Help it out on macOS otherwise openssl's pkgconfig
+# files may not be found down in the /opt/homebrew/opt directory
+if(APPLE)
+  get_filename_component(OPENSSL_LIB_PATH "${OPENSSL_CRYPTO_LIBRARY}" DIRECTORY)
+  set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${OPENSSL_LIB_PATH}/pkgconfig")
+endif()
 set(ENABLE_STATIC ON)
 set(CMAKE_MACOSX_RPATH OFF)
 set(BUILD_ONLY_LIB ON CACHE BOOL "Library only build")


### PR DESCRIPTION
yubihsm's OpenSSL discovery is via pkg-config instead of find_package. On ARM macOS builds pkg-config is having trouble finding openssl due to nonstandard paths. Let's help it out by manually setting the `PKG_CONFIG_PATH` environment variable. After this change, provided prerequisite packages are installed via homebrew, one only needs to
```
cmake -DCMAKE_BUILD_TYPE=Release ..
```
and macOS builds are operational on both Intel & ARM platforms.

This change is a little icky, but I'm trying not to overthink it as YubiHSM will be removed post 3.2.