### PR TITLE
[PH] argparse.ArgumentParser usage updates

### DIFF
--- a/tests/TestHarness/TestHelper.py
+++ b/tests/TestHarness/TestHelper.py
@@ -37,87 +37,100 @@ class TestHelper(object):
     @staticmethod
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-statements
-    def parse_args(includeArgs, applicationSpecificArgs=AppArgs()):
+    def createArgumentParser(includeArgs, applicationSpecificArgs=AppArgs()) -> argparse.ArgumentParser:
         """Accepts set of arguments, builds argument parser and returns parse_args() output."""
         assert(includeArgs)
         assert(isinstance(includeArgs, set))
         assert(isinstance(applicationSpecificArgs, AppArgs))
 
-        parser = argparse.ArgumentParser(add_help=False, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        parser.add_argument('-?', action='help', default=argparse.SUPPRESS,
+        thParser = argparse.ArgumentParser(add_help=False, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        thGrpTitle = "Test Helper Arguments"
+        thGrpDescription="Test Helper configuration items used to configure and spin up the regression test framework and blockchain environment."
+        thGrp = thParser.add_argument_group(title=thGrpTitle, description=thGrpDescription)
+        thGrp.add_argument('-?', action='help', default=argparse.SUPPRESS,
                                  help=argparse._('show this help message and exit'))
 
         if "-p" in includeArgs:
-            parser.add_argument("-p", type=int, help="producing nodes count", default=1)
+            thGrp.add_argument("-p", type=int, help="producing nodes count", default=1)
         if "-n" in includeArgs:
-            parser.add_argument("-n", type=int, help="total nodes", default=0)
+            thGrp.add_argument("-n", type=int, help="total nodes", default=0)
         if "-d" in includeArgs:
-            parser.add_argument("-d", type=int, help="delay between nodes startup", default=1)
+            thGrp.add_argument("-d", type=int, help="delay between nodes startup", default=1)
         if "--nodes-file" in includeArgs:
-            parser.add_argument("--nodes-file", type=str, help="File containing nodes info in JSON format.")
+            thGrp.add_argument("--nodes-file", type=str, help="File containing nodes info in JSON format.")
         if "-s" in includeArgs:
-            parser.add_argument("-s", type=str, help="topology", choices=["mesh"], default="mesh")
+            thGrp.add_argument("-s", type=str, help="topology", choices=["mesh"], default="mesh")
         if "-c" in includeArgs:
-            parser.add_argument("-c", type=str, help="chain strategy",
+            thGrp.add_argument("-c", type=str, help="chain strategy",
                     choices=[Utils.SyncResyncTag, Utils.SyncReplayTag, Utils.SyncNoneTag, Utils.SyncHardReplayTag],
                     default=Utils.SyncResyncTag)
         if "--kill-sig" in includeArgs:
-            parser.add_argument("--kill-sig", type=str, choices=[Utils.SigKillTag, Utils.SigTermTag], help="kill signal.",
+            thGrp.add_argument("--kill-sig", type=str, choices=[Utils.SigKillTag, Utils.SigTermTag], help="kill signal.",
                     default=Utils.SigKillTag)
         if "--kill-count" in includeArgs:
-            parser.add_argument("--kill-count", type=int, help="nodeos instances to kill", default=-1)
+            thGrp.add_argument("--kill-count", type=int, help="nodeos instances to kill", default=-1)
         if "--terminate-at-block" in includeArgs:
-            parser.add_argument("--terminate-at-block", type=int, help="block to terminate on when replaying", default=0)
+            thGrp.add_argument("--terminate-at-block", type=int, help="block to terminate on when replaying", default=0)
         if "--seed" in includeArgs:
-            parser.add_argument("--seed", type=int, help="random seed", default=1)
+            thGrp.add_argument("--seed", type=int, help="random seed", default=1)
 
         if "--host" in includeArgs:
-            parser.add_argument("-h", "--host", type=str, help="%s host name" % (Utils.EosServerName),
+            thGrp.add_argument("-h", "--host", type=str, help="%s host name" % (Utils.EosServerName),
                                      default=TestHelper.LOCAL_HOST)
         if "--port" in includeArgs:
-            parser.add_argument("--port", type=int, help="%s host port" % Utils.EosServerName,
+            thGrp.add_argument("--port", type=int, help="%s host port" % Utils.EosServerName,
                                      default=TestHelper.DEFAULT_PORT)
         if "--wallet-host" in includeArgs:
-            parser.add_argument("--wallet-host", type=str, help="%s host" % Utils.EosWalletName,
+            thGrp.add_argument("--wallet-host", type=str, help="%s host" % Utils.EosWalletName,
                                      default=TestHelper.LOCAL_HOST)
         if "--wallet-port" in includeArgs:
-            parser.add_argument("--wallet-port", type=int, help="%s port" % Utils.EosWalletName,
+            thGrp.add_argument("--wallet-port", type=int, help="%s port" % Utils.EosWalletName,
                                      default=TestHelper.DEFAULT_WALLET_PORT)
         if "--prod-count" in includeArgs:
-            parser.add_argument("-c", "--prod-count", type=int, help="Per node producer count", default=1)
+            thGrp.add_argument("-c", "--prod-count", type=int, help="Per node producer count", default=1)
         if "--defproducera_prvt_key" in includeArgs:
-            parser.add_argument("--defproducera_prvt_key", type=str, help="defproducera private key.")
+            thGrp.add_argument("--defproducera_prvt_key", type=str, help="defproducera private key.")
         if "--defproducerb_prvt_key" in includeArgs:
-            parser.add_argument("--defproducerb_prvt_key", type=str, help="defproducerb private key.")
+            thGrp.add_argument("--defproducerb_prvt_key", type=str, help="defproducerb private key.")
         if "--dump-error-details" in includeArgs:
-            parser.add_argument("--dump-error-details",
+            thGrp.add_argument("--dump-error-details",
                                      help="Upon error print etc/eosio/node_*/config.ini and var/lib/node_*/stderr.log to stdout",
                                      action='store_true')
         if "--dont-launch" in includeArgs:
-            parser.add_argument("--dont-launch", help="Don't launch own node. Assume node is already running.",
+            thGrp.add_argument("--dont-launch", help="Don't launch own node. Assume node is already running.",
                                      action='store_true')
         if "--keep-logs" in includeArgs:
-            parser.add_argument("--keep-logs", help="Don't delete var/lib/node_* folders, or other test specific log directories, upon test completion",
+            thGrp.add_argument("--keep-logs", help="Don't delete var/lib/node_* folders, or other test specific log directories, upon test completion",
                                      action='store_true')
         if "-v" in includeArgs:
-            parser.add_argument("-v", help="verbose logging", action='store_true')
+            thGrp.add_argument("-v", help="verbose logging", action='store_true')
         if "--leave-running" in includeArgs:
-            parser.add_argument("--leave-running", help="Leave cluster running after test finishes", action='store_true')
+            thGrp.add_argument("--leave-running", help="Leave cluster running after test finishes", action='store_true')
         if "--only-bios" in includeArgs:
-            parser.add_argument("--only-bios", help="Limit testing to bios node.", action='store_true')
+            thGrp.add_argument("--only-bios", help="Limit testing to bios node.", action='store_true')
         if "--clean-run" in includeArgs:
-            parser.add_argument("--clean-run", help="Kill all nodeos and keosd instances", action='store_true')
+            thGrp.add_argument("--clean-run", help="Kill all nodeos and keosd instances", action='store_true')
         if "--sanity-test" in includeArgs:
-            parser.add_argument("--sanity-test", help="Validates nodeos and keosd are in path and can be started up.", action='store_true')
+            thGrp.add_argument("--sanity-test", help="Validates nodeos and keosd are in path and can be started up.", action='store_true')
         if "--alternate-version-labels-file" in includeArgs:
-            parser.add_argument("--alternate-version-labels-file", type=str, help="Provide a file to define the labels that can be used in the test and the path to the version installation associated with that.")
+            thGrp.add_argument("--alternate-version-labels-file", type=str, help="Provide a file to define the labels that can be used in the test and the path to the version installation associated with that.")
 
+        appArgsGrpTitle="Application Specific Arguments"
+        appArgsGrpdescription="Test Helper configuration items used to configure and spin up the regression test framework and blockchain environment."
+        appArgsGrp = thParser.add_argument_group(title=appArgsGrpTitle, description=appArgsGrpdescription)
         for arg in applicationSpecificArgs.args:
             if arg.type is not None:
-                parser.add_argument(arg.flag, type=arg.type, help=arg.help, choices=arg.choices, default=arg.default)
+                appArgsGrp.add_argument(arg.flag, type=arg.type, help=arg.help, choices=arg.choices, default=arg.default)
             else:
-                parser.add_argument(arg.flag, help=arg.help, action=arg.action)
+                appArgsGrp.add_argument(arg.flag, help=arg.help, action=arg.action)
 
+        return thParser
+
+    @staticmethod
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
+    def parse_args(includeArgs, applicationSpecificArgs=AppArgs()):
+        parser = TestHelper.createArgumentParser(includeArgs=includeArgs, applicationSpecificArgs=applicationSpecificArgs)
         args = parser.parse_args()
         return args
 

--- a/tests/TestHarness/TestHelper.py
+++ b/tests/TestHarness/TestHelper.py
@@ -115,14 +115,15 @@ class TestHelper(object):
         if "--alternate-version-labels-file" in includeArgs:
             thGrp.add_argument("--alternate-version-labels-file", type=str, help="Provide a file to define the labels that can be used in the test and the path to the version installation associated with that.")
 
-        appArgsGrpTitle="Application Specific Arguments"
-        appArgsGrpdescription="Test Helper configuration items used to configure and spin up the regression test framework and blockchain environment."
-        appArgsGrp = thParser.add_argument_group(title=appArgsGrpTitle, description=appArgsGrpdescription)
-        for arg in applicationSpecificArgs.args:
-            if arg.type is not None:
-                appArgsGrp.add_argument(arg.flag, type=arg.type, help=arg.help, choices=arg.choices, default=arg.default)
-            else:
-                appArgsGrp.add_argument(arg.flag, help=arg.help, action=arg.action)
+        if len(applicationSpecificArgs.args) > 0:
+            appArgsGrpTitle="Application Specific Arguments"
+            appArgsGrpdescription="Test Helper configuration items used to configure and spin up the regression test framework and blockchain environment."
+            appArgsGrp = thParser.add_argument_group(title=appArgsGrpTitle, description=appArgsGrpdescription)
+            for arg in applicationSpecificArgs.args:
+                if arg.type is not None:
+                    appArgsGrp.add_argument(arg.flag, type=arg.type, help=arg.help, choices=arg.choices, default=arg.default)
+                else:
+                    appArgsGrp.add_argument(arg.flag, help=arg.help, action=arg.action)
 
         return thParser
 

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -501,7 +501,7 @@ class PerfTestArgumentsHandler(object):
                                                                     choices=["none", "lmax", "full"], default="none")
         ptParserGroup.add_argument("--del-test-report", help="Whether to save json reports from each test scenario.", action='store_true')
 
-        ptTpsGrpTitle="TPS Test Config"
+        ptTpsGrpTitle="Performance Harness - TPS Test Config"
         ptTpsGrpDescription="TPS Performance Test configuration items."
         ptTpsParserGroup = ptParser.add_argument_group(title=ptTpsGrpTitle, description=ptTpsGrpDescription)
 

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -485,7 +485,7 @@ class PtbArgumentsHandler(object):
         ptbGrpTitle="Performance Test Basic Single Test"
         ptbGrpDescription="Performance Test Basic single test configuration items. Useful for running a single test directly. \
                            These items may not be directly configurable from higher level scripts as the scripts themselves may configure these internally."
-        ptbParserGroup = ptbBaseParser.add_argument_group(title=ptbGrpTitle, description=ptbGrpDescription)
+        ptbParserGroup = ptbParser.add_argument_group(title=ptbGrpTitle, description=ptbGrpDescription)
 
         ptbParserGroup.add_argument("--target-tps", type=int, help="The target transfers per second to send during test", default=8000)
         ptbParserGroup.add_argument("--test-duration-sec", type=int, help="The duration of transfer trx generation for the test in seconds", default=90)


### PR DESCRIPTION
Make use of ArgumentParser parents and groups.

This will greatly reduce work to bubble up arguments between scripts/modules.  Also brings clarity and grouping of arguments by use with group titles and descriptions.

Test Helper arguments can now be bubbled up to user scripts via direct access to the ArgumentParser.  Performance Test Basic makes use of Test Helper arguments.  Perfomance Test makes use of both Performance Test Basic and Test Helper arguments as well.

`./build/tests/performance_tests/performance_test.py -?` now prints:

```
usage: performance_test.py [-?] [-p P] [-n N] [-d D] [--nodes-file NODES_FILE]
                           [-s {mesh}] [--dump-error-details] [-v]
                           [--leave-running] [--clean-run]
                           [--tps-limit-per-generator TPS_LIMIT_PER_GENERATOR]
                           [--genesis GENESIS]
                           [--num-blocks-to-prune NUM_BLOCKS_TO_PRUNE]
                           [--signature-cpu-billable-pct SIGNATURE_CPU_BILLABLE_PCT]
                           [--chain-state-db-size-mb CHAIN_STATE_DB_SIZE_MB]
                           [--chain-threads CHAIN_THREADS]
                           [--database-map-mode {mapped,heap,locked}]
                           [--net-threads NET_THREADS]
                           [--disable-subjective-billing DISABLE_SUBJECTIVE_BILLING]
                           [--last-block-time-offset-us LAST_BLOCK_TIME_OFFSET_US]
                           [--produce-time-offset-us PRODUCE_TIME_OFFSET_US]
                           [--cpu-effort-percent CPU_EFFORT_PERCENT]
                           [--last-block-cpu-effort-percent LAST_BLOCK_CPU_EFFORT_PERCENT]
                           [--producer-threads PRODUCER_THREADS]
                           [--http-max-response-time-ms HTTP_MAX_RESPONSE_TIME_MS]
                           [--del-perf-logs] [--del-report] [--quiet]
                           [--prods-enable-trace-api] [--skip-tps-test]
                           [--calc-producer-threads {none,lmax,full}]
                           [--calc-chain-threads {none,lmax,full}]
                           [--calc-net-threads {none,lmax,full}]
                           [--del-test-report]
                           [--max-tps-to-test MAX_TPS_TO_TEST]
                           [--test-iteration-duration-sec TEST_ITERATION_DURATION_SEC]
                           [--test-iteration-min-step TEST_ITERATION_MIN_STEP]
                           [--final-iterations-duration-sec FINAL_ITERATIONS_DURATION_SEC]

Test Helper Arguments:
  Test Helper configuration items used to configure and spin up the
  regression test framework and blockchain environment.

  -?                    show this help message and exit
  -p P                  producing nodes count (default: 1)
  -n N                  total nodes (default: 0)
  -d D                  delay between nodes startup (default: 1)
  --nodes-file NODES_FILE
                        File containing nodes info in JSON format. (default:
                        None)
  -s {mesh}             topology (default: mesh)
  --dump-error-details  Upon error print etc/eosio/node_*/config.ini and
                        var/lib/node_*/stderr.log to stdout (default: False)
  -v                    verbose logging (default: False)
  --leave-running       Leave cluster running after test finishes (default:
                        False)
  --clean-run           Kill all nodeos and keosd instances (default: False)

Performance Test Basic Base:
  Performance Test Basic base configuration items.

  --tps-limit-per-generator TPS_LIMIT_PER_GENERATOR
                        Maximum amount of transactions per second a single
                        generator can have. (default: 4000)
  --genesis GENESIS     Path to genesis.json (default:
                        tests/performance_tests/genesis.json)
  --num-blocks-to-prune NUM_BLOCKS_TO_PRUNE
                        The number of potentially non-empty blocks, in
                        addition to leading and trailing size 0 blocks, to
                        prune from the beginning and end of the range of
                        blocks of interest for evaluation. (default: 2)
  --signature-cpu-billable-pct SIGNATURE_CPU_BILLABLE_PCT
                        Percentage of actual signature recovery cpu to bill.
                        Whole number percentages, e.g. 50 for 50% (default: 0)
  --chain-state-db-size-mb CHAIN_STATE_DB_SIZE_MB
                        Maximum size (in MiB) of the chain state database
                        (default: 10240)
  --chain-threads CHAIN_THREADS
                        Number of worker threads in controller thread pool
                        (default: 2)
  --database-map-mode {mapped,heap,locked}
                        Database map mode ("mapped", "heap", or "locked"). In
                        "mapped" mode database is memory mapped as a file. In
                        "heap" mode database is preloaded in to swappable
                        memory and will use huge pages if available. In
                        "locked" mode database is preloaded, locked in to
                        memory, and will use huge pages if available.
                        (default: mapped)
  --net-threads NET_THREADS
                        Number of worker threads in net_plugin thread pool
                        (default: 2)
  --disable-subjective-billing DISABLE_SUBJECTIVE_BILLING
                        Disable subjective CPU billing for API/P2P
                        transactions (default: True)
  --last-block-time-offset-us LAST_BLOCK_TIME_OFFSET_US
                        Offset of last block producing time in microseconds.
                        Valid range 0 .. -block_time_interval. (default: 0)
  --produce-time-offset-us PRODUCE_TIME_OFFSET_US
                        Offset of non last block producing time in
                        microseconds. Valid range 0 .. -block_time_interval.
                        (default: 0)
  --cpu-effort-percent CPU_EFFORT_PERCENT
                        Percentage of cpu block production time used to
                        produce block. Whole number percentages, e.g. 80 for
                        80% (default: 100)
  --last-block-cpu-effort-percent LAST_BLOCK_CPU_EFFORT_PERCENT
                        Percentage of cpu block production time used to
                        produce last block. Whole number percentages, e.g. 80
                        for 80% (default: 100)
  --producer-threads PRODUCER_THREADS
                        Number of worker threads in producer thread pool
                        (default: 2)
  --http-max-response-time-ms HTTP_MAX_RESPONSE_TIME_MS
                        Maximum time for processing a request, -1 for
                        unlimited (default: 990000)
  --del-perf-logs       Whether to delete performance test specific logs.
                        (default: False)
  --del-report          Whether to delete overarching performance run report.
                        (default: False)
  --quiet               Whether to quiet printing intermediate results and
                        reports to stdout (default: False)
  --prods-enable-trace-api
                        Determines whether producer nodes should have
                        eosio::trace_api_plugin enabled (default: False)

Performance Harness:
  Performance Harness testing configuration items.

  --skip-tps-test       Determines whether to skip the max TPS measurement
                        tests (default: False)
  --calc-producer-threads {none,lmax,full}
                        Determines whether to calculate number of worker
                        threads to use in producer thread pool ("none",
                        "lmax", or "full"). In "none" mode, the default, no
                        calculation will be attempted and default configured
                        --producer-threads value will be used. In "lmax" mode,
                        producer threads will incrementally be tested until
                        the performance rate ceases to increase with the
                        addition of additional threads. In "full" mode
                        producer threads will incrementally be tested from
                        2..num logical processors, recording each performance
                        and choosing the local max performance (same value as
                        would be discovered in "lmax" mode). Useful for
                        graphing the full performance impact of each available
                        thread. (default: none)
  --calc-chain-threads {none,lmax,full}
                        Determines whether to calculate number of worker
                        threads to use in chain thread pool ("none", "lmax",
                        or "full"). In "none" mode, the default, no
                        calculation will be attempted and default configured
                        --chain-threads value will be used. In "lmax" mode,
                        producer threads will incrementally be tested until
                        the performance rate ceases to increase with the
                        addition of additional threads. In "full" mode
                        producer threads will incrementally be tested from
                        2..num logical processors, recording each performance
                        and choosing the local max performance (same value as
                        would be discovered in "lmax" mode). Useful for
                        graphing the full performance impact of each available
                        thread. (default: none)
  --calc-net-threads {none,lmax,full}
                        Determines whether to calculate number of worker
                        threads to use in net thread pool ("none", "lmax", or
                        "full"). In "none" mode, the default, no calculation
                        will be attempted and default configured --net-threads
                        value will be used. In "lmax" mode, producer threads
                        will incrementally be tested until the performance
                        rate ceases to increase with the addition of
                        additional threads. In "full" mode producer threads
                        will incrementally be tested from 2..num logical
                        processors, recording each performance and choosing
                        the local max performance (same value as would be
                        discovered in "lmax" mode). Useful for graphing the
                        full performance impact of each available thread.
                        (default: none)
  --del-test-report     Whether to save json reports from each test scenario.
                        (default: False)

Performance Harness - TPS Test Config:
  TPS Performance Test configuration items.

  --max-tps-to-test MAX_TPS_TO_TEST
                        The max target transfers realistic as ceiling of test
                        range (default: 50000)
  --test-iteration-duration-sec TEST_ITERATION_DURATION_SEC
                        The duration of transfer trx generation for each
                        iteration of the test during the initial search
                        (seconds) (default: 150)
  --test-iteration-min-step TEST_ITERATION_MIN_STEP
                        The step size determining granularity of tps result
                        during initial search (default: 500)
  --final-iterations-duration-sec FINAL_ITERATIONS_DURATION_SEC
                        The duration of transfer trx generation for each final
                        longer run iteration of the test during the final
                        search (seconds) (default: 300)
```