### PR TITLE
[PH] Perf harness wait for transactions in block

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -500,7 +500,7 @@ class Node(object):
 
     def waitForTransactionsInBlockRange(self, transIds, startBlock=2, maxFutureBlocks=None):
         lastBlockProcessed = startBlock
-        overallFinalBlock = self.getHeadBlockNum()
+        overallFinalBlock = sys.maxsize
         if maxFutureBlocks is not None:
             overallFinalBlock = overallFinalBlock + maxFutureBlocks
         while len(transIds) > 0:

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -498,11 +498,9 @@ class Node(object):
                     transIds.pop(trx['id'])
         return transIds
 
-    def waitForTransactionsInBlockRange(self, transIds, startBlock=2, maxFutureBlocks=None):
+    def waitForTransactionsInBlockRange(self, transIds, startBlock=2, maxFutureBlocks=0):
         lastBlockProcessed = startBlock
-        overallFinalBlock = sys.maxsize
-        if maxFutureBlocks is not None:
-            overallFinalBlock = overallFinalBlock + maxFutureBlocks
+        overallFinalBlock = startBlock + maxFutureBlocks
         while len(transIds) > 0:
             currentLoopEndBlock = self.getHeadBlockNum()
             if currentLoopEndBlock >  overallFinalBlock:

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -212,7 +212,7 @@ class PerformanceBasicTest:
         # Get stats after transaction generation stops
         trxSent = {}
         log_reader.scrapeTrxGenTrxSentDataLogs(trxSent, self.trxGenLogDirPath, self.quiet)
-        blocksToWait = ceil(self.expectedTransactionsSent / min(4000, 0.45 * self.targetTps))
+        blocksToWait = 2 * self.testTrxGenDurationSec + 10
         trxSent = self.validationNode.waitForTransactionsInBlockRange(trxSent, self.data.startBlock, blocksToWait)
         self.data.ceaseBlock = self.validationNode.getHeadBlockNum()
 


### PR DESCRIPTION
Rather than waiting on empty blocks, instead wait for all transactions to appear in blocks. The number to determine is based on total transactions, with a fudge factor of 0.05 * TargetTPS additional blocks.