### PR TITLE
[3.1] Production Plugin Doc Cleanup on Swagger YAML

### DIFF
--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -70,7 +70,7 @@ paths:
   /producer/paused:
     post:
       summary: paused
-      description: Retreives paused status for producer node
+      description: Retrieves paused status for producer node
       operationId: paused
       parameters: []
       requestBody:
@@ -90,7 +90,7 @@ paths:
   /producer/get_runtime_options:
     post:
       summary: get_runtime_options
-      description: Retreives run time options for producer node
+      description: Retrieves runtime options for producer node
       operationId: get_runtime_options
       parameters: []
       requestBody:
@@ -151,7 +151,7 @@ paths:
   /producer/get_whitelist_blacklist:
     post:
       summary: get_whitelist_blacklist
-      description: Retreives the white list and black list for producer node. A json object containing whitelist and blacklist information. `actor_whitelist` , `actor_blacklist`, `contract_whitelist`, `contract_blacklist` are represented by an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
+      description: Retrieves the whitelist and blacklist for producer node. A JSON object containing whitelist and blacklist information. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` are represented by an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
       operationId: get_whitelist_blacklist
 
       responses:
@@ -195,7 +195,7 @@ paths:
   /producer/set_whitelist_blacklist:
     post:
       summary: set_whitelist_blacklist
-      description: Defines the whitelist and blacklist for a producer node. Takes a json object containing whitelist and blacklist information. At least one of actor_whitelist, actor_blacklist, contract_whitelist, contract_blacklist, action_blacklist, and key_blacklist is required. `actor_whitelist` , `actor_blacklist`, `contract_whitelist`, `contract_blacklist` take an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
+      description: Defines the whitelist and blacklist for a producer node. Takes a JSON object containing whitelist and blacklist information. At least one of actor_whitelist, actor_blacklist, contract_whitelist, contract_blacklist, action_blacklist, or key_blacklist is required. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` take an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
       operationId: set_whitelist_blacklist
       required: true
       requestBody:
@@ -289,7 +289,7 @@ paths:
   /producer/get_integrity_hash:
     post:
       summary: get_integrity_hash
-      description: Retreives the integrity hash for producer node
+      description: Retrieves the integrity hash for producer node
       operationId: get_integrity_hash
 
       responses:
@@ -339,7 +339,7 @@ paths:
   /producer/get_supported_protocol_features:
     post:
       summary: get_supported_protocol_features
-      description: Retreives supported protocol features for producer node. Pass filters in as part of the request body.
+      description: Retrieves supported protocol features for producer node. Pass filters in as part of the request body.
       operationId: get_supported_protocol_features
       requestBody:
         content:
@@ -402,7 +402,7 @@ paths:
   /producer/get_account_ram_corrections:
     post:
       summary: get_account_ram_corrections
-      description: Retreives accounts with ram corrections.
+      description: Retrieves accounts with ram corrections.
       operationId: get_account_ram_corrections
       requestBody:
         content:
@@ -465,7 +465,7 @@ paths:
             application/json:
               schema:
                 type: object
-                description: Returns run time options set for the producer
+                description: Returns runtime options set for the producer
                 properties:
                   max_transaction_time:
                     type: integer
@@ -487,11 +487,11 @@ paths:
                     description: Subjective CPU leeway
                   incoming_defer_ratio:
                     type: integer
-                    description: Incoming defer ration
+                    description: Incoming defer ratio
   /producer/update_runtime_options:
     post:
       summary: update_runtime_options
-      description: Update run time options for producer node
+      description: Update runtime options for producer node
       operationId: update_runtime_options
       parameters: []
       requestBody:
@@ -504,7 +504,7 @@ paths:
               properties:
                 options:
                   type: object
-                  description: Defines the run time options to set for the producer
+                  description: Defines the runtime options to set for the producer
                   properties:
                     max_transaction_time:
                       type: integer
@@ -538,7 +538,7 @@ paths:
   /producer/get_greylist:
     post:
       summary: get_greylist
