### PR TITLE
[PH] thread count recommendation tests

### DIFF
--- a/tests/performance_tests/README.md
+++ b/tests/performance_tests/README.md
@@ -229,7 +229,7 @@ The Performance Harness main script `performance_test.py` can be configured usin
 * `--chain-state-db-size-mb CHAIN_STATE_DB_SIZE_MB`
                           Maximum size (in MiB) of the chain state database (default: 10240)
 * `--chain-threads CHAIN_THREADS`
-                          Number of worker threads in controller thread pool (default: 2)
+                          Number of worker threads in controller thread pool (default: 3)
 * `--database-map-mode {mapped,heap,locked}`
                           Database map mode ("mapped", "heap", or "locked").
                           In "mapped" mode database is memory mapped as a file.
@@ -248,7 +248,7 @@ The Performance Harness main script `performance_test.py` can be configured usin
 * `--last-block-cpu-effort-percent LAST_BLOCK_CPU_EFFORT_PERCENT`
                           Percentage of cpu block production time used to produce last block. Whole number percentages, e.g. 80 for 80% (default: 100)
 * `--producer-threads PRODUCER_THREADS`
-                          Number of worker threads in producer thread pool (default: 2)
+                          Number of worker threads in producer thread pool (default: 6)
 * `--http-max-response-time-ms HTTP_MAX_RESPONSE_TIME_MS`
                           Maximum time for processing a request, -1 for unlimited (default: 990000)
 * `--del-perf-logs`       Whether to delete performance test specific logs. (default: False)
@@ -311,7 +311,7 @@ The following scripts are typically used by the Performance Harness main script 
 * `--chain-state-db-size-mb CHAIN_STATE_DB_SIZE_MB`
                           Maximum size (in MiB) of the chain state database (default: 10240)
 * `--chain-threads CHAIN_THREADS`
-                          Number of worker threads in controller thread pool (default: 2)
+                          Number of worker threads in controller thread pool (default: 3)
 * `--database-map-mode {mapped,heap,locked}`
                           Database map mode ("mapped", "heap", or "locked").
                           In "mapped" mode database is memory mapped as a file.
@@ -330,7 +330,7 @@ The following scripts are typically used by the Performance Harness main script 
 * `--last-block-cpu-effort-percent LAST_BLOCK_CPU_EFFORT_PERCENT`
                           Percentage of cpu block production time used to produce last block. Whole number percentages, e.g. 80 for 80% (default: 100)
 * `--producer-threads PRODUCER_THREADS`
-                          Number of worker threads in producer thread pool (default: 2)
+                          Number of worker threads in producer thread pool (default: 6)
 * `--http-max-response-time-ms HTTP_MAX_RESPONSE_TIME_MS`
                           Maximum time for processing a request, -1 for unlimited (default: 990000)
 * `--del-perf-logs`       Whether to delete performance test specific logs. (default: False)

