### PR TITLE
don't skip the "build platforms" job even when there are no platforms to build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,23 +34,24 @@ jobs:
   build-platforms:
     name: Build Platforms
     needs: d
-    if: needs.d.outputs.missing-platforms != '[]'
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{fromJSON(needs.d.outputs.missing-platforms)}}
-    runs-on: ["self-hosted", "enf-x86-beefy"]
+        platform: ${{ needs.d.outputs.missing-platforms == '[]' && fromJSON('["none"]') || fromJSON(needs.d.outputs.missing-platforms) }}
+    runs-on: ${{ matrix.platform == 'none' && 'ubuntu-latest' || fromJSON('["self-hosted", "enf-x86-beefy"]') }}
     permissions:
       packages: write
       contents: read
     steps:
       - name: Login to Container Registry
+        if: matrix.platform != 'none'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{github.repository_owner}}
           password: ${{secrets.GITHUB_TOKEN}}
       - name: Build and push
+        if: matrix.platform != 'none'
         uses: docker/build-push-action@v3
         with:
           push: true
@@ -59,7 +60,6 @@ jobs:
 
   Build:
     needs: [d, build-platforms]
-    if: always() && needs.d.result == 'success' && (needs.build-platforms.result == 'success' || needs.build-platforms.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
@@ -89,7 +89,6 @@ jobs:
   dev-package:
     name: Build leap-dev package
     needs: [d, Build]
-    if: always() && needs.Build.result == 'success'
     runs-on: ubuntu-latest
     container: ${{fromJSON(needs.d.outputs.p)['ubuntu20'].image}}
     steps:
@@ -114,7 +113,6 @@ jobs:
   tests:
     name: Tests
     needs: [d, Build]
-    if: always() && needs.Build.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -141,7 +139,6 @@ jobs:
   np-tests:
     name: NP Tests
     needs: [d, Build]
-    if: always() && needs.Build.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -170,7 +167,6 @@ jobs:
   lr-tests:
     name: LR Tests
     needs: [d, Build]
-    if: always() && needs.Build.result == 'success'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
When there are no platforms to build for the platform cache, it conceptually makes sense to skip the platform building job matrix. But skipping a job in the middle of the graph like this causes some grief downstream: we needed to start doing things like `if: always() && needs.Build.result == 'success'` for dependent jobs because the default `success()` rule didn't like to see an ancestor skipped.

But this `if: always()` hack comes with a nasty side effect: it's impossible to cancel the workflow. Apparently a job with `if: always()` is not cancellable. This is particularly annoying when something like NP Tests fail and you have to wait until LR Tests finish before you can retry the workflow.

So instead, the Build Platforms job will now inject a dummy entry in to its matrix when there are no platforms to build. This allows the job to still pass when it has no work to do and all dependent jobs don't need the `if: always()` hack. Thus making the workflow cancellable.

At some point, the discover & build jobs should be bundled in to a reusable workflow to encapsulate away some of the gory details.