### PR TITLE
[PH] Performance Test - Long running Tests to use linear search

### DIFF
--- a/tests/performance_tests/log_reader.py
+++ b/tests/performance_tests/log_reader.py
@@ -344,20 +344,20 @@ def createReport(guide: chainBlocksGuide, targetTps: int, testDurationSec: int, 
     report['completedRun'] = completedRun
     report['testStart'] = testStart
     report['testFinish'] = testFinish
-    report['nodeosVersion'] = Utils.getNodeosVersion()
-    report['env'] = {'system': system(), 'os': os.name, 'release': release(), 'logical_cpu_count': os.cpu_count()}
-    report['args'] =  argsDict
     report['Analysis'] = {}
+    report['Analysis']['BlockSize'] = asdict(blockSizeStats)
     report['Analysis']['BlocksGuide'] = asdict(guide)
     report['Analysis']['TPS'] = asdict(tpsStats)
     report['Analysis']['TPS']['configTps'] = targetTps
     report['Analysis']['TPS']['configTestDuration'] = testDurationSec
     report['Analysis']['TPS']['tpsPerGenerator'] = math.floor(targetTps / numGenerators)
     report['Analysis']['TPS']['generatorCount'] = numGenerators
-    report['Analysis']['BlockSize'] = asdict(blockSizeStats)
     report['Analysis']['TrxCPU'] = asdict(trxCpuStats)
     report['Analysis']['TrxLatency'] = asdict(trxLatencyStats)
     report['Analysis']['TrxNet'] = asdict(trxNetStats)
+    report['args'] =  argsDict
+    report['env'] = {'system': system(), 'os': os.name, 'release': release(), 'logical_cpu_count': os.cpu_count()}
+    report['nodeosVersion'] = Utils.getNodeosVersion()
     return report
 
 def createJSONReport(guide: chainBlocksGuide, targetTps: int, testDurationSec: int, tpsLimitPerGenerator: int, tpsStats: stats, blockSizeStats: stats,

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -49,14 +49,13 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
                            numAddlBlocksToPrune: int, testLogDir: str, saveJson: bool, quiet: bool) -> PerfTestSearchResults:
     floor = tpsTestFloor
     ceiling = tpsTestCeiling
-    binSearchTarget = 0
+    binSearchTarget = tpsTestCeiling
 
     maxTpsAchieved = 0
     maxTpsReport = {}
     searchResults = []
 
     while ceiling >= floor:
-        binSearchTarget = floor + (math.ceil(((ceiling - floor) / minStep) / 2) * minStep)
         print(f"Running scenario: floor {floor} binSearchTarget {binSearchTarget} ceiling {ceiling}")
         ptbResult = PerfTestBasicResult()
         scenarioResult = PerfTestSearchIndivResult(success=False, searchTarget=binSearchTarget, searchFloor=floor, searchCeiling=ceiling, basicTestResult=ptbResult)
@@ -77,6 +76,8 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
         searchResults.append(scenarioResult)
         if not quiet:
             print(f"searchResult: {binSearchTarget} : {searchResults[-1]}")
+
+        binSearchTarget = floor + (math.ceil(((ceiling - floor) / minStep) / 2) * minStep)
 
     return PerfTestSearchResults(maxTpsAchieved=maxTpsAchieved, searchResults=searchResults, maxTpsReport=maxTpsReport)
 

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -39,14 +39,14 @@ class PerfTestSearchIndivResult:
     basicTestResult: PerfTestBasicResult = PerfTestBasicResult()
 
 @dataclass
-class PerfTestBinSearchResults:
+class PerfTestSearchResults:
     maxTpsAchieved: int = 0
     searchResults: list = field(default_factory=list) #PerfTestSearchIndivResult list
     maxTpsReport: dict = field(default_factory=dict)
 
 def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int, testHelperConfig: PerformanceBasicTest.TestHelperConfig,
                            testClusterConfig: PerformanceBasicTest.ClusterConfig, testDurationSec: int, tpsLimitPerGenerator: int,
-                           numAddlBlocksToPrune: int, testLogDir: str, saveJson: bool, quiet: bool) -> PerfTestBinSearchResults:
+                           numAddlBlocksToPrune: int, testLogDir: str, saveJson: bool, quiet: bool) -> PerfTestSearchResults:
     floor = tpsTestFloor
     ceiling = tpsTestCeiling
     binSearchTarget = 0
@@ -78,7 +78,46 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
         if not quiet:
             print(f"searchResult: {binSearchTarget} : {searchResults[-1]}")
 
