### PR TITLE
Fix undefined behavior - uninitialized variables revealed by valgrind

### DIFF
--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_monitor.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_monitor.cpp
@@ -247,7 +247,7 @@ void launch_compile_monitor(int nodeos_fd) {
    sigaddset(&set, SIGQUIT);
    sigprocmask(SIG_BLOCK, &set, nullptr);
 
-   struct sigaction sa;
+   struct sigaction sa{};
    sa.sa_handler =  SIG_DFL;
    sa.sa_flags = SA_NOCLDWAIT;
    sigaction(SIGCHLD, &sa, nullptr);

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/ipc_helpers.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/ipc_helpers.cpp
@@ -89,7 +89,7 @@ bool write_message_with_fds(int fd_to_send_to, const eosvmoc_message& message, c
       .iov_len = sz
    };
    union {
-      char buf[CMSG_SPACE(max_num_fds * sizeof(int))];
+      char buf[CMSG_SPACE(max_num_fds * sizeof(int))] = {};
       struct cmsghdr align;
    } u;
 

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/ipc_helpers.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/ipc_helpers.cpp
@@ -108,7 +108,6 @@ bool write_message_with_fds(int fd_to_send_to, const eosvmoc_message& message, c
          memcpy(p, &thisfd, sizeof(thisfd));
          p += sizeof(thisfd);
       }
-      msg.msg_controllen = cmsg->cmsg_len;
    }
 
    int wrote;

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/ipc_helpers.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/ipc_helpers.cpp
@@ -108,6 +108,7 @@ bool write_message_with_fds(int fd_to_send_to, const eosvmoc_message& message, c
          memcpy(p, &thisfd, sizeof(thisfd));
          p += sizeof(thisfd);
       }
+      msg.msg_controllen = cmsg->cmsg_len;
    }
 
    int wrote;

--- a/libraries/libfc/test/network/test_message_buffer.cpp
+++ b/libraries/libfc/test/network/test_message_buffer.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(message_buffer_growth)
     BOOST_CHECK_EQUAL(mb.bytes_to_read(), 100u);
     BOOST_CHECK_NE(mb.read_ptr(), nullptr);
     BOOST_CHECK_NE(mb.write_ptr(), nullptr);
