### PR TITLE
[PH] add database map mode

### DIFF
--- a/tests/performance_tests/README.md
+++ b/tests/performance_tests/README.md
@@ -223,6 +223,11 @@ The Performance Harness main script `performance_test.py` can be configured usin
                           Percentage of actual signature recovery cpu to bill. Whole number percentages, e.g. 50 for 50% (default: 0)
 * `--chain-threads CHAIN_THREADS`
                           Number of worker threads in controller thread pool (default: 2)
+* `--database-map-mode {mapped,heap,locked}`
+                          Database map mode ("mapped", "heap", or "locked").
+                          In "mapped" mode database is memory mapped as a file.
+                          In "heap" mode database is preloaded in to swappable memory and will use huge pages if available.
+                          In "locked" mode database is preloaded, locked in to memory, and will use huge pages if available. (default: mapped)
 * `--net-threads NET_THREADS`
                           Number of worker threads in net_plugin thread pool (default: 2)
 * `--disable-subjective-billing DISABLE_SUBJECTIVE_BILLING`
@@ -282,6 +287,11 @@ The following scripts are typically used by the Performance Harness main script 
                           Percentage of actual signature recovery cpu to bill. Whole number percentages, e.g. 50 for 50% (default: 0)
 * `--chain-threads CHAIN_THREADS`
                           Number of worker threads in controller thread pool (default: 2)
+* `--database-map-mode {mapped,heap,locked}`
+                          Database map mode ("mapped", "heap", or "locked").
+                          In "mapped" mode database is memory mapped as a file.
+                          In "heap" mode database is preloaded in to swappable memory and will use huge pages if available.
+                          In "locked" mode database is preloaded, locked in to memory, and will use huge pages if available. (default: mapped)
 * `--net-threads NET_THREADS`
                           Number of worker threads in net_plugin thread pool (default: 2)
 * `--disable-subjective-billing DISABLE_SUBJECTIVE_BILLING`

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -151,7 +151,7 @@ def createReport(maxTpsAchieved, searchResults, maxTpsReport, longRunningMaxTpsA
     report['LongRunningSearchResults'] =  {x: asdict(longRunningSearchResults[x]) for x in range(len(longRunningSearchResults))}
     report['LongRunningMaxTpsReport'] =  longRunningMaxTpsReport
     report['args'] =  argsDict
-    report['env'] = {'system': system(), 'os': os.name, 'release': release()}
+    report['env'] = {'system': system(), 'os': os.name, 'release': release(), 'logical_cpu_count': os.cpu_count()}
     report['nodeosVersion'] = Utils.getNodeosVersion()
     return report
 

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -220,6 +220,11 @@ def parseArgs():
     appArgs.add(flag="--num-blocks-to-prune", type=int, help="The number of potentially non-empty blocks, in addition to leading and trailing size 0 blocks, to prune from the beginning and end of the range of blocks of interest for evaluation.", default=2)
     appArgs.add(flag="--signature-cpu-billable-pct", type=int, help="Percentage of actual signature recovery cpu to bill. Whole number percentages, e.g. 50 for 50%%", default=0)
     appArgs.add(flag="--chain-threads", type=int, help="Number of worker threads in controller thread pool", default=2)
+    appArgs.add(flag="--database-map-mode", type=str, help="Database map mode (\"mapped\", \"heap\", or \"locked\"). \
+                                                            In \"mapped\" mode database is memory mapped as a file. \
+                                                            In \"heap\" mode database is preloaded in to swappable memory and will use huge pages if available. \
+                                                            In \"locked\" mode database is preloaded, locked in to memory, and will use huge pages if available.",
+                                                            choices=["mapped", "heap", "locked"], default="mapped")
     appArgs.add(flag="--net-threads", type=int, help="Number of worker threads in net_plugin thread pool", default=2)
     appArgs.add(flag="--disable-subjective-billing", type=bool, help="Disable subjective CPU billing for API/P2P transactions", default=True)
     appArgs.add(flag="--last-block-time-offset-us", type=int, help="Offset of last block producing time in microseconds. Valid range 0 .. -block_time_interval.", default=0)
@@ -276,14 +281,18 @@ def main():
                                                              dumpErrorDetails=dumpErrorDetails, delay=delay, nodesFile=nodesFile,
                                                              verbose=verbose)
 
