### PR TITLE
[PH] fix trx gen err detection

### DIFF
--- a/tests/performance_tests/CMakeLists.txt
+++ b/tests/performance_tests/CMakeLists.txt
@@ -8,6 +8,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_log_2_0_14.txt.gz ${CMAKE_CURR
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_log_3_2.txt.gz ${CMAKE_CURRENT_BINARY_DIR}/nodeos_log_3_2.txt.gz COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/genesis.json ${CMAKE_CURRENT_BINARY_DIR}/genesis.json COPYONLY)
 
-add_test(NAME performance_test_basic COMMAND tests/performance_tests/performance_test_basic.py -v -p 1 -n 1 --target-tps 6000 --tps-limit-per-generator 3000 --clean-run WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME performance_test_basic COMMAND tests/performance_tests/performance_test_basic.py -v -p 1 -n 1 --target-tps 6000 --tps-limit-per-generator 1500 --clean-run WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME log_reader_tests COMMAND tests/performance_tests/log_reader_tests.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST performance_test_basic PROPERTY LABELS nonparallelizable_tests)

--- a/tests/performance_tests/log_reader.py
+++ b/tests/performance_tests/log_reader.py
@@ -223,8 +223,7 @@ def scrapeTrxGenTrxSentDataLogs(trxSent, trxGenLogDirPath, quiet):
         scrapeTrxGenLog(trxSent, fileName)
 
     if not quiet:
-        print("Transaction Log Files Scraped:")
-        print(filesScraped)
+        print(f"Transaction Log Files Scraped: {filesScraped}")
 
 def populateTrxSentTimestamp(trxSent: dict, trxDict: dict, notFound):
     for sentTrxId in trxSent.keys():


### PR DESCRIPTION
Trx generator can fail to keep up with configured tps generation rate. Detect that failure case and report it as test failure.

Move transaction recvd and expected check to similar location and handling.

Rename launcherExitCodes to trxGenExitCodes for clarity.