### PR TITLE
Fixed broken cleos due to reuse of curl handle

### DIFF
--- a/programs/cleos/do_http_post_libcurl.cpp
+++ b/programs/cleos/do_http_post_libcurl.cpp
@@ -78,7 +78,7 @@ namespace eosio { namespace client { namespace http {
          initialized = true;
       }
 
-      std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> handle(nullptr, &curl_easy_cleanup);
+      static std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> handle(nullptr, &curl_easy_cleanup);
       if (!handle) handle.reset(curl_easy_init());
       auto curl = handle.get();
       EOS_ASSERT(curl != 0, chain::http_exception, "curl_easy_init failed");
@@ -92,6 +92,8 @@ namespace eosio { namespace client { namespace http {
          curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, base_uri.c_str() + unix_socket_prefix_len);
          uri = "http://localhost" + path;
       } else {
+         // Disable use of unix domain in case it was enabled in the previous call
+         curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, nullptr);
          uri = base_uri + path;
       }
 

--- a/programs/cleos/do_http_post_libcurl.cpp
+++ b/programs/cleos/do_http_post_libcurl.cpp
@@ -78,7 +78,7 @@ namespace eosio { namespace client { namespace http {
          initialized = true;
       }
 
-      static std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> handle(nullptr, &curl_easy_cleanup);
+      std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> handle(nullptr, &curl_easy_cleanup);
       if (!handle) handle.reset(curl_easy_init());
       auto curl = handle.get();
       EOS_ASSERT(curl != 0, chain::http_exception, "curl_easy_init failed");


### PR DESCRIPTION
Resolved https://github.com/AntelopeIO/leap/issues/511

`cleos` recently switched from openssl to libcurl. Any command requiring keys stopped working due to that. For example,

```
cleos create account eosio hello EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV -p eosio@active
Error 3110001: Missing Chain API Plugin
Ensure that you have eosio::chain_api_plugin added to your node's configuration!
Error Details:
Chain API plugin is not enabled
```

In `determine_required_keys` in `cleos/main.cpp` which has two curl calls
```
...
const auto& public_keys = call(wallet_url, wallet_public_keys);
...
const auto& required_keys = call(get_required_keys, get_arg);
```
Those two calls go to the same local host but with different ports (80 and 8888). But somehow libcurl uses the same port for both calls. 

The root cause was `do_http_post_libcurl.cpp`'s `handle`, which was declared as a `static` and not completely reset between calls.