### PR TITLE
[PH] log dir add tps target

### DIFF
--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -141,7 +141,7 @@ class PerformanceBasicTest:
 
         self.rootLogDir = rootLogDir
         self.ptbLogDir = f"{self.rootLogDir}/{os.path.splitext(os.path.basename(__file__))[0]}"
-        self.testTimeStampDirPath = f"{self.ptbLogDir}/{self.testStart.strftime('%Y-%m-%d_%H-%M-%S')}"
+        self.testTimeStampDirPath = f"{self.ptbLogDir}/{self.testStart.strftime('%Y-%m-%d_%H-%M-%S')}-{self.targetTps}"
         self.trxGenLogDirPath = f"{self.testTimeStampDirPath}/trxGenLogs"
         self.varLogsDirPath = f"{self.testTimeStampDirPath}/var"
         self.etcLogsDirPath = f"{self.testTimeStampDirPath}/etc"


### PR DESCRIPTION
Add target tps number to test log dir name for ease of locating specific run.

currently log directories are timestamp only:
* `performance_test_basic/2022-11-16_22_26_48`

proposing the addition of the tps target to the dir name to make finding a specific run easier:
* `performance_test_basic/2022-11-16_22_26_48-50000`
* `performance_test_basic/2022-11-16_22_28_25-25000`