### PR TITLE
[4.0] add waitForTransactionsInBlock

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -783,7 +783,7 @@ class Cluster(object):
             #Utils.Print("nextEosIdx: %d, count: %d" % (nextEosIdx, count))
             node=self.nodes[nextEosIdx]
             if Utils.Debug: Utils.Print("Wait for transaction id %s on node port %d" % (transId, node.port))
-            if node.waitForTransInBlock(transId) is False:
+            if node.waitForTransactionInBlock(transId) is False:
                 Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, node.port))
                 return False
 
@@ -804,7 +804,7 @@ class Cluster(object):
         # As an extra step wait for last transaction on the root node
         node=self.nodes[0]
         if Utils.Debug: Utils.Print("Wait for transaction id %s on node port %d" % (transId, node.port))
-        if node.waitForTransInBlock(transId) is False:
+        if node.waitForTransactionInBlock(transId) is False:
             Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, node.port))
             return False
 
@@ -1062,7 +1062,7 @@ class Cluster(object):
 
         Utils.Print("Wait for last transfer transaction to become finalized.")
         transId=Node.getTransId(trans[1])
-        if not biosNode.waitForTransInBlock(transId):
+        if not biosNode.waitForTransactionInBlock(transId):
             Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
             return None
 
@@ -1146,7 +1146,7 @@ class Cluster(object):
             accounts.append(initx)
 
         transId=Node.getTransId(trans)
-        if not biosNode.waitForTransInBlock(transId):
+        if not biosNode.waitForTransactionInBlock(transId):
             Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
             return None
 
@@ -1195,7 +1195,7 @@ class Cluster(object):
 
             trans=trans[1]
             transId=Node.getTransId(trans)
-            if not biosNode.waitForTransInBlock(transId):
+            if not biosNode.waitForTransactionInBlock(transId):
                 Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
                 return None
 
@@ -1238,7 +1238,7 @@ class Cluster(object):
 
         Node.validateTransaction(trans)
         transId=Node.getTransId(trans)
-        if not biosNode.waitForTransInBlock(transId):
+        if not biosNode.waitForTransactionInBlock(transId):
             Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
             return None
 
@@ -1265,7 +1265,7 @@ class Cluster(object):
 
         Node.validateTransaction(trans[1])
         transId=Node.getTransId(trans[1])
-        if not biosNode.waitForTransInBlock(transId):
+        if not biosNode.waitForTransactionInBlock(transId):
             Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
             return None
 
@@ -1282,7 +1282,7 @@ class Cluster(object):
         Node.validateTransaction(trans[1])
         Utils.Print("Wait for issue action transaction to become finalized.")
         transId=Node.getTransId(trans[1])
-        # biosNode.waitForTransInBlock(transId)
+        # biosNode.waitForTransactionInBlock(transId)
         # guesstimating block finalization timeout. Two production rounds of 12 blocks per node, plus 60 seconds buffer
         timeout = .5 * 12 * 2 * len(producerKeys) + 60
         if not biosNode.waitForTransFinalization(transId, timeout=timeout):
@@ -1327,7 +1327,7 @@ class Cluster(object):
 
         Utils.Print("Wait for last transfer transaction to become finalized.")
         transId=Node.getTransId(trans[1])
-        if not biosNode.waitForTransInBlock(transId):
+        if not biosNode.waitForTransactionInBlock(transId):
             Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
             return None
 
@@ -1339,7 +1339,7 @@ class Cluster(object):
             trans=biosNode.pushMessage(eosioAccount.name, action, data, opts)
             transId=Node.getTransId(trans[1])
             Utils.Print("Wait for system init transaction to be in a block.")
-            if not biosNode.waitForTransInBlock(transId):
+            if not biosNode.waitForTransactionInBlock(transId):
                 Utils.Print("ERROR: Failed to validate transaction %s in block on server port %d." % (transId, biosNode.port))
                 return None
 
@@ -1566,7 +1566,7 @@ class Cluster(object):
         if waitForTransBlock and transId is not None:
             node=self.nodes[0]
             if Utils.Debug: Utils.Print("Wait for transaction id %s on server port %d." % ( transId, node.port))
-            if node.waitForTransInBlock(transId) is False:
+            if node.waitForTransactionInBlock(transId) is False:
                 Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, node.port))
                 return False
 

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -384,7 +384,7 @@ class Node(object):
         transId=Node.getTransId(trans)
 
         if stakedDeposit > 0:
-            self.waitForTransInBlock(transId) # seems like account creation needs to be finalized before transfer can happen
+            self.waitForTransactionInBlock(transId) # seems like account creation needs to be finalized before transfer can happen
             trans = self.transferFunds(creatorAccount, account, Node.currencyIntToStr(stakedDeposit, CORE_SYMBOL), "init")
             transId=Node.getTransId(trans)
 
@@ -403,7 +403,7 @@ class Node(object):
         transId=Node.getTransId(trans)
 
         if stakedDeposit > 0:
