### PR TITLE
[3.1 -> main] Do not run maintenance task on shutdown

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -475,6 +475,8 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
 
       // release http_plugin_impl_ptr shared_ptrs captured in url handlers
       my->plugin_state->url_handlers.clear();
+
+      fc_ilog( logger(), "exit shutdown");
    }
 
    void http_plugin::add_handler(const string& url, const url_handler& handler, int priority) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1066,6 +1066,7 @@ void producer_plugin::plugin_shutdown() {
    my->_unapplied_transactions.clear();
 
    app().post( 0, [me = my](){} ); // keep my pointer alive until queue is drained
+   fc_ilog(_log, "exit shutdown");
 }
 
 void producer_plugin::handle_sighup() {

--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -307,8 +307,11 @@ namespace eosio::trace_api {
                _maintenance_condition.wait(lock);
             }
 
+            if (_maintenance_shutdown) {
+               break;
+            }
+
             uint32_t best_known_lib = _best_known_lib;
-            bool shutdown = _maintenance_shutdown;
             lock.unlock();
 
             log(std::string("Waking up to handle lib: ") + std::to_string(best_known_lib));
@@ -318,10 +321,6 @@ namespace eosio::trace_api {
                   run_maintenance_tasks(best_known_lib, log);
                   last_lib = best_known_lib;
                } FC_LOG_AND_DROP();
-            }
-
-            if (shutdown) {
-               break;
             }
          }
       });

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -453,6 +453,7 @@ void trace_api_plugin::plugin_startup() {
 void trace_api_plugin::plugin_shutdown() {
    my->plugin_shutdown();
    rpc->plugin_shutdown();
+   fc_ilog( _log, "exit shutdown");
 }
 
 void trace_api_plugin::handle_sighup() {


### PR DESCRIPTION
There is no need to run the `trace_api_plugin` on shutdown.
Add logging of exit from `http_plugin`, `producer_plugin`, and `trace_api_plugin` to help debug #535.

Resolves #535 (This likely does not actually resolve the issue, but unless it happens again having this issue open is not helpful.)
Merges #541 & #559 into `main`