### PR TITLE
[main] Block-log leap-util subcommand refactoring

### DIFF
--- a/programs/leap-util/actions/blocklog.hpp
+++ b/programs/leap-util/actions/blocklog.hpp
@@ -21,35 +21,23 @@ struct blocklog_options {
    std::optional<block_log_prune_config> blog_keep_prune_conf;
 };
 
-
 class blocklog_actions : public sub_command<blocklog_options> {
 public:
    blocklog_actions() : sub_command() {}
    void setup(CLI::App& app);
-
-   enum class action_type : uint32_t {
-      ac_default = 0,
-      make_index = 1,
-      trim_blocklog = 2,
-      extract_blocks = 3,
-      smoke_test = 4,
-      vacuum = 5,
-      genesis = 6,
-   };
-
-   // callback
-   int run_subcommand(action_type at = action_type::ac_default);
-
-   // exception logger
-   void lippincott() noexcept;
-
 protected:
+   void print_exception() noexcept;
+
    void initialize();
    int trim_blocklog_end(bfs::path block_dir, uint32_t n);
    bool trim_blocklog_front(bfs::path block_dir, uint32_t n);
    bool extract_block_range(bfs::path block_dir, bfs::path output_dir, uint32_t start, uint32_t end);
-   void smoke_test();
+
+   int make_index();
+   int trim_blocklog();
+   int extract_blocks();
+   int smoke_test();
    int do_vacuum();
    int do_genesis();
-   void read_log();
+   int read_log();
 };

--- a/programs/leap-util/actions/blocklog.hpp
+++ b/programs/leap-util/actions/blocklog.hpp
@@ -18,32 +18,38 @@ struct blocklog_options {
    bool no_pretty_print = false;
    bool as_json_array = false;
 
-   // subcommands
-   bool make_index = false;
-   bool trim_blocklog = false;
-   bool extract_blocks = false;
-   bool smoke_test = false;
-   bool vacuum = false;
-   bool genesis = false;
-
    std::optional<block_log_prune_config> blog_keep_prune_conf;
 };
+
 
 class blocklog_actions : public sub_command<blocklog_options> {
 public:
    blocklog_actions() : sub_command() {}
    void setup(CLI::App& app);
 
-   // callbacks
-   int run_subcommand();
+   enum class action_type : uint32_t {
+      ac_default = 0,
+      make_index = 1,
+      trim_blocklog = 2,
+      extract_blocks = 3,
+      smoke_test = 4,
+      vacuum = 5,
+      genesis = 6,
+   };
+
+   // callback
+   int run_subcommand(action_type at = action_type::ac_default);
+
+   // exception logger
+   void lippincott() noexcept;
 
 protected:
    void initialize();
    int trim_blocklog_end(bfs::path block_dir, uint32_t n);
    bool trim_blocklog_front(bfs::path block_dir, uint32_t n);
    bool extract_block_range(bfs::path block_dir, bfs::path output_dir, uint32_t start, uint32_t end);
-   void smoke_test(bfs::path block_dir);
-   int  do_vacuum();
-   int  do_genesis();
+   void smoke_test();
+   int do_vacuum();
+   int do_genesis();
    void read_log();
 };

--- a/programs/leap-util/actions/blocklog.hpp
+++ b/programs/leap-util/actions/blocklog.hpp
@@ -12,7 +12,7 @@ struct blocklog_options {
    std::string output_file = "";
    uint32_t first_block = 0;
    uint32_t last_block = std::numeric_limits<uint32_t>::max();
-   std::string output_dir;
+   std::string output_dir = "";
 
    // flags
    bool no_pretty_print = false;
@@ -25,6 +25,7 @@ class blocklog_actions : public sub_command<blocklog_options> {
 public:
    blocklog_actions() : sub_command() {}
    void setup(CLI::App& app);
+
 protected:
    void print_exception() noexcept;
 


### PR DESCRIPTION
This PR addresses following issues:
- flags and options made applicable to actual subcommands using them
- "default" behavior of printing log changed to a subcommand print-log. Default handler of parent subcommand "block-log" eliminated
- simplified and unified callbacks and error handling for return codes and exceptions
- re-enabled (and tested) smoke-test subcommand
- few other minor fixes