### PR TITLE
[PH] Launch Trx Generators updates

### DIFF
--- a/tests/performance_tests/launch_transaction_generators.py
+++ b/tests/performance_tests/launch_transaction_generators.py
@@ -10,55 +10,88 @@ harnessPath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(harnessPath)
 
 from TestHarness import Utils
-
 Print = Utils.Print
 
-parser = argparse.ArgumentParser(add_help=False)
-parser.add_argument("chain_id", type=str, help="Chain ID")
-parser.add_argument("last_irreversible_block_id", type=str, help="Last irreversible block ID")
-parser.add_argument("handler_account", type=str, help="Cluster handler account name")
-parser.add_argument("account_1_name", type=str, help="First account name")
-parser.add_argument("account_2_name", type=str, help="Second account name")
-parser.add_argument("account_1_priv_key", type=str, help="First account private key")
-parser.add_argument("account_2_priv_key", type=str, help="Second account private key")
-parser.add_argument("trx_gen_duration", type=str, help="How long to run transaction generators")
-parser.add_argument("target_tps", type=int, help="Goal transactions per second")
-parser.add_argument("tps_limit_per_generator", type=int, help="Maximum amount of transactions per second a single generator can have.", default=4000)
-parser.add_argument("log_dir", type=str, help="Path to directory where trx logs should be written.")
-args = parser.parse_args()
+class TransactionGeneratorsLauncher:
 
