### PR TITLE
[3.2] use consistent HTTP server header on both success and failure responses

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -343,9 +343,7 @@ public:
 
 
       if(is_send_exception_response_) {
-         res_->set(http::field::content_type, "application/json");
          res_->keep_alive(false);
-         res_->set(http::field::server, BOOST_BEAST_VERSION_STRING);
 
          send_response(std::move(err_str), static_cast<unsigned int>(http::status::internal_server_error));
          derived().do_eof();


### PR DESCRIPTION
#378 sets a more specific HTTP Host header for replies. Well, apparently it only did on successful replies because the code overwrites that header on error replies, which I missed. There appears to be no reason to set these header fields again here -- they're set when the `res_` object is created.

Also, forcing the connection close on an error reply here seems overkill. There is no reason that needs to happen: an error response doesn't prevent a new request from being sent on the same connection. Not touching that in 3.2 though.