### PR TITLE
[PH] Calculate & Report Transaction Latency Stats

### DIFF
--- a/tests/performance_tests/launch_transaction_generators.py
+++ b/tests/performance_tests/launch_transaction_generators.py
@@ -24,6 +24,7 @@ parser.add_argument("account_2_priv_key", type=str, help="Second account private
 parser.add_argument("trx_gen_duration", type=str, help="How long to run transaction generators")
 parser.add_argument("target_tps", type=int, help="Goal transactions per second")
 parser.add_argument("tps_limit_per_generator", type=int, help="Maximum amount of transactions per second a single generator can have.", default=4000)
+parser.add_argument("log_dir", type=str, help="Path to directory where trx logs should be written.", default="performance_test_basic/logs")
 args = parser.parse_args()
 
 targetTps = args.target_tps
@@ -44,7 +45,8 @@ for num in range(1, numGenerators + 1):
        f'--accounts {args.account_1_name},{args.account_2_name} '
        f'--priv-keys {args.account_1_priv_key},{args.account_2_priv_key} '
        f'--trx-gen-duration {args.trx_gen_duration} '
-       f'--target-tps {tpsPerGenerator}'
+       f'--target-tps {tpsPerGenerator} '
+       f'--log-dir {args.log_dir}'
     )
     subprocess_ret_codes.append(
        subprocess.Popen([
@@ -55,7 +57,8 @@ for num in range(1, numGenerators + 1):
            '--accounts', f'{args.account_1_name},{args.account_2_name}',
            '--priv-keys', f'{args.account_1_priv_key},{args.account_2_priv_key}',
            '--trx-gen-duration', f'{args.trx_gen_duration}',
-           '--target-tps', f'{tpsPerGenerator}'
+           '--target-tps', f'{tpsPerGenerator}',
+           '--log-dir', f'{args.log_dir}'
        ])
     )
 exit_codes = [ret_code.wait() for ret_code in subprocess_ret_codes]

--- a/tests/trx_generator/trx_generator.cpp
+++ b/tests/trx_generator/trx_generator.cpp
@@ -110,10 +110,10 @@ namespace eosio::testing {
 
    transfer_trx_generator::transfer_trx_generator(std::string chain_id_in, std::string handler_acct,
       const std::vector<std::string>& accts, int64_t trx_expr, const std::vector<std::string>& private_keys_str_vector,
-      std::string lib_id_str) :
+      std::string lib_id_str, std::string log_dir) :
       _provider(), _chain_id(chain_id_in), _handler_acct(handler_acct), _accts(accts),
       _trx_expiration(trx_expr*1000000), _private_keys_str_vector(private_keys_str_vector),
-      _last_irr_block_id(fc::variant(lib_id_str).as<block_id_type>()) {
+      _last_irr_block_id(fc::variant(lib_id_str).as<block_id_type>()), _log_dir(log_dir) {
    }
 
    void transfer_trx_generator::push_transaction(p2p_trx_provider& provider, signed_transaction_w_signer& trx, uint64_t& nonce_prefix, uint64_t& nonce, const fc::microseconds& trx_expiration, const chain_id_type& chain_id, const block_id_type& last_irr_block_id) {
@@ -188,6 +188,7 @@ namespace eosio::testing {
    }
 
    bool transfer_trx_generator::tear_down() {
+      _provider.log_trxs(_log_dir);
       _provider.teardown();
 
       std::cout << "Sent transactions: " << _txcount << std::endl;

--- a/tests/trx_generator/trx_generator.hpp
+++ b/tests/trx_generator/trx_generator.hpp
@@ -23,6 +23,7 @@ namespace eosio::testing {
       fc::microseconds _trx_expiration;
       std::vector<std::string> _private_keys_str_vector;
       eosio::chain::block_id_type _last_irr_block_id;
+      std::string _log_dir;
 
       uint64_t _total_us = 0;
       uint64_t _txcount = 0;
@@ -33,7 +34,7 @@ namespace eosio::testing {
       uint64_t _nonce_prefix = 0;
 
       transfer_trx_generator(std::string chain_id_in, std::string handler_acct, const std::vector<std::string>& accts,
-         int64_t trx_expr, const std::vector<std::string>& private_keys_str_vector, std::string lib_id_str);
+         int64_t trx_expr, const std::vector<std::string>& private_keys_str_vector, std::string lib_id_str, std::string log_dir);
 
       void push_transaction(p2p_trx_provider& provider, signed_transaction_w_signer& trx, uint64_t& nonce_prefix,
                             uint64_t& nonce, const fc::microseconds& trx_expiration, const eosio::chain::chain_id_type& chain_id,

--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -64,6 +64,7 @@ namespace eosio::testing {
    void p2p_trx_provider::send(const chain::signed_transaction& trx) {
       chain::packed_transaction pt(trx);
       _peer_connection.send_transaction(pt);
+      _sent_trx_data.push_back(logged_trx_data(trx.id()));
    }
 
    void p2p_trx_provider::send(const std::vector<chain::signed_transaction>& trxs) {
@@ -72,11 +73,22 @@ namespace eosio::testing {
       }
    }
 
-  void p2p_trx_provider::teardown() {
-      _peer_connection.disconnect();
-  }
+   void p2p_trx_provider::log_trxs(const std::string& log_dir) {
+      std::ostringstream fileName;
+      fileName << log_dir << "/trx_data_output_" << getpid() << ".txt";
+      std::ofstream out(fileName.str());
 
-  bool tps_performance_monitor::monitor_test(const tps_test_stats &stats) {
+      for (logged_trx_data data : _sent_trx_data) {
+         out << fc::string(data._trx_id) << ","<< std::string(data._sent_timestamp) << "\n";
+      }
+      out.close();
+   }
+
+   void p2p_trx_provider::teardown() {
+      _peer_connection.disconnect();
+   }
+
+   bool tps_performance_monitor::monitor_test(const tps_test_stats &stats) {
       if ((!stats.expected_sent) || (stats.last_run - stats.start_time < _spin_up_time)) {
          return true;
       }
@@ -110,5 +122,5 @@ namespace eosio::testing {
          }
       }
       return true;
-  }
+   }
 }

--- a/tests/trx_generator/trx_provider.hpp
+++ b/tests/trx_generator/trx_provider.hpp
@@ -14,6 +14,14 @@ using namespace std::chrono_literals;
 namespace eosio::testing {
    using send_buffer_type = std::shared_ptr<std::vector<char>>;
 
+   struct logged_trx_data {
+      eosio::chain::transaction_id_type _trx_id;
+      fc::time_point _sent_timestamp;
+
+      logged_trx_data(eosio::chain::transaction_id_type trx_id, fc::time_point sent=fc::time_point::now()) :
+         _trx_id(trx_id), _sent_timestamp(sent) {}
+   };
+
    struct p2p_connection {
       std::string _peer_endpoint;
       boost::asio::io_service _p2p_service;
@@ -34,10 +42,12 @@ namespace eosio::testing {
       void setup();
       void send(const std::vector<chain::signed_transaction>& trxs);
       void send(const chain::signed_transaction& trx);
+      void log_trxs(const std::string& log_dir);
       void teardown();
 
    private:
       p2p_connection _peer_connection;
+      std::vector<logged_trx_data> _sent_trx_data;
    };
 
    using fc::time_point;


### PR DESCRIPTION
In order to calculate the transaction latency stats, needed to also log transactions at send origination in the transaction provider.

Added managing log directory functionality to setup and cleanup log files.