-targetTps = args.target_tps
-numGenerators = math.ceil(targetTps / args.tps_limit_per_generator)
-tpsPerGenerator = math.floor(targetTps / numGenerators)
-modTps = targetTps % numGenerators
-cleanlyDivisible = modTps == 0
-incrementPoint = numGenerators + 1 - modTps
-subprocess_ret_codes = []
-for num in range(1, numGenerators + 1):
-    if not cleanlyDivisible and num == incrementPoint:
-        tpsPerGenerator = tpsPerGenerator + 1
-    if Utils.Debug: Print(
-       f'Running trx_generator: ./tests/trx_generator/trx_generator  '
-       f'--chain-id {args.chain_id} '
-       f'--last-irreversible-block-id {args.last_irreversible_block_id} '
-       f'--handler-account {args.handler_account} '
-       f'--accounts {args.account_1_name},{args.account_2_name} '
-       f'--priv-keys {args.account_1_priv_key},{args.account_2_priv_key} '
-       f'--trx-gen-duration {args.trx_gen_duration} '
-       f'--target-tps {tpsPerGenerator} '
-       f'--log-dir {args.log_dir}'
-    )
-    subprocess_ret_codes.append(
-       subprocess.Popen([
-           './tests/trx_generator/trx_generator',
-           '--chain-id', f'{args.chain_id}',
-           '--last-irreversible-block-id', f'{args.last_irreversible_block_id}',
-           '--handler-account', f'{args.handler_account}',
-           '--accounts', f'{args.account_1_name},{args.account_2_name}',
-           '--priv-keys', f'{args.account_1_priv_key},{args.account_2_priv_key}',
-           '--trx-gen-duration', f'{args.trx_gen_duration}',
-           '--target-tps', f'{tpsPerGenerator}',
-           '--log-dir', f'{args.log_dir}'
-       ])
-    )
-exit_codes = [ret_code.wait() for ret_code in subprocess_ret_codes]
+    def __init__(self, chainId: int, lastIrreversibleBlockId: int, handlerAcct: str, accts: str, privateKeys: str,
+                 trxGenDurationSec: int, targetTps: int, tpsLimitPerGenerator: int, logDir: str):
+        self.chainId = chainId
+        self.lastIrreversibleBlockId = lastIrreversibleBlockId
+        self.handlerAcct  = handlerAcct
+        self.accts = accts
+        self.privateKeys = privateKeys
+        self.trxGenDurationSec  = trxGenDurationSec
+        self.targetTps = targetTps
+        self.tpsLimitPerGenerator  = tpsLimitPerGenerator
+        self.logDir = logDir
+
+        self.numGenerators = math.ceil(self.targetTps / self.tpsLimitPerGenerator)
+        self.tpsPerGenerator = math.floor(self.targetTps / self.numGenerators)
+        self.modTps = self.targetTps % self.numGenerators
+        self.cleanlyDivisible = self.modTps == 0
+        self.incrementPoint = self.numGenerators + 1 - self.modTps
+
+
+    def launch(self):
+        subprocess_ret_codes = []
+        for num in range(1, self.numGenerators + 1):
+            if not self.cleanlyDivisible and num == self.incrementPoint:
+                self.tpsPerGenerator = self.tpsPerGenerator + 1
+
+            if Utils.Debug:
+                Print(
+                    f'Running trx_generator: ./tests/trx_generator/trx_generator  '
+                    f'--chain-id {self.chainId} '
+                    f'--last-irreversible-block-id {self.lastIrreversibleBlockId} '
+                    f'--handler-account {self.handlerAcct} '
+                    f'--accounts {self.accts} '
+                    f'--priv-keys {self.privateKeys} '
+                    f'--trx-gen-duration {self.trxGenDurationSec} '
+                    f'--target-tps {self.tpsPerGenerator} '
+                    f'--log-dir {self.logDir}'
+                )
+            subprocess_ret_codes.append(
+                subprocess.Popen([
+                    './tests/trx_generator/trx_generator',
+                    '--chain-id', f'{self.chainId}',
+                    '--last-irreversible-block-id', f'{self.lastIrreversibleBlockId}',
+                    '--handler-account', f'{self.handlerAcct}',
+                    '--accounts', f'{self.accts}',
+                    '--priv-keys', f'{self.privateKeys}',
+                    '--trx-gen-duration', f'{self.trxGenDurationSec}',
+                    '--target-tps', f'{self.tpsPerGenerator}',
+                    '--log-dir', f'{self.logDir}'
+                ])
+            )
+        exit_codes = [ret_code.wait() for ret_code in subprocess_ret_codes]
+        return exit_codes
+
+def parseArgs():
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("chain_id", type=str, help="Chain ID")
+    parser.add_argument("last_irreversible_block_id", type=str, help="Last irreversible block ID")
+    parser.add_argument("handler_account", type=str, help="Cluster handler account name")
+    parser.add_argument("accounts", type=str, help="Comma separated list of account names")
+    parser.add_argument("priv_keys", type=str, help="Comma separated list of private keys.")
+    parser.add_argument("trx_gen_duration", type=str, help="How long to run transaction generators")
+    parser.add_argument("target_tps", type=int, help="Goal transactions per second")
+    parser.add_argument("tps_limit_per_generator", type=int, help="Maximum amount of transactions per second a single generator can have.", default=4000)
+    parser.add_argument("log_dir", type=str, help="Path to directory where trx logs should be written.")
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = parseArgs()
+
+    trxGenLauncher = TransactionGeneratorsLauncher(chainId=args.chain_id, lastIrreversibleBlockId=args.last_irreversible_block_id,
+                                                   handlerAcct=args.handler_account, accts=args.accounts,
+                                                   privateKeys=args.priv_keys, trxGenDurationSec=args.trx_gen_duration,
+                                                   targetTps=args.target_tps, tpsLimitPerGenerator=args.tps_limit_per_generator, logDir=args.log_dir)
+
+
+    exit_codes = trxGenLauncher.launch()
+    exit(exit_codes)
+
+if __name__ == '__main__':
+    main()

--- a/tests/performance_tests/log_reader.py
+++ b/tests/performance_tests/log_reader.py
@@ -338,8 +338,8 @@ def calcTrxLatencyCpuNetStats(trxDict : dict, blockDict: dict):
            basicStats(float(np.min(npLatencyCpuNetList[:,2])), float(np.max(npLatencyCpuNetList[:,2])), float(np.average(npLatencyCpuNetList[:,2])), float(np.std(npLatencyCpuNetList[:,2])), len(npLatencyCpuNetList))
 
 def createReport(guide: chainBlocksGuide, targetTps: int, testDurationSec: int, tpsLimitPerGenerator: int, tpsStats: stats, blockSizeStats: stats,
-                     trxLatencyStats: basicStats, trxCpuStats: basicStats, trxNetStats: basicStats, testStart: datetime, testFinish: datetime, argsDict, completedRun) -> dict:
-    numGenerators = math.ceil(targetTps / tpsLimitPerGenerator)
+                 trxLatencyStats: basicStats, trxCpuStats: basicStats, trxNetStats: basicStats, testStart: datetime, testFinish: datetime,
+                 argsDict: dict, completedRun: bool, numTrxGensUsed: int, targetTpsPerGenList: list) -> dict:
     report = {}
     report['completedRun'] = completedRun
     report['testStart'] = testStart