-    return PerfTestBinSearchResults(maxTpsAchieved=maxTpsAchieved, searchResults=searchResults, maxTpsReport=maxTpsReport)
+    return PerfTestSearchResults(maxTpsAchieved=maxTpsAchieved, searchResults=searchResults, maxTpsReport=maxTpsReport)
+
+def performPtbReverseLinearSearch(tpsInitial: int, step: int, testHelperConfig: PerformanceBasicTest.TestHelperConfig,
+                                  testClusterConfig: PerformanceBasicTest.ClusterConfig, testDurationSec: int, tpsLimitPerGenerator: int,
+                                  numAddlBlocksToPrune: int, testLogDir: str, saveJson: bool, quiet: bool) -> PerfTestSearchResults:
+
+    # Default - Decrementing Max TPS in range [0, tpsInitial]
+    absFloor = 0
+    absCeiling = tpsInitial
+
+    searchTarget = tpsInitial
+
+    maxTpsAchieved = 0
+    maxTpsReport = {}
+    searchResults = []
+    maxFound = False
+
+    while not maxFound:
+        print(f"Running scenario: floor {absFloor} searchTarget {searchTarget} ceiling {absCeiling}")
+        ptbResult = PerfTestBasicResult()
+        scenarioResult = PerfTestSearchIndivResult(success=False, searchTarget=searchTarget, searchFloor=absFloor, searchCeiling=absCeiling, basicTestResult=ptbResult)
+
+        myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=searchTarget,
+                                    testTrxGenDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
+                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, saveJsonReport=saveJson, quiet=quiet)
+        testSuccessful = myTest.runTest()
+        if evaluateSuccess(myTest, testSuccessful, ptbResult):
+            maxTpsAchieved = searchTarget
+            maxTpsReport = myTest.report
+            scenarioResult.success = True
+            maxFound = True
+        else:
+            searchTarget = searchTarget - step
+
+        scenarioResult.basicTestResult = ptbResult
+        searchResults.append(scenarioResult)
+        if not quiet:
+            print(f"searchResult: {searchTarget} : {searchResults[-1]}")
+
+    return PerfTestSearchResults(maxTpsAchieved=maxTpsAchieved, searchResults=searchResults, maxTpsReport=maxTpsReport)
 
 def evaluateSuccess(test: PerformanceBasicTest, testSuccessful: bool, result: PerfTestBasicResult) -> bool:
     result.targetTPS = test.targetTps
@@ -245,25 +284,22 @@ def main():
             for i in range(len(binSearchResults.searchResults)):
                 print(f"Search scenario: {i} result: {binSearchResults.searchResults[i]}")
 
-        longRunningFloor = binSearchResults.maxTpsAchieved - 3 * testIterationMinStep if binSearchResults.maxTpsAchieved - 3 * testIterationMinStep > 0 else 0
-        longRunningCeiling = binSearchResults.maxTpsAchieved + 3 * testIterationMinStep
+        longRunningSearchResults = performPtbReverseLinearSearch(tpsInitial=binSearchResults.maxTpsAchieved, step=testIterationMinStep, testHelperConfig=testHelperConfig,
+                                                                 testClusterConfig=testClusterConfig, testDurationSec=finalDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
+                                                                 numAddlBlocksToPrune=numAddlBlocksToPrune, testLogDir=ptbLogsDirPath, saveJson=saveTestJsonReports, quiet=quiet)
 
-        longRunningBinSearchResults = performPtbBinarySearch(tpsTestFloor=longRunningFloor, tpsTestCeiling=longRunningCeiling, minStep=testIterationMinStep, testHelperConfig=testHelperConfig,
-                           testClusterConfig=testClusterConfig, testDurationSec=finalDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
-                           numAddlBlocksToPrune=numAddlBlocksToPrune, testLogDir=ptbLogsDirPath, saveJson=saveTestJsonReports, quiet=quiet)
-
-        print(f"Long Running Test - Successful rate of: {longRunningBinSearchResults.maxTpsAchieved}")
+        print(f"Long Running Test - Successful rate of: {longRunningSearchResults.maxTpsAchieved}")
         perfRunSuccessful = True
 
         if not quiet:
             print("Long Running Test - Search Results:")
-            for i in range(len(longRunningBinSearchResults.searchResults)):
-                print(f"Search scenario: {i} result: {longRunningBinSearchResults.searchResults[i]}")
+            for i in range(len(longRunningSearchResults.searchResults)):
+                print(f"Search scenario: {i} result: {longRunningSearchResults.searchResults[i]}")
 
         testFinish = datetime.utcnow()
         fullReport = createJSONReport(maxTpsAchieved=binSearchResults.maxTpsAchieved, searchResults=binSearchResults.searchResults, maxTpsReport=binSearchResults.maxTpsReport,
-                                      longRunningMaxTpsAchieved=longRunningBinSearchResults.maxTpsAchieved, longRunningSearchResults=longRunningBinSearchResults.searchResults,
-                                      longRunningMaxTpsReport=longRunningBinSearchResults.maxTpsReport, testStart=testStart, testFinish=testFinish, argsDict=argsDict)
+                                      longRunningMaxTpsAchieved=longRunningSearchResults.maxTpsAchieved, longRunningSearchResults=longRunningSearchResults.searchResults,
+                                      longRunningMaxTpsReport=longRunningSearchResults.maxTpsReport, testStart=testStart, testFinish=testFinish, argsDict=argsDict)
 
         if not quiet:
             print(f"Full Performance Test Report: {fullReport}")


### PR DESCRIPTION
### Performance Test Long Duration Tests now use linearly decrementing search instead of binary search.
    
This avoids a problem where the long running test max is outside the window previously dictated for binary search and incorrectly reporting `LongRunningMaxTpsAchieved` = 0.  Long Running max TPS should always be <= short running max tps, thus linearly decrementing search works well for this case.

### Additional changes:

#### For initial binary search, try a short run using ceiling tps first.
In the general case, where `--max-tps-to-test` has been set well above achievable, this change adds one `--test-iteration-duration-sec` of time to the overarching test. In the case where it is successful it could save many cycles of time.  It also puts one data point in the results summary that is basically an optimistic execution showing at potential overload what the avg tps looks like.

#### Re-order items in basic test report to be more in line with how one would read them.
    
Now that reports aren't always explicitly reordered to be alphabetical, put them in a general logical order here as well.