### PR TITLE
[3.1 -> 3.2] Complete Pinned Build Instructions + Other README Updates [docs]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,8 @@ Testing/*
 build.tar.gz
 build/*
 build-debug/*
+deps/*
+dependencies/*
 
 etc/eosio/node_*
 var/lib/node_*

--- a/README.md
+++ b/README.md
@@ -1,126 +1,257 @@
 # Leap
+Leap is a C++ implementation of the [Antelope](https://github.com/AntelopeIO) protocol. It contains blockchain node software and supporting tools for developers and node operators.
 
-Leap is blockchain node software and supporting tools that implements the [Antelope](https://github.com/AntelopeIO) protocol.
+## Branches
+The `main` branch is the development branch; do not use it for production. Refer to the [release page](https://github.com/AntelopeIO/leap/releases) for current information on releases, pre-releases, and obsolete releases, as well as the corresponding tags for those releases.
 
-## Repo Organization
+## Supported Operating Systems
+We currently support the following operating systems.
+- Ubuntu 22.04 Jammy
+- Ubuntu 20.04 Focal
+- Ubuntu 18.04 Bionic
 
-`main` branch is the development branch: do not use this for production. Refer to the [release page](https://github.com/AntelopeIO/leap/releases) for current information on releases, pre-releases, and obsolete releases as well as the corresponding tags for those releases.
+Other Unix derivatives such as macOS are tended to on a best-effort basis and may not be full featured. If you aren't using Ubuntu, please visit the "[Build Unsupported OS](./docs/00_install/01_build-from-source/00_build-unsupported-os.md)" page to explore your options.
 
-## Software Installation
-
-Visit the [release page](https://github.com/AntelopeIO/leap/releases) for Ubuntu binaries. This is the fastest way to get started with the software.
-
-### Building From Source
-
-Recent Ubuntu LTS releases are the only Linux distributions that we fully support. Other Linux distros and other POSIX operating systems (such as macOS) are tended to on a best-effort basis and may not be full featured. Notable requirements to build are:
-* C++17 compiler and standard library
-* boost 1.67+
-* CMake 3.8+
-* (for Linux only) LLVM 7 - 11 (newer versions do not work)
-
-A few other common libraries are tools also required such as openssl 1.1+, libcurl, curl, libusb, GMP, Python 3, and zlib.
-
-**A Warning On Parallel Compilation Jobs (`-j` flag)**: When building C/C++ software often the build is performed in parallel via a command such as `make -j $(nproc)` which uses the number of CPU cores as the number of compilation jobs to perform simultaneously. However, be aware that some compilation units (.cpp files) in Leap are extremely complex and will consume nearly 4GB of memory to compile. You may need to reduce the level of parallelization depending on the amount of memory on your build host. e.g. instead of `make -j $(nproc)` run `make -j2`. Failures due to memory exhaustion will typically but not always manifest as compiler crashes.
-
-Generally we recommend performing what we refer to as a "pinned build" which ensures the compiler and boost version remain the same between builds of different Leap versions (Leap requires these versions remain the same otherwise its state needs to be repopulated from a portable snapshot).
-
-#### Building Pinned Build Binary Packages
-In the directory `<leap src>/scripts` you will find the two scripts `install_deps.sh` and `pinned_build.sh`. If you haven't installed build dependencies then run `install_deps.sh`. Then run `pinned_build.sh <dependencies directory> <leap build directory> <number of jobs>`.
-
-The dependencies directory is where the script will pull the C++ dependencies that need to be built with the pinned compiler for building the pinned binaries for binary packaging.
-
-The binary package will be produced in the Leap build directory that was supplied.
-
-#### Manual (non "pinned") Build Instructions
-
-<details>
-  <summary>Ubuntu 20.04 & 22.04 Build Instructions</summary>
-
-Install required dependencies: 
+If you are running an unsupported Ubuntu derivative, such as Linux Mint, you can find the version of Ubuntu your distribution was based on by using this command:
+```bash
+cat /etc/upstream-release/lsb-release
 ```
-apt-get update && apt-get install   \
-        build-essential             \
-        cmake                       \
-        curl                        \
-        git                         \
-        libboost-all-dev            \
-        libcurl4-openssl-dev        \
-        libgmp-dev                  \
-        libssl-dev                  \
-        libusb-1.0-0-dev            \
-        llvm-11-dev                 \
+Your best bet is to follow the instructions for your Ubuntu base, but we make no guarantees.
+
+## Binary Installation
+This is the fastest way to get started. From the [latest release](https://github.com/AntelopeIO/leap/releases/latest) page, download a binary for one of our [supported operating systems](#supported-operating-systems), or visit the [release tags](https://github.com/AntelopeIO/leap/releases) page to download a binary for a specific version of Leap.
+
+Once you have a `*.deb` file downloaded for your version of Ubuntu, you can install it as follows:
+```bash
+sudo apt-get update
+sudo apt-get install -y ~/Downloads/leap*.deb
+```
+Your download path may vary. If you are in an Ubuntu docker container, omit `sudo` because you run as `root` by default.
+
+Finally, verify Leap was installed correctly:
+```bash
+nodeos --full-version
+```
+You should see a [semantic version](https://semver.org) string followed by a `git` commit hash with no errors. For example:
+```
+v3.1.2-0b64f879e3ebe2e4df09d2e62f1fc164cc1125d1
+```
+
+## Build and Install from Source
+You can also build and install Leap from source.
+
+### Prerequisites
+You will need to build on a [supported operating system](#supported-operating-systems).
+
+Requirements to build:
+- C++17 compiler and standard library
+- boost 1.67+
+- CMake 3.8+
+- LLVM 7 - 11 - for Linux only
+  - newer versions do not work
+- openssl 1.1+
+- libcurl
+- curl
+- libusb
+- git
+- GMP
+- Python 3
+- zlib
+
+### Step 1 - Clone
+If you don't have the Leap repo cloned to your computer yet, [open a terminal](https://itsfoss.com/open-terminal-ubuntu) and navigate to the folder where you want to clone the Leap repository:
+```bash
+cd ~/Downloads
+```
+Clone Leap using either HTTPS...
+```bash
+git clone --recursive https://github.com/AntelopeIO/leap.git
+```
+...or SSH:
+```bash
+git clone --recursive git@github.com:AntelopeIO/leap.git
+```
+
+> ℹ️ **HTTPS vs. SSH Clone** ℹ️  
+Both an HTTPS or SSH git clone will yield the same result - a folder named `leap` containing our source code. It doesn't matter which type you use.
+
+Navigate into that folder:
+```bash
+cd leap
+```
+
+### Step 2 - Checkout Release Tag or Branch
+Choose which [release](https://github.com/AntelopeIO/leap/releases) or [branch](#branches) you would like to build, then check it out. If you are not sure, use the [latest release](https://github.com/AntelopeIO/leap/releases/latest). For example, if you want to build release 3.1.2 then you would check it out using its tag, `v3.1.2`. In the example below, replace `v0.0.0` with your selected release tag accordingly:
+```bash
+git fetch --all --tags
+git checkout v0.0.0
+```
+
+Once you are on the branch or release tag you want to build, make sure everything is up-to-date:
+```bash
+git pull
+git submodule update --init --recursive
+```
+
+### Step 3 - Build
+Select build instructions below for a [pinned build](#pinned-build) (preferred) or an [unpinned build](#unpinned-build).
+
+> ℹ️ **Pinned vs. Unpinned Build** ℹ️  
+We have two types of builds for Leap: "pinned" and "unpinned." The only difference is that pinned builds use specific versions for some dependencies hand-picked by the Leap engineers - they are "pinned" to those versions. In contrast, unpinned builds use the default dependency versions available on the build system at the time. We recommend performing a "pinned" build to ensure the compiler and boost versions remain the same between builds of different Leap versions. Leap requires these versions to remain the same, otherwise its state might need to be recovered from a portable snapshot or the chain needs to be replayed.
+
+> ⚠️ **A Warning On Parallel Compilation Jobs (`-j` flag)** ⚠️  
+When building C/C++ software, often the build is performed in parallel via a command such as `make -j "$(nproc)"` which uses all available CPU threads. However, be aware that some compilation units (`*.cpp` files) in Leap will consume nearly 4GB of memory. Failures due to memory exhaustion will typically, but not always, manifest as compiler crashes. Using all available CPU threads may also prevent you from doing other things on your computer during compilation. For these reasons, consider reducing this value.
+
+> 🐋 **Docker and `sudo`** 🐋  
+If you are in an Ubuntu docker container, omit `sudo` from all commands because you run as `root` by default. Most other docker containers also exclude `sudo`, especially Debian-family containers. If your shell prompt is a hash tag (`#`), omit `sudo`.
+
+#### Pinned Build
+Make sure you are in the root of the `leap` repo, then run the `install_depts.sh` script to install dependencies:
+```bash
+sudo scripts/install_deps.sh
+```
+
+Next, run the pinned build script. You have to give it three arguments, in the following order:
+  - A temporary folder, for all dependencies that need to be built from source.
+  - A build folder, where the binaries you need to install will be built to.
+  - The number of jobs or CPU cores/threads to use (note the [jobs flag](#step-3---build) warning above).
+
+The following command runs the `pinned_build.sh` script, specifies a `deps` and `build` folder in the root of the Leap repo for the first two arguments, then builds the packages using all of your computer's CPU threads (Note: you don't need `sudo` for this command):
+```bash
+scripts/pinned_build.sh deps build "$(nproc)"
+```
+Now you can optionally [test](#step-4---test) your build, or [install](#step-5---install) the `*.deb` binary packages, which will be in the root of your build directory.
+
+#### Unpinned Build
+The following instructions are valid for this branch. Other release branches may have different requirements, so ensure you follow the directions in the branch or release you intend to build. If you are in an Ubuntu docker container, omit `sudo` because you run as `root` by default.
+
+<details> <summary>Ubuntu 22.04 Jammy & Ubuntu 20.04 Focal</summary>
+
+Install dependencies:
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+        build-essential \
+        cmake \
+        curl \
+        git \
+        libboost-all-dev \
+        libcurl4-openssl-dev \
+        libgmp-dev \
+        libssl-dev \
+        libusb-1.0-0-dev \
+        llvm-11-dev \
         pkg-config
 ```
-and perform the build:
-```
-git submodule update --init --recursive
-mkdir build
+To build, make sure you are in the root of the `leap` repo, then run the following command:
+```bash
+mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/llvm-11 ..
 make -j $(nproc) package
 ```
 </details>
 
-<details>
-  <summary>Ubuntu 18.04 Build Instructions</summary>
+<details> <summary>Ubuntu 18.04 Bionic</summary>
 
-Install required dependencies. You will need to build Boost from source on this distribution. 
-```
-apt-get update && apt-get install   \
-        build-essential             \
-        cmake                       \
-        curl                        \
-        g++-8                       \
-        git                         \
-        libcurl4-openssl-dev        \
-        libgmp-dev                  \
-        libssl-dev                  \
-        libusb-1.0-0-dev            \
-        llvm-7-dev                  \
-        pkg-config                  \
-        python3                     \
+Install dependencies:
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+        build-essential \
+        cmake \
+        curl \
+        g++-8 \
+        git \
+        libcurl4-openssl-dev \
+        libgmp-dev \
+        libssl-dev \
+        libusb-1.0-0-dev \
+        llvm-7-dev \
+        pkg-config \
+        python3 \
         zlib1g-dev
-        
-curl -L https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2 | tar jx && \
-   cd boost_1_79_0 &&                                                                                     \
-   ./bootstrap.sh --prefix=$HOME/boost1.79 &&                                                             \
-   ./b2 --with-iostreams --with-date_time --with-filesystem --with-system                                 \
-        --with-program_options --with-chrono --with-test -j$(nproc) install &&                            \
-   cd ..
 ```
-and perform the build:
+You need to build Boost from source on this distribution:
+```bash
+curl -fL https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2 -o ~/Downloads/boost_1_79_0.tar.bz2
+tar -jvxf ~/Downloads/boost_1_79_0.tar.bz2 -C ~/Downloads/
+pushd ~/Downloads/boost_1_79_0
+./bootstrap.sh --prefix="$HOME/boost1.79"
+./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -j "$(nproc)" install
+popd
 ```
-git submodule update --init --recursive
-mkdir build
+The Boost `*.tar.bz2` download and `boost_1_79_0` folder can be removed now if you want more space.
+```bash
+rm -r ~/Downloads/boost_1_79_0.tar.bz2 ~/Downloads/boost_1_79_0
+```
+From a terminal in the root of the `leap` repo, build.
+```bash
+mkdir -p build
 cd build
-cmake -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 \
-      -DCMAKE_PREFIX_PATH="$HOME/boost1.79;/usr/lib/llvm-7/"  -DCMAKE_BUILD_TYPE=Release .. \
-make -j $(nproc) package
+cmake -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 -DCMAKE_PREFIX_PATH="$HOME/boost1.79;/usr/lib/llvm-7/" -DCMAKE_BUILD_TYPE=Release ..
+make -j "$(nproc)" package
 ```
-After building you may remove the `$HOME/boost1.79` directory, or you may keep it around until next time building the software.
+After building, you may remove the `~/boost1.79` directory or you may keep it around for your next build.
 </details>
 
-### Running Tests
+Now you can optionally [test](#step-4---test) your build, or [install](#step-5---install) the `*.deb` binary packages, which will be in the root of your build directory.
 
-When building from source it's recommended to run at least what we refer to as the "parallelizable tests". Not included by default in the "parallelizable tests" are the WASM spec tests which can add additional coverage and can also be run in parallel.
+### Step 4 - Test
+Leap supports the following test suites:
 
+Test Suite | Test Type | [Test Size](https://testing.googleblog.com/2010/12/test-sizes.html) | Notes
+---|:---:|:---:|---
+[Parallelizable tests](#parallelizable-tests) | Unit tests | Small
+[WASM spec tests](#wasm-spec-tests) | Unit tests | Small | Unit tests for our WASM runtime, each short but _very_ CPU-intensive
+[Serial tests](#serial-tests) | Component/Integration | Medium
+[Long-running tests](#long-running-tests) | Integration | Medium-to-Large | Tests which take an extraordinarily long amount of time to run
+
+When building from source, we recommended running at least the [parallelizable tests](#parallelizable-tests).
+
+#### Parallelizable Tests
+This test suite consists of any test that does not require shared resources, such as file descriptors, specific folders, or ports, and can therefore be run concurrently in different threads without side effects (hence, easily parallelized). These are mostly unit tests and [small tests](https://testing.googleblog.com/2010/12/test-sizes.html) which complete in a short amount of time.
+
+You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
+```bash
+ctest -j "$(nproc)" -LE _tests
 ```
-cd build
 
-# "parallelizable tests": the minimum test set that should be run
-ctest -j $(nproc) -LE _tests
+#### WASM Spec Tests
+The WASM spec tests verify that our WASM execution engine is compliant with the web assembly standard. These are very [small](https://testing.googleblog.com/2010/12/test-sizes.html), very fast unit tests. However, there are over a thousand of them so the suite can take a little time to run. These tests are extremely CPU-intensive.
 
-# Also consider running the WASM spec tests for more coverage
-ctest -j $(nproc) -L wasm_spec_tests
+You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
+```bash
+ctest -j "$(nproc)" -L wasm_spec_tests
 ```
+We have observed severe performance issues when multiple virtual machines are running this test suite on the same physical host at the same time, for example in a CICD system. This can be resolved by disabling hyperthreading on the host.
 
-Some other tests are available and recommended but be aware they can be sensitive to other software running on the same host and they may **SIGKILL** other nodeos instances running on the host.
-```
-cd build
+#### Serial Tests
+The serial test suite consists of [medium](https://testing.googleblog.com/2010/12/test-sizes.html) component or integration tests that use specific paths, ports, rely on process names, or similar, and cannot be run concurrently with other tests. Serial tests can be sensitive to other software running on the same host and they may `SIGKILL` other `nodeos` processes. These tests take a moderate amount of time to complete, but we recommend running them.
 
-# These tests can't run in parallel but are recommended.
+You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
+```bash
 ctest -L "nonparallelizable_tests"
+```
 
-# These tests can't run in parallel. They also take a long time to run.
+#### Long-Running Tests
+The long-running tests are [medium-to-large](https://testing.googleblog.com/2010/12/test-sizes.html) integration tests that rely on shared resources and take a very long time to run.
+
+You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
+```bash
 ctest -L "long_running_tests"
+```
+
+### Step 5 - Install
+Once you have [built](#step-3---build-the-source-code) Leap and [tested](#step-4---test) your build, you can install Leap on your system. Don't forget to omit `sudo` if you are running in a docker container.
+
+We recommend installing the binary package you just built. Navigate to your Leap build directory in a terminal and run this command:
+```bash
+sudo apt-get update
+sudo apt-get install -y ./leap[-_][0-9]*.deb
+```
+
+It is also possible to install using `make` instead:
+```bash
+sudo make install
 ```

--- a/docs/00_install/01_build-from-source/index.md
+++ b/docs/00_install/01_build-from-source/index.md
@@ -2,123 +2,19 @@
 content_title: Build Antelope from Source
 ---
 
-The shell scripts previously recommended for building the software have been removed in favor of a build process entirely driven by CMake. Those wishing to build from source are now responsible for installing the necessary dependencies. The list of dependencies and the recommended build procedure are in the README.md file. Instructions are also included for efficiently running the tests.
+The shell scripts previously recommended for building the software have been removed in favor of a build process entirely driven by CMake. Those wishing to build from source are now responsible for installing the necessary dependencies. The list of dependencies and the recommended build procedure are in the [`README.md`](https://github.com/AntelopeIO/leap/blob/release/3.1/README.md) file. Instructions are also included for efficiently running the tests.
 
 ### Using DUNE
-
-As an alternative to building from source try [Docker Utilities for Node Execution](https://github.com/AntelopeIO/DUNE) for the easiest way to get started, and for multi-platform support.  
+As an alternative to building from source, try [Docker Utilities for Node Execution](https://github.com/AntelopeIO/DUNE) for the easiest way to get started and for multi-platform support.
 
 ### Building From Source
-
-Recent Ubuntu LTS releases are the only Linux distributions that we fully support. Other Linux distros and other POSIX operating systems (such as macOS) are tended to on a best-effort basis and may not be full featured. Notable requirements to build are:
-* C++17 compiler and standard library
-* boost 1.67+
-* CMake 3.8+
-* (for Linux only) LLVM 7 - 11 (newer versions do not work)
-
-A few other common libraries are tools also required such as openssl 1.1+, libcurl, curl, libusb, GMP, Python 3, and zlib.
-
-**A Warning On Parallel Compilation Jobs (`-j` flag)**: When building C/C++ software often the build is performed in parallel via a command such as `make -j $(nproc)` which uses the number of CPU cores as the number of compilation jobs to perform simultaneously. However, be aware that some compilation units (.cpp files) in mandel are extremely complex and will consume nearly 4GB of memory to compile. You may need to reduce the level of parallelization depending on the amount of memory on your build host. e.g. instead of `make -j $(nproc)` run `make -j2`. Failures due to memory exhaustion will typically but not always manifest as compiler crashes.
-
-Generally we recommend performing what we refer to as a "pinned build" which ensures the compiler and boost version remain the same between builds of different mandel versions (mandel requires these versions remain the same otherwise its state needs to be repopulated from a portable snapshot).
+You can also build and install Leap from source. Instructions for that currently live [here](https://github.com/AntelopeIO/leap/blob/release/3.1/README.md#build-and-install-from-source).
 
 #### Building Pinned Build Binary Packages
-In the directory `<mandel src>/scripts` you will find the two scripts `install_deps.sh` and `pinned_build.sh`. If you haven't installed build dependencies then run `install_deps.sh`. Then run `pinned_build.sh <dependencies directory> <mandel build directory> <number of jobs>`.
-
-The dependencies directory is where the script will pull the C++ dependencies that need to be built with the pinned compiler for building the pinned binaries for binary packaging.
-
-The binary package will be produced in the mandel build directory that was supplied.
+The pinned build instructions have moved [here](https://github.com/AntelopeIO/leap/blob/release/3.1/README.md#pinned-build). You may want to look at the [prerequisites](https://github.com/AntelopeIO/leap/blob/release/3.1/README.md#prerequisites) and our warning on parallelization using the `-j` jobs flag [here](https://github.com/AntelopeIO/leap/blob/release/3.1/README.md#step-3---build) before you build.
 
 #### Manual (non "pinned") Build Instructions
-
-<details>
-  <summary>Ubuntu 20.04 & 22.04 Build Instructions</summary>
-
-Install required dependencies:
-```
-apt-get update && apt-get install   \
-        build-essential             \
-        cmake                       \
-        curl                        \
-        git                         \
-        libboost-all-dev            \
-        libcurl4-openssl-dev        \
-        libgmp-dev                  \
-        libssl-dev                  \
-        libusb-1.0-0-dev            \
-        llvm-11-dev                 \
-        pkg-config
-```
-and perform the build:
-```
-git submodule update --init --recursive
-mkdir build
-cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j $(nproc) package
-```
-</details>
-
-<details>
-  <summary>Ubuntu 18.04 Build Instructions</summary>
-
-Install required dependencies. You will need to build Boost from source on this distribution.
-```
-apt-get update && apt-get install   \
-        build-essential             \
-        cmake                       \
-        curl                        \
-        g++-8                       \
-        git                         \
-        libcurl4-openssl-dev        \
-        libgmp-dev                  \
-        libssl-dev                  \
-        libusb-1.0-0-dev            \
-        llvm-7-dev                  \
-        pkg-config                  \
-        python3                     \
-        zlib1g-dev
-
-curl -L https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2 | tar jx && \
-   cd boost_1_79_0 &&                                                                                     \
-   ./bootstrap.sh --prefix=$HOME/boost1.79 &&                                                             \
-   ./b2 --with-iostreams --with-date_time --with-filesystem --with-system                                 \
-        --with-program_options --with-chrono --with-test -j$(nproc) install &&                            \
-   cd ..
-```
-and perform the build:
-```
-git submodule update --init --recursive
-mkdir build
-cd build
-cmake -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 \
-      -DCMAKE_PREFIX_PATH="$HOME/boost1.79;/usr/lib/llvm-7/"  -DCMAKE_BUILD_TYPE=Release .. \
-make -j $(nproc) package
-```
-After building you may remove the `$HOME/boost1.79` directory, or you may keep it around until next time building the software.
-</details>
+The unpinned build instructions have moved [here](https://github.com/AntelopeIO/leap/blob/release/3.1/README.md#unpinned-build). You may want to look at the [prerequisites](https://github.com/AntelopeIO/leap/blob/release/3.1/README.md#prerequisites) and our warning on parallelization using the `-j` jobs flag [here](https://github.com/AntelopeIO/leap/blob/release/3.1/README.md#step-3---build) before you build.
 
 ### Running Tests
-
-When building from source it's recommended to run at least what we refer to as the "parallelizable tests". Not included by default in the "parallelizable tests" are the WASM spec tests which can add additional coverage and can also be run in parallel.
-
-```
-cd build
-
-# "parallelizable tests": the minimum test set that should be run
-ctest -j $(nproc) -LE _tests
-
-# Also consider running the WASM spec tests for more coverage
-ctest -j $(nproc) -L wasm_spec_tests
-```
-
-Some other tests are available and recommended but be aware they can be sensitive to other software running on the same host and they may **SIGKILL** other nodeos instances running on the host.
-```
-cd build
-
-# These tests can't run in parallel but are recommended.
-ctest -L "nonparallelizable_tests"
-
-# These tests can't run in parallel. They also take a long time to run.
-ctest -L "long_running_tests"
-```
+Documentation on available test suites and how to run them has moved [here](https://github.com/AntelopeIO/leap/blob/release/3.1/README.md#test).

--- a/docs/00_install/index.md
+++ b/docs/00_install/index.md
@@ -10,9 +10,9 @@ The best way to install and use the Antelope software is to build it from source
 
 Antelope currently supports the following operating systems:
 
-1. Ubuntu 18.04
-2. Ubuntu 20.04
-3. Ubuntu 22.04
+1. Ubuntu 22.04 Jammy
+2. Ubuntu 20.04 Focal
+3. Ubuntu 18.04 Bionic
 
 [[info | Note]]
 | It may be possible to build and install Antelope on other Unix-based operating systems. We gathered helpful information on the following page but please keep in mind that it is experimental and not officially supported. 


### PR DESCRIPTION
From [issue 132](https://github.com/AntelopeIO/leap/issues/132), this pull request updates the build instructions in the `README.md` to be more approachable to new users or novices who wish to build from source without much Linux or BASH experience. [Here](https://github.com/AntelopeIO/leap/blob/13863af69f02d685d82a08a2e198e16fd6d8839e/README.md) is what it looks like now. It may be easier to look over the new document than to try to look through the pull request diff.

I felt motivated so I also improved grammar and readability of the `README.md` overall, simplified the section headers, expanded the explanation of pinned vs. unpinned builds, expanded the section explaining the test suites, and various other things. I was careful to preserve the specific recommendations and commands added by contributors before me.

## See Also
- ~~[Pull Request 340](https://github.com/AntelopeIO/leap/pull/340) - main~~
- ~~[Pull Request 341](https://github.com/AntelopeIO/leap/pull/341) - release/3.2~~
- [Pull Request 342](https://github.com/AntelopeIO/leap/pull/342) - release/3.1
- ~~[Pull Request 368](https://github.com/AntelopeIO/leap/pull/368) - release/3.2~~
