### PR TITLE
[3.2 -> main] Update produced block log output.

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -164,18 +164,19 @@ namespace eosio { namespace chain {
                                                            fc::time_point block_deadline, fc::microseconds max_transaction_time,
                                                            uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time );
 
-         block_state_ptr finalize_block( const signer_callback_type& signer_callback );
-         void sign_block( const signer_callback_type& signer_callback );
-         void commit_block();
-
-         std::future<block_state_ptr> create_block_state_future( const block_id_type& id, const signed_block_ptr& b );
-
          struct block_report {
             size_t             total_net_usage = 0;
             size_t             total_cpu_usage_us = 0;
             fc::microseconds   total_elapsed_time{};
             fc::microseconds   total_time{};
          };
+
+         block_state_ptr finalize_block( block_report& br, const signer_callback_type& signer_callback );
+         void sign_block( const signer_callback_type& signer_callback );
+         void commit_block();
+
+         std::future<block_state_ptr> create_block_state_future( const block_id_type& id, const signed_block_ptr& b );
+
          /**
           * @param br returns statistics for block
           * @param block_state_future provide from call to create_block_state_future

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -428,7 +428,8 @@ namespace eosio { namespace testing {
          }
       });
 
-      control->finalize_block( [&]( digest_type d ) {
+      controller::block_report br;
+      control->finalize_block( br, [&]( digest_type d ) {
          std::vector<signature_type> result;
          result.reserve(signing_keys.size());
          for (const auto& k: signing_keys)


### PR DESCRIPTION
Added total block elapsed time and total block time to `Produced block` log output. Updated scheduled transaction trace `elapsed` to include more of the execution time. Renamed `Received block` log output `conf:` to `confirmed:` to match `Produced block` log output. Includes a bit of refactoring for calculation of cpu/elapsed/time since these are now calculated for produced blocks where the time is spread out over block production time.

```
info  2022-10-11T15:53:27.917 nodeos    producer_plugin.cpp:502       on_incoming_block    ] Received block 9668c6a107d78117... #18 @ 2022-10-11T15:53:28.000 signed by eosio [trxs: 11, lib: 17, confirmed: 0, net: 8304, cpu: 5711, elapsed: 3853, time: 8394, latency: -82 ms]
```

Resolves #312 
Merges #313 into `main`