### PR TITLE
[3.1] Added validation of plugin configuration for deep-mind

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1126,6 +1126,13 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          // For the time being, when `deep-mind = true` is activated, we set `stdout` here to
          // be an unbuffered I/O stream.
          setbuf(stdout, NULL);
+         
+         //verify configuration is correct
+         EOS_ASSERT( options.at("api-accept-transactions").as<bool>() == false, plugin_config_exception,
+            "api-accept-transactions must be set to false in order to enable deep-mind logging.");
+
+         EOS_ASSERT( options.at("p2p-accept-transactions").as<bool>() == false, plugin_config_exception,
+            "p2p-accept-transactions must be set to false in order to enable deep-mind logging.");
 
          my->chain->enable_deep_mind( &_deep_mind_log );
       }


### PR DESCRIPTION
This PR adds validation of plugin configuration for deep-mind and will throw an exception if the plugin is not configured properly

Resolves #286