### PR TITLE
[3.2] disable unused-function warning in secp256k1

### DIFF
--- a/libraries/libfc/secp256k1/CMakeLists.txt
+++ b/libraries/libfc/secp256k1/CMakeLists.txt
@@ -10,6 +10,12 @@ target_include_directories(secp256k1-internal
 
 target_compile_definitions(secp256k1-internal INTERFACE HAVE_CONFIG_H)
 
+# secp256k1 produces over 190 "unused-function" warnings like
+# warning: ‘secp256k1_fe_normalize_weak’ declared ‘static’ but never defined [-Wunused-f unction]
+# As we consider it as a system header and use it verbatim without any modifications,
+# just disable the warning to avoid cluttering compile log
+target_compile_options(secp256k1-internal INTERFACE -Wno-unused-function)
+
 add_library(secp256k1 STATIC
   secp256k1/src/secp256k1.c secp256k1/src/precomputed_ecmult.c secp256k1/src/precomputed_ecmult_gen.c
 )


### PR DESCRIPTION
Resolve https://github.com/AntelopeIO/leap/issues/19

`secp256k1` produced over 190 warnings in the form of
```
/home/lh/work/leap-main/libraries/libfc/secp256k1/secp256k1/src/field.h:44:13: warning: ‘secp256k1_fe_normalize’   declared ‘static’ but never defined [-Wunused-function]
   44 | static void secp256k1_fe_normalize(secp256k1_fe *r);
      |             ^~~~~~~~~~~~~~~~~~~~~~
/home/lh/work/leap-main/libraries/libfc/secp256k1/secp256k1/src/field.h:47:13: warning:                            ‘secp256k1_fe_normalize_weak’ declared ‘static’ but never defined [-Wunused-function]
   47 | static void secp256k1_fe_normalize_weak(secp256k1_fe *r);
.../home/lh/work/leap-main/libraries/libfc/secp256k1/secp256k1/src/field.h:44:13: warning: ‘secp256k1_fe_normalize’   declared ‘static’ but never defined [-Wunused-function]
   44 | static void secp256k1_fe_normalize(secp256k1_fe *r);
      |             ^~~~~~~~~~~~~~~~~~~~~~
/home/lh/work/leap-main/libraries/libfc/secp256k1/secp256k1/src/field.h:47:13: warning:                            ‘secp256k1_fe_normalize_weak’ declared ‘static’ but never defined [-Wunused-function]
   47 | static void secp256k1_fe_normalize_weak(secp256k1_fe *r);
...
```
As we consider `secp256k1` as a system library and use it without any modifications, it is OK to disable the warning to avoid cluttering compile log.

Before the fix, Leap build log was `1,710` lines long; after the fix, it is `1,096` lines. Only `22` warnings remain. We can hopefully have a clean build in `release/3.2`.