-      description: Retreives the greylist for producer node
+      description: Retrieves the greylist for producer node
       operationId: get_greylist
       parameters: []
       requestBody:
@@ -625,7 +625,7 @@ paths:
   /producer/get_whitelist_blacklist:
     post:
       summary: get_whitelist_blacklist
-      description: Retreives the white list and black list for producer node
+      description: Retrieves the whitelist and blacklist for producer node
       operationId: get_whitelist_blacklist
       parameters: []
       requestBody:
@@ -677,7 +677,7 @@ paths:
   /producer/set_whitelist_blacklist:
     post:
       summary: set_whitelist_blacklist
-      description: Sets the white list and black list for producer node
+      description: Sets the whitelist and blacklist for producer node
       operationId: set_whitelist_blacklist
       parameters: []
       requestBody:
@@ -765,7 +765,7 @@ paths:
   /producer/get_integrity_hash:
     post:
       summary: get_integrity_hash
-      description: Retreives the integrity hash for producer node
+      description: Retrieves the integrity hash for producer node
       operationId: get_integrity_hash
       parameters: []
       requestBody:
@@ -823,7 +823,7 @@ paths:
   /producer/get_supported_protocol_features:
     post:
       summary: get_supported_protocol_features
-      description: Retreives supported protocol features for producer node
+      description: Retrieves supported protocol features for producer node
       operationId: get_supported_protocol_features
       parameters: []
       requestBody:

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -98,7 +98,366 @@ paths:
           application/json:
             schema:
               type: object
