### PR TITLE
[PH] TPS Scenario Runner

### DIFF
--- a/tests/performance_tests/CMakeLists.txt
+++ b/tests/performance_tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/performance_test_basic.py ${CMAKE_CURRENT_BINARY_DIR}/performance_test_basic.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/performance_test.py ${CMAKE_CURRENT_BINARY_DIR}/performance_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/log_reader.py ${CMAKE_CURRENT_BINARY_DIR}/log_reader.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/read_log_data.py ${CMAKE_CURRENT_BINARY_DIR}/read_log_data.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/log_reader_tests.py ${CMAKE_CURRENT_BINARY_DIR}/log_reader_tests.py COPYONLY)

--- a/tests/performance_tests/log_reader.py
+++ b/tests/performance_tests/log_reader.py
@@ -335,7 +335,8 @@ def calcTrxLatencyCpuNetStats(trxDict : dict, blockDict: dict):
            basicStats(float(np.min(npLatencyCpuNetList[:,1])), float(np.max(npLatencyCpuNetList[:,1])), float(np.average(npLatencyCpuNetList[:,1])), float(np.std(npLatencyCpuNetList[:,1])), len(npLatencyCpuNetList)), \
            basicStats(float(np.min(npLatencyCpuNetList[:,2])), float(np.max(npLatencyCpuNetList[:,2])), float(np.average(npLatencyCpuNetList[:,2])), float(np.std(npLatencyCpuNetList[:,2])), len(npLatencyCpuNetList))
 
-def createJSONReport(guide: chainBlocksGuide, targetTps: int, testDurationSec: int, tpsStats: stats, blockSizeStats: stats, trxLatencyStats: basicStats, trxCpuStats: basicStats, trxNetStats: basicStats, argsDict, completedRun) -> json:
+def createJSONReport(guide: chainBlocksGuide, targetTps: int, testDurationSec: int, tpsStats: stats, blockSizeStats: stats,
+                     trxLatencyStats: basicStats, trxCpuStats: basicStats, trxNetStats: basicStats, argsDict, completedRun) -> json:
     js = {}
     js['completedRun'] = completedRun
     js['nodeosVersion'] = Utils.getNodeosVersion()

--- a/tests/performance_tests/log_reader.py
+++ b/tests/performance_tests/log_reader.py
@@ -5,8 +5,8 @@ import sys
 import re
 import numpy as np
 import json
-from datetime import datetime
 import glob
+import gzip
 
 harnessPath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(harnessPath)
@@ -14,7 +14,7 @@ sys.path.append(harnessPath)
 from TestHarness import Utils
 from dataclasses import dataclass, asdict, field
 from platform import release, system
-import gzip
+from datetime import datetime
 
 Print = Utils.Print
 errorExit = Utils.errorExit

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -117,35 +117,30 @@ def exportReportAsJSON(report: json, exportPath):
 
 def testDirsCleanup(saveJsonReport, testTimeStampDirPath, ptbLogsDirPath):
     try:
+        def removeArtifacts(path):
+            print(f"Checking if test artifacts dir exists: {path}")
+            if os.path.isdir(f"{path}"):
+                print(f"Cleaning up test artifacts dir and all contents of: {path}")
+                shutil.rmtree(f"{path}")
+
         if saveJsonReport:
-            print(f"Checking if test artifacts dir exists: {ptbLogsDirPath}")
-            if os.path.isdir(f"{ptbLogsDirPath}"):
-                print(f"Cleaning up test artifacts dir and all contents of: {ptbLogsDirPath}")
-                shutil.rmtree(f"{ptbLogsDirPath}")
+            removeArtifacts(ptbLogsDirPath)
         else:
-            print(f"Checking if test artifacts dir exists: {testTimeStampDirPath}")
-            if os.path.isdir(f"{testTimeStampDirPath}"):
-                print(f"Cleaning up test artifacts dir and all contents of: {testTimeStampDirPath}")
-                shutil.rmtree(f"{testTimeStampDirPath}")
+            removeArtifacts(testTimeStampDirPath)
     except OSError as error:
         print(error)
 
 def testDirsSetup(rootLogDir, testTimeStampDirPath, ptbLogsDirPath):
     try:
-        print(f"Checking if test artifacts dir exists: {rootLogDir}")
-        if not os.path.isdir(f"{rootLogDir}"):
-            print(f"Creating test artifacts dir: {rootLogDir}")
-            os.mkdir(f"{rootLogDir}")
+        def createArtifactsDir(path):
+            print(f"Checking if test artifacts dir exists: {path}")
+            if not os.path.isdir(f"{path}"):
+                print(f"Creating test artifacts dir: {path}")
+                os.mkdir(f"{path}")
 
-        print(f"Checking if logs dir exists: {testTimeStampDirPath}")
-        if not os.path.isdir(f"{testTimeStampDirPath}"):
-            print(f"Creating logs dir: {testTimeStampDirPath}")
-            os.mkdir(f"{testTimeStampDirPath}")
-
-        print(f"Checking if logs dir exists: {ptbLogsDirPath}")
-        if not os.path.isdir(f"{ptbLogsDirPath}"):
-            print(f"Creating logs dir: {ptbLogsDirPath}")
-            os.mkdir(f"{ptbLogsDirPath}")
+        createArtifactsDir(rootLogDir)
+        createArtifactsDir(testTimeStampDirPath)
+        createArtifactsDir(ptbLogsDirPath)
 
     except OSError as error:
         print(error)

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -52,8 +52,8 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
     maxTpsReport = {}
     searchResults = []
 
