### PR TITLE
[PH] Remove argument to disable resmon shutdown.

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -252,7 +252,7 @@ class Cluster(object):
         if self.staging:
             cmdArr.append("--nogen")
 
-        nodeosArgs="--resource-monitor-not-shutdown-on-threshold-exceeded --max-transaction-time -1 --abi-serializer-max-time-ms 990000 --p2p-max-nodes-per-host %d --max-clients %d" % (maximumP2pPerHost, maximumClients)
+        nodeosArgs="--max-transaction-time -1 --abi-serializer-max-time-ms 990000 --p2p-max-nodes-per-host %d --max-clients %d" % (maximumP2pPerHost, maximumClients)
         if not self.walletd:
             nodeosArgs += " --plugin eosio::wallet_api_plugin"
         if Utils.Debug:


### PR DESCRIPTION
Removing --resource-monitor-not-shutdown-on-threshold-exceeded in Cluster.py to allow resmon to shutdown as expected.  Shouldn't default to disabling this.  Also allows for Cluster.py to continue to be able to support older versions of nodeos for perf harness testing.