### PR TITLE
[4.0] refactor `boost::beast::string_view` to `std::string` conversion for changes in boost 1.81

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -64,7 +64,7 @@ bool allow_host(const http::request<http::string_body>& req, T& session,
 #endif
    auto local_endpoint = lowest_layer.local_endpoint();
    auto local_socket_host_port = local_endpoint.address().to_string() + ":" + std::to_string(local_endpoint.port());
-   const auto& host_str = req["Host"].to_string();
+   const std::string host_str(req["host"]);
    if(host_str.empty() || !host_is_valid(*plugin_state,
                                          host_str,
                                          local_socket_host_port,


### PR DESCRIPTION
`boost::beast::string_view`'s underlying implementation seems to have changed in boost 1.81. It is now `boost::core::string_view` where as previously it was a `boost::string_view` (in the `utility` directory). This new impl doesn't have `to_string()` so refactor this code to do the conversion to `std::string` differently. This seems to work due to both impls have something like
```c++
//boost::string_view
        template<typename Allocator>
        explicit operator std::basic_string<charT, traits, Allocator>() const {
            return std::basic_string<charT, traits, Allocator>(begin(), end());
            }
```
and
```c++
//boost::core::string_view
    template<class A> operator std::basic_string<Ch, std::char_traits<Ch>, A>() const
    {
        return std::basic_string<Ch, std::char_traits<Ch>, A>( data(), size() );
    }
```

It'd be nice to consider beast's option to use std::string_view, but that option isn't present as far back as boost 1.67.