### PR TITLE
Update management of `in_flight` bytes in http_plugin

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -88,22 +88,22 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
             auto next_ptr = std::make_shared<url_handler>(std::move(next));
             return [my=std::move(my), priority, next_ptr=std::move(next_ptr)]
                        ( detail::abstract_conn_ptr conn, string r, string b, url_response_callback then ) {
-               auto tracked_b = make_in_flight(b, my->plugin_state);
+               auto tracked_b = make_in_flight(std::move(b), my->plugin_state);
                if (!conn->verify_max_bytes_in_flight()) {
                   return;
                }
 
-               url_response_callback wrapped_then = [tracked_b = std::move(tracked_b), then=std::move(then)](int code, const fc::time_point& deadline, std::optional<fc::variant> resp) {
+               url_response_callback wrapped_then = [tracked_b, then=std::move(then)](int code, const fc::time_point& deadline, std::optional<fc::variant> resp) {
                   then(code, deadline, std::move(resp));
                };
 
                // post to the app thread taking shared ownership of next (via std::shared_ptr),
                // sole ownership of the tracked body and the passed in parameters
-               app().post( priority, [next_ptr, conn=std::move(conn), r=std::move(r), b=std::move(b), wrapped_then=std::move(wrapped_then)]() mutable {
+               app().post( priority, [next_ptr, conn=std::move(conn), r=std::move(r), tracked_b, wrapped_then=std::move(wrapped_then)]() mutable {
                   try {
                      if( app().is_quiting() ) return; // http_plugin shutting down, do not call callback
                      // call the `next` url_handler and wrap the response handler
-                     (*next_ptr)( std::move(r), std::move(b), std::move(wrapped_then)) ;
+                     (*next_ptr)( std::move( r ), std::move(tracked_b->obj()), std::move(wrapped_then)) ;
                   } catch( ... ) {
                      conn->handle_exception();
                   }

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -88,22 +88,22 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
             auto next_ptr = std::make_shared<url_handler>(std::move(next));
             return [my=std::move(my), priority, next_ptr=std::move(next_ptr)]
                        ( detail::abstract_conn_ptr conn, string r, string b, url_response_callback then ) {
-               auto tracked_b = make_in_flight<string>(std::move(b), my->plugin_state);
+               auto tracked_b = make_in_flight(b, my->plugin_state);
                if (!conn->verify_max_bytes_in_flight()) {
                   return;
                }
 
-               url_response_callback wrapped_then = [tracked_b, then=std::move(then)](int code, const fc::time_point& deadline, std::optional<fc::variant> resp) {
+               url_response_callback wrapped_then = [tracked_b = std::move(tracked_b), then=std::move(then)](int code, const fc::time_point& deadline, std::optional<fc::variant> resp) {
                   then(code, deadline, std::move(resp));
                };
 
                // post to the app thread taking shared ownership of next (via std::shared_ptr),
                // sole ownership of the tracked body and the passed in parameters
-               app().post( priority, [next_ptr, conn=std::move(conn), r=std::move(r), tracked_b, wrapped_then=std::move(wrapped_then)]() mutable {
+               app().post( priority, [next_ptr, conn=std::move(conn), r=std::move(r), b=std::move(b), wrapped_then=std::move(wrapped_then)]() mutable {
                   try {
                      if( app().is_quiting() ) return; // http_plugin shutting down, do not call callback
                      // call the `next` url_handler and wrap the response handler
-                     (*next_ptr)( std::move( r ), std::move(tracked_b->obj()), std::move(wrapped_then)) ;
+                     (*next_ptr)( std::move(r), std::move(b), std::move(wrapped_then)) ;
                   } catch( ... ) {
                      conn->handle_exception();
                   }

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -88,22 +88,21 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
             auto next_ptr = std::make_shared<url_handler>(std::move(next));
             return [my=std::move(my), priority, next_ptr=std::move(next_ptr)]
                        ( detail::abstract_conn_ptr conn, string r, string b, url_response_callback then ) {
-               auto tracked_b = make_in_flight(std::move(b), my->plugin_state);
-               if (!conn->verify_max_bytes_in_flight()) {
+               if (!conn->verify_max_bytes_in_flight(b.size())) {
                   return;
                }
 
-               url_response_callback wrapped_then = [tracked_b, then=std::move(then)](int code, const fc::time_point& deadline, std::optional<fc::variant> resp) {
+               url_response_callback wrapped_then = [then=std::move(then)](int code, const fc::time_point& deadline, std::optional<fc::variant> resp) {
                   then(code, deadline, std::move(resp));
                };
 
                // post to the app thread taking shared ownership of next (via std::shared_ptr),
                // sole ownership of the tracked body and the passed in parameters
-               app().post( priority, [next_ptr, conn=std::move(conn), r=std::move(r), tracked_b, wrapped_then=std::move(wrapped_then)]() mutable {
+               app().post( priority, [next_ptr, conn=std::move(conn), r=std::move(r), b = std::move(b), wrapped_then=std::move(wrapped_then)]() mutable {
                   try {
                      if( app().is_quiting() ) return; // http_plugin shutting down, do not call callback
                      // call the `next` url_handler and wrap the response handler
-                     (*next_ptr)( std::move( r ), std::move(tracked_b->obj()), std::move(wrapped_then)) ;
+                     (*next_ptr)( std::move( r ), std::move(b), std::move(wrapped_then)) ;
                   } catch( ... ) {
                      conn->handle_exception();
                   }

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -88,7 +88,8 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
             auto next_ptr = std::make_shared<url_handler>(std::move(next));
             return [my=std::move(my), priority, next_ptr=std::move(next_ptr)]
                        ( detail::abstract_conn_ptr conn, string r, string b, url_response_callback then ) {
-               if (!conn->verify_max_bytes_in_flight(b.size())) {
+               if (auto error_str = conn->verify_max_bytes_in_flight(b.size()); !error_str.empty()) {
+                  conn->send_busy_response(std::move(error_str));
                   return;
                }
 

--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -156,8 +156,8 @@ protected:
             error_results results{static_cast<uint16_t>(http::status::not_found), "Not Found",
                                   error_results::error_info( fc::exception( FC_LOG_MESSAGE( error, "Unknown Endpoint" ) ),
                                                              http_plugin::verbose_errors() )};
-            auto json = fc::json::to_string(results, fc::time_point::maximum());
-            send_response(std::move(json), static_cast<unsigned int>(http::status::not_found) );
+            send_response( fc::json::to_string( results, fc::time_point::maximum() ),
+                           static_cast<unsigned int>(http::status::not_found) );
          }
       } catch(...) {
          handle_exception();
@@ -348,7 +348,7 @@ public:
          res_->set(http::field::content_type, "application/json");
          res_->keep_alive(false);
          res_->set(http::field::server, BOOST_BEAST_VERSION_STRING);
-         
+
          send_response(std::move(err_str), static_cast<unsigned int>(http::status::internal_server_error));
          derived().do_eof();
       }

--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -113,7 +113,7 @@ protected:
       if(req.target().empty() || req.target()[0] != '/' || req.target().find("..") != beast::string_view::npos) {
          error_results results{static_cast<uint16_t>(http::status::bad_request), "Illegal request-target"};
          send_response( fc::json::to_string( results, fc::time_point::maximum() ),
-                       static_cast<unsigned int>(http::status::bad_request) );
+                        static_cast<unsigned int>(http::status::bad_request) );
          return;
       }
 

--- a/plugins/http_plugin/include/eosio/http_plugin/common.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/common.hpp
@@ -147,7 +147,6 @@ struct http_plugin_state {
 auto make_http_response_handler(std::shared_ptr<http_plugin_state> plugin_state, detail::abstract_conn_ptr session_ptr) {
    return [plugin_state{std::move(plugin_state)},
            session_ptr{std::move(session_ptr)}](int code, fc::time_point deadline, std::optional<fc::variant> response) {
-      //auto tracked_response = make_in_flight(std::move(response), plugin_state);
       auto payload_size = detail::in_flight_sizeof(response);
       if(!session_ptr->verify_max_bytes_in_flight(payload_size)) {
          return;

--- a/plugins/http_plugin/include/eosio/http_plugin/common.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/common.hpp
@@ -155,7 +155,7 @@ struct http_plugin_state {
 template<typename T>
 struct in_flight {
    in_flight(T&& object, std::shared_ptr<http_plugin_state> plugin_state)
-      : _object(std::forward<T>(object)), _plugin_state(std::move(plugin_state)) {
+      : _object(std::move(object)), _plugin_state(std::move(plugin_state)) {
       _count = detail::in_flight_sizeof(_object);
       _plugin_state->bytes_in_flight += _count;
    }

--- a/plugins/http_plugin/include/eosio/http_plugin/common.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/common.hpp
@@ -50,19 +50,17 @@ namespace ssl = boost::asio::ssl;
 using boost::asio::ip::tcp;// from <boost/asio/ip/tcp.hpp>
 
 
-template<typename T> struct in_flight; // forward declaration
-    
 namespace detail {
 /**
 * virtualized wrapper for the various underlying connection functions needed in req/resp processng
 */
 struct abstract_conn {
    virtual ~abstract_conn() = default;
-   virtual bool verify_max_bytes_in_flight() = 0;
+   virtual bool verify_max_bytes_in_flight(size_t extra_bytes) = 0;
    virtual bool verify_max_requests_in_flight() = 0;
    virtual void handle_exception() = 0;
 
-   virtual void send_response(std::shared_ptr<in_flight<std::string>> json_body, unsigned int code) = 0;
+   virtual void send_response(std::string&& json_body, unsigned int code) = 0;
 };
 
 using abstract_conn_ptr = std::shared_ptr<abstract_conn>;
@@ -101,14 +99,6 @@ static size_t in_flight_sizeof(const std::optional<T>& o) {
    return 0;
 }
 
-/**
-* Helper method to calculate the "in flight" size of a string
-* @param s - the string
-* @return in flight size of s
-*/
-static size_t in_flight_sizeof(const string& s) {
-   return s.size();
-}
 }// namespace detail
 
 // key -> priority, url_handler
@@ -147,66 +137,6 @@ struct http_plugin_state {
 };
 
 /**
-* Helper type that wraps an object of type T and records its "in flight" size to
-* http_plugin_impl::bytes_in_flight using RAII semantics
-*
-* @tparam T - the contained Type
-*/
-template<typename T>
-struct in_flight {
-   in_flight(T&& object, std::shared_ptr<http_plugin_state> plugin_state)
-      : _object(std::move(object)), _plugin_state(std::move(plugin_state)) {
-      _count = detail::in_flight_sizeof(_object);
-      _plugin_state->bytes_in_flight += _count;
-   }
-
-   ~in_flight() {
-      if(_count) {
-         _plugin_state->bytes_in_flight -= _count;
-      }
-   }
-
-   // No copy constructor, but allow move
-   in_flight(const in_flight&) = delete;
-   in_flight(in_flight&& from)
-       : _object(std::move(from._object)), _count(from._count), _plugin_state(std::move(from._plugin_state)) {
-      from._count = 0;
-   }
-
-   // Delete copy/move assignment
-   in_flight& operator=(const in_flight&) = delete;
-   in_flight& operator=(in_flight&& from) = delete;
-
-   /**
-   * const accessor
-   * @return const reference to the contained object
-   */
-   const T& obj() const {
-      return _object;
-   }
-
-   /**
-   * mutable accessor (can be moved from)
-   * @return mutable reference to the contained object
-   */
-   T& obj() {
-      return _object;
-   }
-
-   T _object;
-   size_t _count;
-   std::shared_ptr<http_plugin_state> _plugin_state;
-};
-
-/**
-* convenient wrapper to make an in_flight<T>
-*/
-template<typename T>
-auto make_in_flight(T&& object, std::shared_ptr<http_plugin_state> plugin_state) {
-   return std::make_shared<in_flight<T>>(std::forward<T>(object), std::move(plugin_state));
-}
-
-/**
 * Construct a lambda appropriate for url_response_callback that will
 * JSON-stringify the provided response
 *
@@ -217,8 +147,9 @@ auto make_in_flight(T&& object, std::shared_ptr<http_plugin_state> plugin_state)
 auto make_http_response_handler(std::shared_ptr<http_plugin_state> plugin_state, detail::abstract_conn_ptr session_ptr) {
    return [plugin_state{std::move(plugin_state)},
            session_ptr{std::move(session_ptr)}](int code, fc::time_point deadline, std::optional<fc::variant> response) {
-      auto tracked_response = make_in_flight(std::move(response), plugin_state);
-      if(!session_ptr->verify_max_bytes_in_flight()) {
+      //auto tracked_response = make_in_flight(std::move(response), plugin_state);
+      auto payload_size = detail::in_flight_sizeof(response);
+      if(!session_ptr->verify_max_bytes_in_flight(payload_size)) {
          return;
       }
 
@@ -227,17 +158,19 @@ auto make_http_response_handler(std::shared_ptr<http_plugin_state> plugin_state,
          deadline = start + plugin_state->max_response_time;
       }
 
+      plugin_state->bytes_in_flight += payload_size;
+
       // post back to an HTTP thread to allow the response handler to be called from any thread
       boost::asio::post(plugin_state->thread_pool->get_executor(),
-                        [plugin_state, session_ptr, code, deadline, start,
-                         tracked_response = std::move(tracked_response)]() {
+                        [plugin_state, session_ptr, code, deadline, start, payload_size, response = std::move(response)]() {
                            try {
-                              if(tracked_response->obj().has_value()) {
-                                 std::string json = fc::json::to_string(*tracked_response->obj(), deadline + (fc::time_point::now() - start));
-                                 auto tracked_json = make_in_flight(std::move(json), plugin_state);
-                                 session_ptr->send_response(std::move(tracked_json), code);
+                              plugin_state->bytes_in_flight -= payload_size;
+                              if (response.has_value()) {
+                                 std::string json = fc::json::to_string(*response, deadline + (fc::time_point::now() - start));
+                                 if (session_ptr->verify_max_bytes_in_flight(json.size()))
+                                    session_ptr->send_response(std::move(json), code);
                               } else {
-                                 session_ptr->send_response(make_in_flight(std::string("{}"), plugin_state), code);
+                                 session_ptr->send_response("{}", code);
                               }
                            } catch(...) {
                               session_ptr->handle_exception();


### PR DESCRIPTION
This PR resolves #488.

Management of maximum `in_flight` bytes is updated:
- we remove the overly complicated `in_flight` struct which was not necessary. As a consequence we also don't allocate memory for it via make_shared.
- we make the `verify_max_bytes_in_flight` and `verify_max_requests_in_flight` pure verification functions, returning an error string in case of excess, and add a `send_busy_response` function to send the error response.
- when `max_bytes_in_flight` is exceeded, it means that we are processing incoming requests and enqueuing them via `http::async_write` faster than they can be written. As a result we want to stop enqueuing new writes using `send_response`. 


I have checked that the two http unit tests pass (see below), and also some basic calls using curl:

```
ctest -R http                                                                                       26s 
Test project /home/greg/github/enf/leap/build_debug
    Start 2043: http_plugin_test
1/2 Test #2043: http_plugin_test .................   Passed    5.28 sec
    Start 2044: plugin_http_api_test
2/2 Test #2044: plugin_http_api_test .............   Passed   21.45 sec

100% tests passed, 0 tests failed out of 2
```

```
~/github/enf/leap/build_debug greg7mdp/GH-488_bytes_in_flight !3 ?5 ❯ curl http://127.0.0.1:8888/v1/chain/                                                                    
{"code":404,"message":"Not Found","error":{"code":0,"name":"exception","what":"unspecified","details":[{"message":"Unknown Endpoint","file":"beast_http_session.hpp","line_number":160,"method":"handle_request"}]}}%  

~/github/enf/leap/build_debug greg7mdp/GH-488_bytes_in_flight !3 ?5 ❯ curl http://127.0.0.1:8888/v1/chain/get_info                                                            
{"server_version":"013bbea3","chain_id":"8a34ec7df1b8cd06ff4a8abbaa7cc50300823350cadc59ab296cb00d104d2b8f","head_block_num":38,"last_irreversible_block_num":37,"last_irreversible_block_id":"00000025b42cb1d0b3c146b4534779f269b75cd00ab1f624b16296d7f7ef1cd9","head_block_id":"0000002695635bab48a6d6c778e3d5892150b32b231b814a8c187d5dbeef22eb","head_block_time":"2022-12-05T18:49:20.500","head_block_producer":"eosio","virtual_block_cpu_limit":207526,"virtual_block_net_limit":1088100,"block_cpu_limit":199900,"block_net_limit":1048576,"server_version_string":"v4.0.0-dev","fork_db_head_block_num":38,"fork_db_head_block_id":"0000002695635bab48a6d6c778e3d5892150b32b231b814a8c187d5dbeef22eb","server_full_version_string":"v4.0.0-dev-013bbea3d918382edda60292f6c5cca8952d7a14-dirty","total_cpu_weight":0,"total_net_weight":0,"earliest_available_block_num":1,"last_irreversible_block_time":"2022-12-05T18:49:20.000"}%
```

