### PR TITLE
[3.2] Fix Test: Specify a large time limit for cleos get table

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -420,7 +420,7 @@ class Node(object):
 
     def getTable(self, contract, scope, table, exitOnError=False):
         cmdDesc = "get table"
-        cmd="%s %s %s %s" % (cmdDesc, contract, scope, table)
+        cmd="%s --time-limit 99999 %s %s %s" % (cmdDesc, contract, scope, table)
         msg="contract=%s, scope=%s, table=%s" % (contract, scope, table);
         return self.processCleosCmd(cmd, cmdDesc, exitOnError=exitOnError, exitMsg=msg)
 


### PR DESCRIPTION
#96 Introduced a new `--time-limit` to `/v1/chain/get_table_rows` and defaulted it to 10ms. The `restart-scenarios-test-hard_replay.py` test failed because the get table call exceeded 10ms. Modified the test code to pass in a very large limit so that tests do not hit the 10ms limit.

Resolves #561 
