### PR TITLE
[3.2] fix threading on state_history shutdown leading to hung nodeos shutdown

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -704,7 +704,6 @@ void state_history_plugin::plugin_shutdown() {
    my->applied_transaction_connection.reset();
    my->accepted_block_connection.reset();
    my->block_start_connection.reset();
-   my->sessions.for_each([](auto& s) { s->close(); });
    my->stopping = true;
    my->trace_log->stop();
    my->chain_state_log->stop();


### PR DESCRIPTION
The call to a `session::close()` here leads to a threading violation: ship's network thread is still running at this time (i.e. `async_read()`/`async_write()` could be outstanding for a socket), and a `session::close()` will lead to a `socket::close()` which then could potentially access the socket simultaneously from two threads.

At first I was planning to wrap this one line in a `my->ctx.post()` but this call seems unnecessary: we can simply let the various dtors fire in their proper order. Once `state_history_plugin::plugin_shutdown()` returns there is no separate thread running thus no handlers are outstanding. Then `state_history_plugin` dtor will be fired which will destroy `sessions`, which then destroys the `session_set` which then destroys all the `session`s. This will cause the `socket::close()` to be called as part of the `session` dtor, but that's fine. Neither `session` nor `session_set` have a dtor implemented to anything troublesome here.

I was able to easily repro #411 and confirm this PR resolves #411 