### PR TITLE
Add text/plain content type to http_plugin

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -99,10 +99,9 @@ protected:
 
    // whether response should be sent back to client when an exception occurs
    bool is_send_exception_response_ = true;
-   http_content_type content_type_ = http_content_type::json; // default to json
 
-   void set_content_type_header() {
-      switch (content_type_) {
+   void set_content_type_header(http_content_type content_type) {
+      switch (content_type) {
          case http_content_type::plaintext:
             res_->set(http::field::content_type, "text/plain");
             break;
@@ -164,12 +163,12 @@ protected:
             if(plugin_state_->logger.is_enabled(fc::log_level::all))
                plugin_state_->logger.log(FC_LOG_MESSAGE(all, "resource: ${ep}", ("ep", resource)));
             std::string body = req.body();
-            content_type_ = handler_itr->second.content_type;
-            set_content_type_header();
+            auto content_type = handler_itr->second.content_type;
+            set_content_type_header(content_type);
             handler_itr->second.fn(derived().shared_from_this(),
                                 std::move(resource),
                                 std::move(body),
-                                make_http_response_handler(plugin_state_, derived().shared_from_this(), content_type_));
+                                make_http_response_handler(plugin_state_, derived().shared_from_this(), content_type));
          } else {
             fc_dlog( plugin_state_->logger, "404 - not found: ${ep}", ("ep", resource) );
             error_results results{static_cast<uint16_t>(http::status::not_found), "Not Found",
@@ -359,7 +358,7 @@ public:
 
 
       if(is_send_exception_response_) {
-         set_content_type_header();
+         set_content_type_header(http_content_type::json);
          res_->keep_alive(false);
          res_->set(http::field::server, BOOST_BEAST_VERSION_STRING);
 

--- a/plugins/http_plugin/include/eosio/http_plugin/common.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/common.hpp
@@ -73,7 +73,7 @@ using abstract_conn_ptr = std::shared_ptr<abstract_conn>;
 using internal_url_handler_fn = std::function<void(abstract_conn_ptr, string, string, url_response_callback)>;
 struct internal_url_handler {
    internal_url_handler_fn fn;
-   http_content_type content_type;
+   http_content_type content_type = http_content_type::json;
 };
 /**
 * Helper method to calculate the "in flight" size of a fc::variant
@@ -221,37 +221,54 @@ auto make_http_response_handler(std::shared_ptr<http_plugin_state> plugin_state,
    return [plugin_state{std::move(plugin_state)},
            session_ptr{std::move(session_ptr)}, content_type](int code, fc::time_point deadline, std::optional<fc::variant> response) {
       auto tracked_response = make_in_flight(std::move(response), plugin_state);
-      if(!session_ptr->verify_max_bytes_in_flight()) {
+      if (!session_ptr->verify_max_bytes_in_flight()) {
          return;
       }
 
       auto start = fc::time_point::now();
-      if( deadline == fc::time_point::maximum() ) { // no caller supplied deadline so use http configured deadline
+      if (deadline == fc::time_point::maximum()) { // no caller supplied deadline so use http configured deadline
          deadline = start + plugin_state->max_response_time;
       }
 
-      // post back to an HTTP thread to allow the response handler to be called from any thread
-      boost::asio::post(plugin_state->thread_pool->get_executor(),
-                        [plugin_state, session_ptr, code, deadline, start,
-                         tracked_response = std::move(tracked_response), content_type]() {
-                           try {
-                              if(tracked_response->obj().has_value()) {
-                                 if (content_type == http_content_type::json) {
-                                    std::string json = fc::json::to_string(*tracked_response->obj(),
-                                                                           deadline + (fc::time_point::now() - start));
-                                    auto tracked_json = make_in_flight(std::move(json), plugin_state);
-                                    session_ptr->send_response(std::move(tracked_json->obj()), code);
+      if (content_type == http_content_type::plaintext) {
+         // post back to an HTTP thread to allow the response handler to be called from any thread
+         boost::asio::post(plugin_state->thread_pool->get_executor(),
+                           [plugin_state, session_ptr, code, deadline, start,
+                                 tracked_response = std::move(tracked_response), content_type]() {
+                              try {
+                                 if (tracked_response->obj().has_value()) {
+                                       auto tracked_text = make_in_flight(
+                                             std::move(tracked_response->obj()->as_string()), plugin_state);
+                                       session_ptr->send_response(std::move(tracked_text->obj()), code);
                                  } else {
-                                    session_ptr->send_response(tracked_response->obj()->as_string(), code);
+                                    session_ptr->send_response("{}", code);
                                  }
-                              } else {
-                                 session_ptr->send_response("{}", code);
+                              } catch (...) {
+                                 session_ptr->handle_exception();
                               }
-                           } catch(...) {
-                              session_ptr->handle_exception();
-                           }
-                        });
-   };// end lambda
+                           });
+         } else{
+            boost::asio::post(plugin_state->thread_pool->get_executor(),
+                           [plugin_state, session_ptr, code, deadline, start,
+                                 tracked_response = std::move(tracked_response), content_type]() {
+                              try {
+                                 if (tracked_response->obj().has_value()) {
+                                       std::string json = fc::json::to_string(*tracked_response->obj(),
+                                                                              deadline +
+                                                                              (fc::time_point::now() - start));
+                                       auto tracked_json = make_in_flight(std::move(json), plugin_state);
+                                       session_ptr->send_response(std::move(tracked_json->obj()), code);
+                                 } else {
+                                    session_ptr->send_response("{}", code);
+                                 }
+                              } catch (...) {
+                                 session_ptr->handle_exception();
+                              }
+                           });
+
+         }
+      };// end lambda
+
 }
 
 bool host_port_is_valid(const http_plugin_state& plugin_state,

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -37,6 +37,11 @@ namespace eosio {
     */
    using api_description = std::map<string, url_handler>;
 
+   enum class http_content_type {
+      json = 1,
+      plaintext = 2
+   };
+
    struct http_plugin_defaults {
       //If empty, unix socket support will be completely disabled. If not empty,
       // unix socket support is enabled with the given default path (treated relative
@@ -80,16 +85,16 @@ namespace eosio {
         void plugin_shutdown();
         void handle_sighup() override;
 
-        void add_handler(const string& url, const url_handler&, int priority = appbase::priority::medium_low);
-        void add_api(const api_description& api, int priority = appbase::priority::medium_low) {
+        void add_handler(const string& url, const url_handler&, int priority = appbase::priority::medium_low, http_content_type content_type = http_content_type::json);
+        void add_api(const api_description& api, int priority = appbase::priority::medium_low, http_content_type content_type = http_content_type::json) {
            for (const auto& call : api)
-              add_handler(call.first, call.second, priority);
+              add_handler(call.first, call.second, priority, content_type);
         }
 
-        void add_async_handler(const string& url, const url_handler& handler);
-        void add_async_api(const api_description& api) {
+        void add_async_handler(const string& url, const url_handler& handler, http_content_type content_type = http_content_type::json);
+        void add_async_api(const api_description& api, http_content_type content_type = http_content_type::json) {
            for (const auto& call : api)
-              add_async_handler(call.first, call.second);
+              add_async_handler(call.first, call.second, content_type);
         }
 
         // standard exception handling for api handlers

--- a/plugins/prometheus_plugin/include/eosio/prometheus_plugin/prometheus_plugin.hpp
+++ b/plugins/prometheus_plugin/include/eosio/prometheus_plugin/prometheus_plugin.hpp
@@ -22,7 +22,7 @@ namespace eosio {
       void plugin_startup();
       void plugin_shutdown();
 
-      std::string scrape();
+      std::string metrics();
 
    private:
       std::unique_ptr<struct prometheus_plugin_impl> my;

--- a/plugins/prometheus_plugin/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/prometheus_plugin.cpp
@@ -13,7 +13,7 @@
           try { \
              body = parse_params<std::string, http_params_types::no_params>(body); \
              INVOKE \
-             cb(http_response_code, fc::time_point::maximum(), std::move(fc::variant(result))); \
+             cb(http_response_code, fc::time_point::maximum(), fc::variant(std::move(result))); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \

--- a/plugins/prometheus_plugin/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/prometheus_plugin.cpp
@@ -110,7 +110,7 @@ namespace eosio {
             }
          }
 
-         std::string scrape() {
+         std::string metrics() {
             auto start_time_of_request = std::chrono::steady_clock::now();
 
             update_plugin_metrics();
@@ -155,12 +155,12 @@ namespace eosio {
      my.reset(new prometheus_plugin_impl{});
 
       app().get_plugin<http_plugin>().add_async_api({
-        CALL_WITH_400(prometheus, this, scrape,  INVOKE_R_V(this, scrape), 200), }, http_content_type::plaintext);
+        CALL_WITH_400(prometheus, this, metrics,  INVOKE_R_V(this, metrics), 200), }, http_content_type::plaintext);
    }
 
    prometheus_plugin::~prometheus_plugin() {}
 
-   std::string prometheus_plugin::scrape() {return my->scrape();}
+   std::string prometheus_plugin::metrics() {return my->metrics();}
 
    void prometheus_plugin::set_program_options(options_description&, options_description& cfg) {
 

--- a/plugins/prometheus_plugin/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/prometheus_plugin.cpp
@@ -13,7 +13,7 @@
           try { \
              body = parse_params<std::string, http_params_types::no_params>(body); \
              INVOKE \
-             cb(http_response_code, fc::time_point::maximum(), fc::variant(result)); \
+             cb(http_response_code, fc::time_point::maximum(), std::move(fc::variant(result))); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \

--- a/plugins/prometheus_plugin/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/prometheus_plugin.cpp
@@ -155,7 +155,7 @@ namespace eosio {
      my.reset(new prometheus_plugin_impl{});
 
       app().get_plugin<http_plugin>().add_async_api({
-        CALL_WITH_400(prometheus, this, scrape,  INVOKE_R_V(this, scrape), 200), });
+        CALL_WITH_400(prometheus, this, scrape,  INVOKE_R_V(this, scrape), 200), }, http_content_type::plaintext);
    }
 
    prometheus_plugin::~prometheus_plugin() {}


### PR DESCRIPTION
Added the ability to set a content type for an api in the http plugin.  The default is application/json, but now text/plain is also available.  

Changed prometheus_plugin api to be text/plain.