### PR TITLE
[3.2] initialize slice_directory::index_header::version

### DIFF
--- a/plugins/trace_api_plugin/include/eosio/trace_api/store_provider.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/store_provider.hpp
@@ -96,7 +96,7 @@ namespace eosio::trace_api {
    class slice_directory {
    public:
       struct index_header {
-         uint32_t version;
+         uint32_t version = 0;
       };
 
       enum class open_state { read /*read from front to back*/, write /*write to end of file*/ };


### PR DESCRIPTION
The lack of an initializer for `version` was leading to a use before set warning in the trace_api_plugin tests
https://github.com/AntelopeIO/leap/blob/631b3bf914afb279097f39702a5ed5c7b9d1f712/plugins/trace_api_plugin/test/test_trace_file.cpp#L436-L437
Our general practice is to initialize PODs in structs, so let's do that here.