### PR TITLE
don't triage new issues if they're already assigned to a project

### DIFF
--- a/.github/workflows/label_new_issues.yaml
+++ b/.github/workflows/label_new_issues.yaml
@@ -12,6 +12,7 @@ jobs:
       label: triage
       org-project: 'Team Backlog'
       project-field: Status=Todo
+      skip-if-existing-project: true
     secrets:
       token: ${{secrets.ENFCIBOT_REPO_AND_PROJECTS}}
 


### PR DESCRIPTION
When a new issue is created and it's already assigned to a project, skip the triage action which labels the new issue and adds it to a project. The heuristic here is that if an issue is created already assigned to a project it likely means it has been dispositioned appropriately already.

Requires AntelopeIO/issue-project-labeler-workflow#2
Resolves #294 