### PR TITLE
[3.2 -> main] Changed default error handler to print help in cli apps by default

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2760,6 +2760,7 @@ int main( int argc, char** argv ) {
 
    CLI::App app{"Command Line Interface to EOSIO Client"};
    app.set_help_all_flag("--help-all", "Show all help");
+   app.failure_message(CLI::FailureMessage::help);
    app.require_subcommand();
    // Hide obsolete options by putting them into a group with an empty name.
    app.add_option( "-H,--host", obsoleted_option_host_port, localized("The host where ${n} is running", ("n", node_executable_name)) )->group("");

--- a/programs/leap-util/main.cpp
+++ b/programs/leap-util/main.cpp
@@ -24,6 +24,7 @@ int main(int argc, char** argv) {
    app.formatter(fmt);
 
    app.set_help_all_flag("--help-all", "Show all help");
+   app.failure_message(CLI::FailureMessage::help);
    app.require_subcommand(1, 2);
 
    // generics sc tree


### PR DESCRIPTION
This addresses issue when cli command (such as leap-util or cleos) is being executed with missing/incorrect parameters. Prior behavior displayed error message and exited. This is changed to automatic display of help in a context of existing command/subcommand
Example:

```
bin/cleos system 
ERROR: RequiredError: A subcommand is required
Send eosio.system contract action to the blockchain.
Usage: bin/cleos system [OPTIONS] SUBCOMMAND

Options:
  -h,--help                   Print this help message and exit
  --help-all                  Show all help


Subcommands:
  newaccount                  Create a new account on the blockchain with initial resources
  regproducer                 Register a new producer
  unregprod                   Unregister an existing producer
  voteproducer                Vote for a producer
  listproducers               List producers
  delegatebw                  Delegate bandwidth
  undelegatebw                Undelegate bandwidth
  listbw                      List delegated bandwidth
  bidname                     Name bidding
  bidnameinfo                 Get bidname info
  buyram                      Buy RAM
  sellram                     Sell RAM
  claimrewards                Claim producer rewards
  regproxy                    Register an account as a proxy (for voting)
  unregproxy                  Unregister an account as a proxy (for voting)
  canceldelay                 Cancel a delayed transaction
  activate                    Activate protocol feature by name
  rex                         Actions related to REX (the resource exchange)
```

Resolves #318 
Merges #371 into `main`