### PR TITLE
[4.0] Use libcurl  for cleos

### DIFF
--- a/.cicd/platforms/ubuntu18.Dockerfile
+++ b/.cicd/platforms/ubuntu18.Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get upgrade -y && \
                                                       g++-8                       \
                                                       git                         \
                                                       jq                          \
+                                                      libcurl4-openssl-dev        \
                                                       libgmp-dev                  \
                                                       libssl-dev                  \
                                                       llvm-7-dev                  \

--- a/.cicd/platforms/ubuntu20.Dockerfile
+++ b/.cicd/platforms/ubuntu20.Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get upgrade -y && \
                                                       git                  \
                                                       jq                   \
                                                       libboost-all-dev     \
+                                                      libcurl4-openssl-dev \
                                                       libgmp-dev           \
                                                       libssl-dev           \
                                                       llvm-11-dev          \

--- a/.cicd/platforms/ubuntu22.Dockerfile
+++ b/.cicd/platforms/ubuntu22.Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get upgrade -y && \
                                                       git                  \
                                                       jq                   \
                                                       libboost-all-dev     \
+                                                      libcurl4-openssl-dev \
                                                       libgmp-dev           \
                                                       libssl-dev           \
                                                       llvm-11-dev          \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Requirements to build:
   - newer versions do not work
 - openssl 1.1+
 - curl
+- libcurl 7.40.0+
 - git
 - GMP
 - Python 3
@@ -70,7 +71,7 @@ git clone --recursive https://github.com/AntelopeIO/leap.git
 git clone --recursive git@github.com:AntelopeIO/leap.git
 ```
 
-> ℹ️ **HTTPS vs. SSH Clone** ℹ️  
+> ℹ️ **HTTPS vs. SSH Clone** ℹ️
 Both an HTTPS or SSH git clone will yield the same result - a folder named `leap` containing our source code. It doesn't matter which type you use.
 
 Navigate into that folder:
@@ -94,13 +95,13 @@ git submodule update --init --recursive
 ### Step 3 - Build
 Select build instructions below for a [pinned build](#pinned-build) (preferred) or an [unpinned build](#unpinned-build).
 
-> ℹ️ **Pinned vs. Unpinned Build** ℹ️  
+> ℹ️ **Pinned vs. Unpinned Build** ℹ️
 We have two types of builds for Leap: "pinned" and "unpinned." The only difference is that pinned builds use specific versions for some dependencies hand-picked by the Leap engineers - they are "pinned" to those versions. In contrast, unpinned builds use the default dependency versions available on the build system at the time. We recommend performing a "pinned" build to ensure the compiler and boost versions remain the same between builds of different Leap versions. Leap requires these versions to remain the same, otherwise its state might need to be recovered from a portable snapshot or the chain needs to be replayed.
 
-> ⚠️ **A Warning On Parallel Compilation Jobs (`-j` flag)** ⚠️  
+> ⚠️ **A Warning On Parallel Compilation Jobs (`-j` flag)** ⚠️
 When building C/C++ software, often the build is performed in parallel via a command such as `make -j "$(nproc)"` which uses all available CPU threads. However, be aware that some compilation units (`*.cpp` files) in Leap will consume nearly 4GB of memory. Failures due to memory exhaustion will typically, but not always, manifest as compiler crashes. Using all available CPU threads may also prevent you from doing other things on your computer during compilation. For these reasons, consider reducing this value.
 
-> 🐋 **Docker and `sudo`** 🐋  
+> 🐋 **Docker and `sudo`** 🐋
 If you are in an Ubuntu docker container, omit `sudo` from all commands because you run as `root` by default. Most other docker containers also exclude `sudo`, especially Debian-family containers. If your shell prompt is a hash tag (`#`), omit `sudo`.
 
 #### Pinned Build

--- a/programs/cleos/CMakeLists.txt
+++ b/programs/cleos/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(CURL REQUIRED)
+find_package(CURL 7.40.0 REQUIRED)
 
 configure_file(help_text.cpp.in help_text.cpp @ONLY)
 configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)

--- a/programs/cleos/CMakeLists.txt
+++ b/programs/cleos/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(CURL REQUIRED)
+
 configure_file(help_text.cpp.in help_text.cpp @ONLY)
 configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
 add_executable( ${CLI_CLIENT_EXECUTABLE_NAME} main.cpp httpc.cpp "${CMAKE_CURRENT_BINARY_DIR}/help_text.cpp" localize.hpp "${CMAKE_CURRENT_BINARY_DIR}/config.hpp")