--- a/tests/performance_tests/README.md
+++ b/tests/performance_tests/README.md
@@ -450,9 +450,9 @@ Finally, the full detail test report for each of the determined max TPS throughp
 ``` json
 {
   "InitialMaxTpsAchieved": 16000,
-  "LongRunningMaxTpsAchieved": 15000,
-  "testStart": "2022-11-04T19:31:40.539240",
-  "testFinish": "2022-11-04T19:48:53.096915",
+  "LongRunningMaxTpsAchieved": 16000,
+  "testStart": "2022-11-21T22:17:03.604928",
+  "testFinish": "2022-11-21T22:29:02.923633",
   "InitialSearchResults": {
     "0": {
       "success": false,
@@ -461,16 +461,16 @@ Finally, the full detail test report for each of the determined max TPS throughp
       "searchCeiling": 50000,
       "basicTestResult": {
         "targetTPS": 50000,
-        "resultAvgTps": 15312.09090909091,
+        "resultAvgTps": 15121.925,
         "expectedTxns": 500000,
-        "resultTxns": 362075,
+        "resultTxns": 326102,
         "tpsExpectMet": false,
         "trxExpectMet": false,
-        "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 45,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-31-40",
-        "testStart": "2022-11-04T19:31:40.539927",
-        "testEnd": "2022-11-04T19:33:16.377065"
+        "basicTestSuccess": false,
+        "testAnalysisBlockCnt": 41,
+        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-17-03-50000",
+        "testStart": "2022-11-21T22:17:03.624828",
+        "testEnd": "2022-11-21T22:18:35.048631"
       }
     },
     "1": {
@@ -480,16 +480,16 @@ Finally, the full detail test report for each of the determined max TPS throughp
       "searchCeiling": 49500,
       "basicTestResult": {
         "targetTPS": 25000,
-        "resultAvgTps": 15098.241379310344,
+        "resultAvgTps": 15307.275862068966,
         "expectedTxns": 250000,
         "resultTxns": 250000,
         "tpsExpectMet": false,
         "trxExpectMet": true,
         "basicTestSuccess": true,
         "testAnalysisBlockCnt": 30,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-33-16",
-        "testStart": "2022-11-04T19:33:16.471198",
-        "testEnd": "2022-11-04T19:34:45.441319"
+        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-18-35-25000",
+        "testStart": "2022-11-21T22:18:35.136441",
+        "testEnd": "2022-11-21T22:20:02.355919"
       }
     },
     "2": {
@@ -499,16 +499,16 @@ Finally, the full detail test report for each of the determined max TPS throughp
       "searchCeiling": 24500,
       "basicTestResult": {
         "targetTPS": 12500,
-        "resultAvgTps": 12500.0625,
+        "resultAvgTps": 12494.4375,
         "expectedTxns": 125000,
         "resultTxns": 125000,
         "tpsExpectMet": true,
         "trxExpectMet": true,
         "basicTestSuccess": true,
         "testAnalysisBlockCnt": 17,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-34-45",
-        "testStart": "2022-11-04T19:34:45.507994",
-        "testEnd": "2022-11-04T19:36:01.234060"
+        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-20-02-12500",
+        "testStart": "2022-11-21T22:20:02.419664",
+        "testEnd": "2022-11-21T22:21:17.334219"
       }
     },
     "3": {
@@ -518,16 +518,16 @@ Finally, the full detail test report for each of the determined max TPS throughp
       "searchCeiling": 24500,
       "basicTestResult": {
         "targetTPS": 19000,
-        "resultAvgTps": 15454.0,
+        "resultAvgTps": 15546.55,
         "expectedTxns": 190000,
         "resultTxns": 190000,
         "tpsExpectMet": false,
         "trxExpectMet": true,
         "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 22,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-36-01",
-        "testStart": "2022-11-04T19:36:01.277926",
-        "testEnd": "2022-11-04T19:37:23.028124"
+        "testAnalysisBlockCnt": 21,
+        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-21-17-19000",
+        "testStart": "2022-11-21T22:21:17.380653",
+        "testEnd": "2022-11-21T22:22:37.113095"
       }
     },
     "4": {
@@ -537,16 +537,16 @@ Finally, the full detail test report for each of the determined max TPS throughp
       "searchCeiling": 18500,
       "basicTestResult": {
         "targetTPS": 16000,
-        "resultAvgTps": 15900.625,
+        "resultAvgTps": 15969.375,
         "expectedTxns": 160000,
         "resultTxns": 160000,
         "tpsExpectMet": true,
         "trxExpectMet": true,
         "basicTestSuccess": true,
         "testAnalysisBlockCnt": 17,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-37-23",
-        "testStart": "2022-11-04T19:37:23.085923",
-        "testEnd": "2022-11-04T19:38:41.744418"
+        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-22-37-16000",
+        "testStart": "2022-11-21T22:22:37.166645",
+        "testEnd": "2022-11-21T22:23:51.349987"
       }
     },
     "5": {
@@ -556,16 +556,16 @@ Finally, the full detail test report for each of the determined max TPS throughp
       "searchCeiling": 18500,
       "basicTestResult": {
         "targetTPS": 17500,
-        "resultAvgTps": 15271.526315789473,
+        "resultAvgTps": 15048.263157894737,
         "expectedTxns": 175000,
         "resultTxns": 175000,
         "tpsExpectMet": false,
         "trxExpectMet": true,
         "basicTestSuccess": true,
         "testAnalysisBlockCnt": 20,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-38-41",
-        "testStart": "2022-11-04T19:38:41.796745",
-        "testEnd": "2022-11-04T19:40:02.097920"
+        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-23-51-17500",
+        "testStart": "2022-11-21T22:23:51.399539",
+        "testEnd": "2022-11-21T22:25:11.171614"
       }
     },
     "6": {
@@ -575,16 +575,16 @@ Finally, the full detail test report for each of the determined max TPS throughp
       "searchCeiling": 17000,
       "basicTestResult": {
         "targetTPS": 17000,
-        "resultAvgTps": 15876.176470588236,
+        "resultAvgTps": 15659.058823529413,
         "expectedTxns": 170000,
         "resultTxns": 170000,
         "tpsExpectMet": false,
         "trxExpectMet": true,
         "basicTestSuccess": true,
         "testAnalysisBlockCnt": 18,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-40-02",
-        "testStart": "2022-11-04T19:40:02.150305",
-        "testEnd": "2022-11-04T19:41:21.802272"
+        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-25-11-17000",
+        "testStart": "2022-11-21T22:25:11.225775",
+        "testEnd": "2022-11-21T22:26:30.102913"
       }
     },
     "7": {
@@ -594,16 +594,16 @@ Finally, the full detail test report for each of the determined max TPS throughp
       "searchCeiling": 16500,
       "basicTestResult": {
         "targetTPS": 16500,
-        "resultAvgTps": 16096.823529411764,
+        "resultAvgTps": 15714.823529411764,
         "expectedTxns": 165000,
         "resultTxns": 165000,
         "tpsExpectMet": false,
         "trxExpectMet": true,
         "basicTestSuccess": true,
         "testAnalysisBlockCnt": 18,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-41-21",
-        "testStart": "2022-11-04T19:41:21.851918",
-        "testEnd": "2022-11-04T19:42:40.991794"
+        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-26-30-16500",
+        "testStart": "2022-11-21T22:26:30.155632",
+        "testEnd": "2022-11-21T22:27:48.093871"
       }
     }
   },
@@ -622,60 +622,22 @@ Finally, the full detail test report for each of the determined max TPS throughp
   },
   "LongRunningSearchResults": {
     "0": {
-      "success": false,
+      "success": true,
       "searchTarget": 16000,
       "searchFloor": 0,
       "searchCeiling": 16000,
       "basicTestResult": {
         "targetTPS": 16000,
-        "resultAvgTps": 14954.266666666666,
-        "expectedTxns": 480000,
-        "resultTxns": 480000,
-        "tpsExpectMet": false,
-        "trxExpectMet": true,
-        "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 61,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-42-41",
-        "testStart": "2022-11-04T19:42:41.051468",
-        "testEnd": "2022-11-04T19:44:47.365905"
-      }
-    },
-    "1": {
-      "success": false,
-      "searchTarget": 15500,
-      "searchFloor": 0,
-      "searchCeiling": 16000,
-      "basicTestResult": {
-        "targetTPS": 15500,
-        "resultAvgTps": 15001.827586206897,
-        "expectedTxns": 465000,
-        "resultTxns": 465000,
-        "tpsExpectMet": false,
-        "trxExpectMet": true,
-        "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 59,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-44-47",
-        "testStart": "2022-11-04T19:44:47.472961",
-        "testEnd": "2022-11-04T19:46:52.818564"
-      }
-    },
-    "2": {
-      "success": true,
-      "searchTarget": 15000,
-      "searchFloor": 0,
-      "searchCeiling": 16000,
-      "basicTestResult": {
-        "targetTPS": 15000,
-        "resultAvgTps": 15023.464285714286,
-        "expectedTxns": 450000,
-        "resultTxns": 450000,
+        "resultAvgTps": 15933.1875,
+        "expectedTxns": 160000,
+        "resultTxns": 160000,
         "tpsExpectMet": true,
         "trxExpectMet": true,
         "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 57,
-        "logsDir": "performance_test/2022-11-04_19-31-40/testRunLogs/performance_test_basic/2022-11-04_19-46-52",
-        "testStart": "2022-11-04T19:46:52.960531",
-        "testEnd": "2022-11-04T19:48:52.989694"
+        "testAnalysisBlockCnt": 17,
+        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-27-48-16000",
+        "testStart": "2022-11-21T22:27:48.146027",
+        "testEnd": "2022-11-21T22:29:02.871273"
       }
     }
   },
@@ -707,17 +669,24 @@ Finally, the full detail test report for each of the determined max TPS throughp
     "topo": "mesh",
     "extraNodeosArgs": {
       "chainPluginArgs": {
-        "signatureCpuBillablePct": 0
+        "signatureCpuBillablePct": 0,
+        "chainStateDbSizeMb": 10240,
+        "chainThreads": 2,
+        "databaseMapMode": "mapped"
       },
       "producerPluginArgs": {
         "disableSubjectiveBilling": true,
         "lastBlockTimeOffsetUs": 0,
         "produceTimeOffsetUs": 0,
         "cpuEffortPercent": 100,
-        "lastBlockCpuEffortPercent": 100
+        "lastBlockCpuEffortPercent": 100,
+        "producerThreads": 2
       },
       "httpPluginArgs": {
         "httpMaxResponseTimeMs": 990000
+      },
+      "netPluginArgs": {
+        "netThreads": 2
       }
     },
     "useBiosBootFile": false,
@@ -734,7 +703,7 @@ Finally, the full detail test report for each of the determined max TPS throughp
     "_totalNodes": 2,
     "testDurationSec": 10,
     "finalDurationSec": 30,
-    "logsDir": "performance_test/2022-11-04_19-31-40",
+    "delPerfLogs": false,
     "maxTpsToTest": 50000,
     "testIterationMinStep": 500,
     "tpsLimitPerGenerator": 4000,
@@ -742,12 +711,17 @@ Finally, the full detail test report for each of the determined max TPS throughp
     "delTestReport": false,
     "numAddlBlocksToPrune": 2,
     "quiet": false,
-    "delPerfLogs": false
+    "logDirRoot": ".",
+    "logDirBase": "./performance_test",
+    "logDirTimestamp": "2022-11-21_22-17-03",
+    "logDirPath": "./performance_test/2022-11-21_22-17-03",
+    "ptbLogsDirPath": "./performance_test/2022-11-21_22-17-03/testRunLogs"
   },
   "env": {
     "system": "Linux",
     "os": "posix",
-    "release": "5.10.102.1-microsoft-standard-WSL2"
+    "release": "5.15.74.2-microsoft-standard-WSL2",
+    "logical_cpu_count": 16
   },
   "nodeosVersion": "v4.0.0-dev"
 }
@@ -765,67 +739,67 @@ The Performance Test Basic generates, by default, a report that details results 
 ``` json
 {
   "completedRun": true,
-  "testStart": "2022-11-04T19:46:52.960531",
-  "testFinish": "2022-11-04T19:48:52.989694",
+  "testStart": "2022-11-21T22:27:48.146027",
+  "testFinish": "2022-11-21T22:29:02.871273",
   "Analysis": {
     "BlockSize": {
-      "min": 1389312,
-      "max": 1575800,
-      "avg": 1474814.3157894737,
-      "sigma": 40921.65290309434,
+      "min": 1369536,
+      "max": 1624896,
+      "avg": 1530567.5294117648,
+      "sigma": 58850.381839050766,
       "emptyBlocks": 0,
-      "numBlocks": 57
+      "numBlocks": 17
     },
     "BlocksGuide": {
       "firstBlockNum": 2,
-      "lastBlockNum": 232,
-      "totalBlocks": 231,
+      "lastBlockNum": 147,
+      "totalBlocks": 146,
       "testStartBlockNum": 105,
-      "testEndBlockNum": 199,
+      "testEndBlockNum": 136,
       "setupBlocksCnt": 103,
-      "tearDownBlocksCnt": 33,
+      "tearDownBlocksCnt": 11,
       "leadingEmptyBlocksCnt": 1,
-      "trailingEmptyBlocksCnt": 33,
+      "trailingEmptyBlocksCnt": 10,
       "configAddlDropCnt": 2,
-      "testAnalysisBlockCnt": 57
+      "testAnalysisBlockCnt": 17
     },
     "TPS": {
-      "min": 14532,
-      "max": 15477,
-      "avg": 15023.464285714286,
-      "sigma": 178.66938384762454,
+      "min": 14996,
+      "max": 16486,
+      "avg": 15933.1875,
+      "sigma": 403.137727512261,
       "emptyBlocks": 0,
-      "numBlocks": 57,
-      "configTps": 15000,
-      "configTestDuration": 30,
+      "numBlocks": 17,
+      "configTps": 16000,
+      "configTestDuration": 10,
       "tpsPerGenerator": [
-        3750,
-        3750,
-        3750,
-        3750
+        4000,
+        4000,
+        4000,
+        4000
       ],
       "generatorCount": 4
     },
     "TrxCPU": {
       "min": 7.0,
-      "max": 2647.0,
-      "avg": 23.146035555555557,
-      "sigma": 11.415769514864671,
-      "samples": 450000
+      "max": 657.0,
+      "avg": 21.81190625,
+      "sigma": 9.853241319038672,
+      "samples": 160000
     },
     "TrxLatency": {
       "min": 0.0009999275207519531,
-      "max": 0.5539999008178711,
-      "avg": 0.2614889088874393,
-      "sigma": 0.1450651327531534,
-      "samples": 450000
+      "max": 0.565000057220459,
+      "avg": 0.27573538126200436,
+      "sigma": 0.14606770516057177,
+      "samples": 160000
     },
     "TrxNet": {
       "min": 24.0,
-      "max": 25.0,
-      "avg": 24.555564444444446,
-      "sigma": 0.49690300111146485,
-      "samples": 450000
+      "max": 24.0,
+      "avg": 24.0,
+      "sigma": 0.0,
+      "samples": 160000
     }
   },
   "args": {
@@ -843,17 +817,24 @@ The Performance Test Basic generates, by default, a report that details results 
     "topo": "mesh",
     "extraNodeosArgs": {
       "chainPluginArgs": {
-        "signatureCpuBillablePct": 0
+        "signatureCpuBillablePct": 0,
+        "chainStateDbSizeMb": 10240,
+        "chainThreads": 2,
+        "databaseMapMode": "mapped"
       },
       "producerPluginArgs": {
         "disableSubjectiveBilling": true,
         "lastBlockTimeOffsetUs": 0,
         "produceTimeOffsetUs": 0,
         "cpuEffortPercent": 100,
-        "lastBlockCpuEffortPercent": 100
+        "lastBlockCpuEffortPercent": 100,
+        "producerThreads": 2
       },
       "httpPluginArgs": {
         "httpMaxResponseTimeMs": 990000
+      },
+      "netPluginArgs": {
+        "netThreads": 2
       }
     },
     "useBiosBootFile": false,
@@ -868,19 +849,24 @@ The Performance Test Basic generates, by default, a report that details results 
       "1": "--plugin eosio::trace_api_plugin"
     },
     "_totalNodes": 2,
-    "delPerfLogs": false,
-    "delReport": false,
-    "expectedTransactionsSent": 450000,
+    "targetTps": 16000,
+    "testTrxGenDurationSec": 10,
+    "tpsLimitPerGenerator": 4000,
     "numAddlBlocksToPrune": 2,
+    "logDirRoot": "./performance_test/2022-11-21_22-17-03/testRunLogs",
+    "delReport": false,
     "quiet": false,
-    "targetTps": 15000,
-    "testTrxGenDurationSec": 30,
-    "tpsLimitPerGenerator": 4000
+    "delPerfLogs": false,
+    "expectedTransactionsSent": 160000,
+    "logDirBase": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic",
+    "logDirTimestamp": "2022-11-21_22-27-48",
+    "logDirTimestampedOptSuffix": "-16000",
+    "logDirPath": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-27-48-16000"
   },
   "env": {
     "system": "Linux",
     "os": "posix",
-    "release": "5.10.102.1-microsoft-standard-WSL2",
+    "release": "5.15.74.2-microsoft-standard-WSL2",
     "logical_cpu_count": 16
   },
   "nodeosVersion": "v4.0.0-dev"