-              properties: {}
+              properties:
+                  accounts:
+                    type: array
+                    description: List of account names to add
+                    items:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/OK'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Error'
+  /producer/remove_greylist_accounts:
+    post:
+      summary: remove_greylist_accounts
+      description: Removes accounts from greylist for producer node. At least one account is required.
+      operationId: remove_greylist_accounts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                accounts:
+                  type: array
+                  description: List of account names to remove
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/OK'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Error'
+  /producer/get_whitelist_blacklist:
+    post:
+      summary: get_whitelist_blacklist
+      description: Retreives the white list and black list for producer node. A json object containing whitelist and blacklist information. `actor_whitelist` , `actor_blacklist`, `contract_whitelist`, `contract_blacklist` are represented by an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
+      operationId: get_whitelist_blacklist
+
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actor_whitelist:
+                    type: array
+                    items:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                  actor_blacklist:
+                    type: array
+                    items:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                  contract_whitelist:
+                    type: array
+                    items:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                  contract_blacklist:
+                    type: array
+                    items:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                  action_blacklist:
+                    type: array
+                    items:
+                      type: array
+                      description: Array of two string values, the account name as the first and action name as the second
+                      items:
+                        allOf:
+                          - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                          - $ref: "https://docs.eosnetwork.com/openapi/v2.0/CppSignature.yaml"
+                  key_blacklist:
+                    type: array
+                    items:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/KeyType.yaml"
+
+  /producer/set_whitelist_blacklist:
+    post:
+      summary: set_whitelist_blacklist
+      description: Defines the whitelist and blacklist for a producer node. Takes a json object containing whitelist and blacklist information. At least one of actor_whitelist, actor_blacklist, contract_whitelist, contract_blacklist, action_blacklist, and key_blacklist is required. `actor_whitelist` , `actor_blacklist`, `contract_whitelist`, `contract_blacklist` take an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
+      operationId: set_whitelist_blacklist
+      required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                actor_whitelist:
+                  type: array
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                actor_blacklist:
+                  type: array
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                contract_whitelist:
+                  type: array
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                contract_blacklist:
+                  type: array
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                action_blacklist:
+                  type: array
+                  items:
+                    type: array
+                    description: Array of two string values, the account name as the first and action name as the second
+                    items:
+                      anyOf:
+                        - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                        - $ref: "https://docs.eosnetwork.com/openapi/v2.0/CppSignature.yaml"
+                key_blacklist:
+                  type: array
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/KeyType.yaml"
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/OK'
+
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Error'
+
+  /producer/create_snapshot:
+    post:
+      summary: create_snapshot
+      description: Creates a snapshot for producer node. Returns error when unable to create snapshot.
+      operationId: create_snapshot
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  head_block_id:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                  head_block_num:
+                    type: integer
+                    descripiton: Highest block number on the chain
+                    example: 5102
+                  head_block_time:
+                    type: string
+                    description: Highest block unix timestamp
+                    example: 2020-11-16T00:00:00.000
+                  version:
+                    type: integer
+                    description: version number
+                    example: 6
+                  snapshot_name:
+                    type: string
+                    description: The path and file name of the snapshot
+                    example: /home/me/nodes/node-name/snapshots/snapshot-0000999f99999f9f999f99f99ff9999f999f9fff99ff99ffff9f9f9fff9f9999.bin
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Error'
+
+  /producer/get_integrity_hash:
+    post:
+      summary: get_integrity_hash
+      description: Retreives the integrity hash for producer node
+      operationId: get_integrity_hash
+
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Defines the integrity hash information details
+                properties:
+                  head_block_id:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                  integrity_hash:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+
+  /producer/schedule_protocol_feature_activations:
+    post:
+      summary: schedule_protocol_feature_activations
+      description: Schedule protocol feature activation for producer node. Note some features may require pre-activation. Will return error for duplicate requests or when feature required pre-activation.
+      operationId: schedule_protocol_feature_activations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                protocol_features_to_activate:
+                  type: array
+                  description: List of protocol features to activate
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/OK'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Error'
+
+  /producer/get_supported_protocol_features:
+    post:
+      summary: get_supported_protocol_features
+      description: Retreives supported protocol features for producer node. Pass filters in as part of the request body.
+      operationId: get_supported_protocol_features
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                exclude_disabled:
+                  type: boolean
+                  description: Exclude disabled protocol features
+                exclude_unactivatable:
+                  type: boolean
+                  description: Exclude unactivatable protocol features
+                  example: false
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                description: Variant type, an array of strings with the supported protocol features
+                items:
+                  type: object
+                  properties:
+                    feature_digest:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                    subjective_restrictions:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                          example: true
+                        preactivation_required:
+                          type: boolean
+                          example: true
+                        earliest_allowed_activation_time:
+                          type: string
+                          example: "1970-01-01T00:00:00.000"
+                        description_digest:
+                          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                        dependancies:
+                          type: array
+                          items:
+                            $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                        protocol_feature_type:
+                          type: string
+                          example: "builtin"
+                        specification:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+
+
+  /producer/get_account_ram_corrections:
+    post:
+      summary: get_account_ram_corrections
+      description: Retreives accounts with ram corrections.
+      operationId: get_account_ram_corrections
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lower_bound:
+                  type: int
+                  description: lowest account key
+                upper_bound:
+                  type: int
+                  description: highest account key
+                limit:
+                  type: int
+                  description: number of rows to scans
+                  example: 10
+                reverse:
+                  type: boolean
+                  description: direction of search
+                  example: false
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rows:
+                    type: array
+                    items:
+                      type: string
+
+  /producer/get_unapplied_transactions:
+    post:
+      summary: get_unapplied_transactions
+      description: Get Unapplied Transactions. No required parameters.
+      operationId: get_unapplied_transactions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                limit:
+                  type: int
+                  description: number of transactions to return, defaults to 4,294,967,295
+                  example: 2
+                lower_bound:
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                time_limit_ms:
+                  type: int
+                  description: defaults to 10ms
+                  example: 10
       responses:
         "200":
           description: OK


### PR DESCRIPTION
Originally started as a request to fix double `producer/producer` in URL. When looking back through commit logs saw the need to pull in improved documentation  back into the release/3.1 branch. 

This PR updates the producer plugin api documentation and fixes the doubled `producer` in the `get_unapplied_transactions` URL.  
