### PR TITLE
[3.2] change the HTTP Server header to be nodeos/keosd version

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -359,6 +359,8 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
             }
          }
 
+         my->plugin_state->server_header = current_http_plugin_defaults.server_header;
+
          
          //watch out for the returns above when adding new code here
       } FC_LOG_AND_RETHROW()

--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -106,7 +106,8 @@ protected:
       res_->version(req.version());
       res_->set(http::field::content_type, "application/json");
       res_->keep_alive(req.keep_alive());
-      res_->set(http::field::server, BOOST_BEAST_VERSION_STRING);
+      if(plugin_state_->server_header.size())
+         res_->set(http::field::server, plugin_state_->server_header);
 
       // Request path must be absolute and not contain "..".
       if(req.target().empty() || req.target()[0] != '/' || req.target().find("..") != beast::string_view::npos) {

--- a/plugins/http_plugin/include/eosio/http_plugin/common.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/common.hpp
@@ -130,6 +130,8 @@ struct http_plugin_state {
    bool validate_host = true;
    set<string> valid_hosts;
 
+   string server_header;
+
    url_handlers_type url_handlers;
    bool keep_alive = false;
 

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -45,6 +45,8 @@ namespace eosio {
       //If non 0, HTTP will be enabled by default on the given port number. If
       // 0, HTTP will not be enabled by default
       uint16_t default_http_port{0};
+      //If set, a Server header will be added to the HTTP reply with this value
+      string server_header;
    };
 
    /**

--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -81,7 +81,8 @@ int main(int argc, char** argv)
       app().set_default_config_dir(home / "eosio-wallet");
       http_plugin::set_defaults({
          .default_unix_socket_path = keosd::config::key_store_executable_name + ".sock",
-         .default_http_port = 0
+         .default_http_port = 0,
+         .server_header = keosd::config::key_store_executable_name + "/" + app().version_string()
       });
       app().register_plugin<wallet_api_plugin>();
       if(!app().initialize<wallet_plugin, wallet_api_plugin, http_plugin>(argc, argv)) {

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -120,7 +120,8 @@ int main(int argc, char** argv)
       app().set_default_config_dir(root / "eosio" / nodeos::config::node_executable_name / "config" );
       http_plugin::set_defaults({
          .default_unix_socket_path = "",
-         .default_http_port = 8888
+         .default_http_port = 8888,
+         .server_header = nodeos::config::node_executable_name + "/" + app().version_string()
       });
       if(!app().initialize<chain_plugin, net_plugin, producer_plugin, resource_monitor_plugin>(argc, argv)) {
          const auto& opts = app().get_options();


### PR DESCRIPTION
Prior to Leap 3.2, the HTTP server would respond with `Server: WebSocket++/0.7.0`. In 3.2, the response became `Server: Boost.Beast/330` (or potentially some other number based on boost version being used).

Instead, we can set this to the nodeos version, so the response is something like `Server: nodeos/v3.2.0-rc2`. Besides being more accurate, this may help troubleshoot issues when a user isn't sure what nodeos version they are communicating with. But there is also a school of thought that a server shouldn't reveal too much about itself for security reasons.

Would resolve #378