-    extraNodeosChainPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ChainPluginArgs(signatureCpuBillablePct=args.signature_cpu_billable_pct, chainThreads=args.chain_threads)
-    extraNodeosProducerPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ProducerPluginArgs(disableSubjectiveBilling=args.disable_subjective_billing,
-                lastBlockTimeOffsetUs=args.last_block_time_offset_us, produceTimeOffsetUs=args.produce_time_offset_us, cpuEffortPercent=args.cpu_effort_percent,
-                lastBlockCpuEffortPercent=args.last_block_cpu_effort_percent, producerThreads=args.producer_threads)
-    extraNodeosHttpPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.HttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
-    extraNodeosNetPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.NetPluginArgs(netThreads=args.net_threads)
-    extraNodeosArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs(chainPluginArgs=extraNodeosChainPluginArgs, httpPluginArgs=extraNodeosHttpPluginArgs, producerPluginArgs=extraNodeosProducerPluginArgs, netPluginArgs=extraNodeosNetPluginArgs)
-    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=pnodes, totalNodes=totalNodes, topo=topo, genesisPath=genesisPath, prodsEnableTraceApi=prodsEnableTraceApi, extraNodeosArgs=extraNodeosArgs)
+    ENA = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs
+    chainPluginArgs = ENA.ChainPluginArgs(signatureCpuBillablePct=args.signature_cpu_billable_pct,
+                                          chainThreads=args.chain_threads, databaseMapMode=args.database_map_mode)
+    producerPluginArgs = ENA.ProducerPluginArgs(disableSubjectiveBilling=args.disable_subjective_billing,
+                                                lastBlockTimeOffsetUs=args.last_block_time_offset_us, produceTimeOffsetUs=args.produce_time_offset_us,
+                                                cpuEffortPercent=args.cpu_effort_percent, lastBlockCpuEffortPercent=args.last_block_cpu_effort_percent,
+                                                producerThreads=args.producer_threads)
+    httpPluginArgs = ENA.HttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
+    netPluginArgs = ENA.NetPluginArgs(netThreads=args.net_threads)
+    extraNodeosArgs = ENA(chainPluginArgs=chainPluginArgs, httpPluginArgs=httpPluginArgs, producerPluginArgs=producerPluginArgs, netPluginArgs=netPluginArgs)
+    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis,
+                                                           prodsEnableTraceApi=args.prods_enable_trace_api, extraNodeosArgs=extraNodeosArgs)
 
     argsDict = prepArgsDict(testDurationSec=testDurationSec, finalDurationSec=finalDurationSec, logsDir=testTimeStampDirPath,
                         maxTpsToTest=maxTpsToTest, testIterationMinStep=testIterationMinStep, tpsLimitPerGenerator=tpsLimitPerGenerator,

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -276,12 +276,12 @@ def main():
                                                              dumpErrorDetails=dumpErrorDetails, delay=delay, nodesFile=nodesFile,
                                                              verbose=verbose)
 
-    extraNodeosChainPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosChainPluginArgs(signatureCpuBillablePct=args.signature_cpu_billable_pct, chainThreads=args.chain_threads)
-    extraNodeosProducerPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosProducerPluginArgs(disableSubjectiveBilling=args.disable_subjective_billing,
+    extraNodeosChainPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ChainPluginArgs(signatureCpuBillablePct=args.signature_cpu_billable_pct, chainThreads=args.chain_threads)
+    extraNodeosProducerPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ProducerPluginArgs(disableSubjectiveBilling=args.disable_subjective_billing,
                 lastBlockTimeOffsetUs=args.last_block_time_offset_us, produceTimeOffsetUs=args.produce_time_offset_us, cpuEffortPercent=args.cpu_effort_percent,
                 lastBlockCpuEffortPercent=args.last_block_cpu_effort_percent, producerThreads=args.producer_threads)
-    extraNodeosHttpPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosHttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
-    extraNodeosNetPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosNetPluginArgs(netThreads=args.net_threads)
+    extraNodeosHttpPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.HttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
+    extraNodeosNetPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.NetPluginArgs(netThreads=args.net_threads)
     extraNodeosArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs(chainPluginArgs=extraNodeosChainPluginArgs, httpPluginArgs=extraNodeosHttpPluginArgs, producerPluginArgs=extraNodeosProducerPluginArgs, netPluginArgs=extraNodeosNetPluginArgs)
     testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=pnodes, totalNodes=totalNodes, topo=topo, genesisPath=genesisPath, prodsEnableTraceApi=prodsEnableTraceApi, extraNodeosArgs=extraNodeosArgs)
 

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -48,7 +48,7 @@ class PerformanceBasicTest:
         @dataclass
         class ExtraNodeosArgs:
             @dataclass