--- a/tests/performance_tests/README.md
+++ b/tests/performance_tests/README.md
@@ -37,6 +37,11 @@ Please refer to [Leap: Build and Install from Source](https://github.com/Antelop
         performance_test/
         └── 2022-10-27_15-28-09
             ├── report.json
+            ├── pluginThreadOptRunLogs
+            │   ├── performance_test_basic
+            │   ├── chainThreadResults.txt
+            │   ├── netThreadResults.txt
+            │   └── producerThreadResults.txt
             └── testRunLogs
                 └── performance_test_basic
                     └── 2022-10-19_10-29-07
@@ -252,6 +257,22 @@ The Performance Harness main script `performance_test.py` can be configured usin
 * `--quiet`               Whether to quiet printing intermediate results and reports to stdout (default: False)
 * `--prods-enable-trace-api`
                           Determines whether producer nodes should have eosio::trace_api_plugin enabled (default: False)
+* `--skip-tps-test`       Determines whether to skip the max TPS measurement tests (default: False)
+* `--calc-producer-threads {none,lmax,full}`
+                          Determines whether to calculate number of worker threads to use in producer thread pool ("none", "lmax", or "full").
+                          In "none" mode, the default, no calculation will be attempted and default configured --producer-threads value will be used.
+                          In "lmax" mode, producer threads will incrementally be tested until the performance rate ceases to increase with the addition of additional threads.
+                          In "full" mode producer threads will incrementally be tested from 2..num logical processors, recording each performance and choosing the local max performance (same value as would be discovered in "lmax" mode). Useful for graphing the full performance impact of each available thread. (default: none)
+* `--calc-chain-threads {none,lmax,full}`
+                          Determines whether to calculate number of worker threads to use in chain thread pool ("none", "lmax", or "full").
+                          In "none" mode, the default, no calculation will be attempted and default configured --chain-threads value will be used.
+                          In "lmax" mode, producer threads will incrementally be tested until the performance rate ceases to increase with the addition of additional threads.
+                          In "full" mode producer threads will incrementally be tested from 2..num logical processors, recording each performance and choosing the local max performance (same value as would be discovered in "lmax" mode). Useful for graphing the full performance impact of each available thread. (default: none)
+* `--calc-net-threads {none,lmax,full}`
+                          Determines whether to calculate number of worker threads to use in net thread pool ("none", "lmax", or "full").
+                          In "none" mode, the default, no calculation will be attempted and default configured --net-threads value will be used.
+                          In "lmax" mode, producer threads will incrementally be tested until the performance rate ceases to increase with the addition of additional threads.
+                          In "full" mode producer threads will incrementally be tested from 2..num logical processors, recording each performance and choosing the local max performance (same value as would be discovered in "lmax" mode). Useful for graphing the full performance impact of each available thread. (default: none)
 </details>
 
 ### Support Scripts
@@ -386,7 +407,7 @@ The Performance Harness generates a report to summarize results of test scenario
 Command used to run test and generate report:
 
 ``` bash
-.build/tests/performance_tests/performance_test.py --test-iteration-duration-sec 10 --final-iterations-duration-sec 30
+.build/tests/performance_tests/performance_test.py --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-producer-threads lmax --calc-chain-threads lmax --calc-net-threads lmax
 ```
 
 #### Report Breakdown
@@ -400,23 +421,23 @@ Next, a summary of the search scenario conducted and respective results is inclu
     <summary>Expand Search Scenario Summary Example</summary>
 
 ``` json
-    "0": {
-      "success": false,
-      "searchTarget": 25000,
+    "1": {
+      "success": true,
+      "searchTarget": 26000,
       "searchFloor": 0,
-      "searchCeiling": 50000,
+      "searchCeiling": 26500,
       "basicTestResult": {
-        "targetTPS": 25000,
-        "resultAvgTps": 17160.4,
-        "expectedTxns": 250000,
-        "resultTxns": 250000,
-        "tpsExpectMet": false,
+        "targetTPS": 26000,
+        "resultAvgTps": 25986.9375,
+        "expectedTxns": 260000,
+        "resultTxns": 260000,
+        "tpsExpectMet": true,
         "trxExpectMet": true,
         "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 26,
-        "logsDir": "performance_test/2022-10-26_15-01-51/testRunLogs/performance_test_basic/2022-10-26_15-01-51",
-        "testStart": "2022-10-26T15:03:37.764242",
-        "testEnd": "2022-10-26T15:01:51.128328"
+        "testAnalysisBlockCnt": 17,
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-18-52-26000",
+        "testStart": "2022-11-23T15:18:52.115767",
+        "testEnd": "2022-11-23T15:20:16.911367"
       }
     }
 ```
@@ -449,10 +470,12 @@ Finally, the full detail test report for each of the determined max TPS throughp
 
 ``` json
 {
-  "InitialMaxTpsAchieved": 16000,
-  "LongRunningMaxTpsAchieved": 16000,
-  "testStart": "2022-11-21T22:17:03.604928",
-  "testFinish": "2022-11-21T22:29:02.923633",
+  "perfTestsBegin": "2022-11-23T12:56:58.699686",
+  "perfTestsFinish": "2022-11-23T15:20:16.979815",
+  "InitialMaxTpsAchieved": 26500,
+  "LongRunningMaxTpsAchieved": 26000,
+  "tpsTestStart": "2022-11-23T15:05:42.005050",
+  "tpsTestFinish": "2022-11-23T15:20:16.979800",
   "InitialSearchResults": {
     "0": {
       "success": false,
@@ -461,149 +484,149 @@ Finally, the full detail test report for each of the determined max TPS throughp
       "searchCeiling": 50000,
       "basicTestResult": {
         "targetTPS": 50000,
-        "resultAvgTps": 15121.925,
+        "resultAvgTps": 23784.324324324323,
         "expectedTxns": 500000,
-        "resultTxns": 326102,
+        "resultTxns": 500000,
         "tpsExpectMet": false,
-        "trxExpectMet": false,
-        "basicTestSuccess": false,
-        "testAnalysisBlockCnt": 41,
-        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-17-03-50000",
-        "testStart": "2022-11-21T22:17:03.624828",
-        "testEnd": "2022-11-21T22:18:35.048631"
+        "trxExpectMet": true,
+        "basicTestSuccess": true,
+        "testAnalysisBlockCnt": 38,
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-05-42-50000",
+        "testStart": "2022-11-23T15:05:42.005080",
+        "testEnd": "2022-11-23T15:07:24.111044"
       }
     },
     "1": {
-      "success": false,
+      "success": true,
       "searchTarget": 25000,
       "searchFloor": 0,
       "searchCeiling": 49500,
       "basicTestResult": {
         "targetTPS": 25000,
-        "resultAvgTps": 15307.275862068966,
+        "resultAvgTps": 25013.3125,
         "expectedTxns": 250000,
         "resultTxns": 250000,
-        "tpsExpectMet": false,
-        "trxExpectMet": true,
-        "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 30,
-        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-18-35-25000",
-        "testStart": "2022-11-21T22:18:35.136441",
-        "testEnd": "2022-11-21T22:20:02.355919"
-      }
-    },
-    "2": {
-      "success": true,
-      "searchTarget": 12500,
-      "searchFloor": 0,
-      "searchCeiling": 24500,
-      "basicTestResult": {
-        "targetTPS": 12500,
-        "resultAvgTps": 12494.4375,
-        "expectedTxns": 125000,
-        "resultTxns": 125000,
         "tpsExpectMet": true,
         "trxExpectMet": true,
         "basicTestSuccess": true,
         "testAnalysisBlockCnt": 17,
-        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-20-02-12500",
-        "testStart": "2022-11-21T22:20:02.419664",
-        "testEnd": "2022-11-21T22:21:17.334219"
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-07-24-25000",
+        "testStart": "2022-11-23T15:07:24.225706",
+        "testEnd": "2022-11-23T15:08:47.510691"
+      }
+    },
+    "2": {
+      "success": false,
+      "searchTarget": 37500,
+      "searchFloor": 25500,
+      "searchCeiling": 49500,
+      "basicTestResult": {
+        "targetTPS": 37500,
+        "resultAvgTps": 24912.576923076922,
+        "expectedTxns": 375000,
+        "resultTxns": 375000,
+        "tpsExpectMet": false,
+        "trxExpectMet": true,
+        "basicTestSuccess": true,
+        "testAnalysisBlockCnt": 27,
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-08-47-37500",
+        "testStart": "2022-11-23T15:08:47.579754",
+        "testEnd": "2022-11-23T15:10:23.342881"
       }
     },
     "3": {
       "success": false,
-      "searchTarget": 19000,
-      "searchFloor": 13000,
-      "searchCeiling": 24500,
+      "searchTarget": 31500,
+      "searchFloor": 25500,
+      "searchCeiling": 37000,
       "basicTestResult": {
-        "targetTPS": 19000,
-        "resultAvgTps": 15546.55,
-        "expectedTxns": 190000,
-        "resultTxns": 190000,
+        "targetTPS": 31500,
+        "resultAvgTps": 24525.095238095237,
+        "expectedTxns": 315000,
+        "resultTxns": 315000,
         "tpsExpectMet": false,
         "trxExpectMet": true,
         "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 21,
-        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-21-17-19000",
-        "testStart": "2022-11-21T22:21:17.380653",
-        "testEnd": "2022-11-21T22:22:37.113095"
+        "testAnalysisBlockCnt": 22,
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-10-23-31500",
+        "testStart": "2022-11-23T15:10:23.432821",
+        "testEnd": "2022-11-23T15:11:53.366694"
       }
     },
     "4": {
-      "success": true,
-      "searchTarget": 16000,
-      "searchFloor": 13000,
-      "searchCeiling": 18500,
+      "success": false,
+      "searchTarget": 28500,
+      "searchFloor": 25500,
+      "searchCeiling": 31000,
       "basicTestResult": {
-        "targetTPS": 16000,
-        "resultAvgTps": 15969.375,
-        "expectedTxns": 160000,
-        "resultTxns": 160000,
-        "tpsExpectMet": true,
+        "targetTPS": 28500,
+        "resultAvgTps": 25896.666666666668,
+        "expectedTxns": 285000,
+        "resultTxns": 285000,
+        "tpsExpectMet": false,
         "trxExpectMet": true,
         "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 17,
-        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-22-37-16000",
-        "testStart": "2022-11-21T22:22:37.166645",
-        "testEnd": "2022-11-21T22:23:51.349987"
+        "testAnalysisBlockCnt": 19,
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-11-53-28500",
+        "testStart": "2022-11-23T15:11:53.448449",
+        "testEnd": "2022-11-23T15:13:17.714663"
       }
     },
     "5": {
       "success": false,
-      "searchTarget": 17500,
-      "searchFloor": 16500,
-      "searchCeiling": 18500,
+      "searchTarget": 27000,
+      "searchFloor": 25500,
+      "searchCeiling": 28000,
       "basicTestResult": {
-        "targetTPS": 17500,
-        "resultAvgTps": 15048.263157894737,
-        "expectedTxns": 175000,
-        "resultTxns": 175000,
+        "targetTPS": 27000,
+        "resultAvgTps": 26884.625,
+        "expectedTxns": 270000,
+        "resultTxns": 270000,
         "tpsExpectMet": false,
         "trxExpectMet": true,
         "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 20,
-        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-23-51-17500",
-        "testStart": "2022-11-21T22:23:51.399539",
-        "testEnd": "2022-11-21T22:25:11.171614"
+        "testAnalysisBlockCnt": 17,
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-13-17-27000",
+        "testStart": "2022-11-23T15:13:17.787205",
+        "testEnd": "2022-11-23T15:14:40.753850"
       }
     },
     "6": {
-      "success": false,
-      "searchTarget": 17000,
-      "searchFloor": 16500,
-      "searchCeiling": 17000,
+      "success": true,
+      "searchTarget": 26000,
+      "searchFloor": 25500,
+      "searchCeiling": 26500,
       "basicTestResult": {
-        "targetTPS": 17000,
-        "resultAvgTps": 15659.058823529413,
-        "expectedTxns": 170000,
-        "resultTxns": 170000,
-        "tpsExpectMet": false,
+        "targetTPS": 26000,
+        "resultAvgTps": 25959.0,
+        "expectedTxns": 260000,
+        "resultTxns": 260000,
+        "tpsExpectMet": true,
         "trxExpectMet": true,
         "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 18,
-        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-25-11-17000",
-        "testStart": "2022-11-21T22:25:11.225775",
-        "testEnd": "2022-11-21T22:26:30.102913"
+        "testAnalysisBlockCnt": 17,
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-14-40-26000",
+        "testStart": "2022-11-23T15:14:40.823681",
+        "testEnd": "2022-11-23T15:16:02.884525"
       }
     },
     "7": {
-      "success": false,
-      "searchTarget": 16500,
-      "searchFloor": 16500,
-      "searchCeiling": 16500,
+      "success": true,
+      "searchTarget": 26500,
+      "searchFloor": 26500,
+      "searchCeiling": 26500,
       "basicTestResult": {
-        "targetTPS": 16500,
-        "resultAvgTps": 15714.823529411764,
-        "expectedTxns": 165000,
-        "resultTxns": 165000,
-        "tpsExpectMet": false,
+        "targetTPS": 26500,
+        "resultAvgTps": 26400.5625,
+        "expectedTxns": 265000,
+        "resultTxns": 265000,
+        "tpsExpectMet": true,
         "trxExpectMet": true,
         "basicTestSuccess": true,
-        "testAnalysisBlockCnt": 18,
-        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-26-30-16500",
-        "testStart": "2022-11-21T22:26:30.155632",
-        "testEnd": "2022-11-21T22:27:48.093871"
+        "testAnalysisBlockCnt": 17,
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-16-02-26500",
+        "testStart": "2022-11-23T15:16:02.953195",
+        "testEnd": "2022-11-23T15:17:28.412837"
       }
     }
   },
@@ -622,22 +645,41 @@ Finally, the full detail test report for each of the determined max TPS throughp
   },
   "LongRunningSearchResults": {
     "0": {
-      "success": true,
-      "searchTarget": 16000,
+      "success": false,
+      "searchTarget": 26500,
       "searchFloor": 0,
-      "searchCeiling": 16000,
+      "searchCeiling": 26500,
       "basicTestResult": {
-        "targetTPS": 16000,
-        "resultAvgTps": 15933.1875,
-        "expectedTxns": 160000,
-        "resultTxns": 160000,
+        "targetTPS": 26500,
+        "resultAvgTps": 22554.42105263158,
+        "expectedTxns": 265000,
+        "resultTxns": 265000,
+        "tpsExpectMet": false,
+        "trxExpectMet": true,
+        "basicTestSuccess": true,
+        "testAnalysisBlockCnt": 20,
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-17-28-26500",
+        "testStart": "2022-11-23T15:17:28.483195",
+        "testEnd": "2022-11-23T15:18:52.048868"
+      }
+    },
+    "1": {
+      "success": true,
+      "searchTarget": 26000,
+      "searchFloor": 0,
+      "searchCeiling": 26500,
+      "basicTestResult": {
+        "targetTPS": 26000,
+        "resultAvgTps": 25986.9375,
+        "expectedTxns": 260000,
+        "resultTxns": 260000,
         "tpsExpectMet": true,
         "trxExpectMet": true,
         "basicTestSuccess": true,
         "testAnalysisBlockCnt": 17,
-        "logsDir": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-27-48-16000",
-        "testStart": "2022-11-21T22:27:48.146027",
-        "testEnd": "2022-11-21T22:29:02.871273"
+        "logsDir": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-18-52-26000",
+        "testStart": "2022-11-23T15:18:52.115767",
+        "testEnd": "2022-11-23T15:20:16.911367"
       }
     }
   },
@@ -653,6 +695,38 @@ Finally, the full detail test report for each of the determined max TPS throughp
       <truncated>
     },
     <truncated>
+  },
+  "ProducerThreadAnalysis": {
+    "recommendedThreadCount": 6,
+    "threadToMaxTpsDict": {
+      "2": 16000,
+      "3": 21000,
+      "4": 24000,
+      "5": 25500,
+      "6": 27000,
+      "7": 26000
+    },
+    "analysisStart": "2022-11-23T12:56:58.730271",
+    "analysisFinish": "2022-11-23T14:05:45.727625"
+  },
+  "ChainThreadAnalysis": {
+    "recommendedThreadCount": 3,
+    "threadToMaxTpsDict": {
+      "2": 25000,
+      "3": 26500,
+      "4": 26500
+    },
+    "analysisStart": "2022-11-23T14:05:45.728348",
+    "analysisFinish": "2022-11-23T14:41:43.721885"
+  },
+  "NetThreadAnalysis": {
+    "recommendedThreadCount": 2,
+    "threadToMaxTpsDict": {
+      "2": 25500,
+      "3": 25000
+    },
+    "analysisStart": "2022-11-23T14:41:43.722862",
+    "analysisFinish": "2022-11-23T15:05:42.004421"
   },
   "args": {
     "killAll": false,
@@ -671,7 +745,7 @@ Finally, the full detail test report for each of the determined max TPS throughp
       "chainPluginArgs": {
         "signatureCpuBillablePct": 0,
         "chainStateDbSizeMb": 10240,
-        "chainThreads": 2,
+        "chainThreads": 3,
         "databaseMapMode": "mapped"
       },
       "producerPluginArgs": {
@@ -680,7 +754,7 @@ Finally, the full detail test report for each of the determined max TPS throughp
         "produceTimeOffsetUs": 0,
         "cpuEffortPercent": 100,
         "lastBlockCpuEffortPercent": 100,
-        "producerThreads": 2
+        "producerThreads": 6
       },
       "httpPluginArgs": {
         "httpMaxResponseTimeMs": 990000
@@ -712,10 +786,15 @@ Finally, the full detail test report for each of the determined max TPS throughp
     "numAddlBlocksToPrune": 2,
     "quiet": false,
     "logDirRoot": ".",
+    "skipTpsTests": false,
+    "calcProducerThreads": "lmax",
+    "calcChainThreads": "lmax",
+    "calcNetThreads": "lmax",
     "logDirBase": "./performance_test",
-    "logDirTimestamp": "2022-11-21_22-17-03",
-    "logDirPath": "./performance_test/2022-11-21_22-17-03",
-    "ptbLogsDirPath": "./performance_test/2022-11-21_22-17-03/testRunLogs"
+    "logDirTimestamp": "2022-11-23_12-56-58",
+    "logDirPath": "./performance_test/2022-11-23_12-56-58",
+    "ptbLogsDirPath": "./performance_test/2022-11-23_12-56-58/testRunLogs",
+    "pluginThreadOptLogsDirPath": "./performance_test/2022-11-23_12-56-58/pluginThreadOptRunLogs"
   },
   "env": {
     "system": "Linux",
@@ -739,67 +818,70 @@ The Performance Test Basic generates, by default, a report that details results 
 ``` json
 {
   "completedRun": true,
-  "testStart": "2022-11-21T22:27:48.146027",
-  "testFinish": "2022-11-21T22:29:02.871273",
+  "testStart": "2022-11-23T15:18:52.115767",
+  "testFinish": "2022-11-23T15:20:16.911367",
   "Analysis": {
     "BlockSize": {
-      "min": 1369536,
-      "max": 1624896,
-      "avg": 1530567.5294117648,
-      "sigma": 58850.381839050766,
+      "min": 1937088,
+      "max": 2971200,
+      "avg": 2493345.882352941,
+      "sigma": 186567.07030350564,
       "emptyBlocks": 0,
       "numBlocks": 17
     },
     "BlocksGuide": {
       "firstBlockNum": 2,
-      "lastBlockNum": 147,
-      "totalBlocks": 146,
-      "testStartBlockNum": 105,
-      "testEndBlockNum": 136,
-      "setupBlocksCnt": 103,
-      "tearDownBlocksCnt": 11,
+      "lastBlockNum": 165,
+      "totalBlocks": 164,
+      "testStartBlockNum": 106,
+      "testEndBlockNum": 149,
+      "setupBlocksCnt": 104,
+      "tearDownBlocksCnt": 16,
       "leadingEmptyBlocksCnt": 1,
-      "trailingEmptyBlocksCnt": 10,
+      "trailingEmptyBlocksCnt": 22,
       "configAddlDropCnt": 2,
       "testAnalysisBlockCnt": 17
     },
     "TPS": {
-      "min": 14996,
-      "max": 16486,
-      "avg": 15933.1875,
-      "sigma": 403.137727512261,
+      "min": 23164,
+      "max": 28791,
+      "avg": 25986.9375,
+      "sigma": 1033.1693634606816,
       "emptyBlocks": 0,
       "numBlocks": 17,
-      "configTps": 16000,
+      "configTps": 26000,
       "configTestDuration": 10,
       "tpsPerGenerator": [
-        4000,
-        4000,
-        4000,
-        4000
+        3714,
+        3714,
+        3714,
+        3714,
+        3714,
+        3715,
+        3715
       ],
-      "generatorCount": 4
+      "generatorCount": 7
     },
     "TrxCPU": {
       "min": 7.0,
-      "max": 657.0,
-      "avg": 21.81190625,
-      "sigma": 9.853241319038672,
-      "samples": 160000
+      "max": 10893.0,
+      "avg": 17.314342307692307,
+      "sigma": 41.16144172726996,
+      "samples": 260000
     },
     "TrxLatency": {
       "min": 0.0009999275207519531,
-      "max": 0.565000057220459,
-      "avg": 0.27573538126200436,
-      "sigma": 0.14606770516057177,
-      "samples": 160000
+      "max": 0.6380000114440918,
+      "avg": 0.26549454224201346,
+      "sigma": 0.14674558675649374,
+      "samples": 260000
     },
     "TrxNet": {
       "min": 24.0,
       "max": 24.0,
       "avg": 24.0,
       "sigma": 0.0,
-      "samples": 160000
+      "samples": 260000
     }
   },
   "args": {
@@ -819,7 +901,7 @@ The Performance Test Basic generates, by default, a report that details results 
       "chainPluginArgs": {
         "signatureCpuBillablePct": 0,
         "chainStateDbSizeMb": 10240,
-        "chainThreads": 2,
+        "chainThreads": 3,
         "databaseMapMode": "mapped"
       },
       "producerPluginArgs": {
@@ -828,7 +910,7 @@ The Performance Test Basic generates, by default, a report that details results 
         "produceTimeOffsetUs": 0,
         "cpuEffortPercent": 100,
         "lastBlockCpuEffortPercent": 100,
-        "producerThreads": 2
+        "producerThreads": 6
       },
       "httpPluginArgs": {
         "httpMaxResponseTimeMs": 990000
@@ -849,19 +931,19 @@ The Performance Test Basic generates, by default, a report that details results 
       "1": "--plugin eosio::trace_api_plugin"
     },
     "_totalNodes": 2,
-    "targetTps": 16000,
+    "targetTps": 26000,
     "testTrxGenDurationSec": 10,
     "tpsLimitPerGenerator": 4000,
     "numAddlBlocksToPrune": 2,
-    "logDirRoot": "./performance_test/2022-11-21_22-17-03/testRunLogs",
+    "logDirRoot": "./performance_test/2022-11-23_12-56-58/testRunLogs",
     "delReport": false,
     "quiet": false,
     "delPerfLogs": false,
-    "expectedTransactionsSent": 160000,
-    "logDirBase": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic",
-    "logDirTimestamp": "2022-11-21_22-27-48",
-    "logDirTimestampedOptSuffix": "-16000",
-    "logDirPath": "./performance_test/2022-11-21_22-17-03/testRunLogs/performance_test_basic/2022-11-21_22-27-48-16000"
+    "expectedTransactionsSent": 260000,
+    "logDirBase": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic",
+    "logDirTimestamp": "2022-11-23_15-18-52",
+    "logDirTimestampedOptSuffix": "-26000",
+    "logDirPath": "./performance_test/2022-11-23_12-56-58/testRunLogs/performance_test_basic/2022-11-23_15-18-52-26000"
   },
   "env": {
     "system": "Linux",

--- a/tests/performance_tests/log_reader.py
+++ b/tests/performance_tests/log_reader.py
@@ -376,10 +376,16 @@ def createReport(guide: chainBlocksGuide, tpsTestConfig: TpsTestConfig, tpsStats
     report['nodeosVersion'] = Utils.getNodeosVersion()
     return report
 
+class LogReaderEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        if obj is None:
+            return "Unknown"
+        return json.JSONEncoder.default(self, obj)
+
 def reportAsJSON(report: dict) -> json:
-    report['testStart'] = "Unknown" if report['testStart'] is None else report['testStart'].isoformat()
-    report['testFinish'] = "Unknown" if report['testFinish'] is None else report['testFinish'].isoformat()
-    return json.dumps(report, sort_keys=True, indent=2)
+    return json.dumps(report, sort_keys=True, indent=2, cls=LogReaderEncoder)
 
 def calcAndReport(data: chainData, tpsTestConfig: TpsTestConfig, artifacts: ArtifactPaths, argsDict: dict, testStart: datetime=None, completedRun: bool=True) -> dict:
     scrapeLog(data, artifacts.nodeosLogPath)

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -300,26 +300,16 @@ class PerformanceTest:
         report['nodeosVersion'] = Utils.getNodeosVersion()
         return report
 
+    class PtReportEncoder(json.JSONEncoder):
+        def default(self, obj):
+            if isinstance(obj, datetime):
+                return obj.isoformat()
+            if obj is None:
+                return "Unknown"
+            return json.JSONEncoder.default(self, obj)
+
     def reportAsJSON(self, report: dict) -> json:
-        if 'ProducerThreadAnalysis' in report:
-            report['ProducerThreadAnalysis']['analysisStart'] = report['ProducerThreadAnalysis']['analysisStart'].isoformat()
-            report['ProducerThreadAnalysis']['analysisFinish'] = report['ProducerThreadAnalysis']['analysisFinish'].isoformat()
-        if 'ChainThreadAnalysis' in report:
-            report['ChainThreadAnalysis']['analysisStart'] = report['ChainThreadAnalysis']['analysisStart'].isoformat()
-            report['ChainThreadAnalysis']['analysisFinish'] = report['ChainThreadAnalysis']['analysisFinish'].isoformat()
-        if 'NetThreadAnalysis' in report:
-            report['NetThreadAnalysis']['analysisStart'] = report['NetThreadAnalysis']['analysisStart'].isoformat()
-            report['NetThreadAnalysis']['analysisFinish'] = report['NetThreadAnalysis']['analysisFinish'].isoformat()
-
-        if 'tpsTestStart' in report:
-            report['tpsTestStart'] = report['tpsTestStart'].isoformat()
-        if 'tpsTestFinish' in report:
-            report['tpsTestFinish'] = report['tpsTestFinish'].isoformat()
-
-        report['perfTestsBegin'] = report['perfTestsBegin'].isoformat()
-        report['perfTestsFinish'] = report['perfTestsFinish'].isoformat()
-
-        return json.dumps(report, indent=2)
+        return json.dumps(report, indent=2, cls=PerformanceTest.PtReportEncoder)
 
     def exportReportAsJSON(self, report: json, exportPath):
         with open(exportPath, 'wt') as f:

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -17,6 +17,7 @@ from platform import release, system
 from dataclasses import dataclass, asdict, field
 from datetime import datetime
 from enum import Enum
+from log_reader import LogReaderEncoder
 
 class PerformanceTest:
 
@@ -298,16 +299,8 @@ class PerformanceTest:
         report['nodeosVersion'] = Utils.getNodeosVersion()
         return report
 
-    class PtReportEncoder(json.JSONEncoder):
-        def default(self, obj):
-            if isinstance(obj, datetime):
-                return obj.isoformat()
-            if obj is None:
-                return "Unknown"
-            return json.JSONEncoder.default(self, obj)
-
     def reportAsJSON(self, report: dict) -> json:
-        return json.dumps(report, indent=2, cls=PerformanceTest.PtReportEncoder)
+        return json.dumps(report, indent=2, cls=LogReaderEncoder)
 
     def exportReportAsJSON(self, report: json, exportPath):
         with open(exportPath, 'wt') as f:

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -423,7 +423,7 @@ class PerformanceTest:
             print(f"Producer Thread Optimization results: {prodResults}")
             self.clusterConfig.extraNodeosArgs.producerPluginArgs.producerThreads = prodResults.recommendedThreadCount
 
-        if self.ptConfig.calcChainThreads:
+        if self.ptConfig.calcChainThreads != "none":
             print(f"Performing Chain Thread Optimization Tests")
             if self.ptConfig.calcChainThreads == "full":
                 optType = PerformanceTest.PluginThreadOptRunType.FULL
@@ -433,7 +433,7 @@ class PerformanceTest:
             print(f"Chain Thread Optimization results: {chainResults}")
             self.clusterConfig.extraNodeosArgs.chainPluginArgs.chainThreads = chainResults.recommendedThreadCount
 
-        if self.ptConfig.calcNetThreads:
+        if self.ptConfig.calcNetThreads != "none":
             print(f"Performing Net Thread Optimization Tests")
             if self.ptConfig.calcNetThreads == "full":
                 optType = PerformanceTest.PluginThreadOptRunType.FULL

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -413,6 +413,7 @@ class PerformanceTest:
         self.testDirsCleanup()
         self.testDirsSetup()
 
+        prodResults = None
         if self.ptConfig.calcProducerThreads != "none":
             print(f"Performing Producer Thread Optimization Tests")
             if self.ptConfig.calcProducerThreads == "full":
@@ -423,6 +424,7 @@ class PerformanceTest:
             print(f"Producer Thread Optimization results: {prodResults}")
             self.clusterConfig.extraNodeosArgs.producerPluginArgs.producerThreads = prodResults.recommendedThreadCount
 
+        chainResults = None
         if self.ptConfig.calcChainThreads != "none":
             print(f"Performing Chain Thread Optimization Tests")
             if self.ptConfig.calcChainThreads == "full":
@@ -433,6 +435,7 @@ class PerformanceTest:
             print(f"Chain Thread Optimization results: {chainResults}")
             self.clusterConfig.extraNodeosArgs.chainPluginArgs.chainThreads = chainResults.recommendedThreadCount
 
+        netResults = None
         if self.ptConfig.calcNetThreads != "none":
             print(f"Performing Net Thread Optimization Tests")
             if self.ptConfig.calcNetThreads == "full":
@@ -443,6 +446,7 @@ class PerformanceTest:
             print(f"Net Thread Optimization results: {netResults}")
             self.clusterConfig.extraNodeosArgs.netPluginArgs.netThreads = netResults.recommendedThreadCount
 
+        tpsTestResult = None
         if not self.ptConfig.skipTpsTests:
             print(f"Performing TPS Performance Tests")
             testSuccessful = False

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -223,7 +223,6 @@ class PerformanceTest:
 
         with open(resultsFile, 'w') as log:
             log.write(f"{optPlugin.value}Threads, maxTpsAchieved\n")
-        log.close()
 
         lastMaxTpsAchieved = 0
         for threadCount in range(minThreadCount, maxThreadCount+1):
@@ -242,7 +241,6 @@ class PerformanceTest:
 
             with open(resultsFile, 'a') as log:
                 log.write(f"{threadCount},{binSearchResults.maxTpsAchieved}\n")
-            log.close()
 
             if optType == PerformanceTest.PluginThreadOptRunType.LOCAL_MAX:
                 if binSearchResults.maxTpsAchieved <= lastMaxTpsAchieved:

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -51,21 +51,21 @@ class PerformanceTestBasic:
             class ChainPluginArgs:
                 signatureCpuBillablePct: int = 0
                 chainStateDbSizeMb: int = 10 * 1024
-                chainThreads: int = 3
+                threads: int = 3
                 databaseMapMode: str = "mapped"
 
                 def __str__(self) -> str:
                     return f"--signature-cpu-billable-pct {self.signatureCpuBillablePct} \
                              --chain-state-db-size-mb {self.chainStateDbSizeMb} \
-                             --chain-threads {self.chainThreads} \
+                             --chain-threads {self.threads} \
                              --database-map-mode {self.databaseMapMode}"
 
             @dataclass
             class NetPluginArgs:
-                netThreads: int = 2
+                threads: int = 2
 
                 def __str__(self) -> str:
-                    return f"--net-threads {self.netThreads}"
+                    return f"--net-threads {self.threads}"
 
             @dataclass
             class ProducerPluginArgs:
@@ -74,7 +74,7 @@ class PerformanceTestBasic:
                 produceTimeOffsetUs: int = 0
                 cpuEffortPercent: int = 100
                 lastBlockCpuEffortPercent: int = 100
-                producerThreads: int = 6
+                threads: int = 6
 
                 def __str__(self) -> str:
                     return f"--disable-subjective-billing {self.disableSubjectiveBilling} \
@@ -82,7 +82,7 @@ class PerformanceTestBasic:
                              --produce-time-offset-us {self.produceTimeOffsetUs} \
                              --cpu-effort-percent {self.cpuEffortPercent} \
                              --last-block-cpu-effort-percent {self.lastBlockCpuEffortPercent} \
-                             --producer-threads {self.producerThreads}"
+                             --producer-threads {self.threads}"
 
             @dataclass
             class HttpPluginArgs:
@@ -480,13 +480,13 @@ def main():
 
     ENA = PerformanceTestBasic.ClusterConfig.ExtraNodeosArgs
     chainPluginArgs = ENA.ChainPluginArgs(signatureCpuBillablePct=args.signature_cpu_billable_pct, chainStateDbSizeMb=args.chain_state_db_size_mb,
-                                          chainThreads=args.chain_threads, databaseMapMode=args.database_map_mode)
+                                          threads=args.chain_threads, databaseMapMode=args.database_map_mode)
     producerPluginArgs = ENA.ProducerPluginArgs(disableSubjectiveBilling=args.disable_subjective_billing,
                                                 lastBlockTimeOffsetUs=args.last_block_time_offset_us, produceTimeOffsetUs=args.produce_time_offset_us,
                                                 cpuEffortPercent=args.cpu_effort_percent, lastBlockCpuEffortPercent=args.last_block_cpu_effort_percent,
-                                                producerThreads=args.producer_threads)
+                                                threads=args.producer_threads)
     httpPluginArgs = ENA.HttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
-    netPluginArgs = ENA.NetPluginArgs(netThreads=args.net_threads)
+    netPluginArgs = ENA.NetPluginArgs(threads=args.net_threads)
     extraNodeosArgs = ENA(chainPluginArgs=chainPluginArgs, httpPluginArgs=httpPluginArgs, producerPluginArgs=producerPluginArgs, netPluginArgs=netPluginArgs)
     testClusterConfig = PerformanceTestBasic.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis,
                                                            prodsEnableTraceApi=args.prods_enable_trace_api, extraNodeosArgs=extraNodeosArgs)

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -240,12 +240,10 @@ class PerformanceTestBasic:
             btdf_append_write = self.fileOpenMode(blockTrxDataPath)
             with open(blockTrxDataPath, btdf_append_write) as trxDataFile:
                 [trxDataFile.write(f"{trx['id']},{trx['block_num']},{trx['cpu_usage_us']},{trx['net_usage_words']}\n") for trx in block['payload']['transactions'] if block['payload']['transactions']]
-            trxDataFile.close()
 
             bdf_append_write = self.fileOpenMode(blockDataPath)
             with open(blockDataPath, bdf_append_write) as blockDataFile:
                 blockDataFile.write(f"{block['payload']['number']},{block['payload']['id']},{block['payload']['producer']},{block['payload']['status']},{block['payload']['timestamp']}\n")
-            blockDataFile.close()
 
     def waitForEmptyBlocks(self, node, numEmptyToWaitOn):
         emptyBlocks = 0

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -51,7 +51,7 @@ class PerformanceTestBasic:
             class ChainPluginArgs:
                 signatureCpuBillablePct: int = 0
                 chainStateDbSizeMb: int = 10 * 1024
-                chainThreads: int = 2
+                chainThreads: int = 3
                 databaseMapMode: str = "mapped"
 
                 def __str__(self) -> str:
@@ -74,7 +74,7 @@ class PerformanceTestBasic:
                 produceTimeOffsetUs: int = 0
                 cpuEffortPercent: int = 100
                 lastBlockCpuEffortPercent: int = 100
-                producerThreads: int = 2
+                producerThreads: int = 6
 
                 def __str__(self) -> str:
                     return f"--disable-subjective-billing {self.disableSubjectiveBilling} \

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -119,7 +119,7 @@ class PerformanceTestBasic:
 
     @dataclass
     class PtbConfig:
-        targetTps: int=8000,
+        targetTps: int=8000
         testTrxGenDurationSec: int=30
         tpsLimitPerGenerator: int=4000
         numAddlBlocksToPrune: int=2

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -19,9 +19,9 @@ from dataclasses import dataclass, asdict, field
 from datetime import datetime
 from math import ceil
 
-class PerformanceBasicTest:
+class PerformanceTestBasic:
     @dataclass
-    class PbtTpsTestResult:
+    class PtbTpsTestResult:
         completedRun: bool = False
         numGeneratorsUsed: int = 0
         targetTpsPerGenList: list = field(default_factory=list)
@@ -267,7 +267,7 @@ class PerformanceBasicTest:
         self.account1PrivKey = self.cluster.accounts[0].activePrivateKey
         self.account2PrivKey = self.cluster.accounts[1].activePrivateKey
 
-    def runTpsTest(self) -> PbtTpsTestResult:
+    def runTpsTest(self) -> PtbTpsTestResult:
         completedRun = False
         self.producerNode = self.cluster.getNode(self.producerNodeId)
         self.validationNode = self.cluster.getNode(self.validationNodeId)
@@ -301,7 +301,7 @@ class PerformanceBasicTest:
         trxSent = self.validationNode.waitForTransactionsInBlockRange(trxSent, self.data.startBlock, blocksToWait)
         self.data.ceaseBlock = self.validationNode.getHeadBlockNum()
 
-        return PerformanceBasicTest.PbtTpsTestResult(completedRun=completedRun, numGeneratorsUsed=tpsTrxGensConfig.numGenerators,
+        return PerformanceTestBasic.PtbTpsTestResult(completedRun=completedRun, numGeneratorsUsed=tpsTrxGensConfig.numGenerators,
                                                      targetTpsPerGenList=tpsTrxGensConfig.targetTpsPerGenList, trxGenExitCodes=trxGenExitCodes)
 
     def prepArgs(self) -> dict:
@@ -334,7 +334,7 @@ class PerformanceBasicTest:
                     print(f"Failed to move '{etcEosioDir}/{path}' to '{self.etcEosioLogsDirPath}/{path}': {type(e)}: {e}")
 
 
-    def analyzeResultsAndReport(self, testResult: PbtTpsTestResult):
+    def analyzeResultsAndReport(self, testResult: PtbTpsTestResult):
         args = self.prepArgs()
         artifactsLocate = log_reader.ArtifactPaths(nodeosLogPath=self.nodeosLogPath, trxGenLogDirPath=self.trxGenLogDirPath, blockTrxDataPath=self.blockTrxDataPath,
                                                    blockDataPath=self.blockDataPath)
@@ -386,7 +386,7 @@ class PerformanceBasicTest:
 
             testSuccessful = self.ptbTestResult.completedRun
 
-            if not self.PbtTpsTestResult.completedRun:
+            if not self.PtbTpsTestResult.completedRun:
                 for exitCode in self.ptbTestResult.trxGenExitCodes:
                     if exitCode != 0:
                         print(f"Error: Transaction Generator exited with error {exitCode}")
@@ -458,10 +458,10 @@ def main():
     args = parseArgs()
     Utils.Debug = args.v
 
-    testHelperConfig = PerformanceBasicTest.TestHelperConfig(killAll=args.clean_run, dontKill=args.leave_running, keepLogs=not args.del_perf_logs,
+    testHelperConfig = PerformanceTestBasic.TestHelperConfig(killAll=args.clean_run, dontKill=args.leave_running, keepLogs=not args.del_perf_logs,
                                                              dumpErrorDetails=args.dump_error_details, delay=args.d, nodesFile=args.nodes_file, verbose=args.v)
 
-    ENA = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs
+    ENA = PerformanceTestBasic.ClusterConfig.ExtraNodeosArgs
     chainPluginArgs = ENA.ChainPluginArgs(signatureCpuBillablePct=args.signature_cpu_billable_pct, chainStateDbSizeMb=args.chain_state_db_size_mb,
                                           chainThreads=args.chain_threads, databaseMapMode=args.database_map_mode)
     producerPluginArgs = ENA.ProducerPluginArgs(disableSubjectiveBilling=args.disable_subjective_billing,
@@ -471,10 +471,10 @@ def main():
     httpPluginArgs = ENA.HttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
     netPluginArgs = ENA.NetPluginArgs(netThreads=args.net_threads)
     extraNodeosArgs = ENA(chainPluginArgs=chainPluginArgs, httpPluginArgs=httpPluginArgs, producerPluginArgs=producerPluginArgs, netPluginArgs=netPluginArgs)
-    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis,
+    testClusterConfig = PerformanceTestBasic.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis,
                                                            prodsEnableTraceApi=args.prods_enable_trace_api, extraNodeosArgs=extraNodeosArgs)
 
-    myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=args.target_tps,
+    myTest = PerformanceTestBasic(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=args.target_tps,
                                   testTrxGenDurationSec=args.test_duration_sec, tpsLimitPerGenerator=args.tps_limit_per_generator,
                                   numAddlBlocksToPrune=args.num_blocks_to_prune, delReport=args.del_report, quiet=args.quiet,
                                   delPerfLogs=args.del_perf_logs)


### PR DESCRIPTION
### Develop performance tests to establish thread count recommendations (net, chain, producer)

Add options to calculate recommended producer, chain, and net worker thread pool size.
    
Each plugin's option determines whether to calculate number of worker threads to use in the thread pool with options of: `none`, `lmax`, or `full`. In `none` mode, the default, no calculation will be attempted and default configured thread count will be used. In `lmax` mode, thread count will incrementally be tested until the performance rate ceases to increase with the addition of subsequent threads. In `full` mode thread count will incrementally be tested from 2..num logical processors, recording each performance and choosing the local max performance (same value as would be discovered in `lmax` mode). Useful for graphing the full performance impact of each available thread.
    
#### New Arguments
* `--calc-producer-threads {none,lmax,full}`
                          Determines whether to calculate number of worker threads to use in producer thread pool ("none", "lmax", or "full").
                          In "none" mode, the default, no calculation will be attempted and default configured --producer-threads value will be used.
                          In "lmax" mode, producer threads will incrementally be tested until the performance rate ceases to increase with the addition of additional threads.
                          In "full" mode producer threads will incrementally be tested from 2..num logical processors, recording each performance and choosing the local max performance (same value as would be discovered in "lmax" mode). Useful for graphing the full performance impact of each available thread. (default: none)
* `--calc-chain-threads {none,lmax,full}`
                          Determines whether to calculate number of worker threads to use in chain thread pool ("none", "lmax", or "full").
                          In "none" mode, the default, no calculation will be attempted and default configured --chain-threads value will be used.
                          In "lmax" mode, producer threads will incrementally be tested until the performance rate ceases to increase with the addition of additional threads.
                          In "full" mode producer threads will incrementally be tested from 2..num logical processors, recording each performance and choosing the local max performance (same value as would be discovered in "lmax" mode). Useful for graphing the full performance impact of each available thread. (default: none)
* `--calc-net-threads {none,lmax,full}`
                          Determines whether to calculate number of worker threads to use in net thread pool ("none", "lmax", or "full").
                          In "none" mode, the default, no calculation will be attempted and default configured --net-threads value will be used.
                          In "lmax" mode, producer threads will incrementally be tested until the performance rate ceases to increase with the addition of additional threads.
                          In "full" mode producer threads will incrementally be tested from 2..num logical processors, recording each performance and choosing the local max performance (same value as would be discovered in "lmax" mode). Useful for graphing the full performance impact of each available thread. (default: none)
                        
#### Added option to opt out of running the tps test.

* `--skip-tps-test`       Determines whether to skip the max TPS measurement tests (default: False)

#### Updated thread configurations based on test recommendations

* `--producer-threads PRODUCER_THREADS`
                          Number of worker threads in producer thread pool (default: 6)
* `--chain-threads CHAIN_THREADS`
                          Number of worker threads in controller thread pool (default: 3)