-    BOOST_CHECK_EQUAL((mb.read_ptr() + 100), mb.write_ptr());
+    BOOST_CHECK_EQUAL(static_cast<void*>(mb.read_ptr() + 100), static_cast<void*>(mb.write_ptr()));
 
     {
       auto mbs = mb.get_buffer_sequence_for_boost_async_read();

--- a/libraries/wasm-jit/Include/IR/Operators.h
+++ b/libraries/wasm-jit/Include/IR/Operators.h
@@ -14,60 +14,60 @@ namespace IR
 
 	struct ControlStructureImm
 	{
-		ResultType resultType;
+		ResultType resultType{};
 	};
 
 	struct BranchImm
 	{
-		U32 targetDepth;
+		U32 targetDepth{};
 	};
 
 	struct BranchTableImm
 	{
-		Uptr defaultTargetDepth;
-		Uptr branchTableIndex; // An index into the FunctionDef's branchTables array.
+		Uptr defaultTargetDepth{};
+		Uptr branchTableIndex{}; // An index into the FunctionDef's branchTables array.
 	};
 
 	template<typename Value>
 	struct LiteralImm
 	{
-		Value value;
+		Value value{};
 	};
 
 	template<bool isGlobal>
 	struct GetOrSetVariableImm
 	{
-		U32 variableIndex;
+		U32 variableIndex{};
 	};
 
 	struct CallImm
 	{
-		U32 functionIndex;
+		U32 functionIndex{};
 	};
 
 	struct CallIndirectImm
 	{
-		IndexedFunctionType type;
+		IndexedFunctionType type{};
 	};
 
 	template<Uptr naturalAlignmentLog2>
 	struct LoadOrStoreImm
 	{
-		U8 alignmentLog2;
-		U32 offset;
+		U8 alignmentLog2{};
+		U32 offset{};
 	};
 
 	#if ENABLE_SIMD_PROTOTYPE
 	template<Uptr numLanes>
 	struct LaneIndexImm
 	{
-		U8 laneIndex;
+		U8 laneIndex{};
 	};
 	
 	template<Uptr numLanes>
 	struct ShuffleImm
 	{
-		U8 laneIndices[numLanes];
+		U8 laneIndices[numLanes] = {};
 	};
 	#endif
 

--- a/libraries/wasm-jit/Include/IR/Operators.h
+++ b/libraries/wasm-jit/Include/IR/Operators.h
@@ -19,55 +19,55 @@ namespace IR
 
 	struct BranchImm
 	{
-		U32 targetDepth{};
+		U32 targetDepth;
 	};
 
 	struct BranchTableImm
 	{
-		Uptr defaultTargetDepth{};
-		Uptr branchTableIndex{}; // An index into the FunctionDef's branchTables array.
+		Uptr defaultTargetDepth;
+		Uptr branchTableIndex; // An index into the FunctionDef's branchTables array.
 	};
 
 	template<typename Value>
 	struct LiteralImm
 	{
-		Value value{};
+		Value value;
 	};
 
 	template<bool isGlobal>
 	struct GetOrSetVariableImm
 	{
-		U32 variableIndex{};
+		U32 variableIndex;
 	};
 
 	struct CallImm
 	{
-		U32 functionIndex{};
+		U32 functionIndex;
 	};
 
 	struct CallIndirectImm
 	{
-		IndexedFunctionType type{};
+		IndexedFunctionType type;
 	};
 
 	template<Uptr naturalAlignmentLog2>
 	struct LoadOrStoreImm
 	{
-		U8 alignmentLog2{};
-		U32 offset{};
+		U8 alignmentLog2;
+		U32 offset;
 	};
 
 	#if ENABLE_SIMD_PROTOTYPE
 	template<Uptr numLanes>
 	struct LaneIndexImm
 	{
-		U8 laneIndex{};
+		U8 laneIndex;
 	};
 	
 	template<Uptr numLanes>
 	struct ShuffleImm
 	{
-		U8 laneIndices[numLanes] = {};
+		U8 laneIndices[numLanes];
 	};
 	#endif
 

--- a/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
+++ b/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp
@@ -406,8 +406,8 @@ namespace WASM
 
 	struct LocalSet
 	{
-		Uptr num;
-		ValueType type;
+		Uptr num{};
+		ValueType type{};
 	};
 	
 	template<typename Stream>


### PR DESCRIPTION
Fixing https://github.com/AntelopeIO/leap/issues/493.

Fixed undefined behavior revealed by valgrind. After fixes all mentioned issues are cleared out:
1.
```
valgrind nodeos -e -p eosio --data-dir /home/mikel/app/nodeos --plugin eosio::producer_plugin --plugin eosio::producer_api_plugin --plugin eosio::chain_plugin --plugin eosio::chain_api_plugin --plugin eosio::http_plugin --plugin eosio::state_history_plugin --contracts-console --disable-replay-opts --access-control-allow-origin=* --http-validate-host=false --verbose-http-errors --trace-history --chain-state-history --delete-all-blocks

(...)
==46508== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
2.
`valgrind /home/mikel/repo/leap/debug/plugins/chain_plugin/test/test_account_query_db`

Valgrind reports only issues which are created as a separate issue (https://github.com/AntelopeIO/leap/issues/494).

3.
Original warning is gone:

```
valgrind /home/mikel/repo/leap/debug/unittests/unit_test "--run_test=chain_tests" "--report_level=detailed" "--color_output" "--catch_system_errors=no" "--" "--eos-vm-oc"
(...)
==46794== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

4. 
```
valgrind /home/mikel/repo/leap/debug/libraries/libfc/test/network/test_message_buffer
(...)
==46567== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
