### PR TITLE
[4.0] Added snapshot to-json subcommand to leap-util

### DIFF
--- a/programs/leap-util/CMakeLists.txt
+++ b/programs/leap-util/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable( ${LEAP_UTIL_EXECUTABLE_NAME} main.cpp actions/generic.cpp actions/blocklog.cpp actions/snapshot.cpp actions/chain.cpp)
+add_executable( ${LEAP_UTIL_EXECUTABLE_NAME} main.cpp actions/subcommand.cpp actions/generic.cpp actions/blocklog.cpp actions/snapshot.cpp actions/chain.cpp)
 
 if( UNIX AND NOT APPLE )
   set(rt_library rt )

--- a/programs/leap-util/actions/blocklog.cpp
+++ b/programs/leap-util/actions/blocklog.cpp
@@ -104,22 +104,6 @@ void blocklog_actions::setup(CLI::App& app) {
    genesis->add_option("--output-file,-o", opt->output_file, "The file to write the output to (absolute or relative path).  If not specified then output is to stdout.");
 }
 
-void blocklog_actions::print_exception() noexcept {
-   try {
-      throw;
-   } catch(const fc::exception& e) {
-      elog("${e}", ("e", e.to_detail_string()));
-   } catch(const boost::exception& e) {
-      elog("${e}", ("e", boost::diagnostic_information(e)));
-   } catch(const CLI::RuntimeError& e) {
-      // avoid reporting it twice, RuntimeError is only for cli11
-   } catch(const std::exception& e) {
-      elog("${e}", ("e", e.what()));
-   } catch(...) {
-      elog("unknown exception");
-   }
-}
-
 void blocklog_actions::initialize() {
    try {
       bfs::path bld = opt->blocks_dir;

--- a/programs/leap-util/actions/blocklog.hpp
+++ b/programs/leap-util/actions/blocklog.hpp
@@ -27,8 +27,6 @@ public:
    void setup(CLI::App& app);
 
 protected:
-   void print_exception() noexcept;
-
    void initialize();
    int trim_blocklog_end(bfs::path block_dir, uint32_t n);
    bool trim_blocklog_front(bfs::path block_dir, uint32_t n);

--- a/programs/leap-util/actions/snapshot.cpp
+++ b/programs/leap-util/actions/snapshot.cpp
@@ -22,13 +22,13 @@ using namespace eosio::chain;
 namespace bfs = boost::filesystem;
 
 void snapshot_actions::setup(CLI::App& app) {
-   auto* sub = app.add_subcommand("snapshot", "snapshot utility");
+   auto* sub = app.add_subcommand("snapshot", "Snapshot utility");
    sub->require_subcommand(1);
 
    // subcommand -convert snapshot to json
-   auto to_json = sub->add_subcommand("to-json", "convert snapshot file to json format");
-   to_json->add_option("--input-file,-i", opt->input_file, "snapshot file to convert to json format, writes to <file>.json if output file not specified (tmp state dir used), and exit.")->required();
-   to_json->add_option("--output-file,-o", opt->output_file, "the file to write the output to (absolute or relative path).  if not specified then output is to stdout.");
+   auto to_json = sub->add_subcommand("to-json", "Convert snapshot file to json format");
+   to_json->add_option("--input-file,-i", opt->input_file, "Snapshot file to convert to json format, writes to <file>.json if output file not specified (tmp state dir used).")->required();
+   to_json->add_option("--output-file,-o", opt->output_file, "The file to write the output to (absolute or relative path).  If not specified then output is to <input-file>.json.");
 
    to_json->callback([this]() {
       try {

--- a/programs/leap-util/actions/snapshot.cpp
+++ b/programs/leap-util/actions/snapshot.cpp
@@ -1,4 +1,10 @@
 #include "snapshot.hpp"
+#include <eosio/chain/abi_serializer.hpp>
+#include <eosio/chain/block_log.hpp>
+#include <eosio/chain/config.hpp>
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/fork_database.hpp>
+
 #include <memory>
 
 #include <fc/bitutil.hpp>
@@ -10,29 +16,86 @@
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/path.hpp>
 
+using namespace eosio;
+using namespace eosio::chain;
+
+namespace bfs = boost::filesystem;
+
 void snapshot_actions::setup(CLI::App& app) {
    auto* sub = app.add_subcommand("snapshot", "snapshot utility");
-   sub->add_subcommand("to-json", "convert snapshot file to convert to json format");
+   sub->require_subcommand(1);
 
-   // options
-   sub->add_option("--input-file,-i", opt->input_file, "snapshot file to convert to json format, writes to <file>.json if output file not specified (tmp state dir used), and exit.")->required();
-   sub->add_option("--output-file,-o", opt->output_file, "the file to write the output to (absolute or relative path).  if not specified then output is to stdout.");
+   // subcommand -convert snapshot to json
+   auto to_json = sub->add_subcommand("to-json", "convert snapshot file to json format");
+   to_json->add_option("--input-file,-i", opt->input_file, "snapshot file to convert to json format, writes to <file>.json if output file not specified (tmp state dir used), and exit.")->required();
+   to_json->add_option("--output-file,-o", opt->output_file, "the file to write the output to (absolute or relative path).  if not specified then output is to stdout.");
 
-   sub->callback([this]() {
-      int rc = run_subcommand();
-      // properly return err code in main
-      if(rc) throw(CLI::RuntimeError(rc));
+   to_json->callback([this]() {
+      try {
+         int rc = run_subcommand();
+         if(rc) throw(CLI::RuntimeError(rc));
+      } catch(...) {
+         print_exception();
+         throw(CLI::RuntimeError(-1));
+      }
    });
 }
 
 int snapshot_actions::run_subcommand() {
    if(!opt->input_file.empty()) {
       if(!fc::exists(opt->input_file)) {
-         std::cerr << "cannot load snapshot, " << opt->input_file << " does not exist" << std::endl;
+         std::cerr << "cannot load snapshot, " << opt->input_file
+                   << " does not exist" << std::endl;
          return -1;
       }
    }
-   // todo: implementation here
 
+   bfs::path snapshot_path = opt->input_file;
+   bfs::path json_path = opt->output_file.empty()
+                               ? snapshot_path.generic_string() + ".json"
+                               : opt->output_file;
+   // pull chain id
+   auto infile = std::ifstream(snapshot_path.generic_string(),
+                               (std::ios::in | std::ios::binary));
+   istream_snapshot_reader reader(infile);
+   reader.validate();
+   auto chain_id = controller::extract_chain_id(reader);
+   infile.close();
+
+   // setup controller
+   bfs::path temp_dir = boost::filesystem::temp_directory_path() /
+                        boost::filesystem::unique_path();
+   bfs::path state_dir = temp_dir / "state";
+   bfs::path blocks_dir = temp_dir / "blocks";
+   std::unique_ptr<controller> control;
+   protocol_feature_set pfs;
+   controller::config cfg;
+   cfg.blocks_dir = blocks_dir;
+   cfg.state_dir = state_dir;
+
+   try {
+      auto infile = std::ifstream(snapshot_path.generic_string(),
+                                  (std::ios::in | std::ios::binary));
+      auto reader = std::make_shared<istream_snapshot_reader>(infile);
+      control.reset(new controller(cfg, std::move(pfs), chain_id));
+      control->add_indices();
+      control->startup([]() {}, []() { return false; }, reader);
+      infile.close();
+
+      ilog("Writing snapshot: ${s}", ("s", json_path.generic_string()));
+      auto snap_out = std::ofstream(json_path.generic_string(), (std::ios::out));
+      auto writer = std::make_shared<ostream_json_snapshot_writer>(snap_out);
+      control->write_snapshot(writer);
+      writer->finalize();
+      snap_out.flush();
+      snap_out.close();
+   } catch(const database_guard_exception& e) {
+      control.reset();
+      fc::remove_all(temp_dir);
+      throw;
+   }
+
+   fc::remove_all(temp_dir);
+   ilog("Completed writing snapshot: ${s}", ("s", json_path.generic_string()));
    return 0;
 }

--- a/programs/leap-util/actions/snapshot.hpp
+++ b/programs/leap-util/actions/snapshot.hpp
@@ -5,6 +5,9 @@
 struct snapshot_options {
    std::string input_file = "";
    std::string output_file = "";
+   uint64_t db_size = 65536ll;
+   uint64_t guard_size = 128;
+   std::string chain_id = "";
 };
 
 class snapshot_actions : public sub_command<snapshot_options> {

--- a/programs/leap-util/actions/snapshot.hpp
+++ b/programs/leap-util/actions/snapshot.hpp
@@ -5,8 +5,8 @@
 struct snapshot_options {
    std::string input_file = "";
    std::string output_file = "";
-   uint64_t db_size = 65536ll;
-   uint64_t guard_size = 128;
+   uint64_t db_size = 65536ull;
+   uint64_t guard_size = 1;
    std::string chain_id = "";
 };
 

--- a/programs/leap-util/actions/subcommand.cpp
+++ b/programs/leap-util/actions/subcommand.cpp
@@ -1,0 +1,20 @@
+#include "subcommand.hpp"
+#include <boost/exception/diagnostic_information.hpp>
+#include <boost/exception_ptr.hpp>
+#include <fc/exception/exception.hpp>
+
+void leap_util_exception_handler::print_exception() noexcept {
+   try {
+      throw;
+   } catch(const fc::exception& e) {
+      elog("${e}", ("e", e.to_detail_string()));
+   } catch(const boost::exception& e) {
+      elog("${e}", ("e", boost::diagnostic_information(e)));
+   } catch(const CLI::RuntimeError& e) {
+      // avoid reporting it twice, RuntimeError is only for cli11
+   } catch(const std::exception& e) {
+      elog("${e}", ("e", e.what()));
+   } catch(...) {
+      elog("unknown exception");
+   }
+}

--- a/programs/leap-util/actions/subcommand.hpp
+++ b/programs/leap-util/actions/subcommand.hpp
@@ -1,35 +1,25 @@
 #pragma once
 
 #include <cli11/CLI11.hpp>
-
 #include <memory>
-#include <fc/exception/exception.hpp>
 
-#include <boost/exception/diagnostic_information.hpp>
-#include <boost/exception_ptr.hpp>
+class leap_util_exception_handler {
+public:
+   leap_util_exception_handler() {}
+   virtual ~leap_util_exception_handler() {}
+   void print_exception() noexcept;
+};
 
-template <class subcommand_options> class sub_command {
+template<class subcommand_options, class exception_handler = leap_util_exception_handler>
+class sub_command {
 protected:
-  std::shared_ptr<subcommand_options> opt;
-  sub_command() : opt(std::make_shared<subcommand_options>()) {}
+   std::shared_ptr<subcommand_options> opt;
+   std::shared_ptr<exception_handler> exh;
 
-  void print_exception() noexcept {
-    try {
-      throw;
-    } catch (const fc::exception &e) {
-      elog("${e}", ("e", e.to_detail_string()));
-    } catch (const boost::exception &e) {
-      elog("${e}", ("e", boost::diagnostic_information(e)));
-    } catch (const CLI::RuntimeError &e) {
-      // avoid reporting it twice, RuntimeError is only for cli11
-    } catch (const std::exception &e) {
-      elog("${e}", ("e", e.what()));
-    } catch (...) {
-      elog("unknown exception");
-    }
-  }
+   sub_command() : opt(std::make_shared<subcommand_options>()), exh(std::make_shared<exception_handler>()) {}
+   void print_exception() noexcept { exh->print_exception(); };
 
 public:
-  virtual ~sub_command() {}
-  virtual void setup(CLI::App &app) = 0;
+   virtual ~sub_command() {}
+   virtual void setup(CLI::App& app) = 0;
 };

--- a/programs/leap-util/actions/subcommand.hpp
+++ b/programs/leap-util/actions/subcommand.hpp
@@ -6,7 +6,7 @@
 class leap_util_exception_handler {
 public:
    leap_util_exception_handler() {}
-   virtual ~leap_util_exception_handler() {}
+   ~leap_util_exception_handler() {}
    void print_exception() noexcept;
 };
 
@@ -14,9 +14,9 @@ template<class subcommand_options, class exception_handler = leap_util_exception
 class sub_command {
 protected:
    std::shared_ptr<subcommand_options> opt;
-   std::shared_ptr<exception_handler> exh;
+   std::unique_ptr<exception_handler> exh;
 
-   sub_command() : opt(std::make_shared<subcommand_options>()), exh(std::make_shared<exception_handler>()) {}
+   sub_command() : opt(std::make_shared<subcommand_options>()), exh(std::make_unique<exception_handler>()) {}
    void print_exception() noexcept { exh->print_exception(); };
 
 public:

--- a/programs/leap-util/actions/subcommand.hpp
+++ b/programs/leap-util/actions/subcommand.hpp
@@ -3,14 +3,33 @@
 #include <cli11/CLI11.hpp>
 
 #include <memory>
+#include <fc/exception/exception.hpp>
 
-template<class subcommand_options>
-class sub_command {
+#include <boost/exception/diagnostic_information.hpp>
+#include <boost/exception_ptr.hpp>
+
+template <class subcommand_options> class sub_command {
 protected:
-   std::shared_ptr<subcommand_options> opt;
-   sub_command() : opt(std::make_shared<subcommand_options>()) {}
+  std::shared_ptr<subcommand_options> opt;
+  sub_command() : opt(std::make_shared<subcommand_options>()) {}
+
+  void print_exception() noexcept {
+    try {
+      throw;
+    } catch (const fc::exception &e) {
+      elog("${e}", ("e", e.to_detail_string()));
+    } catch (const boost::exception &e) {
+      elog("${e}", ("e", boost::diagnostic_information(e)));
+    } catch (const CLI::RuntimeError &e) {
+      // avoid reporting it twice, RuntimeError is only for cli11
+    } catch (const std::exception &e) {
+      elog("${e}", ("e", e.what()));
+    } catch (...) {
+      elog("unknown exception");
+    }
+  }
 
 public:
-   virtual ~sub_command(){}
-   virtual void setup(CLI::App& app) = 0;
+  virtual ~sub_command() {}
+  virtual void setup(CLI::App &app) = 0;
 };

--- a/programs/leap-util/main.cpp
+++ b/programs/leap-util/main.cpp
@@ -33,9 +33,9 @@ int main(int argc, char** argv) {
    auto blocklog_subcommand = std::make_shared<blocklog_actions>();
    blocklog_subcommand->setup(app);
 
-   // snapshot sc tree, reserved
-   // auto snapshot_subcommand = std::make_shared<snapshot_actions>();
-   // snapshot_subcommand->setup(app);
+   // snapshot sc tree
+   auto snapshot_subcommand = std::make_shared<snapshot_actions>();
+   snapshot_subcommand->setup(app);
 
    // chain subcommand from nodeos chain_plugin
    auto chain_subcommand = std::make_shared<chain_actions>();


### PR DESCRIPTION
This PR adds the following subcommand:

```
bin/leap-util snapshot to-json --help
convert snapshot file to json format
Usage: bin/leap-util snapshot to-json [OPTIONS]

Options:
  -h,--help              Print this help message and exit
  --help-all             Show all help
  -i,--input-file TEXT REQUIRED
                         snapshot file to convert to json format, writes to <file>.json if output file not specified (tmp state dir used), and exit.
  -o,--output-file TEXT  the file to write the output to (absolute or relative path).  if not specified then output is to stdout.

```