### PR TITLE
[3.2] more compiler warnings cleanup

### DIFF
--- a/libraries/libfc/include/fc/exception/exception.hpp
+++ b/libraries/libfc/include/fc/exception/exception.hpp
@@ -496,6 +496,22 @@ namespace fc
       wlog( "${details}", ("details",e.to_detail_string()) ); \
    }
 
+#define FC_LOG_AND_DROP_NO_INTERPROCESS_BAD_ALLOC( ... )  \
+   catch( fc::exception& er ) { \
+      wlog( "${details}", ("details",er.to_detail_string()) ); \
+   } catch( const std::exception& e ) {  \
+      fc::std_exception_wrapper sew( \
+                FC_LOG_MESSAGE( warn, "rethrow ${what}: ",FC_FORMAT_ARG_PARAMS( __VA_ARGS__  )("what",e.what()) ), \
+                std::current_exception(), \
+                BOOST_CORE_TYPEID(e).name(), \
+                e.what() ) ; \
+      wlog( "${details}", ("details",sew.to_detail_string()) ); \
+   } catch( ... ) {  \
+      fc::unhandled_exception e( \
+                FC_LOG_MESSAGE( warn, "rethrow", FC_FORMAT_ARG_PARAMS( __VA_ARGS__) ), \
+                std::current_exception() ); \
+      wlog( "${details}", ("details",e.to_detail_string()) ); \
+   }
 
 /**
  *  @def FC_RETHROW_EXCEPTIONS(LOG_LEVEL,FORMAT,...)

--- a/libraries/libfc/include/fc/exception/exception.hpp
+++ b/libraries/libfc/include/fc/exception/exception.hpp
@@ -478,25 +478,6 @@ namespace fc
    }
 
 #define FC_LOG_AND_DROP( ... )  \
-   catch( const boost::interprocess::bad_alloc& ) {\
-      throw;\
-   } catch( fc::exception& er ) { \
-      wlog( "${details}", ("details",er.to_detail_string()) ); \
-   } catch( const std::exception& e ) {  \
-      fc::std_exception_wrapper sew( \
-                FC_LOG_MESSAGE( warn, "rethrow ${what}: ",FC_FORMAT_ARG_PARAMS( __VA_ARGS__  )("what",e.what()) ), \
-                std::current_exception(), \
-                BOOST_CORE_TYPEID(e).name(), \
-                e.what() ) ; \
-      wlog( "${details}", ("details",sew.to_detail_string()) ); \
-   } catch( ... ) {  \
-      fc::unhandled_exception e( \
-                FC_LOG_MESSAGE( warn, "rethrow", FC_FORMAT_ARG_PARAMS( __VA_ARGS__) ), \
-                std::current_exception() ); \
-      wlog( "${details}", ("details",e.to_detail_string()) ); \
-   }
-
-#define FC_LOG_AND_DROP_NO_INTERPROCESS_BAD_ALLOC( ... )  \
    catch( fc::exception& er ) { \
       wlog( "${details}", ("details",er.to_detail_string()) ); \
    } catch( const std::exception& e ) {  \

--- a/libraries/libfc/src/crypto/elliptic_webauthn.cpp
+++ b/libraries/libfc/src/crypto/elliptic_webauthn.cpp
@@ -88,9 +88,12 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
             return true;
          case IN_NESTED_CONTAINER:
             return true;
-         default:
-            FC_THROW_EXCEPTION( exception, "String: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+         // default may not be added now, as consensus could be broken.
       }
+      // Add elog to report the error and __builtin_unreachable to surpress
+      // warning of control reaches end of non-void function.
+      elog("String: current_state(${current_statea}) out of bound", ("current_state", current_state) );
+      __builtin_unreachable();
    }
 
    bool StartObject() {
@@ -110,9 +113,12 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          case EXPECT_ORIGIN_VALUE:
          case EXPECT_TYPE_VALUE:
             return false;
-         default:
-            FC_THROW_EXCEPTION( exception, "Key: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+         // default may not be added now, as consensus could be broken.
       }
+      // Add elog to report the error and __builtin_unreachable to surpress
+      // warning of control reaches end of non-void function.
+      elog( "Key: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+      __builtin_unreachable();
    }
    bool Key(const char* str, rapidjson::SizeType length, bool copy) {
       switch(current_state) {
@@ -135,9 +141,12 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          }
          case IN_NESTED_CONTAINER:
             return true;
-         default:
-            FC_THROW_EXCEPTION( exception, "Key: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+         // default may not be added now, as consensus could be broken.
       }
+      // Add elog to report the error and __builtin_unreachable to surpress
+      // warning of control reaches end of non-void function.
+      elog( "Key: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+      __builtin_unreachable();
    }
    bool EndObject(rapidjson::SizeType memberCount) {
       switch(current_state) {
@@ -153,9 +162,12 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
             return true;
          case EXPECT_FIRST_OBJECT_KEY:
             return true;
-         default:
-            FC_THROW_EXCEPTION( exception, "EndObject: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+         // default may not be added now, as consensus could be broken.
       }
+      // Add elog to report the error and __builtin_unreachable to surpress
+      // warning of control reaches end of non-void function.
+      elog( "EndObject: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+      __builtin_unreachable();
    }
 
    bool StartArray() {
@@ -173,9 +185,13 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          case EXPECT_ORIGIN_VALUE:
          case EXPECT_TYPE_VALUE:
             return false;
-         default:
-            FC_THROW_EXCEPTION( exception, "StartArray: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+         // default may not be added now, as consensus could be broken.
       }
+      // Add elog to report the error and __builtin_unreachable to surpress
+      // warning of control reaches end of non-void function.
+      elog( "StartArray: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+      __builtin_unreachable();
+
    }
    bool EndArray(rapidjson::SizeType elementCount) {
       switch(current_state) {
@@ -190,9 +206,12 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
             if(!--current_nested_container_depth)
                current_state = EXPECT_FIRST_OBJECT_KEY;
             return true;
-         default:
-            FC_THROW_EXCEPTION( exception, "EndArray: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+         // default may not be added now, as consensus could be broken.
       }
+      // Add elog to report the error and __builtin_unreachable to surpress
+      // warning of control reaches end of non-void function.
+      elog( "EndArray: current_state (${current_statea}) out of bound", ("current_state", current_state) );
+      __builtin_unreachable();
    }
 };
 } //detail

--- a/libraries/libfc/src/crypto/elliptic_webauthn.cpp
+++ b/libraries/libfc/src/crypto/elliptic_webauthn.cpp
@@ -88,6 +88,8 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
             return true;
          case IN_NESTED_CONTAINER:
             return true;
+         default:
+            FC_THROW_EXCEPTION( exception, "String: current_state (${current_statea}) out of bound", ("current_state", current_state) );
       }
    }
 
@@ -108,6 +110,8 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          case EXPECT_ORIGIN_VALUE:
          case EXPECT_TYPE_VALUE:
             return false;
+         default:
+            FC_THROW_EXCEPTION( exception, "Key: current_state (${current_statea}) out of bound", ("current_state", current_state) );
       }
    }
    bool Key(const char* str, rapidjson::SizeType length, bool copy) {
@@ -131,6 +135,8 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          }
          case IN_NESTED_CONTAINER:
             return true;
+         default:
+            FC_THROW_EXCEPTION( exception, "Key: current_state (${current_statea}) out of bound", ("current_state", current_state) );
       }
    }
    bool EndObject(rapidjson::SizeType memberCount) {
@@ -147,6 +153,8 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
             return true;
          case EXPECT_FIRST_OBJECT_KEY:
             return true;
+         default:
+            FC_THROW_EXCEPTION( exception, "EndObject: current_state (${current_statea}) out of bound", ("current_state", current_state) );
       }
    }
 
@@ -165,6 +173,8 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          case EXPECT_ORIGIN_VALUE:
          case EXPECT_TYPE_VALUE:
             return false;
+         default:
+            FC_THROW_EXCEPTION( exception, "StartArray: current_state (${current_statea}) out of bound", ("current_state", current_state) );
       }
    }
    bool EndArray(rapidjson::SizeType elementCount) {
@@ -180,6 +190,8 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
             if(!--current_nested_container_depth)
                current_state = EXPECT_FIRST_OBJECT_KEY;
             return true;
+         default:
+            FC_THROW_EXCEPTION( exception, "EndArray: current_state (${current_statea}) out of bound", ("current_state", current_state) );
       }
    }
 };

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2170,7 +2170,7 @@ void read_write::push_block(read_write::push_block_params&& params, next_functio
       chain_plugin::handle_db_exhaustion();
    } catch ( const std::bad_alloc& ) {
       chain_plugin::handle_bad_alloc();
-   } FC_LOG_AND_DROP()
+   } FC_LOG_AND_DROP_NO_INTERPROCESS_BAD_ALLOC()
    next(read_write::push_block_results{});
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2170,7 +2170,7 @@ void read_write::push_block(read_write::push_block_params&& params, next_functio
       chain_plugin::handle_db_exhaustion();
    } catch ( const std::bad_alloc& ) {
       chain_plugin::handle_bad_alloc();
-   } FC_LOG_AND_DROP_NO_INTERPROCESS_BAD_ALLOC()
+   } FC_LOG_AND_DROP()
    next(read_write::push_block_results{});
 }
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1258,7 +1258,9 @@ BOOST_FIXTURE_TEST_CASE(checktime_intrinsic, TESTER) { try {
                                           5000, 10, 10 ),
                                deadline_exception, is_deadline_exception );
 
-#warning TODO validate that the contract was successfully cached
+// https://github.com/AntelopeIO/leap/issues/260 was created to track this TODO.
+// Remove those comments after the issue is resolved.
+// #warning TODO validate that the contract was successfully cached
 
         //it will always call
         BOOST_CHECK_EXCEPTION( call_test( *this, test_api_action<TEST_METHOD("doesn't matter", "doesn't matter")>{},
@@ -1295,7 +1297,9 @@ BOOST_FIXTURE_TEST_CASE(checktime_grow_memory, TESTER) { try {
                                           5000, 10, 10 ),
                                deadline_exception, is_deadline_exception );
 
-#warning TODO validate that the contract was successfully cached
+// https://github.com/AntelopeIO/leap/issues/260 was created to track this TODO.
+// Remove those comments after the issue is resolved.
+//#warning TODO validate that the contract was successfully cached
 
         //it will always call
         BOOST_CHECK_EXCEPTION( call_test( *this, test_api_action<TEST_METHOD("doesn't matter", "doesn't matter")>{},
@@ -1315,7 +1319,9 @@ BOOST_FIXTURE_TEST_CASE(checktime_hashing_fail, TESTER) { try {
                                           5000, 3, 3 ),
                                deadline_exception, is_deadline_exception );
 
-#warning TODO validate that the contract was successfully cached
+// https://github.com/AntelopeIO/leap/issues/260 was created to track this TODO.
+// Remove those comments after the issue is resolved.
+//#warning TODO validate that the contract was successfully cached
 
         //the contract should be cached, now we should get deadline_exception because of calls to checktime() from hashing function
         BOOST_CHECK_EXCEPTION( call_test( *this, test_api_action<TEST_METHOD("test_checktime", "checktime_sha1_failure")>{},

--- a/unittests/eosio.token_tests.cpp
+++ b/unittests/eosio.token_tests.cpp
@@ -152,7 +152,8 @@ BOOST_FIXTURE_TEST_CASE( create_max_supply, eosio_token_tester ) try {
    share_type amount = 4611686018427387904;
    static_assert(sizeof(share_type) <= sizeof(asset), "asset changed so test is no longer valid");
    static_assert(std::is_trivially_copyable<asset>::value, "asset is not trivially copyable");
-   memcpy(&max, &amount, sizeof(share_type)); // hack in an invalid amount
+   // OK to cast as this is a test and it is a hack to construct an invalid amount
+   memcpy((char*)&max, (char*)&amount, sizeof(share_type)); // hack in an invalid amount.
 
    BOOST_CHECK_EXCEPTION( create( "alice"_n, max) , asset_type_exception, [](const asset_type_exception& e) {
       return expect_assert_message(e, "magnitude of asset amount must be less than 2^62");
@@ -177,7 +178,8 @@ BOOST_FIXTURE_TEST_CASE( create_max_decimals, eosio_token_tester ) try {
    share_type amount = 0x8ac7230489e80000L;
    static_assert(sizeof(share_type) <= sizeof(asset), "asset changed so test is no longer valid");
    static_assert(std::is_trivially_copyable<asset>::value, "asset is not trivially copyable");
-   memcpy(&max, &amount, sizeof(share_type)); // hack in an invalid amount
+   // OK to cast as this is a test and it is a hack to construct an invalid amount
+   memcpy((char*)&max, (char*)&amount, sizeof(share_type)); // hack in an invalid amount
 
    BOOST_CHECK_EXCEPTION( create( "alice"_n, max) , asset_type_exception, [](const asset_type_exception& e) {
       return expect_assert_message(e, "magnitude of asset amount must be less than 2^62");

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -71,7 +71,9 @@ FC_REFLECT_EMPTY(provereset);
 
 BOOST_AUTO_TEST_SUITE(wasm_tests)
 
-#warning Change this back to using TESTER
+// https://github.com/AntelopeIO/leap/issues/259 was created to track this.
+// Remove those comments after the issue is resolved.
+//#warning Change this back to using TESTER
 struct old_wasm_tester : tester {
    old_wasm_tester() : tester{setup_policy::old_wasm_parser} {}
 };


### PR DESCRIPTION
Partially resolve https://github.com/AntelopeIO/leap/issues/254

After this PR, only 4 warnings remain in submodules `abieos` and `libfc/libraries/ff/libff`.

Most of the changes are straightforward. The following two need to be noted.

1. For #warning directives in `wasm_tests.cpp` and `api_tests.cpp`, I created issues for them https://github.com/AntelopeIO/leap/issues/259 and https://github.com/AntelopeIO/leap/issues/260. I think this is a better way to handle TODOs. Leaving them in #warning will not get them to be done. I kept them as comments for easier identification if we decide to work on them.
2. To resolve the warning in `chain_plugin.cpp`, I need to introduce a new macro `FC_LOG_AND_DROP_NO_INTERPROCESS_BAD_ALLOC`. The warning was

```
In file included from /home/lh/work/leap-main/libraries/chain/include/eosio/chain/          exceptions.hpp:3,
                 from /home/lh/work/leap-main/libraries/chain/include/eosio/chain/asset.hpp:2,
                 from /home/lh/work/leap-main/plugins/chain_plugin/include/eosio/           chain_plugin/chain_plugin.hpp:3,
                 from /home/lh/work/leap-main/plugins/chain_plugin/chain_plugin.cpp:1:
/home/lh/work/leap-main/plugins/chain_plugin/chain_plugin.cpp: In member function ‘void     eosio::chain_apis::read_write::push_block(eosio::chain_apis::read_write::                   push_block_params&&, eosio::chain_apis::next_function<eosio::chain_apis::empty>)’:
/home/lh/work/leap-main/libraries/libfc/include/fc/exception/exception.hpp:481:4: warning:  exception of type ‘boost::interprocess::bad_alloc’ will be caught
  481 |    catch( const boost::interprocess::bad_alloc& ) {\
      |    ^~~~~
/home/lh/work/leap-main/libraries/libfc/include/fc/exception/exception.hpp:481:4: note: in  definition of macro ‘FC_LOG_AND_DROP’
  481 |    catch( const boost::interprocess::bad_alloc& ) {\
      |    ^~~~~
/home/lh/work/leap-main/plugins/chain_plugin/chain_plugin.cpp:2169:6: warning:    by        earlier handler for ‘boost::interprocess::bad_alloc’
 2169 |    } catch ( boost::interprocess::bad_alloc& ) {
      |      ^~~~~
```