### PR TITLE
[ main ] update libfc path in EosioTesterBuild.cmake.in for building integration tests in CDT and System Contracts

### DIFF
--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -51,7 +51,7 @@ find_package(Boost @Boost_MAJOR_VERSION@.@Boost_MINOR_VERSION@ EXACT REQUIRED CO
 
 find_library(libtester eosio_testing @CMAKE_BINARY_DIR@/libraries/testing NO_DEFAULT_PATH)
 find_library(libchain eosio_chain @CMAKE_BINARY_DIR@/libraries/chain NO_DEFAULT_PATH)
-find_library(libfc fc @CMAKE_BINARY_DIR@/libraries/fc NO_DEFAULT_PATH)
+find_library(libfc fc @CMAKE_BINARY_DIR@/libraries/libfc NO_DEFAULT_PATH)
 find_library(libsecp256k1 secp256k1 @CMAKE_BINARY_DIR@/libraries/libfc/secp256k1 NO_DEFAULT_PATH)
 
 find_library(libff ff @CMAKE_BINARY_DIR@/libraries/libfc/libraries/ff/libff NO_DEFAULT_PATH)


### PR DESCRIPTION
Resolve https://github.com/AntelopeIO/leap/issues/370.

Update `libfc` path in `CMakeModules/EosioTesterBuild.cmake.in` to match the new location after FC demodulation.

This is required for CDT and System Contracts to build integration tests.

Before the fix, building CDT' integration_tests had following error:

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
libfc
    linked by target "integration_tests" in directory /Users/lh/work/cdt-fc-test/tests/integration
```