### PR TITLE
[3.1] Do not add empty account name to bill_to_accounts if only_bill_first_authorizer is activated

### DIFF
--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -142,7 +142,12 @@ namespace eosio { namespace chain {
 
       // Record accounts to be billed for network and CPU usage
       if( control.is_builtin_activated(builtin_protocol_feature_t::only_bill_first_authorizer) ) {
-         bill_to_accounts.insert( trx.first_authorizer() );
+         // first_authorizer can be empty in read only and dry run transactions.
+         // Empty account name in bill_to_accounts will cause unintended
+         // assert violation later
+         if ( trx.first_authorizer().good() ) {
+            bill_to_accounts.insert( trx.first_authorizer() );
+         }
       } else {
          for( const auto& act : trx.actions ) {
             for( const auto& auth : act.authorization ) {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -145,8 +145,9 @@ namespace eosio { namespace chain {
          // first_authorizer can be empty in read only and dry run transactions.
          // Empty account name in bill_to_accounts will cause unintended
          // assert violation later
-         if ( trx.first_authorizer().good() ) {
-            bill_to_accounts.insert( trx.first_authorizer() );
+         auto first_authorizer = trx.first_authorizer();
+         if ( first_authorizer.good() ) {
+            bill_to_accounts.insert( first_authorizer );
          }
       } else {
          for( const auto& act : trx.actions ) {

--- a/tests/compute_transaction_test.py
+++ b/tests/compute_transaction_test.py
@@ -190,7 +190,7 @@ try:
     wasmFile="payloadless.wasm"
     abiFile="payloadless.abi"
     Print("Publish payloadless contract")
-    node.publishContract(payloadless, contractDir, wasmFile, abiFile,waitForTransBlock=True)
+    node.publishContract(payloadless.name, contractDir, wasmFile, abiFile, waitForTransBlock=True)
 
     # test a transaction without authorization works
     trx4 = { "actions": [{"account": "payloadless", "name": "doit", "authorization": [], "data": ""}] };

--- a/tests/compute_transaction_test.py
+++ b/tests/compute_transaction_test.py
@@ -94,8 +94,14 @@ try:
     account2.activePublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
     cluster.createAccountAndVerify(account2, cluster.eosioAccount, stakedDeposit=1000, stakeCPU=1)
 
+    Print("Creating payloadless")
+    payloadless = Account('payloadless')
+    payloadless.ownerPublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+    payloadless.activePublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+    cluster.createAccountAndVerify(payloadless, cluster.eosioAccount)
+
     Print("Validating accounts after bootstrap")
-    cluster.validateAccounts([account1, account2])
+    cluster.validateAccounts([account1, account2, payloadless])
 
     node = cluster.getNode()
 
@@ -178,6 +184,17 @@ try:
                      "compression": "none"}]
     }
     results = npnode.pushTransaction(trx3, opts="--read-only")
+    assert(results[0])
+
+    contractDir="unittests/test-contracts/payloadless"
+    wasmFile="payloadless.wasm"
+    abiFile="payloadless.abi"
+    Print("Publish payloadless contract")
+    node.publishContract(payloadless, contractDir, wasmFile, abiFile,waitForTransBlock=True)
+
+    # test a transaction without authorization works
+    trx4 = { "actions": [{"account": "payloadless", "name": "doit", "authorization": [], "data": ""}] };
+    results = npnode.pushTransaction(trx4, opts="--read-only")
     assert(results[0])
 
     testSuccessful = True


### PR DESCRIPTION
Resolved https://github.com/AntelopeIO/leap/issues/526

Previously, empty account name would be added to `bill_to_accounts` if `only_bill_first_authorizer` was activated and a transaction did not have the authorization field. This caused resources not found for non-existing account.

A new test is added. 

Without the fix, the test would produce the following  error:

```
2022-12-07T19:00:43.366542  cmd: ['programs/cleos/cleos', '--url', 'http://localhost:8890', '--wallet-url', 'http://localhost:9899', '--no-auto-keosd', 'push', 'transaction', '-j', '{"actions":[{"account":"payloadless","name":"doit","authorization":[],"data":""}]}', '--read-only']
2022-12-07T19:00:43.376589  Test failed.
2022-12-07T19:00:43.376687  Shut down the cluster.
2022-12-07T19:00:43.376792   cmd: programs/eosio-launcher/eosio-launcher -k 15
2022-12-07T19:00:43.383628   cmd: pkill -9 nodeos
2022-12-07T19:00:43.393896  Shut down the wallet.
2022-12-07T19:00:43.394064   cmd: pkill -9 keosd
Traceback (most recent call last):
  File "tests/compute_transaction_test.py", line 197, in <module>
    results = npnode.pushTransaction(trx4, opts="--read-only")
  File "/home/lh/work/leap-3.1-empty-auth-fix/build/tests/Node.py", line 836, in pushTransaction
    self.trackCmdTransaction(retTrans, ignoreNonTrans=True)
  File "/home/lh/work/leap-3.1-empty-auth-fix/build/tests/Node.py", line 1338, in trackCmdTransaction
    blockNum=Node.getTransBlockNum(trans)
  File "/home/lh/work/leap-3.1-empty-auth-fix/build/tests/Node.py", line 156, in getTransBlockNum
    cntxt.index(0)
  File "/home/lh/work/leap-3.1-empty-auth-fix/build/tests/Node.py", line 127, in index
    assert i < listLen, f"ERROR: Index {i} is beyond the size of the current list ({listLen}).  {self.__contextDesc()} in {self.__json()}"
AssertionError: ERROR: Index 0 is beyond the size of the current list (0).  trans[processed][action_traces] in trans=
{
 "transaction_id": "f36385ae6e874dca17b657b63f79a2924235045ddd7b1b0775024ddd0949a865",
 "processed": {
  "id": "f36385ae6e874dca17b657b63f79a2924235045ddd7b1b0775024ddd0949a865",
  "block_num": 193,
  "block_time": "2022-12-07T19:00:43.500",
  "producer_block_id": null,
  "receipt": null,
  "elapsed": 73,
  "net_usage": 0,
  "scheduled": false,
  "action_traces": [],
  "account_ram_delta": null,
  "except": {
   "code": 13,
   "name": "N5boost10wrapexceptISt12out_of_rangeEE",
   "message": "unknown key (eosio::chain::name): ",
   "stack": [
    {
     "context": {
      "level": "warn",
      "file": "exception.cpp",
      "line": 337,
      "method": "from_current_exception",
      "hostname": "",
      "thread_name": "nodeos",
      "timestamp": "2022-12-07T19:00:43.375"
     },
     "format": "rethrow ${what}: ",
     "data": {
      "what": "unknown key (eosio::chain::name): "
     }
    }
   ]
  },
  "error_code": null
 }
}
```