### PR TITLE
[PH] Perf harness wait for transactions in block

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -500,7 +500,7 @@ class Node(object):
 
     def waitForTransactionsInBlockRange(self, transIds, startBlock=2, maxFutureBlocks=None):
         lastBlockProcessed = startBlock
-        overallFinalBlock = self.getHeadBlockNum()
+        overallFinalBlock = sys.maxsize
         if maxFutureBlocks is not None:
             overallFinalBlock = overallFinalBlock + maxFutureBlocks
         while len(transIds) > 0:


### PR DESCRIPTION
Rather than waiting on empty blocks, instead wait for all transactions to appear in blocks. The number to determine is based on total transactions, with a fudge factor of 0.05 * TargetTPS additional blocks.