### PR TITLE
[3.2 -> main] Use net_plugin_impl logger instead of default logger

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2686,7 +2686,7 @@ namespace eosio {
          my_impl->producer_plug->log_failed_transaction(ptr->id(), ptr, reason);
          if (fc::time_point::now() - fc::seconds(1) >= last_dropped_trx_msg_time) {
             last_dropped_trx_msg_time = fc::time_point::now();
-            wlog(reason);
+            peer_wlog(this, reason);
          }
          return true;
       }


### PR DESCRIPTION
Use correct logger for log of too many trxs in progress in net_plugin.

Resolves #485 
Merges #486 & #490 into `main`