@@ -350,8 +350,8 @@ def createReport(guide: chainBlocksGuide, targetTps: int, testDurationSec: int, 
     report['Analysis']['TPS'] = asdict(tpsStats)
     report['Analysis']['TPS']['configTps'] = targetTps
     report['Analysis']['TPS']['configTestDuration'] = testDurationSec
-    report['Analysis']['TPS']['tpsPerGenerator'] = math.floor(targetTps / numGenerators)
-    report['Analysis']['TPS']['generatorCount'] = numGenerators
+    report['Analysis']['TPS']['tpsPerGenerator'] = targetTpsPerGenList
+    report['Analysis']['TPS']['generatorCount'] = numTrxGensUsed
     report['Analysis']['TrxCPU'] = asdict(trxCpuStats)
     report['Analysis']['TrxLatency'] = asdict(trxLatencyStats)
     report['Analysis']['TrxNet'] = asdict(trxNetStats)
@@ -366,7 +366,8 @@ def reportAsJSON(report: dict) -> json:
     return json.dumps(report, sort_keys=True, indent=2)
 
 def calcAndReport(data, targetTps, testDurationSec, tpsLimitPerGenerator, nodeosLogPath, trxGenLogDirPath, blockTrxDataPath, blockDataPath,
-                  numBlocksToPrune, argsDict, testStart: datetime, completedRun, quiet: bool) -> dict:
+                  numBlocksToPrune, argsDict: dict, testStart: datetime, completedRun: bool, numTrxGensUsed: int, targetTpsPerGenList: list,
+                  quiet: bool) -> dict:
     scrapeLog(data, nodeosLogPath)
 
     trxSent = {}
@@ -400,7 +401,7 @@ def calcAndReport(data, targetTps, testDurationSec, tpsLimitPerGenerator, nodeos
 
     report = createReport(guide=guide, targetTps=targetTps, testDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator, tpsStats=tpsStats,
                               blockSizeStats=blkSizeStats, trxLatencyStats=trxLatencyStats, trxCpuStats=trxCpuStats, trxNetStats=trxNetStats, testStart=start,
-                              testFinish=finish, argsDict=argsDict, completedRun=completedRun)
+                              testFinish=finish, argsDict=argsDict, completedRun=completedRun, numTrxGensUsed=numTrxGensUsed, targetTpsPerGenList=targetTpsPerGenList)
     return report
 
 def exportReportAsJSON(report: json, exportPath):