-            self.waitForTransInBlock(transId) # seems like account creation needs to be finlized before transfer can happen
+            self.waitForTransactionInBlock(transId) # seems like account creation needs to be finlized before transfer can happen
             trans = self.transferFunds(creatorAccount, account, "%0.04f %s" % (stakedDeposit/10000, CORE_SYMBOL), "init")
             self.trackCmdTransaction(trans)
             transId=Node.getTransId(trans)
@@ -482,12 +482,16 @@ class Node(object):
 
         return None
 
-    def waitForTransInBlock(self, transId, timeout=None):
+    def waitForTransactionInBlock(self, transId, timeout=None):
         """Wait for trans id to be finalized."""
         assert(isinstance(transId, str))
         lam = lambda: self.isTransInAnyBlock(transId)
         ret=Utils.waitForBool(lam, timeout)
         return ret
+
+    def waitForTransactionsInBlock(self, transIds, timeout=None):
+        for transId in transIds:
+            self.waitForTransactionInBlock(transId, timeout)
 
     def waitForTransFinalization(self, transId, timeout=None):
         """Wait for trans id to be finalized."""
@@ -1079,7 +1083,7 @@ class Node(object):
             return trans
 
         transId=Node.getTransId(trans)
-        if not self.waitForTransInBlock(transId):
+        if not self.waitForTransactionInBlock(transId):
             if exitOnError:
                 Utils.cmdError("transaction with id %s never made it to a block" % (transId))
                 Utils.errorExit("Failed to find transaction with id %s in a block before timeout" % (transId))

--- a/tests/launcher_test.py
+++ b/tests/launcher_test.py
@@ -180,7 +180,7 @@ try:
         cmdError("FAILURE - transfer failed")
         errorExit("Transfer verification failed. Excepted %s, actual: %s" % (expectedAmount, actualAmount))
 
-    node.waitForTransInBlock(transId)
+    node.waitForTransactionInBlock(transId)
 
     transaction=node.getTransaction(transId, exitOnError=True, delayedRetry=False)
 

--- a/tests/nodeos_high_transaction_test.py
+++ b/tests/nodeos_high_transaction_test.py
@@ -171,7 +171,7 @@ try:
                         Print("Transaction not found for trans id: %s. Will wait %d seconds to see if it arrives in a block." %
                               (transId, args.transaction_time_delta))
                     transTimeDelayed = True
-                    node.waitForTransInBlock(transId, timeout = args.transaction_time_delta)
+                    node.waitForTransactionInBlock(transId, timeout = args.transaction_time_delta)
                     continue
 
             lastIrreversibleBlockNum = node.getIrreversibleBlockNum()

--- a/tests/nodeos_retry_transaction_test.py
+++ b/tests/nodeos_retry_transaction_test.py
@@ -192,7 +192,7 @@ try:
                         Print("Transaction not found for trans id: %s. Will wait %d seconds to see if it arrives in a block." %
                               (transId, args.transaction_time_delta))
                     transTimeDelayed = True
-                    node.waitForTransInBlock(transId, timeout = args.transaction_time_delta)
+                    node.waitForTransactionInBlock(transId, timeout = args.transaction_time_delta)
                     continue
 
             lastIrreversibleBlockNum = node.getIrreversibleBlockNum()

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -277,7 +277,7 @@ try:
         cmdError("FAILURE - transfer failed")
         errorExit("Transfer verification failed. Excepted %s, actual: %s" % (expectedAmount, actualAmount))
 
-    node.waitForTransInBlock(transId)
+    node.waitForTransactionInBlock(transId)
 
     transaction=node.getTransaction(transId, exitOnError=True, delayedRetry=False)
 
@@ -417,7 +417,7 @@ try:
         errorExit("Failed to reject duplicate message for currency1111 contract")
 
     Print("verify transaction exists")
-    if not node.waitForTransInBlock(transId):
+    if not node.waitForTransactionInBlock(transId):
         cmdError("%s get transaction trans_id" % (ClientName))
         errorExit("Failed to verify push message transaction id.")
 

--- a/tests/p2p_stress.py
+++ b/tests/p2p_stress.py
@@ -59,7 +59,7 @@ class StressNetwork:
         if trid is None:
             return ([], "", 0.0, "failed to issue currency0000")
         print("transaction id %s" % (trid))
-        node.waitForTransInBlock(trid)
+        node.waitForTransactionInBlock(trid)
 
         self.trList = []
         expBal = 0
@@ -97,7 +97,7 @@ class StressNetwork:
         for tr in self.trList:
             trid = node.getTransId(tr)
             transIdlist.append(trid)
-            node.waitForTransInBlock(trid)
+            node.waitForTransactionInBlock(trid)
         return (transIdlist, acc2.name, expBal, "")
     
     def on_exit(self):


### PR DESCRIPTION
change name of waitForTransInBlock and added waitForTransactionsInBlock which can take a list of transactions to wait for. Not currently used anywhere but was testing in launcher_test.py by altering code from

```
   node.waitForTransactionInBlock(transId)
```
to 
```
    tid = []
    tid.append(transId)
    node.waitForTransactionsInBlock(tid)
```
and the test passed.
Additionally testing by adding a junk transactions causes a timeout as expected.