@@ -13,6 +15,11 @@ target_include_directories(${CLI_CLIENT_EXECUTABLE_NAME} PUBLIC ${CMAKE_CURRENT_
 target_link_libraries( ${CLI_CLIENT_EXECUTABLE_NAME}
                        PRIVATE appbase version leap-cli11 chain_api_plugin producer_plugin chain_plugin http_plugin eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 
+if (CURL_FOUND)
+  target_sources(${CLI_CLIENT_EXECUTABLE_NAME} PRIVATE do_http_post_libcurl.cpp)
+  target_include_directories(${CLI_CLIENT_EXECUTABLE_NAME} PRIVATE ${CURL_INCLUDE_DIRS})
+  target_link_libraries(${CLI_CLIENT_EXECUTABLE_NAME} PRIVATE ${CURL_LIBRARIES})
+endif()
 
 copy_bin( ${CLI_CLIENT_EXECUTABLE_NAME} )
 install( TARGETS

--- a/programs/cleos/do_http_post.hpp
+++ b/programs/cleos/do_http_post.hpp
@@ -1,0 +1,14 @@
+
+#pragma once
+
+#include <cstring>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace eosio { namespace client { namespace http {
+   std::tuple<unsigned int, std::string> do_http_post(const std::string& base_uri, const std::string& path,
+                                                      const std::vector<std::string>& headers,
+                                                      const std::string& postjson, bool verify_cert, bool verbose,
+                                                      bool trace);
+}}} // namespace eosio::client::http

--- a/programs/cleos/do_http_post_libcurl.cpp
+++ b/programs/cleos/do_http_post_libcurl.cpp
@@ -80,7 +80,7 @@ namespace eosio { namespace client { namespace http {
 
       auto curl = curl_easy_init();
       EOS_ASSERT(curl != 0, chain::http_exception, "curl_easy_init failed");
-      fc::make_scoped_exit([curl]() {
+      auto on_exit = fc::make_scoped_exit([curl]() {
          curl_easy_cleanup(curl);
       });
 

--- a/programs/cleos/do_http_post_libcurl.cpp
+++ b/programs/cleos/do_http_post_libcurl.cpp
@@ -1,0 +1,135 @@
+
+
+#include "do_http_post.hpp"
+#include <curl/curl.h>
+#include <eosio/chain/exceptions.hpp>
+
+namespace eosio { namespace client { namespace http {
+
+   static size_t write_callback(void* data, size_t size, size_t nmemb, void* userp) {
+      size_t       realsize = size * nmemb;
+      std::string& mem      = *(std::string*)userp;
+      mem.append((const char*)data, realsize);
+      return realsize;
+   }
+
+   void dump(const char* text, FILE* stream, unsigned char* ptr, size_t size) {
+      size_t       i;
+      size_t       c;
+      unsigned int width = 0x10;
+
+      fprintf(stream, "%s, %10.10ld bytes (0x%8.8lx)\n", text, (long)size, (long)size);
+
+      for (i = 0; i < size; i += width) {
+         fprintf(stream, "%4.4lx: ", (long)i);
+
+         /* show hex to the left */
+         for (c = 0; c < width; c++) {
+            if (i + c < size)
+               fprintf(stream, "%02x ", ptr[i + c]);
+            else
+               fputs("   ", stream);
+         }
+
+         /* show data on the right */
+         for (c = 0; (c < width) && (i + c < size); c++) {
+            char x = (ptr[i + c] >= 0x20 && ptr[i + c] < 0x80) ? ptr[i + c] : '.';
+            fputc(x, stream);
+         }
+
+         fputc('\n', stream); /* newline */
+      }
+   }
+
+   int my_trace(CURL* handle, curl_infotype type, char* data, size_t size, void* userp) {
+      const char* text;
+      (void)handle; /* prevent compiler warning */
+      (void)userp;
+
+      switch (type) {
+         case CURLINFO_TEXT: fprintf(stderr, "== Info: %s", data);
+         default: /* in case a new one is introduced to shock us */ return 0;
+
+         case CURLINFO_HEADER_OUT: text = "=> Send header"; break;
+         case CURLINFO_DATA_OUT: text = "=> Send data"; break;
+         case CURLINFO_SSL_DATA_OUT: text = "=> Send SSL data"; break;
+         case CURLINFO_HEADER_IN: text = "<= Recv header"; break;
+         case CURLINFO_DATA_IN: text = "<= Recv data"; break;
+         case CURLINFO_SSL_DATA_IN: text = "<= Recv SSL data"; break;
+      }
+
+      dump(text, stderr, (unsigned char*)data, size);
+      return 0;
+   }
+
+   std::tuple<unsigned int, std::string> do_http_post(const std::string& base_uri, const std::string& path,
+                                                      const std::vector<std::string>& headers,
+                                                      const std::string& postjson, bool verify_cert, bool verbose,
+                                                      bool trace) {
+
+      static bool initialized = false;
+
+      if (!initialized) {
+         auto res = curl_global_init(CURL_GLOBAL_DEFAULT);
+         EOS_ASSERT(res == CURLE_OK, chain::http_exception, curl_easy_strerror(res));
+         initialized = true;
+      }
+
+      auto curl = curl_easy_init();
+      EOS_ASSERT(curl != 0, chain::http_exception, "curl_easy_init failed");
+
+      std::string uri;
+
+      const char* unix_socket_prefix     = "unix://";
+      const int   unix_socket_prefix_len = strlen(unix_socket_prefix);
+
+      if (strncmp(unix_socket_prefix, base_uri.c_str(), unix_socket_prefix_len) == 0) {
+         curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, base_uri.c_str() + unix_socket_prefix_len);
+         uri = "http://localhost" + path;
+      } else {
+         uri = base_uri + path;
+      }
+
+      curl_easy_setopt(curl, CURLOPT_URL, uri.c_str());
+      curl_easy_setopt(curl, CURLOPT_POST, 1L);
+      curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, (long)CURL_HTTP_VERSION_1_1);
+      curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, postjson.size());
+      curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postjson.c_str());
+
+      if (trace) {
+         curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, my_trace);
+         curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+      }
+
+      if (verbose || trace)
+         curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+
+      struct curl_slist* list = NULL;
+
+      for (auto& h : headers) list = curl_slist_append(list, h.c_str());
+
+      list = curl_slist_append(list, "Content-Type: application/json");
+
+      curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
+      curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+
+      std::string response;
+
+      curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)&response);
+      if (verify_cert)
+         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+
+      auto res = curl_easy_perform(curl);
+
+      long http_code = 0;
+      if (res == CURLE_OK) {
+         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+      }
+
+      curl_easy_cleanup(curl);
+
+      EOS_ASSERT(res == CURLE_OK, chain::http_exception, curl_easy_strerror(res));
+
+      return { http_code, response };
+   }
+}}} // namespace eosio::client::http

