### PR TITLE
Added validation of plugin configuration for deep-mind

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1124,6 +1124,17 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          //
          // For the time being, when `deep-mind = true` is activated, we set `stdout` here to
          // be an unbuffered I/O stream.
+
+         //verify configuration is correct
+         EOS_ASSERT( my->chain_config->read_mode == db_read_mode::HEAD, plugin_config_exception, 
+            "read-mode must be set to head in order to enable deep-mind logging.");
+
+         EOS_ASSERT( options.at("api-accept-transactions").as<bool>() == false, plugin_config_exception,
+            "api-accept-transactions must be set to false in order to enable deep-mind logging.");
+
+         EOS_ASSERT( options.at("p2p-accept-transactions").as<bool>() == false, plugin_config_exception,
+            "p2p-accept-transactions must be set to false in order to enable deep-mind logging.");
+
          setbuf(stdout, NULL);
 
          my->chain->enable_deep_mind( &_deep_mind_log );

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1126,9 +1126,6 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          // be an unbuffered I/O stream.
 
          //verify configuration is correct
-         EOS_ASSERT( my->chain_config->read_mode == db_read_mode::HEAD, plugin_config_exception, 
-            "read-mode must be set to head in order to enable deep-mind logging.");
-
          EOS_ASSERT( options.at("api-accept-transactions").as<bool>() == false, plugin_config_exception,
             "api-accept-transactions must be set to false in order to enable deep-mind logging.");
 


### PR DESCRIPTION
This PR adds validation of plugin configuration for deep-mind and will throw an exception if the plugin is not configured properly

See : https://github.com/AntelopeIO/leap/issues/286