### PR TITLE
[3.2->main] compute_transaction: add --dry-run, deprecate --read-only, and sign a transaction only when explicitly requested

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -171,6 +171,7 @@ bool   tx_skip_sign = false;
 bool   tx_print_json = false;
 bool   tx_rtn_failure_trace = true;
 bool   tx_read_only = false;
+bool   tx_dry_run = false;
 bool   tx_retry_lib = false;
 uint16_t tx_retry_num_blocks = 0;
 bool   tx_use_old_rpc = false;
@@ -435,7 +436,7 @@ fc::variant push_transaction( signed_transaction& trx, const std::vector<public_
       trx.delay_sec = delaysec;
    }
 
-   if (!tx_skip_sign) {
+   auto sign_trx = [&] () {
       fc::variant required_keys;
       if (signing_keys.size() > 0) {
          required_keys = fc::variant(signing_keys);
@@ -444,6 +445,16 @@ fc::variant push_transaction( signed_transaction& trx, const std::vector<public_
          required_keys = determine_required_keys(trx);
       }
       sign_transaction(trx, required_keys, info.chain_id);
+   };
+   if (!tx_skip_sign) {
+      // sign dry-run transactions only when explcitly requested
+      if ( tx_dry_run ) {
+         if ( signing_keys.size() > 0 ) {
+            sign_trx();
+         }
+      } else {
+         sign_trx();
+      }
    }
 
    packed_transaction::compression_type compression = to_compression_type( tx_compression );
@@ -452,12 +463,14 @@ fc::variant push_transaction( signed_transaction& trx, const std::vector<public_
       EOSC_ASSERT( !(tx_retry_lib && tx_retry_num_blocks > 0), "ERROR: --retry-irreversible and --retry-num-blocks are mutually exclusive" );
       if (tx_use_old_rpc) {
          EOSC_ASSERT( !tx_read_only, "ERROR: --read-only can not be used with --use-old-rpc" );
+         EOSC_ASSERT( !tx_dry_run, "ERROR: --dry-run can not be used with --use-old-rpc" );
          EOSC_ASSERT( !tx_rtn_failure_trace, "ERROR: --return-failure-trace can not be used with --use-old-rpc" );
          EOSC_ASSERT( !tx_retry_lib, "ERROR: --retry-irreversible can not be used with --use-old-rpc" );
          EOSC_ASSERT( !tx_retry_num_blocks, "ERROR: --retry-num-blocks can not be used with --use-old-rpc" );
          return call( push_txn_func, packed_transaction( trx, compression ) );
       } else if (tx_use_old_send_rpc) {
          EOSC_ASSERT( !tx_read_only, "ERROR: --read-only can not be used with --use-old-send-rpc" );
+         EOSC_ASSERT( !tx_dry_run, "ERROR: --dry-run can not be used with --use-old-send-rpc" );
          EOSC_ASSERT( !tx_rtn_failure_trace, "ERROR: --return-failure-trace can not be used with --use-old-send-rpc" );
          EOSC_ASSERT( !tx_retry_lib, "ERROR: --retry-irreversible can not be used with --use-old-send-rpc" );
          EOSC_ASSERT( !tx_retry_num_blocks, "ERROR: --retry-num-blocks can not be used with --use-old-send-rpc" );
@@ -468,9 +481,9 @@ fc::variant push_transaction( signed_transaction& trx, const std::vector<public_
             throw;
          }
       } else {
-         if( tx_read_only ) {
-            EOSC_ASSERT( !tx_retry_lib, "ERROR: --retry-irreversible can not be used with --read-only" );
-            EOSC_ASSERT( !tx_retry_num_blocks, "ERROR: --retry-num-blocks can not be used with --read-only" );
+         if( tx_dry_run || tx_read_only ) {
+            EOSC_ASSERT( !tx_retry_lib, "ERROR: --retry-irreversible can not be used with --dry-run or --read-only" );
+            EOSC_ASSERT( !tx_retry_num_blocks, "ERROR: --retry-num-blocks can not be used with --dry-run or --read-only" );
             try {
                auto compute_txn_arg = fc::mutable_variant_object ("transaction",
                                                                   packed_transaction(trx,compression));
@@ -3918,7 +3931,8 @@ int main( int argc, char** argv ) {
    trxSubcommand->add_option("transaction", trx_to_push, localized("The JSON string or filename defining the transaction to push"))->required();
    trxSubcommand->add_option("--signature", extra_sig_opt_callback, localized("append a signature to the transaction; repeat this option to append multiple signatures"))->type_size(0, 1000);
    add_standard_transaction_options_plus_signing(trxSubcommand);
-   trxSubcommand->add_flag("-o,--read-only", tx_read_only, localized("Specify a transaction is read-only"));
+   trxSubcommand->add_flag("-o,--read-only", tx_read_only, localized("Deprecated, use --dry-run instead"));
+   trxSubcommand->add_flag("--dry-run", tx_dry_run, localized("Specify a transaction is dry-run"));
 
    trxSubcommand->callback([&] {
       fc::variant trx_var = json_from_file_or_string(trx_to_push);

--- a/tests/compute_transaction_test.py
+++ b/tests/compute_transaction_test.py
@@ -115,12 +115,16 @@ try:
 
     results = node.pushTransaction(trx, opts='--read-only', permissions=account1.name)
     assert(results[0])
+    results = node.pushTransaction(trx, opts='--dry-run', permissions=account1.name)
+    assert(results[0])
     node.waitForLibToAdvance(30)
 
     postBalances = node.getEosBalances([account1, account2])
     assert(postBalances == preBalances)
 
     results = node.pushTransaction(trx, opts='--read-only --skip-sign')
+    assert(results[0])
+    results = node.pushTransaction(trx, opts='--dry-run --skip-sign')
     assert(results[0])
     node.waitForLibToAdvance(30)
 
@@ -140,6 +144,8 @@ try:
         }
 
         results = npnode.pushTransaction(trx2, opts="--read-only")
+        assert(not results[0])
+        results = npnode.pushTransaction(trx2, opts="--dry-run")
         assert(not results[0])
 
 # Verify that no subjective billing was charged
@@ -173,6 +179,8 @@ try:
                      "compression": "none"}]
     }
     results = npnode.pushTransaction(trx3, opts="--read-only")
+    assert(results[0])
+    results = npnode.pushTransaction(trx3, opts="--dry-run")
     assert(results[0])
 
     testSuccessful = True


### PR DESCRIPTION
This is a merge of https://github.com/AntelopeIO/leap/pull/483 from `release/3.2` to `main`.

Resolve https://github.com/AntelopeIO/leap/issues/482

Currently `cleos push transaction --read-only` is used to send transactions to `compute_transaction` endpoint.  Those are not true read-only transactions. To avoid confusions when true read-only transactions are introduced, we plan to use `--read` for true read-only transaction endpoint, deprecate `--read-only`, and use `--dry-run` to send transactions to `compute_transaction` endpoint.

In addition, to prevent dry-run transactions from accidentally being included in a block, `cleos` will change to not sign dry-run transactions by default, unless explicitly requested with `--sign-with` option. Behavior of transactions by `--read-only` is not changed.