--- a/tests/performance_tests/log_reader.py
+++ b/tests/performance_tests/log_reader.py
@@ -360,12 +360,6 @@ def createReport(guide: chainBlocksGuide, targetTps: int, testDurationSec: int, 
     report['nodeosVersion'] = Utils.getNodeosVersion()
     return report
 
-def createJSONReport(guide: chainBlocksGuide, targetTps: int, testDurationSec: int, tpsLimitPerGenerator: int, tpsStats: stats, blockSizeStats: stats,
-                     trxLatencyStats: basicStats, trxCpuStats: basicStats, trxNetStats: basicStats, testStart: datetime, testFinish: datetime, argsDict, completedRun) -> json:
-    report = createReport(guide=guide, targetTps=targetTps, testDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator, tpsStats=tpsStats, blockSizeStats=blockSizeStats,
-                     trxLatencyStats=trxLatencyStats, trxCpuStats=trxCpuStats, trxNetStats=trxNetStats, testStart=testStart, testFinish=testFinish, argsDict=argsDict, completedRun=completedRun)
-    return reportAsJSON(report)
-
 def reportAsJSON(report: dict) -> json:
     report['testStart'] = "Unknown" if report['testStart'] is None else report['testStart'].isoformat()
     report['testFinish'] = "Unknown" if report['testFinish'] is None else report['testFinish'].isoformat()

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -204,7 +204,7 @@ class PerformanceBasicTest:
         subprocess.run([
             f"./tests/performance_tests/launch_transaction_generators.py",
             f"{chainId}", f"{lib_id}", f"{self.cluster.eosioAccount.name}",
-            f"{self.account1Name}", f"{self.account2Name}", f"{self.account1PrivKey}", f"{self.account2PrivKey}",
+            f"{self.account1Name},{self.account2Name}", f"{self.account1PrivKey},{self.account2PrivKey}",
             f"{self.testTrxGenDurationSec}", f"{self.targetTps}", f"{self.tpsLimitPerGenerator}", f"{self.trxGenLogDirPath}"
             ])
 

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -7,6 +7,7 @@ import shutil
 import signal
 import log_reader
 import inspect
+import launch_transaction_generators as ltg
 
 harnessPath = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(harnessPath)
@@ -201,12 +202,12 @@ class PerformanceBasicTest:
 
         self.data.startBlock = self.waitForEmptyBlocks(self.validationNode, self.emptyBlockGoal)
 
-        subprocess.run([
-            f"./tests/performance_tests/launch_transaction_generators.py",
-            f"{chainId}", f"{lib_id}", f"{self.cluster.eosioAccount.name}",
-            f"{self.account1Name},{self.account2Name}", f"{self.account1PrivKey},{self.account2PrivKey}",
-            f"{self.testTrxGenDurationSec}", f"{self.targetTps}", f"{self.tpsLimitPerGenerator}", f"{self.trxGenLogDirPath}"
-            ])
+        trxGenLauncher = ltg.TransactionGeneratorsLauncher(chainId=chainId, lastIrreversibleBlockId=lib_id,
+                                                           handlerAcct=self.cluster.eosioAccount.name, accts=f"{self.account1Name},{self.account2Name}",
+                                                           privateKeys=f"{self.account1PrivKey},{self.account2PrivKey}", trxGenDurationSec=self.testTrxGenDurationSec,
+                                                           targetTps=self.targetTps, tpsLimitPerGenerator=self.tpsLimitPerGenerator, logDir=self.trxGenLogDirPath)
+
+        trxGenLauncherExitCodes = trxGenLauncher.launch()
 
         # Get stats after transaction generation stops
         self.data.ceaseBlock = self.waitForEmptyBlocks(self.validationNode, self.emptyBlockGoal) - self.emptyBlockGoal + 1

--- a/tests/performance_tests/read_log_data.py
+++ b/tests/performance_tests/read_log_data.py
@@ -2,6 +2,7 @@
  
 import argparse
 import log_reader
+import launch_transaction_generators as ltg
 
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument("--target-tps", type=int, help="The target transfers per second to send during test", default=8000)
@@ -25,10 +26,16 @@ data.startBlock = args.start_block
 data.ceaseBlock = args.cease_block
 blockDataPath = f"{blockDataLogDirPath}/blockData.txt"
 blockTrxDataPath = f"{blockDataLogDirPath}/blockTrxData.txt"
-report = log_reader.calcAndReport(data=data, targetTps=args.target_tps, testDurationSec=args.test_duration_sec, tpsLimitPerGenerator=args.tps_limit_per_generator,
+tpsLimitPerGenerator=args.tps_limit_per_generator
+targetTps=args.target_tps
+tpsTrxGensConfig = ltg.TpsTrxGensConfig(targetTps=targetTps, tpsLimitPerGenerator=tpsLimitPerGenerator)
+
+
+report = log_reader.calcAndReport(data=data, targetTps=targetTps, testDurationSec=args.test_duration_sec, tpsLimitPerGenerator=tpsLimitPerGenerator,
                                   nodeosLogPath=nodeosLogPath, trxGenLogDirPath=trxGenLogDirPath, blockTrxDataPath=blockTrxDataPath, blockDataPath=blockDataPath,
                                   numBlocksToPrune=args.num_blocks_to_prune, argsDict=dict(item.split("=") for item in f"{args}"[10:-1].split(", ")), testStart=None,
-                                  completedRun=True, quiet=args.quiet)
+                                  completedRun=True, numTrxGensUsed=tpsTrxGensConfig.numGenerators, targetTpsPerGenList=tpsTrxGensConfig.targetTpsPerGenList,
+                                  quiet=args.quiet)
 
 if not args.quiet:
     print(data)


### PR DESCRIPTION
Updates to `launch_transaction_generators.py`:

1.  Support dynamic lists for account names and account private keys in similar fashion to how `trx_generator` is handling currently for extensibility.
2. Refactor to support use as an import module. This will allow returning configuration items back to caller.
3. Refactor to provide calculated configuration items to be passed back to the caller (num generators it will instantiate and list of TPS each generator will send) to allow validation in report as well as remove duplication of calculation.