-    while floor <= ceiling:
-        binSearchTarget = round(((ceiling + floor) // 2) / 100) * 100 if not lastRun else round(ceiling / 100) * 100
+    while floor < ceiling:
+        binSearchTarget = round(((ceiling + floor) // 2) / 100) * 100
         print(f"Running scenario: floor {floor} binSearchTarget {binSearchTarget} ceiling {ceiling}")
         ptbResult = PerfTestBasicResult()
         scenarioResult = PerfTestSearchIndivResult(success=False, searchTarget=binSearchTarget, searchFloor=floor, searchCeiling=ceiling, basicTestResult=ptbResult)
@@ -76,7 +76,7 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
         print(f"searchResult: {binSearchTarget} : {searchResults[-1]}")
         if lastRun:
             break
-        if scenarioResult.success and ceiling - floor <= minStep:
+        if ceiling - floor <= minStep:
             lastRun = True
 
     return PerfTestBinSearchResults(maxTpsAchieved=maxTpsAchieved, searchResults=searchResults, maxTpsReport=maxTpsReport)

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 from dataclasses import dataclass, asdict, field
-from math import floor
 import os
+from platform import release, system
 import sys
 import json
 from datetime import datetime
@@ -107,6 +107,8 @@ def createJSONReport(maxTpsAchieved, searchResults, maxTpsReport, longRunningMax
     js['LongRunningSearchResults'] =  {x: asdict(longRunningSearchResults[x]) for x in range(len(longRunningSearchResults))}
     js['LongRunningMaxTpsReport'] =  longRunningMaxTpsReport
     js['args'] =  argsDict
+    js['env'] = {'system': system(), 'os': os.name, 'release': release()}
+    js['nodeosVersion'] = Utils.getNodeosVersion()
     return json.dumps(js, indent=2)
 
 def exportReportAsJSON(report: json, exportPath):

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+
+from dataclasses import dataclass, asdict, field
+from math import floor
+import os
+import sys
+import json
+from datetime import datetime
+import shutil
+
+harnessPath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(harnessPath)
+
+from TestHarness import TestHelper, Utils
+from TestHarness.TestHelper import AppArgs
+from performance_test_basic import PerformanceBasicTest
+
+@dataclass
+class PerfTestBasicResult:
+    targetTPS: int = 0
+    resultAvgTps: float = 0
+    expectedTxns: int = 0
+    resultTxns: int = 0
+    tpsExpectMet: bool = False
+    trxExpectMet: bool = False
+    basicTestSuccess: bool = False
+    logsDir: str = ""
+
+@dataclass
+class PerfTestSearchIndivResult:
+    success: bool = False
+    searchTarget: int = 0
+    searchFloor: int = 0
+    searchCeiling: int = 0
+    basicTestResult: PerfTestBasicResult = PerfTestBasicResult()
+
+@dataclass
+class PerfTestBinSearchResults:
+    maxTpsAchieved: int = 0
+    searchResults: list = field(default_factory=list) #PerfTestSearchIndivResult list
+    maxTpsReport: dict = field(default_factory=dict)
+
+def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int, testHelperConfig: PerformanceBasicTest.TestHelperConfig,
+                           testClusterConfig: PerformanceBasicTest.ClusterConfig, testDurationSec: int, tpsLimitPerGenerator: int,
+                           numAddlBlocksToPrune: int, testLogDir: str, saveJson: bool) -> PerfTestBinSearchResults:
+    floor = tpsTestFloor
+    ceiling = tpsTestCeiling
+    binSearchTarget = 0
+    lastRun = False
+
+    maxTpsAchieved = 0
+    maxTpsReport = {}
+    searchResults = []
+
+    while floor <= ceiling:
+        binSearchTarget = (ceiling + floor) // 2 if not lastRun else ceiling
+        print(f"Running scenario: floor {floor} binSearchTarget {binSearchTarget} ceiling {ceiling}")
+        ptbResult = PerfTestBasicResult()
+        scenarioResult = PerfTestSearchIndivResult(success=False, searchTarget=binSearchTarget, searchFloor=floor, searchCeiling=ceiling, basicTestResult=ptbResult)
+
+        myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=binSearchTarget,
+                                    testTrxGenDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
+                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, saveJsonReport=saveJson)
+        testSuccessful = myTest.runTest()
+
+        if evaluateSuccess(myTest, testSuccessful, ptbResult):
+            maxTpsAchieved = binSearchTarget
+            maxTpsReport = json.loads(myTest.report)
+            floor = binSearchTarget + 1
+            scenarioResult.success = True
+        else:
+            ceiling = binSearchTarget - 1
+
+        scenarioResult.basicTestResult = ptbResult
+        searchResults.append(scenarioResult)
+        print(f"searchResult: {binSearchTarget} : {searchResults[-1]}")
+        if lastRun:
+            break
+        if scenarioResult.success and ceiling - floor <= minStep:
+            lastRun = True
+
+    return PerfTestBinSearchResults(maxTpsAchieved=maxTpsAchieved, searchResults=searchResults, maxTpsReport=maxTpsReport)
+
+def evaluateSuccess(test: PerformanceBasicTest, testSuccessful: bool, result: PerfTestBasicResult) -> bool:
+    result.targetTPS = test.targetTps
+    result.expectedTxns = test.expectedTransactionsSent
+    reportDict = json.loads(test.report)
+    result.resultAvgTps = reportDict["Analysis"]["TPS"]["avg"]
+    result.resultTxns = reportDict["Analysis"]["TrxLatency"]["samples"]
+    print(f"targetTPS: {result.targetTPS} expectedTxns: {result.expectedTxns} resultAvgTps: {result.resultAvgTps} resultTxns: {result.resultTxns}")
+
+    result.tpsExpectMet = True if result.resultAvgTps >= result.targetTPS else abs(result.targetTPS - result.resultAvgTps) < 100
+    result.trxExpectMet = result.expectedTxns == result.resultTxns
+    result.basicTestSuccess = testSuccessful
+    result.logsDir = test.testTimeStampDirPath
+
+    print(f"basicTestSuccess: {result.basicTestSuccess} tpsExpectationMet: {result.tpsExpectMet} trxExpectationMet: {result.trxExpectMet}")
+
+    return result.basicTestSuccess and result.tpsExpectMet and result.trxExpectMet
+
+def createJSONReport(maxTpsAchieved, searchResults, maxTpsReport, longRunningMaxTpsAchieved, longRunningSearchResults, longRunningMaxTpsReport, argsDict) -> json:
+    js = {}
+    js['InitialMaxTpsAchieved'] = maxTpsAchieved
+    js['LongRunningMaxTpsAchieved'] = longRunningMaxTpsAchieved
+    js['InitialSearchResults'] =  {x: asdict(searchResults[x]) for x in range(len(searchResults))}
+    js['InitialMaxTpsReport'] =  maxTpsReport
+    js['LongRunningSearchResults'] =  {x: asdict(longRunningSearchResults[x]) for x in range(len(longRunningSearchResults))}
+    js['LongRunningMaxTpsReport'] =  longRunningMaxTpsReport
+    js['args'] =  argsDict
+    return json.dumps(js, indent=2)
+
+def exportReportAsJSON(report: json, exportPath):
+    with open(exportPath, 'wt') as f:
+        f.write(report)
+
+def testDirsCleanup(testTimeStampDirPath):
+    try:
+        print(f"Checking if test artifacts dir exists: {testTimeStampDirPath}")
+        if os.path.isdir(f"{testTimeStampDirPath}"):
+            print(f"Cleaning up test artifacts dir and all contents of: {testTimeStampDirPath}")
+            shutil.rmtree(f"{testTimeStampDirPath}")
+    except OSError as error:
+        print(error)
+
+def testDirsSetup(rootLogDir, testTimeStampDirPath):
+    try:
+        print(f"Checking if test artifacts dir exists: {rootLogDir}")
+        if not os.path.isdir(f"{rootLogDir}"):
+            print(f"Creating test artifacts dir: {rootLogDir}")
+            os.mkdir(f"{rootLogDir}")
+
+        print(f"Checking if logs dir exists: {testTimeStampDirPath}")
+        if not os.path.isdir(f"{testTimeStampDirPath}"):
+            print(f"Creating logs dir: {testTimeStampDirPath}")
+            os.mkdir(f"{testTimeStampDirPath}")
+
+    except OSError as error:
+        print(error)
+
+def prepArgsDict(testDurationSec, finalDurationSec, testTimeStampDirPath, maxTpsToTest, testIterationMinStep,
+             tpsLimitPerGenerator, saveJsonReport, numAddlBlocksToPrune, testHelperConfig, testClusterConfig) -> dict:
+    argsDict = {}
+    argsDict.update(asdict(testHelperConfig))
+    argsDict.update(asdict(testClusterConfig))
+    argsDict["testDurationSec"] = testDurationSec
+    argsDict["finalDurationSec"] = finalDurationSec
+    argsDict["maxTpsToTest"] = maxTpsToTest
+    argsDict["testIterationMinStep"] = testIterationMinStep
+    argsDict["tpsLimitPerGenerator"] = tpsLimitPerGenerator
+    argsDict["saveJsonReport"] = saveJsonReport
+    argsDict["numAddlBlocksToPrune"] = numAddlBlocksToPrune
+    argsDict["logsDir"] = testTimeStampDirPath
+    return argsDict
+
+def parseArgs():
+    appArgs=AppArgs()
+    appArgs.add(flag="--max-tps-to-test", type=int, help="The max target transfers realistic as ceiling of test range", default=50000)
+    appArgs.add(flag="--test-iteration-duration-sec", type=int, help="The duration of transfer trx generation for each iteration of the test during the initial search (seconds)", default=30)
+    appArgs.add(flag="--test-iteration-min-step", type=int, help="The step size determining granularity of tps result during initial search", default=200)
+    appArgs.add(flag="--final-iterations-duration-sec", type=int, help="The duration of transfer trx generation for each final longer run iteration of the test during the final search (seconds)", default=90)
+    appArgs.add(flag="--tps-limit-per-generator", type=int, help="Maximum amount of transactions per second a single generator can have.", default=4000)
+    appArgs.add(flag="--genesis", type=str, help="Path to genesis.json", default="tests/performance_tests/genesis.json")
+    appArgs.add(flag="--num-blocks-to-prune", type=int, help="The number of potentially non-empty blocks, in addition to leading and trailing size 0 blocks, to prune from the beginning and end of the range of blocks of interest for evaluation.", default=2)
+    appArgs.add(flag="--save-json", type=bool, help="Whether to save json output of stats", default=False)
+    args=TestHelper.parse_args({"-p","-n","-d","-s","--nodes-file"
+                                ,"--dump-error-details","-v","--leave-running"
+                                ,"--clean-run","--keep-logs"}, applicationSpecificArgs=appArgs)
+    return args
+
+def main():
+
+    args = parseArgs()
+    Utils.Debug = args.v
+    testDurationSec=args.test_iteration_duration_sec
+    finalDurationSec=args.final_iterations_duration_sec
+    killAll=args.clean_run
+    dontKill=args.leave_running
+    keepLogs=args.keep_logs
+    dumpErrorDetails=args.dump_error_details
+    delay=args.d
+    nodesFile=args.nodes_file
+    verbose=args.v
+    pnodes=args.p
+    totalNodes=args.n
+    topo=args.s
+    genesisPath=args.genesis
+    maxTpsToTest=args.max_tps_to_test
+    testIterationMinStep=args.test_iteration_min_step
+    tpsLimitPerGenerator=args.tps_limit_per_generator
+    saveJsonReport=args.save_json
+    numAddlBlocksToPrune=args.num_blocks_to_prune
+
+    rootLogDir: str=os.path.splitext(os.path.basename(__file__))[0]
+    testTimeStampDirPath = f"{rootLogDir}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+
+    testDirsSetup(rootLogDir=rootLogDir, testTimeStampDirPath=testTimeStampDirPath)
+
+    testHelperConfig = PerformanceBasicTest.TestHelperConfig(killAll=killAll, dontKill=dontKill, keepLogs=keepLogs,
+                                                             dumpErrorDetails=dumpErrorDetails, delay=delay, nodesFile=nodesFile,
+                                                             verbose=verbose)
+
+    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=pnodes, totalNodes=totalNodes, topo=topo, genesisPath=genesisPath)
+
+    argsDict = prepArgsDict(testDurationSec=testDurationSec, finalDurationSec=finalDurationSec, testTimeStampDirPath=testTimeStampDirPath,
+                        maxTpsToTest=maxTpsToTest, testIterationMinStep=testIterationMinStep, tpsLimitPerGenerator=tpsLimitPerGenerator,
+                        saveJsonReport=saveJsonReport, numAddlBlocksToPrune=numAddlBlocksToPrune, testHelperConfig=testHelperConfig, testClusterConfig=testClusterConfig)
+
+    perfRunSuccessful = False
+
+    try:
+        binSearchResults = performPtbBinarySearch(tpsTestFloor=0, tpsTestCeiling=maxTpsToTest, minStep=testIterationMinStep, testHelperConfig=testHelperConfig,
+                           testClusterConfig=testClusterConfig, testDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
+                           numAddlBlocksToPrune=numAddlBlocksToPrune, testLogDir=testTimeStampDirPath, saveJson=saveJsonReport)
+
+        print(f"Successful rate of: {binSearchResults.maxTpsAchieved}")
+
+        print("Search Results:")
+        for i in range(len(binSearchResults.searchResults)):
+            print(f"Search scenario: {i} result: {binSearchResults.searchResults[i]}")
+
+        longRunningFloor = binSearchResults.maxTpsAchieved - 3 * testIterationMinStep if binSearchResults.maxTpsAchieved - 3 * testIterationMinStep > 0 else 0
+        longRunningCeiling = binSearchResults.maxTpsAchieved + 3 * testIterationMinStep
+
+        longRunningBinSearchResults = performPtbBinarySearch(tpsTestFloor=longRunningFloor, tpsTestCeiling=longRunningCeiling, minStep=(testIterationMinStep // 2), testHelperConfig=testHelperConfig,
+                           testClusterConfig=testClusterConfig, testDurationSec=finalDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
+                           numAddlBlocksToPrune=numAddlBlocksToPrune, testLogDir=testTimeStampDirPath, saveJson=saveJsonReport)
+
+        print(f"Long Running Test - Successful rate of: {longRunningBinSearchResults.maxTpsAchieved}")
+        perfRunSuccessful = True
+
+        print("Long Running Test - Search Results:")
+        for i in range(len(longRunningBinSearchResults.searchResults)):
+            print(f"Search scenario: {i} result: {longRunningBinSearchResults.searchResults[i]}")
+
+        fullReport = createJSONReport(maxTpsAchieved=binSearchResults.maxTpsAchieved, searchResults=binSearchResults.searchResults, maxTpsReport=binSearchResults.maxTpsReport,
+                                      longRunningMaxTpsAchieved=longRunningBinSearchResults.maxTpsAchieved, longRunningSearchResults=longRunningBinSearchResults.searchResults,
+                                      longRunningMaxTpsReport=longRunningBinSearchResults.maxTpsReport, argsDict=argsDict)
+
+        print(f"Full Performance Test Report: {fullReport}")
+
+        if saveJsonReport:
+            exportReportAsJSON(fullReport, f"{testTimeStampDirPath}/report.json")
+
+    finally:
+
+        if not keepLogs:
+            print(f"Cleaning up logs directory: {testTimeStampDirPath}")
+            testDirsCleanup(testTimeStampDirPath)
+
+    exitCode = 0 if perfRunSuccessful else 1
+    exit(exitCode)
+
+if __name__ == '__main__':
+    main()

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -145,20 +145,13 @@ def testDirsSetup(rootLogDir, testTimeStampDirPath, ptbLogsDirPath):
     except OSError as error:
         print(error)
 
-def prepArgsDict(testDurationSec, finalDurationSec, testTimeStampDirPath, maxTpsToTest, testIterationMinStep,
+def prepArgsDict(testDurationSec, finalDurationSec, logsDir, maxTpsToTest, testIterationMinStep,
              tpsLimitPerGenerator, saveJsonReport, saveTestJsonReports, numAddlBlocksToPrune, testHelperConfig, testClusterConfig) -> dict:
     argsDict = {}
     argsDict.update(asdict(testHelperConfig))
     argsDict.update(asdict(testClusterConfig))
-    argsDict["testDurationSec"] = testDurationSec
-    argsDict["finalDurationSec"] = finalDurationSec
-    argsDict["maxTpsToTest"] = maxTpsToTest
-    argsDict["testIterationMinStep"] = testIterationMinStep
-    argsDict["tpsLimitPerGenerator"] = tpsLimitPerGenerator
-    argsDict["saveJsonReport"] = saveJsonReport
-    argsDict["saveTestJsonReports"] = saveTestJsonReports
-    argsDict["numAddlBlocksToPrune"] = numAddlBlocksToPrune
-    argsDict["logsDir"] = testTimeStampDirPath
+    argsDict.update({key:val for key, val in locals().items() if key in set(['testDurationSec', 'finalDurationSec', 'maxTpsToTest', 'testIterationMinStep', 'tpsLimitPerGenerator',
+                                                                                  'saveJsonReport', 'saveTestJsonReports', 'numAddlBlocksToPrune', 'logsDir'])})
     return argsDict
 
 def parseArgs():
@@ -213,7 +206,7 @@ def main():
 
     testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=pnodes, totalNodes=totalNodes, topo=topo, genesisPath=genesisPath)
 
-    argsDict = prepArgsDict(testDurationSec=testDurationSec, finalDurationSec=finalDurationSec, testTimeStampDirPath=testTimeStampDirPath,
+    argsDict = prepArgsDict(testDurationSec=testDurationSec, finalDurationSec=finalDurationSec, logsDir=testTimeStampDirPath,
                         maxTpsToTest=maxTpsToTest, testIterationMinStep=testIterationMinStep, tpsLimitPerGenerator=tpsLimitPerGenerator,
                         saveJsonReport=saveJsonReport, saveTestJsonReports=saveTestJsonReports, numAddlBlocksToPrune=numAddlBlocksToPrune, testHelperConfig=testHelperConfig, testClusterConfig=testClusterConfig)
 

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -53,7 +53,7 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
     searchResults = []
 
     while floor <= ceiling:
-        binSearchTarget = (ceiling + floor) // 2 if not lastRun else ceiling
+        binSearchTarget = round(((ceiling + floor) // 2) / 100) * 100 if not lastRun else round(ceiling / 100) * 100
         print(f"Running scenario: floor {floor} binSearchTarget {binSearchTarget} ceiling {ceiling}")
         ptbResult = PerfTestBasicResult()
         scenarioResult = PerfTestSearchIndivResult(success=False, searchTarget=binSearchTarget, searchFloor=floor, searchCeiling=ceiling, basicTestResult=ptbResult)
@@ -66,10 +66,10 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
         if evaluateSuccess(myTest, testSuccessful, ptbResult):
             maxTpsAchieved = binSearchTarget
             maxTpsReport = json.loads(myTest.report)
-            floor = binSearchTarget + 1
+            floor = binSearchTarget
             scenarioResult.success = True
         else:
-            ceiling = binSearchTarget - 1
+            ceiling = binSearchTarget
 
         scenarioResult.basicTestResult = ptbResult
         searchResults.append(scenarioResult)
@@ -156,7 +156,7 @@ def parseArgs():
     appArgs=AppArgs()
     appArgs.add(flag="--max-tps-to-test", type=int, help="The max target transfers realistic as ceiling of test range", default=50000)
     appArgs.add(flag="--test-iteration-duration-sec", type=int, help="The duration of transfer trx generation for each iteration of the test during the initial search (seconds)", default=30)
-    appArgs.add(flag="--test-iteration-min-step", type=int, help="The step size determining granularity of tps result during initial search", default=200)
+    appArgs.add(flag="--test-iteration-min-step", type=int, help="The step size determining granularity of tps result during initial search", default=500)
     appArgs.add(flag="--final-iterations-duration-sec", type=int, help="The duration of transfer trx generation for each final longer run iteration of the test during the final search (seconds)", default=90)
     appArgs.add(flag="--tps-limit-per-generator", type=int, help="Maximum amount of transactions per second a single generator can have.", default=4000)
     appArgs.add(flag="--genesis", type=str, help="Path to genesis.json", default="tests/performance_tests/genesis.json")
@@ -221,7 +221,7 @@ def main():
         longRunningFloor = binSearchResults.maxTpsAchieved - 3 * testIterationMinStep if binSearchResults.maxTpsAchieved - 3 * testIterationMinStep > 0 else 0
         longRunningCeiling = binSearchResults.maxTpsAchieved + 3 * testIterationMinStep
 
-        longRunningBinSearchResults = performPtbBinarySearch(tpsTestFloor=longRunningFloor, tpsTestCeiling=longRunningCeiling, minStep=(testIterationMinStep // 2), testHelperConfig=testHelperConfig,
+        longRunningBinSearchResults = performPtbBinarySearch(tpsTestFloor=longRunningFloor, tpsTestCeiling=longRunningCeiling, minStep=testIterationMinStep, testHelperConfig=testHelperConfig,
                            testClusterConfig=testClusterConfig, testDurationSec=finalDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
                            numAddlBlocksToPrune=numAddlBlocksToPrune, testLogDir=testTimeStampDirPath, saveJson=saveJsonReport)
 

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 
-from dataclasses import dataclass, asdict, field
 import os
-from platform import release, system
 import sys
 import json
-from datetime import datetime
 import shutil
 
 harnessPath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -14,6 +11,9 @@ sys.path.append(harnessPath)
 from TestHarness import TestHelper, Utils
 from TestHarness.TestHelper import AppArgs
 from performance_test_basic import PerformanceBasicTest
+from platform import release, system
+from dataclasses import dataclass, asdict, field
+from datetime import datetime
 
 @dataclass
 class PerfTestBasicResult:

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -84,12 +84,23 @@ class PerformanceBasicTest():
         self.cluster.killall(allInstances=self.testHelperConfig.killAll)
         self.cluster.cleanup()
 
-    def testDirsCleanup(self):
+    def testDirsCleanup(self, saveJsonReport: bool=False):
         try:
-            print(f"Checking if test artifacts dir exists: {self.testTimeStampDirPath}")
-            if os.path.isdir(f"{self.testTimeStampDirPath}"):
-                print(f"Cleaning up test artifacts dir and all contents of: {self.testTimeStampDirPath}")
-                shutil.rmtree(f"{self.testTimeStampDirPath}")
+            if saveJsonReport:
+                print(f"Checking if test artifacts dir exists: {self.trxGenLogDirPath}")
+                if os.path.isdir(f"{self.trxGenLogDirPath}"):
+                    print(f"Cleaning up test artifacts dir and all contents of: {self.trxGenLogDirPath}")
+                    shutil.rmtree(f"{self.trxGenLogDirPath}")
+
+                print(f"Checking if test artifacts dir exists: {self.blockDataLogDirPath}")
+                if os.path.isdir(f"{self.blockDataLogDirPath}"):
+                    print(f"Cleaning up test artifacts dir and all contents of: {self.blockDataLogDirPath}")
+                    shutil.rmtree(f"{self.blockDataLogDirPath}")
+            else:
+                print(f"Checking if test artifacts dir exists: {self.testTimeStampDirPath}")
+                if os.path.isdir(f"{self.testTimeStampDirPath}"):
+                    print(f"Cleaning up test artifacts dir and all contents of: {self.testTimeStampDirPath}")
+                    shutil.rmtree(f"{self.testTimeStampDirPath}")
         except OSError as error:
             print(error)
 
@@ -276,7 +287,7 @@ class PerformanceBasicTest():
 
             if not self.testHelperConfig.keepLogs:
                 print(f"Cleaning up logs directory: {self.testTimeStampDirPath}")
-                self.testDirsCleanup()
+                self.testDirsCleanup(self.saveJsonReport)
 
             return testSuccessful
 

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -86,50 +86,34 @@ class PerformanceBasicTest():
 
     def testDirsCleanup(self, saveJsonReport: bool=False):
         try:
-            if saveJsonReport:
-                print(f"Checking if test artifacts dir exists: {self.trxGenLogDirPath}")
-                if os.path.isdir(f"{self.trxGenLogDirPath}"):
-                    print(f"Cleaning up test artifacts dir and all contents of: {self.trxGenLogDirPath}")
-                    shutil.rmtree(f"{self.trxGenLogDirPath}")
+            def removeArtifacts(path):
+                print(f"Checking if test artifacts dir exists: {path}")
+                if os.path.isdir(f"{path}"):
+                    print(f"Cleaning up test artifacts dir and all contents of: {path}")
+                    shutil.rmtree(f"{path}")
 
-                print(f"Checking if test artifacts dir exists: {self.blockDataLogDirPath}")
-                if os.path.isdir(f"{self.blockDataLogDirPath}"):
-                    print(f"Cleaning up test artifacts dir and all contents of: {self.blockDataLogDirPath}")
-                    shutil.rmtree(f"{self.blockDataLogDirPath}")
+            if saveJsonReport:
+                removeArtifacts(self.trxGenLogDirPath)
+                removeArtifacts(self.blockDataLogDirPath)
             else:
-                print(f"Checking if test artifacts dir exists: {self.testTimeStampDirPath}")
-                if os.path.isdir(f"{self.testTimeStampDirPath}"):
-                    print(f"Cleaning up test artifacts dir and all contents of: {self.testTimeStampDirPath}")
-                    shutil.rmtree(f"{self.testTimeStampDirPath}")
+                removeArtifacts(self.testTimeStampDirPath)
         except OSError as error:
             print(error)
 
     def testDirsSetup(self):
         try:
-            print(f"Checking if root log dir exists: {self.rootLogDir}")
-            if not os.path.isdir(f"{self.rootLogDir}"):
-                print(f"Creating root log dir: {self.rootLogDir}")
-                os.mkdir(f"{self.rootLogDir}")
+            def createArtifactsDir(path):
+                print(f"Checking if test artifacts dir exists: {path}")
+                if not os.path.isdir(f"{path}"):
+                    print(f"Creating test artifacts dir: {path}")
+                    os.mkdir(f"{path}")
 
-            print(f"Checking if test artifacts dir exists: {self.ptbLogDir}")
-            if not os.path.isdir(f"{self.ptbLogDir}"):
-                print(f"Creating test artifacts dir: {self.ptbLogDir}")
-                os.mkdir(f"{self.ptbLogDir}")
+            createArtifactsDir(self.rootLogDir)
+            createArtifactsDir(self.ptbLogDir)
+            createArtifactsDir(self.testTimeStampDirPath)
+            createArtifactsDir(self.trxGenLogDirPath)
+            createArtifactsDir(self.blockDataLogDirPath)
 
-            print(f"Checking if logs dir exists: {self.testTimeStampDirPath}")
-            if not os.path.isdir(f"{self.testTimeStampDirPath}"):
-                print(f"Creating logs dir: {self.testTimeStampDirPath}")
-                os.mkdir(f"{self.testTimeStampDirPath}")
-
-            print(f"Checking if logs dir exists: {self.trxGenLogDirPath}")
-            if not os.path.isdir(f"{self.trxGenLogDirPath}"):
-                print(f"Creating logs dir: {self.trxGenLogDirPath}")
-                os.mkdir(f"{self.trxGenLogDirPath}")
-
-            print(f"Checking if logs dir exists: {self.blockDataLogDirPath}")
-            if not os.path.isdir(f"{self.blockDataLogDirPath}"):
-                print(f"Creating logs dir: {self.blockDataLogDirPath}")
-                os.mkdir(f"{self.blockDataLogDirPath}")
         except OSError as error:
             print(error)
 

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -6,6 +6,7 @@ import subprocess
 import shutil
 import signal
 import log_reader
+import inspect
 
 harnessPath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(harnessPath)
@@ -201,8 +202,8 @@ class PerformanceBasicTest():
         args = {}
         args.update(asdict(self.testHelperConfig))
         args.update(asdict(self.clusterConfig))
-        args.update({key:val for key, val in self.__class__.__dict__.items() if key in set(['targetTps', 'testTrxGenDurationSec', 'tpsLimitPerGenerator',
-                                                                                            'expectedTransactionsSent', 'saveJsonReport', 'numAddlBlocksToPrune'])})
+        args.update({key:val for key, val in inspect.getmembers(self) if key in set(['targetTps', 'testTrxGenDurationSec', 'tpsLimitPerGenerator',
+                                                                                     'expectedTransactionsSent', 'saveJsonReport', 'numAddlBlocksToPrune'])})
         return args
 
 

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
+from dataclasses import dataclass, asdict
 import os
 import sys
 import subprocess
 import shutil
 import signal
-import time
 from datetime import datetime
 
 harnessPath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -15,218 +15,291 @@ from TestHarness import Cluster, TestHelper, Utils, WalletMgr
 from TestHarness.TestHelper import AppArgs
 import log_reader
 
-Print = Utils.Print
-errorExit = Utils.errorExit
-cmdError = Utils.cmdError
-relaunchTimeout = 30
-emptyBlockGoal = 5
+class PerformanceBasicTest():
+    @dataclass
+    class TestHelperConfig():
+        killAll: bool = True # clean_run
+        dontKill: bool = False # leave_running
+        keepLogs: bool = False
+        dumpErrorDetails: bool = False
+        delay: int = 1
+        nodesFile: str = None
+        verbose: bool = False
+        _killEosInstances: bool = True
+        _killWallet: bool = True
 
-def fileOpenMode(filePath) -> str:
+        def __post_init__(self):
+            self._killEosInstances = not self.dontKill
+            self._killWallet = not self.dontKill
+
+    @dataclass
+    class ClusterConfig():
+        pnodes: int = 1
+        totalNodes: int = 2
+        topo: str = "mesh"
+        extraNodeosArgs: str = ' --http-max-response-time-ms 990000 --disable-subjective-api-billing true '
+        useBiosBootFile: bool = False
+        genesisPath: str = "tests/performance_tests/genesis.json"
+        maximumP2pPerHost: int = 5000
+        maximumClients: int = 0
+        loggingDict = { "bios": "off" }
+        _totalNodes: int = 2
+
+        def __post_init__(self):
+            self._totalNodes = max(2, self.pnodes if self.totalNodes < self.pnodes else self.totalNodes)
+
+    def __init__(self, testHelperConfig: TestHelperConfig=TestHelperConfig(), clusterConfig: ClusterConfig=ClusterConfig(), targetTps: int=8000, testTrxGenDurationSec: int=30, tpsLimitPerGenerator: int=4000, numAddlBlocksToPrune: int=2, rootLogDir: str=os.path.splitext(os.path.basename(__file__))[0], saveJsonReport: bool=False):
+        self.testHelperConfig = testHelperConfig
+        self.clusterConfig = clusterConfig
+        self.targetTps = targetTps
+        self.testTrxGenDurationSec = testTrxGenDurationSec
+        self.tpsLimitPerGenerator = tpsLimitPerGenerator
+        self.expectedTransactionsSent = self.testTrxGenDurationSec * self.targetTps
+        self.saveJsonReport = saveJsonReport
+        self.numAddlBlocksToPrune = numAddlBlocksToPrune
+        self.saveJsonReport = saveJsonReport
+
+        Utils.Debug = self.testHelperConfig.verbose
+        self.errorExit = Utils.errorExit
+        self.emptyBlockGoal = 5
+
+        self.rootLogDir = rootLogDir
+        self.testTimeStampDirPath = f"{self.rootLogDir}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+        self.trxGenLogDirPath = f"{self.testTimeStampDirPath}/trxGenLogs"
+        self.blockDataLogDirPath = f"{self.testTimeStampDirPath}/blockDataLogs"
+        self.blockDataPath = f"{self.blockDataLogDirPath}/blockData.txt"
+        self.blockTrxDataPath = f"{self.blockDataLogDirPath}/blockTrxData.txt"
+        self.reportPath = f"{self.testTimeStampDirPath}/data.json"
+        self.nodeosLogPath = "var/lib/node_01/stderr.txt"
+
+        # Setup cluster and its wallet manager
+        self.walletMgr=WalletMgr(True)
+        self.cluster=Cluster(walletd=True, loggingLevel="info", loggingLevelDict=self.clusterConfig.loggingDict)
+        self.cluster.setWalletMgr(self.walletMgr)
+
+    def cleanupOldClusters(self):
+        self.cluster.killall(allInstances=self.testHelperConfig.killAll)
+        self.cluster.cleanup()
+
+    def testDirsCleanup(self):
+        try:
+            print(f"Checking if test artifacts dir exists: {self.testTimeStampDirPath}")
+            if os.path.isdir(f"{self.testTimeStampDirPath}"):
+                print(f"Cleaning up test artifacts dir and all contents of: {self.testTimeStampDirPath}")
+                shutil.rmtree(f"{self.testTimeStampDirPath}")
+        except OSError as error:
+            print(error)
+
+    def testDirsSetup(self):
+        try:
+            print(f"Checking if test artifacts dir exists: {self.rootLogDir}")
+            if not os.path.isdir(f"{self.rootLogDir}"):
+                print(f"Creating test artifacts dir: {self.rootLogDir}")
+                os.mkdir(f"{self.rootLogDir}")
+
+            print(f"Checking if logs dir exists: {self.testTimeStampDirPath}")
+            if not os.path.isdir(f"{self.testTimeStampDirPath}"):
+                print(f"Creating logs dir: {self.testTimeStampDirPath}")
+                os.mkdir(f"{self.testTimeStampDirPath}")
+
+            print(f"Checking if logs dir exists: {self.trxGenLogDirPath}")
+            if not os.path.isdir(f"{self.trxGenLogDirPath}"):
+                print(f"Creating logs dir: {self.trxGenLogDirPath}")
+                os.mkdir(f"{self.trxGenLogDirPath}")
+
+            print(f"Checking if logs dir exists: {self.blockDataLogDirPath}")
+            if not os.path.isdir(f"{self.blockDataLogDirPath}"):
+                print(f"Creating logs dir: {self.blockDataLogDirPath}")
+                os.mkdir(f"{self.blockDataLogDirPath}")
+        except OSError as error:
+            print(error)
+
+    def fileOpenMode(self, filePath) -> str:
         if os.path.exists(filePath):
             append_write = 'a'
         else:
             append_write = 'w'
         return append_write
 
-def queryBlockTrxData(node, blockDataPath, blockTrxDataPath, startBlockNum, endBlockNum):
-    for blockNum in range(startBlockNum, endBlockNum):
-        block = node.processCurlCmd("trace_api", "get_block", f'{{"block_num":{blockNum}}}', silentErrors=False, exitOnError=True)
+    def queryBlockTrxData(self, node, blockDataPath, blockTrxDataPath, startBlockNum, endBlockNum):
+        for blockNum in range(startBlockNum, endBlockNum):
+            block = node.processCurlCmd("trace_api", "get_block", f'{{"block_num":{blockNum}}}', silentErrors=False, exitOnError=True)
 
-        btdf_append_write = fileOpenMode(blockTrxDataPath)
-        with open(blockTrxDataPath, btdf_append_write) as trxDataFile:
-            [trxDataFile.write(f"{trx['id']},{trx['block_num']},{trx['cpu_usage_us']},{trx['net_usage_words']}\n") for trx in block['transactions'] if block['transactions']]
-        trxDataFile.close()
+            btdf_append_write = self.fileOpenMode(blockTrxDataPath)
+            with open(blockTrxDataPath, btdf_append_write) as trxDataFile:
+                [trxDataFile.write(f"{trx['id']},{trx['block_num']},{trx['cpu_usage_us']},{trx['net_usage_words']}\n") for trx in block['transactions'] if block['transactions']]
+            trxDataFile.close()
 
-        bdf_append_write = fileOpenMode(blockDataPath)
-        with open(blockDataPath, bdf_append_write) as blockDataFile:
-            blockDataFile.write(f"{block['number']},{block['id']},{block['producer']},{block['status']},{block['timestamp']}\n")
-        blockDataFile.close()
+            bdf_append_write = self.fileOpenMode(blockDataPath)
+            with open(blockDataPath, bdf_append_write) as blockDataFile:
+                blockDataFile.write(f"{block['number']},{block['id']},{block['producer']},{block['status']},{block['timestamp']}\n")
+            blockDataFile.close()
 
-def waitForEmptyBlocks(node):
-    emptyBlocks = 0
-    while emptyBlocks < emptyBlockGoal:
-        headBlock = node.getHeadBlockNum()
-        block = node.processCurlCmd("chain", "get_block_info", f'{{"block_num":{headBlock}}}', silentErrors=False, exitOnError=True)
-        node.waitForHeadToAdvance()
-        if block['transaction_mroot'] == "0000000000000000000000000000000000000000000000000000000000000000":
-            emptyBlocks += 1
-        else:
-            emptyBlocks = 0
-    return node.getHeadBlockNum()
+    def waitForEmptyBlocks(self, node, numEmptyToWaitOn):
+        emptyBlocks = 0
+        while emptyBlocks < numEmptyToWaitOn:
+            headBlock = node.getHeadBlockNum()
+            block = node.processCurlCmd("chain", "get_block_info", f'{{"block_num":{headBlock}}}', silentErrors=False, exitOnError=True)
+            node.waitForHeadToAdvance()
+            if block['transaction_mroot'] == "0000000000000000000000000000000000000000000000000000000000000000":
+                emptyBlocks += 1
+            else:
+                emptyBlocks = 0
+        return node.getHeadBlockNum()
 
-def testDirsCleanup(rootDir):
-    try:
-        print(f"Checking if test artifacts dir exists: {rootDir}")
-        if os.path.isdir(f"{rootDir}"):
-            print(f"Cleaning up test artifacts dir and all contents of: {rootDir}")
-            shutil.rmtree(f"{rootDir}")
-    except OSError as error:
-        print(error)
+    def launchCluster(self):
+        return self.cluster.launch(
+            pnodes=self.clusterConfig.pnodes,
+            totalNodes=self.clusterConfig._totalNodes,
+            useBiosBootFile=self.clusterConfig.useBiosBootFile,
+            topo=self.clusterConfig.topo,
+            genesisPath=self.clusterConfig.genesisPath,
+            maximumP2pPerHost=self.clusterConfig.maximumP2pPerHost,
+            maximumClients=self.clusterConfig.maximumClients,
+            extraNodeosArgs=self.clusterConfig.extraNodeosArgs
+            )
 
-def testDirsSetup(scriptName, testRunTimestamp, trxGenLogDir, blockDataLogDir):
-    try:
-        print(f"Checking if test artifacts dir exists: {scriptName}")
-        if not os.path.isdir(f"{scriptName}"):
-            print(f"Creating test artifacts dir: {scriptName}")
-            os.mkdir(f"{scriptName}")
+    def setupWalletAndAccounts(self):
+        self.wallet = self.walletMgr.create('default')
+        self.cluster.populateWallet(2, self.wallet)
+        self.cluster.createAccounts(self.cluster.eosioAccount, stakedDeposit=0)
 
-        print(f"Checking if logs dir exists: {testRunTimestamp}")
-        if not os.path.isdir(f"{testRunTimestamp}"):
-            print(f"Creating logs dir: {testRunTimestamp}")
-            os.mkdir(f"{testRunTimestamp}")
+        self.account1Name = self.cluster.accounts[0].name
+        self.account2Name = self.cluster.accounts[1].name
 
-        print(f"Checking if logs dir exists: {trxGenLogDir}")
-        if not os.path.isdir(f"{trxGenLogDir}"):
-            print(f"Creating logs dir: {trxGenLogDir}")
-            os.mkdir(f"{trxGenLogDir}")
+        self.account1PrivKey = self.cluster.accounts[0].activePrivateKey
+        self.account2PrivKey = self.cluster.accounts[1].activePrivateKey
 
-        print(f"Checking if logs dir exists: {blockDataLogDir}")
-        if not os.path.isdir(f"{blockDataLogDir}"):
-            print(f"Creating logs dir: {blockDataLogDir}")
-            os.mkdir(f"{blockDataLogDir}")
-    except OSError as error:
-        print(error)
+    def runTpsTest(self) -> bool:
+        self.producerNode = self.cluster.getNode(0)
+        self.validationNode = self.cluster.getNode(1)
+        info = self.producerNode.getInfo()
+        chainId = info['chain_id']
+        lib_id = info['last_irreversible_block_id']
+        self.data = log_reader.chainData()
 
-appArgs=AppArgs()
-appArgs.add(flag="--target-tps", type=int, help="The target transfers per second to send during test", default=8000)
-appArgs.add(flag="--tps-limit-per-generator", type=int, help="Maximum amount of transactions per second a single generator can have.", default=4000)
-appArgs.add(flag="--test-duration-sec", type=int, help="The duration of transfer trx generation for the test in seconds", default=30)
-appArgs.add(flag="--genesis", type=str, help="Path to genesis.json", default="tests/performance_tests/genesis.json")
-appArgs.add(flag="--num-blocks-to-prune", type=int, help="The number of potentially non-empty blocks, in addition to leading and trailing size 0 blocks, to prune from the beginning and end of the range of blocks of interest for evaluation.", default=2)
-appArgs.add(flag="--save-json", type=bool, help="Whether to save json output of stats", default=False)
-appArgs.add(flag="--json-path", type=str, help="Path to save json output", default="data.json")
-args=TestHelper.parse_args({"-p","-n","-d","-s","--nodes-file"
-                            ,"--dump-error-details","-v","--leave-running"
-                            ,"--clean-run","--keep-logs"}, applicationSpecificArgs=appArgs)
+        self.cluster.biosNode.kill(signal.SIGTERM)
 
-pnodes=args.p
-topo=args.s
-delay=args.d
-total_nodes = max(2, pnodes if args.n < pnodes else args.n)
-Utils.Debug = args.v
-killAll=args.clean_run
-dumpErrorDetails=args.dump_error_details
-dontKill=args.leave_running
-killEosInstances = not dontKill
-killWallet=not dontKill
-keepLogs=args.keep_logs
-testGenerationDurationSec = args.test_duration_sec
-targetTps = args.target_tps
-genesisJsonFile = args.genesis
-tpsLimitPerGenerator = args.tps_limit_per_generator
-numAddlBlocksToPrune = args.num_blocks_to_prune
-logging_dict = {
-    "bios": "off"
-}
+        self.data.startBlock = self.waitForEmptyBlocks(self.validationNode, self.emptyBlockGoal)
 
-# Setup cluster and its wallet manager
-walletMgr=WalletMgr(True)
-cluster=Cluster(walletd=True, loggingLevel="info", loggingLevelDict=logging_dict)
-cluster.setWalletMgr(walletMgr)
+        subprocess.run([
+            f"./tests/performance_tests/launch_transaction_generators.py",
+            f"{chainId}", f"{lib_id}", f"{self.cluster.eosioAccount.name}",
+            f"{self.account1Name}", f"{self.account2Name}", f"{self.account1PrivKey}", f"{self.account2PrivKey}",
+            f"{self.testTrxGenDurationSec}", f"{self.targetTps}", f"{self.tpsLimitPerGenerator}", f"{self.trxGenLogDirPath}"
+            ])
 
-testSuccessful = False
-completedRun = False
+        # Get stats after transaction generation stops
+        self.data.ceaseBlock = self.waitForEmptyBlocks(self.validationNode, self.emptyBlockGoal) - self.emptyBlockGoal + 1
 
-try:
-    # Kill any existing instances and launch cluster
-    TestHelper.printSystemInfo("BEGIN")
-    cluster.killall(allInstances=killAll)
-    cluster.cleanup()
+        return True
 
-    scriptName  = os.path.splitext(os.path.basename(__file__))[0]
-    testTimeStampDirPath = f"{scriptName}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
-    trxGenLogDirPath = f"{testTimeStampDirPath}/trxGenLogs"
-    blockDataLogDirPath = f"{testTimeStampDirPath}/blockDataLogs"
+    def prepArgs(self) -> dict:
+        args = {}
+        args.update(asdict(self.testHelperConfig))
+        args.update(asdict(self.clusterConfig))
+        args["targetTps"] = self.targetTps
+        args["testTrxGenDurationSec"] = self.testTrxGenDurationSec
+        args["tpsLimitPerGenerator"] = self.tpsLimitPerGenerator
+        args["expectedTransactionsSent"] = self.expectedTransactionsSent
+        args["saveJsonReport"] = self.saveJsonReport
+        args["numAddlBlocksToPrune"] = self.numAddlBlocksToPrune
+        args["saveJsonReport"] = self.saveJsonReport
+        return args
 
-    testDirsCleanup(testTimeStampDirPath)
+    def analyzeResultsAndReport(self, completedRun):
+        args = self.prepArgs()
+        self.report = log_reader.calcAndReport(self.data, self.targetTps, self.testTrxGenDurationSec, self.nodeosLogPath, self.trxGenLogDirPath, self.blockTrxDataPath, self.blockDataPath, self.numAddlBlocksToPrune, args, completedRun)
 
-    testDirsSetup(scriptName, testTimeStampDirPath, trxGenLogDirPath, blockDataLogDirPath)
+        print(self.data)
 
-    extraNodeosArgs=' --http-max-response-time-ms 990000 --disable-subjective-api-billing true '
-    if cluster.launch(
-       pnodes=pnodes,
-       totalNodes=total_nodes,
-       useBiosBootFile=False,
-       topo=topo,
-       genesisPath=genesisJsonFile,
-       maximumP2pPerHost=5000,
-       maximumClients=0,
-       extraNodeosArgs=extraNodeosArgs
-    ) == False:
-        errorExit('Failed to stand up cluster.')
+        print("Report:")
+        print(self.report)
 
-    wallet = walletMgr.create('default')
-    cluster.populateWallet(2, wallet)
-    cluster.createAccounts(cluster.eosioAccount, stakedDeposit=0)
+        if self.saveJsonReport:
+            log_reader.exportReportAsJSON(self.report, self.reportPath)
 
-    account1Name = cluster.accounts[0].name
-    account2Name = cluster.accounts[1].name
+    def preTestSpinup(self):
+        self.cleanupOldClusters()
+        self.testDirsCleanup()
+        self.testDirsSetup()
 
-    account1PrivKey = cluster.accounts[0].activePrivateKey
-    account2PrivKey = cluster.accounts[1].activePrivateKey
+        if self.launchCluster() == False:
+            self.errorExit('Failed to stand up cluster.')
 
-    producerNode = cluster.getNode(0)
-    validationNode = cluster.getNode(1)
-    info = producerNode.getInfo()
-    chainId = info['chain_id']
-    lib_id = info['last_irreversible_block_id']
-    cluster.biosNode.kill(signal.SIGTERM)
+        self.setupWalletAndAccounts()
 
-    transactionsSent = testGenerationDurationSec * targetTps
-    data = log_reader.chainData()
+    def postTpsTestSteps(self):
+        self.queryBlockTrxData(self.validationNode, self.blockDataPath, self.blockTrxDataPath, self.data.startBlock, self.data.ceaseBlock)
 
-    data.startBlock = waitForEmptyBlocks(validationNode)
+    def runTest(self) -> bool:
+        testSuccessful = False
+        completedRun = False
 
-    subprocess.run([
-       f"./tests/performance_tests/launch_transaction_generators.py",
-       f"{chainId}", f"{lib_id}", f"{cluster.eosioAccount.name}",
-       f"{account1Name}", f"{account2Name}", f"{account1PrivKey}", f"{account2PrivKey}",
-       f"{testGenerationDurationSec}", f"{targetTps}", f"{tpsLimitPerGenerator}", f"{trxGenLogDirPath}"
-    ])
-    # Get stats after transaction generation stops
-    data.ceaseBlock = waitForEmptyBlocks(validationNode) - emptyBlockGoal + 1
-    completedRun = True
+        try:
+            # Kill any existing instances and launch cluster
+            TestHelper.printSystemInfo("BEGIN")
+            self.preTestSpinup()
 
-    blockDataPath = f"{blockDataLogDirPath}/blockData.txt"
-    blockTrxDataPath = f"{blockDataLogDirPath}/blockTrxData.txt"
+            completedRun = self.runTpsTest()
+            self.postTpsTestSteps()
 
-    queryBlockTrxData(validationNode, blockDataPath, blockTrxDataPath, data.startBlock, data.ceaseBlock)
+            testSuccessful = True
 
-except subprocess.CalledProcessError as err:
-    print(f"trx_generator return error code: {err.returncode}.  Test aborted.")
-finally:
-    TestHelper.shutdown(
-       cluster,
-       walletMgr,
-       testSuccessful,
-       killEosInstances,
-       killWallet,
-       keepLogs,
-       killAll,
-       dumpErrorDetails
-    )
+        except subprocess.CalledProcessError as err:
+            print(f"trx_generator return error code: {err.returncode}.  Test aborted.")
+        finally:
+            TestHelper.shutdown(
+                self.cluster,
+                self.walletMgr,
+                testSuccessful,
+                self.testHelperConfig._killEosInstances,
+                self.testHelperConfig._killWallet,
+                self.testHelperConfig.keepLogs,
+                self.testHelperConfig.killAll,
+                self.testHelperConfig.dumpErrorDetails
+                )
 
-    report = log_reader.calcAndReport(data, "var/lib/node_01/stderr.txt", trxGenLogDirPath, blockTrxDataPath, blockDataPath, args, completedRun)
+            self.analyzeResultsAndReport(completedRun)
 
-    print(data)
+            if completedRun:
+                assert self.expectedTransactionsSent == self.data.totalTransactions , f"Error: Transactions received: {self.data.totalTransactions} did not match expected total: {self.expectedTransactionsSent}"
+            else:
+                os.system("pkill trx_generator")
+                print("Test run cancelled early via SIGINT")
 
-    print("Report:")
-    print(report)
+            if not self.testHelperConfig.keepLogs:
+                print(f"Cleaning up logs directory: {self.testTimeStampDirPath}")
+                self.testDirsCleanup(self.testTimeStampDirPath)
 
-    if args.save_json:
-        log_reader.exportAsJSON(report, args)
+            return testSuccessful
 
-    if completedRun:
-        assert transactionsSent == data.totalTransactions , f"Error: Transactions received: {data.totalTransactions} did not match expected total: {transactionsSent}"
-    else:
-        os.system("pkill trx_generator")
-        print("Test run cancelled early via SIGINT")
+def parseArgs():
+    appArgs=AppArgs()
+    appArgs.add(flag="--target-tps", type=int, help="The target transfers per second to send during test", default=8000)
+    appArgs.add(flag="--tps-limit-per-generator", type=int, help="Maximum amount of transactions per second a single generator can have.", default=4000)
+    appArgs.add(flag="--test-duration-sec", type=int, help="The duration of transfer trx generation for the test in seconds", default=30)
+    appArgs.add(flag="--genesis", type=str, help="Path to genesis.json", default="tests/performance_tests/genesis.json")
+    appArgs.add(flag="--num-blocks-to-prune", type=int, help="The number of potentially non-empty blocks, in addition to leading and trailing size 0 blocks, to prune from the beginning and end of the range of blocks of interest for evaluation.", default=2)
+    appArgs.add(flag="--save-json", type=bool, help="Whether to save json output of stats", default=False)
+    args=TestHelper.parse_args({"-p","-n","-d","-s","--nodes-file"
+                                ,"--dump-error-details","-v","--leave-running"
+                                ,"--clean-run","--keep-logs"}, applicationSpecificArgs=appArgs)
+    return args
 
-    if not keepLogs:
-        print(f"Cleaning up logs directory: {testTimeStampDirPath}")
-        testDirsCleanup(testTimeStampDirPath)
+def main():
 
-    testSuccessful = True
+    args = parseArgs()
+    Utils.Debug = args.v
 
-exitCode = 0 if testSuccessful else 1
-exit(exitCode)
+    testHelperConfig = PerformanceBasicTest.TestHelperConfig(killAll=args.clean_run, dontKill=args.leave_running, keepLogs=args.keep_logs, dumpErrorDetails=args.dump_error_details, delay=args.d, nodesFile=args.nodes_file, verbose=args.v)
+    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis)
+
+    myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=args.target_tps, testTrxGenDurationSec=args.test_duration_sec , tpsLimitPerGenerator=args.tps_limit_per_generator, numAddlBlocksToPrune=args.num_blocks_to_prune, saveJsonReport=args.save_json)
+    testSuccessful = myTest.runTest()
+
+    exitCode = 0 if testSuccessful else 1
+    exit(exitCode)
+
+if __name__ == '__main__':
+    main()

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -48,7 +48,9 @@ class PerformanceBasicTest():
         def __post_init__(self):
             self._totalNodes = max(2, self.pnodes if self.totalNodes < self.pnodes else self.totalNodes)
 
-    def __init__(self, testHelperConfig: TestHelperConfig=TestHelperConfig(), clusterConfig: ClusterConfig=ClusterConfig(), targetTps: int=8000, testTrxGenDurationSec: int=30, tpsLimitPerGenerator: int=4000, numAddlBlocksToPrune: int=2, rootLogDir: str=os.path.splitext(os.path.basename(__file__))[0], saveJsonReport: bool=False):
+    def __init__(self, testHelperConfig: TestHelperConfig=TestHelperConfig(), clusterConfig: ClusterConfig=ClusterConfig(), targetTps: int=8000,
+                 testTrxGenDurationSec: int=30, tpsLimitPerGenerator: int=4000, numAddlBlocksToPrune: int=2,
+                 rootLogDir: str=os.path.splitext(os.path.basename(__file__))[0], saveJsonReport: bool=False):
         self.testHelperConfig = testHelperConfig
         self.clusterConfig = clusterConfig
         self.targetTps = targetTps
@@ -209,7 +211,8 @@ class PerformanceBasicTest():
 
     def analyzeResultsAndReport(self, completedRun):
         args = self.prepArgs()
-        self.report = log_reader.calcAndReport(self.data, self.targetTps, self.testTrxGenDurationSec, self.nodeosLogPath, self.trxGenLogDirPath, self.blockTrxDataPath, self.blockDataPath, self.numAddlBlocksToPrune, args, completedRun)
+        self.report = log_reader.calcAndReport(self.data, self.targetTps, self.testTrxGenDurationSec, self.nodeosLogPath, self.trxGenLogDirPath,
+                                               self.blockTrxDataPath, self.blockDataPath, self.numAddlBlocksToPrune, args, completedRun)
 
         print(self.data)
 
@@ -263,7 +266,8 @@ class PerformanceBasicTest():
             self.analyzeResultsAndReport(completedRun)
 
             if completedRun:
-                assert self.expectedTransactionsSent == self.data.totalTransactions , f"Error: Transactions received: {self.data.totalTransactions} did not match expected total: {self.expectedTransactionsSent}"
+                assert self.expectedTransactionsSent == self.data.totalTransactions , \
+                    f"Error: Transactions received: {self.data.totalTransactions} did not match expected total: {self.expectedTransactionsSent}"
             else:
                 os.system("pkill trx_generator")
                 print("Test run cancelled early via SIGINT")
@@ -280,7 +284,8 @@ def parseArgs():
     appArgs.add(flag="--tps-limit-per-generator", type=int, help="Maximum amount of transactions per second a single generator can have.", default=4000)
     appArgs.add(flag="--test-duration-sec", type=int, help="The duration of transfer trx generation for the test in seconds", default=30)
     appArgs.add(flag="--genesis", type=str, help="Path to genesis.json", default="tests/performance_tests/genesis.json")
-    appArgs.add(flag="--num-blocks-to-prune", type=int, help="The number of potentially non-empty blocks, in addition to leading and trailing size 0 blocks, to prune from the beginning and end of the range of blocks of interest for evaluation.", default=2)
+    appArgs.add(flag="--num-blocks-to-prune", type=int, help=("The number of potentially non-empty blocks, in addition to leading and trailing size 0 blocks, "
+                "to prune from the beginning and end of the range of blocks of interest for evaluation."), default=2)
     appArgs.add(flag="--save-json", type=bool, help="Whether to save json output of stats", default=False)
     args=TestHelper.parse_args({"-p","-n","-d","-s","--nodes-file"
                                 ,"--dump-error-details","-v","--leave-running"
@@ -292,10 +297,13 @@ def main():
     args = parseArgs()
     Utils.Debug = args.v
 
-    testHelperConfig = PerformanceBasicTest.TestHelperConfig(killAll=args.clean_run, dontKill=args.leave_running, keepLogs=args.keep_logs, dumpErrorDetails=args.dump_error_details, delay=args.d, nodesFile=args.nodes_file, verbose=args.v)
+    testHelperConfig = PerformanceBasicTest.TestHelperConfig(killAll=args.clean_run, dontKill=args.leave_running, keepLogs=args.keep_logs,
+                                                             dumpErrorDetails=args.dump_error_details, delay=args.d, nodesFile=args.nodes_file, verbose=args.v)
     testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis)
 
-    myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=args.target_tps, testTrxGenDurationSec=args.test_duration_sec , tpsLimitPerGenerator=args.tps_limit_per_generator, numAddlBlocksToPrune=args.num_blocks_to_prune, saveJsonReport=args.save_json)
+    myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=args.target_tps,
+                                  testTrxGenDurationSec=args.test_duration_sec , tpsLimitPerGenerator=args.tps_limit_per_generator,
+                                  numAddlBlocksToPrune=args.num_blocks_to_prune, saveJsonReport=args.save_json)
     testSuccessful = myTest.runTest()
 
     exitCode = 0 if testSuccessful else 1

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -201,13 +201,10 @@ class PerformanceBasicTest():
         args = {}
         args.update(asdict(self.testHelperConfig))
         args.update(asdict(self.clusterConfig))
-        args["targetTps"] = self.targetTps
-        args["testTrxGenDurationSec"] = self.testTrxGenDurationSec
-        args["tpsLimitPerGenerator"] = self.tpsLimitPerGenerator
-        args["expectedTransactionsSent"] = self.expectedTransactionsSent
-        args["saveJsonReport"] = self.saveJsonReport
-        args["numAddlBlocksToPrune"] = self.numAddlBlocksToPrune
+        args.update({key:val for key, val in self.__class__.__dict__.items() if key in set(['targetTps', 'testTrxGenDurationSec', 'tpsLimitPerGenerator',
+                                                                                            'expectedTransactionsSent', 'saveJsonReport', 'numAddlBlocksToPrune'])})
         return args
+
 
     def analyzeResultsAndReport(self, completedRun):
         args = self.prepArgs()

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 
-from dataclasses import dataclass, asdict
 import os
 import sys
 import subprocess
 import shutil
 import signal
-from datetime import datetime
+import log_reader
 
 harnessPath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(harnessPath)
 
 from TestHarness import Cluster, TestHelper, Utils, WalletMgr
 from TestHarness.TestHelper import AppArgs
-import log_reader
+from dataclasses import dataclass, asdict
+from datetime import datetime
 
 class PerformanceBasicTest():
     @dataclass

--- a/tests/performance_tests/read_log_data.py
+++ b/tests/performance_tests/read_log_data.py
@@ -2,7 +2,6 @@
  
 import argparse
 import log_reader
-import glob
 
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument("--target-tps", type=int, help="The target transfers per second to send during test", default=8000)

--- a/tests/performance_tests/read_log_data.py
+++ b/tests/performance_tests/read_log_data.py
@@ -25,7 +25,7 @@ data.ceaseBlock = args.cease_block
 blockDataPath = f"{blockDataLogDirPath}/blockData.txt"
 blockTrxDataPath = f"{blockDataLogDirPath}/blockTrxData.txt"
 
-report = log_reader.calcAndReport(data, nodeosLogPath, trxGenLogDirPath, blockTrxDataPath, blockDataPath, args, True)
+report = log_reader.calcAndReport(data, args.target_tps, args.test_duration_sec, nodeosLogPath, trxGenLogDirPath, blockTrxDataPath, blockDataPath, args.num_blocks_to_prune, dict(item.split("=") for item in f"{args}"[10:-1].split(", ")), True)
 
 print(data)
 data.printBlockData()
@@ -34,4 +34,4 @@ print("Report:")
 print(report)
 
 if args.save_json:
-    log_reader.exportAsJSON(report, args)
+    log_reader.exportReportAsJSON(report, args.json_path)


### PR DESCRIPTION
### TPS Scenario Runner
Create script and adapt existing scripts to do a binary search of tps range at low test duration with primitive scoring algorithm to find where Transfer Transactions Per Second (TPS) seems to be topping out.  Then do a longer duration run at the discovered TPS.

Performance Test Results Report reports the results of the initial short duration test binary search to zero in on max TPS as well as the follow-on longer running tests to determine if the max TPS was sustainable and zero in on the true max.

### Arguments
**New** Arguments for control of `performance_test`:

- `--max-tps-to-test` - The max target transfers realistic as ceiling of test range, default=50000
- `--test-iteration-duration-sec` - The duration of transfer trx generation for each iteration of the test during the initial search (seconds), default=30
- `--test-iteration-min-step` - The step size determining granularity of tps result during initial search, default=500
- `--final-iterations-duration-sec` - The duration of transfer trx generation for each final longer run iteration of the test during the final search (seconds), default=90
- `--save-json` - Whether to save overarching performance run report, default=False
- `--save-test-json` - Whether to save json reports from each test scenario, default=False

_Existing_ Arguments to configure pass-through to `performance_test_basic` test scenarios:
- `--tps-limit-per-generator` - Maximum amount of transactions per second a single generator can have., default=4000
- `--genesis` - Path to genesis.json, default="tests/performance_tests/genesis.json"
- `--num-blocks-to-prune` - The number of potentially non-empty blocks, in addition to leading and trailing size 0 blocks, to prune from the beginning and end of the range of blocks of interest for evaluation., default=2
- `-p` - producing nodes count
- `-n` - total nodes
- `-d` - delay between nodes startup
- `-s` - topology
- `--nodes-file` - File containing nodes info in JSON format.
- `--dump-error-details` - Upon error print etc/eosio/node_*/config.ini and var/lib/node_*/stderr.log to stdout
- `-v` - verbose logging
- `--leave-running` - Leave cluster running after test finishes
- `--clean-run` - Kill all nodeos and kleos instances
- `--keep-logs` - Don't delete var/lib/node_* folders, or other test specific log directories, upon test completion

### Report: Performance Test

Command used to run test and generate report:
```
./tests/performance_tests/performance_test.py --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --save-json True
```

**Note**: Truncated some search result scenarios as well as the bulk of the `MaxTpsReport` and `LongRunningMaxTpsReport` as they are single performance test basic run reports as detailed at the end of this PR.

`InitialMaxTpsAchieved` - the max TPS throughput achieved during initial, short duration test scenarios to narrow search window
`LongRunningMaxTpsAchieved` - the max TPS throughput achieved during final, longer duration test scenarios to zero in on sustainable max TPS

```
{
  "InitialMaxTpsAchieved": 16200,
  "LongRunningMaxTpsAchieved": 15400,
  "InitialSearchResults": {
    "0": {
      "success": false,
      "searchTarget": 25000,
      "searchFloor": 0,
      "searchCeiling": 50000,
      "basicTestResult": {
        "targetTPS": 25000,
        "resultAvgTps": 15382.714285714286,
        "expectedTxns": 250000,
        "resultTxns": 250000,
        "tpsExpectMet": false,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_16-55-27"
      }
    },
    "1": {
      "success": true,
      "searchTarget": 12500,
      "searchFloor": 0,
      "searchCeiling": 25000,
      "basicTestResult": {
        "targetTPS": 12500,
        "resultAvgTps": 12499.375,
        "expectedTxns": 125000,
        "resultTxns": 125000,
        "tpsExpectMet": true,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_16-57-15"
      }
    },
    "2": {
      "success": false,
      "searchTarget": 18800,
      "searchFloor": 12500,
      "searchCeiling": 25000,
      "basicTestResult": {
        "targetTPS": 18800,
        "resultAvgTps": 16209.105263157895,
        "expectedTxns": 188000,
        "resultTxns": 188000,
        "tpsExpectMet": false,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_16-58-53"
      }
    },
    "3": {
      "success": true,
      "searchTarget": 15600,
      "searchFloor": 12500,
      "searchCeiling": 18800,
      "basicTestResult": {
        "targetTPS": 15600,
        "resultAvgTps": 15623.1875,
        "expectedTxns": 156000,
        "resultTxns": 156000,
        "tpsExpectMet": true,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_17-00-35"
      }
    },
    "4": {
      "success": false,
      "searchTarget": 17200,
      "searchFloor": 15600,
      "searchCeiling": 18800,
      "basicTestResult": {
        "targetTPS": 17200,
        "resultAvgTps": 16264.64705882353,
        "expectedTxns": 172000,
        "resultTxns": 172000,
        "tpsExpectMet": false,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_17-02-15"
      }
    },
    "5": {
      "success": false,
      "searchTarget": 16400,
      "searchFloor": 15600,
      "searchCeiling": 17200,
      "basicTestResult": {
        "targetTPS": 16400,
        "resultAvgTps": 16263.235294117647,
        "expectedTxns": 164000,
        "resultTxns": 164000,
        "tpsExpectMet": false,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_17-03-55"
      }
    },
    "6": {
      "success": true,
      "searchTarget": 16000,
      "searchFloor": 15600,
      "searchCeiling": 16400,
      "basicTestResult": {
        "targetTPS": 16000,
        "resultAvgTps": 16098.9375,
        "expectedTxns": 160000,
        "resultTxns": 160000,
        "tpsExpectMet": true,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_17-05-36"
      }
    },
    "7": {
      "success": true,
      "searchTarget": 16200,
      "searchFloor": 16000,
      "searchCeiling": 16400,
      "basicTestResult": {
        "targetTPS": 16200,
        "resultAvgTps": 16135.5625,
        "expectedTxns": 162000,
        "resultTxns": 162000,
        "tpsExpectMet": true,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_17-07-16"
      }
    }
  },
  "InitialMaxTpsReport": {
    "Analysis": {
<truncated>
    },
    "args": {
<truncated>
    },
<truncated>
  },
  "LongRunningSearchResults": {
    "0": {
      "success": false,
      "searchTarget": 16200,
      "searchFloor": 14700,
      "searchCeiling": 17700,
      "basicTestResult": {
        "targetTPS": 16200,
        "resultAvgTps": 15782.413793103447,
        "expectedTxns": 486000,
        "resultTxns": 486000,
        "tpsExpectMet": false,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_17-08-56"
      }
    },
    "1": {
      "success": true,
      "searchTarget": 15400,
      "searchFloor": 14700,
      "searchCeiling": 16200,
      "basicTestResult": {
        "targetTPS": 15400,
        "resultAvgTps": 15343.875,
        "expectedTxns": 462000,
        "resultTxns": 462000,
        "tpsExpectMet": true,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_17-11-11"
      }
    },
    "2": {
      "success": false,
      "searchTarget": 15800,
      "searchFloor": 15400,
      "searchCeiling": 16200,
      "basicTestResult": {
        "targetTPS": 15800,
        "resultAvgTps": 15523.30357142857,
        "expectedTxns": 474000,
        "resultTxns": 474000,
        "tpsExpectMet": false,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_17-13-24"
      }
    },
    "3": {
      "success": false,
      "searchTarget": 15600,
      "searchFloor": 15400,
      "searchCeiling": 15800,
      "basicTestResult": {
        "targetTPS": 15600,
        "resultAvgTps": 15464.589285714286,
        "expectedTxns": 468000,
        "resultTxns": 468000,
        "tpsExpectMet": false,
        "trxExpectMet": true,
        "basicTestSuccess": true,
        "logsDir": "performance_test/2022-10-12_16-55-27/testRunLogs/performance_test_basic/2022-10-12_17-15-38"
      }
    }
  },
  "LongRunningMaxTpsReport": {
    "Analysis": {
<truncated>
    },
    "args": {
<truncated>
    },
<truncated>
  },
  "args": {
    "killAll": false,
    "dontKill": false,
    "keepLogs": false,
    "dumpErrorDetails": false,
    "delay": 1,
    "nodesFile": null,
    "verbose": false,
    "_killEosInstances": true,
    "_killWallet": true,
    "pnodes": 1,
    "totalNodes": 0,
    "topo": "mesh",
    "extraNodeosArgs": " --http-max-response-time-ms 990000 --disable-subjective-api-billing true ",
    "useBiosBootFile": false,
    "genesisPath": "tests/performance_tests/genesis.json",
    "maximumP2pPerHost": 5000,
    "maximumClients": 0,
    "_totalNodes": 2,
    "testDurationSec": 10,
    "finalDurationSec": 30,
    "maxTpsToTest": 50000,
    "testIterationMinStep": 500,
    "tpsLimitPerGenerator": 4000,
    "saveJsonReport": true,
    "saveTestJsonReports": false,
    "numAddlBlocksToPrune": 2,
    "logsDir": "performance_test/2022-10-12_16-55-27"
  },
  "env": {
    "system": "Linux",
    "os": "posix",
    "release": "5.10.102.1-microsoft-standard-WSL2"
  },
  "nodeosVersion": "v3.2.0-dev"
}
```

### Updates to existing in support of new functionality:
Rework `performance_test_basic.py` to work as an import module and as a script.

This was necessary as a first step to being able to use this functionality as an import module for an orchestrator to run multiple instances of `PerformanceBasicTest` with different tps configurations.

Some rework to how args are handled in the report.  When run as an import module, command line args won't be the same or available.  Get args/config info from how the `PerformanceBasicTest` was configured instead.

Created `TestHelperConfig` and `ClusterConfig` classes to help simplify and separate concerns for all the parameters to the test.

### Report: Performance Test Basic
Output report for individual test run now looks like:
```
{
    "Analysis": {
      "BlockSize": {
        "avg": 1507950.0350877193,
        "emptyBlocks": 0,
        "max": 1897400,
        "min": 1184064,
        "numBlocks": 57,
        "sigma": 140462.7045683851
      },
      "BlocksGuide": {
        "configAddlDropCnt": 2,
        "firstBlockNum": 2,
        "lastBlockNum": 259,
        "leadingEmptyBlocksCnt": 1,
        "setupBlocksCnt": 127,
        "tearDownBlocksCnt": 37,
        "testAnalysisBlockCnt": 57,
        "testEndBlockNum": 222,
        "testStartBlockNum": 129,
        "totalBlocks": 258,
        "trailingEmptyBlocksCnt": 32
      },
      "TPS": {
        "avg": 15343.875,
        "configTestDuration": 30,
        "configTps": 15400,
        "emptyBlocks": 0,
        "max": 17218,
        "min": 13555,
        "numBlocks": 57,
        "sigma": 695.6516488285334
      },
      "TrxCPU": {
        "avg": 43.294225108225106,
        "max": 1389.0,
        "min": 24.0,
        "samples": 462000,
        "sigma": 15.451334956307504
      },
      "TrxLatency": {
        "avg": 0.4002558766164821,
        "max": 0.806999921798706,
        "min": 0.10100007057189941,
        "samples": 462000,
        "sigma": 0.15376674034615292
      },
      "TrxNet": {
        "avg": 24.567108225108225,
        "max": 25.0,
        "min": 24.0,
        "samples": 462000,
        "sigma": 0.4954760197252983
      }
    },
    "args": {
      "_killEosInstances": true,
      "_killWallet": true,
      "_totalNodes": 2,
      "delay": 1,
      "dontKill": false,
      "dumpErrorDetails": false,
      "expectedTransactionsSent": 462000,
      "extraNodeosArgs": " --http-max-response-time-ms 990000 --disable-subjective-api-billing true ",
      "genesisPath": "tests/performance_tests/genesis.json",
      "keepLogs": false,
      "killAll": false,
      "maximumClients": 0,
      "maximumP2pPerHost": 5000,
      "nodesFile": null,
      "numAddlBlocksToPrune": 2,
      "pnodes": 1,
      "saveJsonReport": false,
      "targetTps": 15400,
      "testTrxGenDurationSec": 30,
      "topo": "mesh",
      "totalNodes": 0,
      "tpsLimitPerGenerator": 4000,
      "useBiosBootFile": false,
      "verbose": false
    },
    "completedRun": true,
    "env": {
      "os": "posix",
      "release": "5.10.102.1-microsoft-standard-WSL2",
      "system": "Linux"
    },
    "nodeosVersion": "v3.2.0-dev"
  }
```