### PR TITLE
[3.1 -> main] Fix replay to correctly add trxs into the de-dup list

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1528,7 +1528,7 @@ struct controller_impl {
                trx_context.init_for_implicit_trx();
                trx_context.enforce_whiteblacklist = false;
             } else {
-               bool skip_recording = replay_head_time && (time_point(trn.expiration) <= *replay_head_time);
+               bool skip_recording = replay_head_time && (time_point(trn.expiration) < *replay_head_time);
                trx_context.init_for_input_trx( trx->packed_trx()->get_unprunable_size(),
                                                trx->packed_trx()->get_prunable_size(),
                                                skip_recording);
@@ -2404,7 +2404,8 @@ struct controller_impl {
             break;
          }
       }
-      dlog("removed ${n} expired transactions of the ${t} input dedup list", ("n", num_removed)("t", total));
+      dlog("removed ${n} expired transactions of the ${t} input dedup list, pending block time ${pt}",
+           ("n", num_removed)("t", total)("pt", now));
    }
 
    bool sender_avoids_whitelist_blacklist_enforcement( account_name sender )const {


### PR DESCRIPTION
When replaying a block log, the transactions with expirations equal to the last irreversible block time were not added to the trx de-dup list. This creates a difference in the de-dup list vs starting from state or a snapshot. Note transactions are cleared from the de-dup list at the start of a block according to if they are less than (not less than or equal) the pending block time.

Regression test will come in a different PR. See https://github.com/AntelopeIO/leap/pull/268.

Resolves https://github.com/eosnetworkfoundation/mandel/issues/301