### PR TITLE
[3.2 -> main] SHiP Fix log output

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -439,7 +439,7 @@ class state_history_log {
             index.skip(-sizeof(uint64_t));
 
             if (!(remaining % 10000))
-               ilog("${remaining} blocks remaining, log pos = ${pos}", ("num_found", remaining)("pos", pos));
+               ilog("${r} blocks remaining, log pos = ${pos}", ("r", remaining)("pos", pos));
          }
       }
 


### PR DESCRIPTION
Fix log statement so output includes value of `remaining`.

Resolves #346 
Merges #347 & #348 into `main`