-            class ExtraNodeosChainPluginArgs:
+            class ChainPluginArgs:
                 signatureCpuBillablePct: int = 0
                 chainThreads: int = 2
 
@@ -56,14 +56,14 @@ class PerformanceBasicTest:
                     return f"--signature-cpu-billable-pct {self.signatureCpuBillablePct} --chain-threads {self.chainThreads}"
 
             @dataclass
-            class ExtraNodeosNetPluginArgs:
+            class NetPluginArgs:
                 netThreads: int = 2
 
                 def argsStr(self) -> str:
                     return f"--net-threads {self.netThreads}"
 
             @dataclass
-            class ExtraNodeosProducerPluginArgs:
+            class ProducerPluginArgs:
                 disableSubjectiveBilling: bool = True
                 lastBlockTimeOffsetUs: int = 0
                 produceTimeOffsetUs: int = 0
@@ -80,16 +80,16 @@ class PerformanceBasicTest:
                              --producer-threads {self.producerThreads}"
 
             @dataclass
-            class ExtraNodeosHttpPluginArgs:
+            class HttpPluginArgs:
                 httpMaxResponseTimeMs: int = 990000
 
                 def argsStr(self) -> str:
                     return f"--http-max-response-time-ms {self.httpMaxResponseTimeMs}"
 
-            chainPluginArgs: ExtraNodeosChainPluginArgs = ExtraNodeosChainPluginArgs()
-            producerPluginArgs: ExtraNodeosProducerPluginArgs = ExtraNodeosProducerPluginArgs()
-            httpPluginArgs: ExtraNodeosHttpPluginArgs = ExtraNodeosHttpPluginArgs()
-            netPluginArgs: ExtraNodeosNetPluginArgs = ExtraNodeosNetPluginArgs()
+            chainPluginArgs: ChainPluginArgs = ChainPluginArgs()
+            producerPluginArgs: ProducerPluginArgs = ProducerPluginArgs()
+            httpPluginArgs: HttpPluginArgs = HttpPluginArgs()
+            netPluginArgs: NetPluginArgs = NetPluginArgs()
 
             def argsStr(self) -> str:
                 return f" {self.httpPluginArgs.argsStr()} {self.producerPluginArgs.argsStr()} {self.chainPluginArgs.argsStr()} {self.netPluginArgs.argsStr()}"
@@ -435,12 +435,12 @@ def main():
     testHelperConfig = PerformanceBasicTest.TestHelperConfig(killAll=args.clean_run, dontKill=args.leave_running, keepLogs=not args.del_perf_logs,
                                                              dumpErrorDetails=args.dump_error_details, delay=args.d, nodesFile=args.nodes_file, verbose=args.v)
 
