### PR TITLE
Fixed test harness crash when actiob_traces is empty

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -156,6 +156,12 @@ class Node(object):
         if cntxt.hasKey("processed"):
             cntxt.add("processed")
             cntxt.add("action_traces")
+            # action_traces could be empty when an exception happened in the transaction
+            # cntxt.index(0) below will crash action_traces is empty
+            cur=cntxt.getCurrent()
+            assert isinstance(cur, list), f"ERROR: action_traces is not a list."
+            if len(cur) == 0:
+                return "no_block"
             cntxt.index(0)
             if not cntxt.isSectionNull("except"):
                 return "no_block"

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -155,16 +155,10 @@ class Node(object):
         # could be a transaction response
         if cntxt.hasKey("processed"):
             cntxt.add("processed")
-            cntxt.add("action_traces")
-            # action_traces could be empty when an exception happened in the transaction
-            # cntxt.index(0) below will crash action_traces is empty
-            cur=cntxt.getCurrent()
-            assert isinstance(cur, list), f"ERROR: action_traces is not a list."
-            if len(cur) == 0:
-                return "no_block"
-            cntxt.index(0)
             if not cntxt.isSectionNull("except"):
                 return "no_block"
+            cntxt.add("action_traces")
+            cntxt.index(0)
             return cntxt.add("block_num")
 
         # or what the trace api plugin returns


### PR DESCRIPTION
Resolved https://github.com/AntelopeIO/leap/issues/529.

When an assert occurred in a transaction, `action_traces` could be empty in the transaction response. Test harness will crash if `action_traces` is accessed.

An example empty `action_traces` transaction response is

`{'transaction_id':  '3190cf67d3044a4e0043998d0c82f61cd57f430e5a3232154a295a72d7b0464e',                  'processed': {'id':  '3190cf67d3044a4e0043998d0c82f61cd57f430e5a3232154a295a72d7b0464e',                  'block_num': 246, 'block_time': '2022-12-01T19:52:43.500', 'producer_block_id':  None, 'receipt': None, 'elapsed': 161, 'net_usage': 0, 'scheduled': False,  'action_traces': [], 'account_ram_delta': None, 'except': {'code': 3040000,  'name': 'transaction_exception', 'message': 'Transaction exception', 'stack':   [{'context': {'level': 'error', 'file': 'transaction_context.cpp', 'line': 832,   'method': 'validate_referenced_accounts', 'hostname': '', 'thread_name':  'nodeos', 'timestamp': '2022-12-01T19:52:43.231'}, 'format': "read-only action  '${account}' has permissions", 'data': {'account': 'readonly'}}]},  'error_code': '10000000000000000000'}}`