### PR TITLE
[4.0] SHiP: Store initial chain state on startup if state_history_plugin chain state log is empty

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -570,14 +570,14 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
          return;
       bool fresh = chain_state_log->begin_block() == chain_state_log->end_block();
       if (fresh)
-         fc_ilog(_log, "Placing initial state in block ${n}", ("n", block_state->block->block_num()));
+         fc_ilog(_log, "Placing initial state in block ${n}", ("n", block_state->block_num));
 
       std::vector<table_delta> deltas     = state_history::create_deltas(chain_plug->chain().db(), fresh);
       auto                     deltas_bin = state_history::zlib_compress_bytes(fc::raw::pack(deltas));
       state_history_log_header header{.magic        = ship_magic(ship_current_version, 0),
                                       .block_id     = block_state->id,
                                       .payload_size = sizeof(uint32_t) + deltas_bin.size()};
-      chain_state_log->write_entry(header, block_state->block->previous, [&](auto& stream) {
+      chain_state_log->write_entry(header, block_state->header.previous, [&](auto& stream) {
          // Compressed deltas now exceeds 4GB on one of the public chains. This length prefix
          // was intended to support adding additional fields in the future after the
          // packed deltas. For now we're going to ignore on read. The 0 is an attempt to signal
@@ -694,6 +694,12 @@ void state_history_plugin::plugin_startup() {
 
    try {
       my->thr = std::thread([ptr = my.get()] { ptr->ctx.run(); });
+      auto bsp = my->chain_plug->chain().head_block_state();
+      if( bsp && my->chain_state_log && my->chain_state_log->begin_block() == my->chain_state_log->end_block() ) {
+         fc_ilog( _log, "Storing initial state on startup, this can take a considerable amount of time" );
+         my->store_chain_state( bsp );
+         fc_ilog( _log, "Done storing initial state on startup" );
+      }
       my->listen();
    } catch (std::exception& ex) {
       appbase::app().quit();


### PR DESCRIPTION
Store initial chain state on startup if `state_history_plugin` chain state log is empty. For example, if starting from a snapshot or if first time started with ` --chain-state-history` option. This storage will happen in `state_history_plugin` `plugin_startup` before `net_plugin` `plugin_startup` posted started runs. This will result in the complete storage of chain state in SHiP state log before any `net_plugin` connections are attempted.

Note this changes the behavior of SHiP storage of initial chain state deltas. The chain state deltas are stored in the chain state log associated with the head block at startup instead of the first received block after startup.

Example result from starting from a snapshot:
```
{ "get_status_result_v0":
{
    "head": {
        "block_num": 267988579,
        "block_id": "0FF92E63F1325AA2119857A5CB0B649262660577A3D65D9498682E8C4D5985BB"
    },
    "last_irreversible": {
        "block_num": 267988249,
        "block_id": "0FF92D19466325264CEC086F2A59960781BCCCFF173F7D3B2EAF22184900C105"
    },
    "trace_begin_block": 267673531,
    "trace_end_block": 267988580,
    "chain_state_begin_block": 267673530,
    "chain_state_end_block": 267988580,
    "chain_id": "ACA376F206B8FC25A6ED44DBDC66547C36C6C33E3A119FFBEAEF943642F0E906"
}
}
```
Note that `chain_state_begin_block` is different than `trace_begin_block`.

Resolves #191 