--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -8,252 +8,41 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#include <eosio/chain/exceptions.hpp>
+#include <eosio/chain_plugin/chain_plugin.hpp>
+#include <eosio/http_plugin/http_plugin.hpp>
+#include <fc/io/json.hpp>
+#include <fc/variant.hpp>
 #include <iostream>
 #include <istream>
 #include <ostream>
-#include <string>
-#include <regex>
-#include <boost/algorithm/string.hpp>
-#include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
-#include <fc/variant.hpp>
-#include <fc/io/json.hpp>
-#include <fc/network/platform_root_ca.hpp>
-#include <eosio/chain/exceptions.hpp>
-#include <eosio/http_plugin/http_plugin.hpp>
-#include <eosio/chain_plugin/chain_plugin.hpp>
-#include <boost/asio/ssl/rfc2818_verification.hpp>
 #include "httpc.hpp"
+#include "do_http_post.hpp"
 
-using boost::asio::ip::tcp;
 using namespace eosio::chain;
+
 namespace eosio { namespace client { namespace http {
 
-   namespace detail {
-      class http_context_impl {
-         public:
-            boost::asio::io_service ios;
-      };
-
-      void http_context_deleter::operator()(http_context_impl* p) const {
-         delete p;
-      }
-   }
-
-   http_context create_http_context() {
-      return http_context(new detail::http_context_impl, detail::http_context_deleter());
-   }
-
-   void do_connect(tcp::socket& sock, const resolved_url& url) {
-      // Get a list of endpoints corresponding to the server name.
-      vector<tcp::endpoint> endpoints;
-      endpoints.reserve(url.resolved_addresses.size());
-      for (const auto& addr: url.resolved_addresses) {
-         endpoints.emplace_back(boost::asio::ip::make_address(addr), url.resolved_port);
-      }
-      boost::asio::connect(sock, endpoints);
-   }
-
-   template<class T>
-   std::string do_txrx(T& socket, boost::asio::streambuf& request_buff, unsigned int& status_code) {
-      // Send the request.
-      boost::asio::write(socket, request_buff);
-
-      // Read the response status line. The response streambuf will automatically
-      // grow to accommodate the entire line. The growth may be limited by passing
-      // a maximum size to the streambuf constructor.
-      boost::asio::streambuf response;
-      boost::asio::read_until(socket, response, "\r\n");
-
-      // Check that response is OK.
-      std::istream response_stream(&response);
-      std::string http_version;
-      response_stream >> http_version;
-      response_stream >> status_code;
-
-      std::string status_message;
-      std::getline(response_stream, status_message);
-      EOS_ASSERT( !(!response_stream || http_version.substr(0, 5) != "HTTP/"), invalid_http_response, "Invalid Response" );
-
-      // Read the response headers, which are terminated by a blank line.
-      boost::asio::read_until(socket, response, "\r\n\r\n");
-
-      // Process the response headers.
-      std::string header;
-      int response_content_length = -1;
-      std::regex clregex(R"xx(^content-length:\s+(\d+))xx", std::regex_constants::icase);
-      while (std::getline(response_stream, header) && header != "\r") {
-         std::smatch match;
-         if(std::regex_search(header, match, clregex))
-            response_content_length = std::stoi(match[1]);
-      }
-
-      // Attempt to read the response body using the length indicated by the
-      // Content-length header. If the header was not present just read all available bytes.
-      if( response_content_length != -1 ) {
-         response_content_length -= response.size();
-         if( response_content_length > 0 )
-            boost::asio::read(socket, response, boost::asio::transfer_exactly(response_content_length));
-      } else {
-         boost::system::error_code ec;
-         boost::asio::read(socket, response, boost::asio::transfer_all(), ec);
-         EOS_ASSERT(!ec || ec == boost::asio::ssl::error::stream_truncated, http_exception, "Unable to read http response: ${err}", ("err",ec.message()));
-      }
-
-      std::stringstream re;
-      re << &response;
-      return re.str();
-   }
-
-   parsed_url parse_url( const string& server_url ) {
-      parsed_url res;
-
-      //unix socket doesn't quite follow classical "URL" rules so deal with it manually
-      if(boost::algorithm::starts_with(server_url, "unix://")) {
-         res.scheme = "unix";
-         res.server = server_url.substr(strlen("unix://"));
-         return res;
-      }
-
-      //via rfc3986 and modified a bit to suck out the port number
-      //Sadly this doesn't work for ipv6 addresses
-      std::regex rgx(R"xx(^(([^:/?#]+):)?(//([^:/?#]*)(:(\d+))?)?([^?#]*)(\?([^#]*))?(#(.*))?)xx");
-      std::smatch match;
-      if(std::regex_search(server_url.begin(), server_url.end(), match, rgx)) {
-         res.scheme = match[2];
-         res.server = match[4];
-         res.port = match[6];
-         res.path = match[7];
-      }
-      if(res.scheme != "http" && res.scheme != "https")
-         EOS_THROW(fail_to_resolve_host, "Unrecognized URL scheme (${s}) in URL \"${u}\"", ("s", res.scheme)("u", server_url));
-      if(res.server.empty())
-         EOS_THROW(fail_to_resolve_host, "No server parsed from URL \"${u}\"", ("u", server_url));
-      if(res.port.empty())
-         res.port = res.scheme == "http" ? "80" : "443";
-      boost::trim_right_if(res.path, boost::is_any_of("/"));
-      return res;
-   }
-
-   resolved_url resolve_url( const http_context& context, const parsed_url& url ) {
-      if(url.scheme == "unix")
-         return resolved_url(url);
-
-      tcp::resolver resolver(context->ios);
-      boost::system::error_code ec;
-      auto result = resolver.resolve(tcp::v4(), url.server, url.port, ec);
-      if (ec) {
-         EOS_THROW(fail_to_resolve_host, "Error resolving \"${server}:${port}\" : ${m}", ("server", url.server)("port",url.port)("m",ec.message()));
-      }
-
-      // non error results are guaranteed to return a non-empty range
-      vector<string> resolved_addresses;
-      resolved_addresses.reserve(result.size());
-      std::optional<uint16_t> resolved_port;
-      bool is_loopback = true;
-
-      for(const auto& r : result) {
-         const auto& addr = r.endpoint().address();
-         if (addr.is_v6()) continue;
-         uint16_t port = r.endpoint().port();
-         resolved_addresses.emplace_back(addr.to_string());
-         is_loopback = is_loopback && addr.is_loopback();
-
-         if (resolved_port) {
-            EOS_ASSERT(*resolved_port == port, resolved_to_multiple_ports, "Service name \"${port}\" resolved to multiple ports and this is not supported!", ("port",url.port));
-         } else {
-            resolved_port = port;
-         }
-      }
-
-      return resolved_url(url, std::move(resolved_addresses), *resolved_port, is_loopback);
-   }
-
-   string format_host_header(const resolved_url& url) {
-      // common practice is to only make the port explicit when it is the non-default port
-      if (
-         (url.scheme == "https" && url.resolved_port == 443) ||
-         (url.scheme == "http" && url.resolved_port == 80)
-      ) {
-         return url.server;
-      } else {
-         return url.server + ":" + url.port;
-      }
-   }
-
-   fc::variant do_http_call( const connection_param& cp,
-                             const fc::variant& postdata,
-                             bool print_request,
-                             bool print_response ) {
+fc::variant do_http_call(const config_t& config, const std::string& base_uri, const std::string& path,
+                            const fc::variant& postdata) {
    std::string postjson;
-   if( !postdata.is_null() ) {
-      postjson = print_request ? fc::json::to_pretty_string( postdata ) : fc::json::to_string( postdata, fc::time_point::maximum() );
-   }
-
-   const auto& url = cp.url;
-
-   boost::asio::streambuf request;
-   std::ostream request_stream(&request);
-   auto host_header_value = format_host_header(url);
-   request_stream << "POST " << url.path << " HTTP/1.1\r\n";
-   request_stream << "Host: " << host_header_value << "\r\n";
-   request_stream << "content-length: " << postjson.size() << "\r\n";
-   request_stream << "Accept: */*\r\n";
-   request_stream << "Connection: close\r\n";
-   // append more customized headers
-   std::vector<string>::iterator itr;
-   for (itr = cp.headers.begin(); itr != cp.headers.end(); itr++) {
-      request_stream << *itr << "\r\n";
-   }
-   request_stream << "\r\n";
-   request_stream << postjson;
-
-   if ( print_request ) {
-      string s(request.size(), '\0');
-      buffer_copy(boost::asio::buffer(s), request.data());
-      std::cerr << "REQUEST:" << std::endl
-                << "---------------------" << std::endl
-                << s << std::endl
-                << "---------------------" << std::endl;
-   }
-
-   unsigned int status_code;
-   std::string re;
-
-   try {
-      if(url.scheme == "unix") {
-         boost::asio::local::stream_protocol::socket unix_socket(cp.context->ios);
-         unix_socket.connect(boost::asio::local::stream_protocol::endpoint(url.server));
-         re = do_txrx(unix_socket, request, status_code);
+   if (!postdata.is_null()) {
+      if (config.print_request) {
+         postjson = fc::json::to_pretty_string(postdata);
+         std::cerr << "REQUEST:\n"
+                     << "---------------------\n"
+                     << postjson << "\n"
+                     << "---------------------" << std::endl;
+      } else {
+         postjson = fc::json::to_string(postdata, fc::time_point::maximum());
       }
-      else if(url.scheme == "http") {
-         tcp::socket socket(cp.context->ios);
-         do_connect(socket, url);
-         re = do_txrx(socket, request, status_code);
-      }
-      else { //https
-         boost::asio::ssl::context ssl_context(boost::asio::ssl::context::sslv23_client);
-         fc::add_platform_root_cas_to_context(ssl_context);
-
-         boost::asio::ssl::stream<boost::asio::ip::tcp::socket> socket(cp.context->ios, ssl_context);
-         SSL_set_tlsext_host_name(socket.native_handle(), url.server.c_str());
-         if(cp.verify_cert) {
-            socket.set_verify_mode(boost::asio::ssl::verify_peer);
-            socket.set_verify_callback(boost::asio::ssl::rfc2818_verification(url.server));
-         }
-         do_connect(socket.next_layer(), url);
-         socket.handshake(boost::asio::ssl::stream_base::client);
-         re = do_txrx(socket, request, status_code);
-         //try and do a clean shutdown; but swallow if this fails (other side could have already gave TCP the ax)
-         try {socket.shutdown();} catch(...) {}
-      }
-   } catch ( invalid_http_request& e ) {
-      e.append_log( FC_LOG_MESSAGE( info, "Please verify this url is valid: ${url}", ("url", url.scheme + "://" + url.server + ":" + url.port + url.path) ) );
-      e.append_log( FC_LOG_MESSAGE( info, "If the condition persists, please contact the RPC server administrator for ${server}!", ("server", url.server) ) );
-      throw;
    }
+
+   auto [status_code, re] = do_http_post(base_uri, path, config.headers, postjson, !config.no_verify_cert,
+                                          config.verbose, config.trace);
 
    fc::variant response_result;
+   bool        print_response = config.print_response;
    try {
       response_result = fc::json::from_string(re);
    } catch(...) {
@@ -273,13 +62,13 @@ namespace eosio { namespace client { namespace http {
          return response_result;
       } else if( status_code == 404 ) {
          // Unknown endpoint
-         if (url.path.compare(0, chain_func_base.size(), chain_func_base) == 0) {
+         if (path.compare(0, chain_func_base.size(), chain_func_base) == 0) {
             throw chain::missing_chain_api_plugin_exception(FC_LOG_MESSAGE(error, "Chain API plugin is not enabled"));
-         } else if (url.path.compare(0, wallet_func_base.size(), wallet_func_base) == 0) {
+         } else if (path.compare(0, wallet_func_base.size(), wallet_func_base) == 0) {
             throw chain::missing_wallet_api_plugin_exception(FC_LOG_MESSAGE(error, "Wallet is not available"));
-         } else if (url.path.compare(0, history_func_base.size(), history_func_base) == 0) {
+         } else if (path.compare(0, history_func_base.size(), history_func_base) == 0) {
             throw chain::missing_history_api_plugin_exception(FC_LOG_MESSAGE(error, "History API plugin is not enabled"));
-         } else if (url.path.compare(0, net_func_base.size(), net_func_base) == 0) {
+         } else if (path.compare(0, net_func_base.size(), net_func_base) == 0) {
             throw chain::missing_net_api_plugin_exception(FC_LOG_MESSAGE(error, "Net API plugin is not enabled"));
          }
       } else {

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -1,82 +1,23 @@
 #pragma once
-
 #include "config.hpp"
+#include <fc/variant.hpp>
+#include <string>
+#include <vector>
 
 namespace eosio { namespace client { namespace http {
+   using std::string;
 
-   namespace detail {
-      class http_context_impl;
-
-      struct http_context_deleter {
-         void operator()(http_context_impl*) const;
-      };
-   }
-
-   using http_context = std::unique_ptr<detail::http_context_impl, detail::http_context_deleter>;
-
-   http_context create_http_context();
-
-   struct parsed_url {
-      string scheme;
-      string server;
-      string port;
-      string path;
-
-      static string normalize_path(const string& path);
-
-      parsed_url operator+ (string sub_path) {
-         return {scheme, server, port, path + sub_path};
-      }
+   struct config_t {
+      std::vector<std::string> headers;
+      bool                     no_verify_cert = false;
+      bool                     verbose        = false;
+      bool                     trace          = false;
+      bool                     print_request  = false;
+      bool                     print_response = false;
    };
 
-   parsed_url parse_url( const string& server_url );
-
-   struct resolved_url : parsed_url {
-      resolved_url( const parsed_url& url, vector<string>&& resolved_addresses, uint16_t resolved_port, bool is_loopback)
-      :parsed_url(url)
-      ,resolved_addresses(std::move(resolved_addresses))
-      ,resolved_port(resolved_port)
-      ,is_loopback(is_loopback)
-      {
-      }
-
-      //used for unix domain, where resolving and ports are nonapplicable
-      resolved_url(const parsed_url& url) : parsed_url(url) {}
-
-      vector<string> resolved_addresses;
-      uint16_t resolved_port = 0;
-      bool is_loopback = false;
-   };
-
-   resolved_url resolve_url( const http_context& context,
-                             const parsed_url& url );
-
-   struct connection_param {
-      const http_context& context;
-      resolved_url url;
-      bool verify_cert;
-      std::vector<string>& headers;
-
-      connection_param( const http_context& context,
-                        const resolved_url& url,
-                        bool verify,
-                        std::vector<string>& h) : context(context),url(url), headers(h) {
-         verify_cert = verify;
-      }
-
-      connection_param( const http_context& context,
-                        const parsed_url& url,
-                        bool verify,
-                        std::vector<string>& h) : context(context),url(resolve_url(context, url)), headers(h) {
-         verify_cert = verify;
-      }
-   };
-
-   fc::variant do_http_call(
-                             const connection_param& cp,
-                             const fc::variant& postdata = fc::variant(),
-                             bool print_request = false,
-                             bool print_response = false);
+   fc::variant do_http_call(const config_t& config, const std::string& base_uri, const std::string& path,
+                            const fc::variant& postdata);
 
    const string chain_func_base = "/v1/chain";
    const string get_info_func = chain_func_base + "/get_info";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -155,12 +155,10 @@ std::string clean_output( std::string str ) {
    return fc::escape_string( str, nullptr, escape_control_chars );
 }
 
-string default_url = "http://127.0.0.1:8888/";
+string default_url = "http://127.0.0.1:8888";
 string default_wallet_url = "unix://" + (determine_home_directory() / "eosio-wallet" / (string(key_store_executable_name) + ".sock")).string();
 string wallet_url; //to be set to default_wallet_url in main
 std::map<name, std::string>  abi_files_override;
-bool no_verify = false;
-vector<string> headers;
 
 auto   tx_expiration = fc::seconds(30);
 const fc::microseconds abi_serializer_max_time = fc::seconds(10); // No risk to client side serialization taking a long time
@@ -178,8 +176,7 @@ uint16_t tx_retry_num_blocks = 0;
 bool   tx_use_old_rpc = false;
 bool   tx_use_old_send_rpc = false;
 string tx_json_save_file;
-bool   print_request = false;
-bool   print_response = false;
+eosio::client::http::config_t http_config;
 bool   no_auto_keosd = false;
 bool   verbose = false;
 int    return_code = 0;
@@ -190,8 +187,6 @@ uint32_t tx_max_net_usage = 0;
 uint32_t delaysec = 0;
 
 vector<string> tx_permission;
-
-eosio::client::http::http_context context;
 
 enum class tx_compression_type {
    none,
@@ -319,8 +314,7 @@ fc::variant call( const std::string& url,
                   const std::string& path,
                   const T& v ) {
    try {
-      auto sp = std::make_unique<eosio::client::http::connection_param>(context, parse_url(url) + path, no_verify ? false : true, headers);
-      return eosio::client::http::do_http_call(*sp, fc::variant(v), print_request, print_response );
+      return eosio::client::http::do_http_call(http_config, url, path, fc::variant(v));
    }
    catch(boost::system::system_error& e) {
       std::string exec_name;
@@ -2728,7 +2722,7 @@ CLI::callback_t header_opt_callback = [](CLI::results_t res) {
    vector<string>::iterator itr;
 
    for (itr = res.begin(); itr != res.end(); itr++) {
-       headers.push_back(*itr);
+       http_config.headers.push_back(*itr);
    }
 
    return true;
@@ -2755,7 +2749,7 @@ CLI::callback_t abi_files_overide_callback = [](CLI::results_t account_abis) {
 int main( int argc, char** argv ) {
 
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
-   context = eosio::client::http::create_http_context();
+
    wallet_url = default_wallet_url;
 
    CLI::App app{"Command Line Interface to EOSIO Client"};
@@ -2775,18 +2769,23 @@ int main( int argc, char** argv ) {
    app.add_option( "--wallet-host", obsoleted_option_host_port, localized("The host where ${k} is running", ("k", key_store_executable_name)) )->group("");
    app.add_option( "--wallet-port", obsoleted_option_host_port, localized("The port where ${k} is running", ("k", key_store_executable_name)) )->group("");
 
-   app.add_option( "-u,--url", ::default_url, localized( "The http/https URL where ${n} is running", ("n", node_executable_name)))->capture_default_str();
+   app.add_option_function<std::string>( "-u,--url", [](const std::string& url) {
+      ::default_url = url;
+      if (url.back()=='/') ::default_url.resize(url.size()-1); // remove trailing slash
+   }, localized( "The http/https URL where ${n} is running", ("n", node_executable_name)))->default_str(::default_url);
    app.add_option( "--wallet-url", wallet_url, localized("The http/https URL where ${k} is running", ("k", key_store_executable_name)))->capture_default_str();
 
    app.add_option( "--abi-file", abi_files_overide_callback, localized("In form of <contract name>:<abi file path>, use a local abi file for serialization and deserialization instead of getting the abi data from the blockchain; repeat this option to pass multiple abi files for different contracts"))->type_size(0, 1000);
    app.add_option( "-r,--header", header_opt_callback, localized("Pass specific HTTP header; repeat this option to pass multiple headers"));
-   app.add_flag( "-n,--no-verify", no_verify, localized("Don't verify peer certificate when using HTTPS"));
+   app.add_flag( "-n,--no-verify", http_config.no_verify_cert, localized("Don't verify peer certificate when using HTTPS"));
    app.add_flag( "--no-auto-" + string(key_store_executable_name), no_auto_keosd, localized("Don't automatically launch a ${k} if one is not currently running", ("k", key_store_executable_name)));
    app.parse_complete_callback([&app]{ ensure_keosd_running(&app);});
 
    app.add_flag( "-v,--verbose", verbose, localized("Output verbose errors and action console output"));
-   app.add_flag("--print-request", print_request, localized("Print HTTP request to STDERR"));
-   app.add_flag("--print-response", print_response, localized("Print HTTP response to STDERR"));
+   app.add_flag("--print-request", http_config.print_request, localized("Print HTTP request to STDERR"));
+   app.add_flag("--print-response", http_config.print_response, localized("Print HTTP response to STDERR"));
+   app.add_flag("--http-verbose", http_config.verbose, localized("Print HTTP verbose information to STDERR"));
+   app.add_flag("--http-trace", http_config.trace, localized("Print HTTP debug trace information to STDERR"));
 
    auto version = app.add_subcommand("version", localized("Retrieve version information"));
    version->require_subcommand();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -142,6 +142,7 @@ add_test(NAME keosd_auto_launch_test COMMAND tests/keosd_auto_launch_test.py WOR
 set_property(TEST keosd_auto_launch_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME trx_finality_status_test COMMAND tests/trx_finality_status_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_tests_properties(trx_finality_status_test PROPERTIES TIMEOUT 200)
 set_property(TEST trx_finality_status_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME trx_finality_status_forked_test COMMAND tests/trx_finality_status_forked_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -224,7 +224,7 @@ set_tests_properties(plugin_http_api_test PROPERTIES TIMEOUT 40)
 set_property(TEST plugin_http_api_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME trace_plugin_test COMMAND tests/trace_plugin_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-set_tests_properties(trace_plugin_test PROPERTIES TIMEOUT 100)
+set_tests_properties(trace_plugin_test PROPERTIES TIMEOUT 200)
 set_property(TEST trace_plugin_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME resource_monitor_plugin_test COMMAND tests/resource_monitor_plugin_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -45,7 +45,7 @@ def cli11_bugfix_test():
 
     # Make sure that the command failed because of the connection error,
     # not the command line parsing error.
-    assert(b'Connection refused' in completed_process.stderr)
+    assert(b'http exception' in completed_process.stderr)
 
 
 def cli11_optional_option_arg_test():
@@ -164,7 +164,7 @@ def cleos_abi_file_test():
     # use URL http://127.0.0.1:12345 to make sure cleos not to connect to any running nodeos
     cmd = ['./programs/cleos/cleos', '-u', 'http://127.0.0.1:12345', 'convert', 'pack_action_data', account, action, unpacked_action_data]
     outs, errs = processCleosCommand(cmd)
-    assert(b'Connection refused' in errs)
+    assert(b'http exception' in errs)
 
     # invalid option --abi-file
     invalid_abi_arg = 'eosio.token' + ' ' + token_abi_path

--- a/tests/keosd_auto_launch_test.py
+++ b/tests/keosd_auto_launch_test.py
@@ -40,7 +40,7 @@ def keosd_auto_launch_test():
     # cleos.
     completed_process = run_cleos_wallet_command('list', no_auto_keosd=True)
     assert completed_process.returncode != 0
-    check_cleos_stderr(completed_process.stderr, b'Failed http request to keosd')
+    check_cleos_stderr(completed_process.stderr, b'http exception')
 
     # Verify that keosd auto-launching works.
     completed_process = run_cleos_wallet_command('list', no_auto_keosd=False)


### PR DESCRIPTION
This PR
- uses libcurl instead of asio+openssl for http connection
- adds new options `--http-verbose` and `--http-trace` for debugging