### PR TITLE
only use ENF runners for builds in AntelopeIO Leap repository

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ${{fromJSON(needs.d.outputs.missing-platforms)}}
-    runs-on: ["self-hosted", "enf-x86-beefy"]
+    runs-on: ${{github.repository_owner == 'AntelopeIO' && fromJSON('["self-hosted", "enf-x86-beefy"]') || 'ubuntu-latest'}}
     permissions:
       packages: write
       contents: read
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu18, ubuntu20, ubuntu22]
-    runs-on: ["self-hosted", "enf-x86-beefy"]
+    runs-on: ${{github.repository_owner == 'AntelopeIO' && fromJSON('["self-hosted", "enf-x86-beefy"]') || 'ubuntu-latest'}}
     container: ${{fromJSON(needs.d.outputs.p)[matrix.platform].image}}
     steps:
         - uses: actions/checkout@v3
@@ -119,7 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu20, ubuntu22]
-    runs-on: ["self-hosted", "enf-x86-hightier"]
+    runs-on: ${{github.repository_owner == 'AntelopeIO' && fromJSON('["self-hosted", "enf-x86-hightier"]') || 'ubuntu-latest'}}
     container: ${{fromJSON(needs.d.outputs.p)[matrix.platform].image}}
     steps:
       - uses: actions/checkout@v3
@@ -146,7 +146,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu18, ubuntu20, ubuntu22]
-    runs-on: ["self-hosted", "enf-x86-midtier"]
+    runs-on: ${{github.repository_owner == 'AntelopeIO' && fromJSON('["self-hosted", "enf-x86-midtier"]') || 'ubuntu-latest'}}
     steps:
       - uses: actions/checkout@v3
       - name: Download builddir
@@ -175,7 +175,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu18, ubuntu20, ubuntu22]
-    runs-on: ["self-hosted", "enf-x86-lowtier"]
+    runs-on: ${{github.repository_owner == 'AntelopeIO' && fromJSON('["self-hosted", "enf-x86-lowtier"]') || 'ubuntu-latest'}}
     steps:
       - uses: actions/checkout@v3
       - name: Download builddir


### PR DESCRIPTION
One of the great strengths with Github Actions is that a user can fork a public repository and inherit a fully operational CI pipeline they can use for free on their public fork.

But that doesn't work for Leap currently because the workflow requires use of ENF runners which of course no other fork can utilize. Since we only use ENF runners for speed (Github's free runners do build the software as expected, afaik), let's only use ENF runners for builds in the AntelopeIO org. Forks will use Github's free runners.

Is there a better way to do this? Maybe only check the string once in the `d` job and reference a boolean elsewhere?