### PR TITLE
Set keosd max http response time to unlimited

### DIFF
--- a/plugins/wallet_api_plugin/wallet_api_plugin.cpp
+++ b/plugins/wallet_api_plugin/wallet_api_plugin.cpp
@@ -25,7 +25,7 @@ using namespace eosio;
    [&api_handle](string, string body, url_response_callback cb) mutable { \
           try { \
              INVOKE \
-             cb(http_response_code, fc::time_point::maximum(), fc::variant(result)); \
+             cb(http_response_code, fc::time_point::now() + fc::days(365), fc::variant(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \


### PR DESCRIPTION
Users sometimes hit the default 30ms issue with timeouts when using `keosd` due to the default `http-max-response-time-ms` 30ms. Setting contracts or ABI can often take longer than 30ms to parse in `keosd`. This error is confusing to users and often hard to track down what is going wrong. Also `keosd` is meant to only be run locally and not provided as a service.

This PR makes `http-max-response-time-ms` unlimited for `keosd`.

Also includes a bit of cleanup around exception handling in `beast_http_session`.

Resolves #230 