-    extraNodeosChainPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosChainPluginArgs(signatureCpuBillablePct=args.signature_cpu_billable_pct, chainThreads=args.chain_threads)
-    extraNodeosProducerPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosProducerPluginArgs(disableSubjectiveBilling=args.disable_subjective_billing,
+    extraNodeosChainPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ChainPluginArgs(signatureCpuBillablePct=args.signature_cpu_billable_pct, chainThreads=args.chain_threads)
+    extraNodeosProducerPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ProducerPluginArgs(disableSubjectiveBilling=args.disable_subjective_billing,
                 lastBlockTimeOffsetUs=args.last_block_time_offset_us, produceTimeOffsetUs=args.produce_time_offset_us, cpuEffortPercent=args.cpu_effort_percent,
                 lastBlockCpuEffortPercent=args.last_block_cpu_effort_percent, producerThreads=args.producer_threads)
-    extraNodeosHttpPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosHttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
-    extraNodeosNetPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosNetPluginArgs(netThreads=args.net_threads)
+    extraNodeosHttpPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.HttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
+    extraNodeosNetPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.NetPluginArgs(netThreads=args.net_threads)
     extraNodeosArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs(chainPluginArgs=extraNodeosChainPluginArgs, httpPluginArgs=extraNodeosHttpPluginArgs, producerPluginArgs=extraNodeosProducerPluginArgs, netPluginArgs=extraNodeosNetPluginArgs)
     testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis, prodsEnableTraceApi=args.prods_enable_trace_api, extraNodeosArgs=extraNodeosArgs)
 

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -52,14 +52,14 @@ class PerformanceBasicTest:
                 signatureCpuBillablePct: int = 0
                 chainThreads: int = 2
 
-                def argsStr(self) -> str:
+                def __str__(self) -> str:
                     return f"--signature-cpu-billable-pct {self.signatureCpuBillablePct} --chain-threads {self.chainThreads}"
 
             @dataclass
             class NetPluginArgs:
                 netThreads: int = 2
 
-                def argsStr(self) -> str:
+                def __str__(self) -> str:
                     return f"--net-threads {self.netThreads}"
 
             @dataclass
@@ -71,7 +71,7 @@ class PerformanceBasicTest:
                 lastBlockCpuEffortPercent: int = 100
                 producerThreads: int = 2
 
-                def argsStr(self) -> str:
+                def __str__(self) -> str:
                     return f"--disable-subjective-billing {self.disableSubjectiveBilling} \
                              --last-block-time-offset-us {self.lastBlockTimeOffsetUs} \
                              --produce-time-offset-us {self.produceTimeOffsetUs} \
@@ -83,7 +83,7 @@ class PerformanceBasicTest:
             class HttpPluginArgs:
                 httpMaxResponseTimeMs: int = 990000
 
-                def argsStr(self) -> str:
+                def __str__(self) -> str:
                     return f"--http-max-response-time-ms {self.httpMaxResponseTimeMs}"
 
             chainPluginArgs: ChainPluginArgs = ChainPluginArgs()
@@ -91,8 +91,8 @@ class PerformanceBasicTest:
             httpPluginArgs: HttpPluginArgs = HttpPluginArgs()
             netPluginArgs: NetPluginArgs = NetPluginArgs()
 
-            def argsStr(self) -> str:
-                return f" {self.httpPluginArgs.argsStr()} {self.producerPluginArgs.argsStr()} {self.chainPluginArgs.argsStr()} {self.netPluginArgs.argsStr()}"
+            def __str__(self) -> str:
+                return f" {self.httpPluginArgs} {self.producerPluginArgs} {self.chainPluginArgs} {self.netPluginArgs}"
 
         pnodes: int = 1
         totalNodes: int = 2
@@ -247,7 +247,7 @@ class PerformanceBasicTest:
             genesisPath=self.clusterConfig.genesisPath,
             maximumP2pPerHost=self.clusterConfig.maximumP2pPerHost,
             maximumClients=self.clusterConfig.maximumClients,
-            extraNodeosArgs=self.clusterConfig.extraNodeosArgs.argsStr(),
+            extraNodeosArgs=str(self.clusterConfig.extraNodeosArgs),
             prodsEnableTraceApi=self.clusterConfig.prodsEnableTraceApi,
             specificExtraNodeosArgs=self.clusterConfig.specificExtraNodeosArgs
             )


### PR DESCRIPTION
Provide the ability to configure:

* `--database-map-mode {mapped,heap,locked}`
                          Database map mode ("mapped", "heap", or "locked").
                          In "mapped" mode database is memory mapped as a file.
                          In "heap" mode database is preloaded in to swappable memory and will use huge pages if available.
                          In "locked" mode database is preloaded, locked in to memory, and will use huge pages if available. (default: mapped)

Added logical cpu count to top level `performance_test.py` report.