### PR TITLE
[3.1] Fixes Producer Plugin Schema Fixes and Better Alignment with OpenAPI spec

### DIFF
--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -39,7 +39,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OK_PAUSED'
+                $ref: '#/components/schemas/OK'
         "400":
           description: client error
           content:
@@ -77,7 +77,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OK'
+                $ref: '#/components/schemas/OK_PAUSED'
         "400":
           description: client error
           content:
@@ -527,7 +527,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-                
+
 components:
   securitySchemes: {}
   schemas:

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -9,9 +9,12 @@ info:
   contact:
     url: https://antelope.io
 tags:
-  - name: eosio
+  - name: eos
+    description: distributed organization and related software infrastructure supporting EOS
+  - name: antelope
+    description: protocol and framework powering this blockchain
 servers:
-  - url: "{protocol}://{host}:{port}/v1/"
+  - url: "{protocol}://{host}:{port}/v1"
     variables:
       protocol:
         enum:
@@ -37,6 +40,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OK_PAUSED'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /producer/resume:
     post:
@@ -50,6 +59,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OK'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /producer/paused:
     post:
@@ -63,6 +78,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OK'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /producer/get_runtime_options:
     post:
@@ -76,6 +97,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Runtime_Options'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /producer/update_runtime_options:
     post:
@@ -94,6 +121,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OK'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /producer/get_greylist:
     post:
@@ -113,6 +146,12 @@ paths:
                     description: Array of account names stored in the greylist
                     items:
                       $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /producer/add_greylist_accounts:
     post:
@@ -216,6 +255,12 @@ paths:
                     type: array
                     items:
                       - $ref: "https://docs.eosnetwork.com/openapi/v2.0/KeyType.yaml"
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /producer/set_whitelist_blacklist:
     post:
@@ -288,7 +333,7 @@ paths:
                     $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                   head_block_num:
                     type: integer
-                    descripiton: Highest block number on the chain
+                    description: Highest block number on the chain
                     example: 5102
                   head_block_time:
                     type: string
@@ -327,6 +372,12 @@ paths:
                     $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
                   integrity_hash:
                     $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /producer/schedule_protocol_feature_activations:
     post:
@@ -419,6 +470,12 @@ paths:
                                 type: string
                               value:
                                 type: string
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 
   /producer/get_account_ram_corrections:
@@ -464,6 +521,13 @@ paths:
                     type: array
                     items:
                       - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+                
 components:
   securitySchemes: {}
   schemas:

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -29,7 +29,7 @@ paths:
   /producer/pause:
     post:
       summary: pause
-      description: Pause producer node. Takes no arguments returns no values.
+      description: Pause producer node. Takes no arguments and returns no values.
       operationId: pause
       responses:
         "201":
@@ -48,7 +48,7 @@ paths:
   /producer/resume:
     post:
       summary: resume
-      description: Resume producer node. Takes no arguments returns no values.
+      description: Resume producer node. Takes no arguments and returns no values.
       operationId: resume
       responses:
         "201":
@@ -67,7 +67,7 @@ paths:
   /producer/paused:
     post:
       summary: paused
-      description: Retrieves paused status for producer node. Takes no arguments returns no values.
+      description: Retrieves paused status for producer node. Takes no arguments and returns no values.
       operationId: paused
       responses:
         "201":

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -22,9 +22,6 @@ servers:
         default: localhost
       port:
         default: "8080"
-components:
-  securitySchemes: {}
-  schemas: {}
 security:
   - {}
 paths:
@@ -39,7 +36,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/OK_PAUSED'
+                $ref: '#/components/schemas/OK_PAUSED'
 
   /producer/resume:
     post:
@@ -52,7 +49,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/OK'
+                $ref: '#/components/schemas/OK'
 
   /producer/paused:
     post:
@@ -65,7 +62,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/OK'
+                $ref: '#/components/schemas/OK'
 
   /producer/get_runtime_options:
     post:
@@ -78,7 +75,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/Runtime_Options'
+                $ref: '#/components/schemas/Runtime_Options'
 
   /producer/update_runtime_options:
     post:
@@ -89,14 +86,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/component/schema/Runtime_Options'
+              $ref: '#/components/schemas/Runtime_Options'
       responses:
         "201":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/OK'
+                $ref: '#/components/schemas/OK'
 
   /producer/get_greylist:
     post:
@@ -139,13 +136,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/OK'
+                $ref: '#/components/schemas/OK'
         "400":
           description: client error
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/Error'
+                $ref: '#/components/schemas/Error'
 
   /producer/remove_greylist_accounts:
     post:
@@ -169,13 +166,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/OK'
+                $ref: '#/components/schemas/OK'
         "400":
           description: client error
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/Error'
+                $ref: '#/components/schemas/Error'
 
   /producer/get_whitelist_blacklist:
     post:
@@ -218,14 +215,13 @@ paths:
                   key_blacklist:
                     type: array
                     items:
-                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/KeyType.yaml"
+                      - $ref: "https://docs.eosnetwork.com/openapi/v2.0/KeyType.yaml"
 
   /producer/set_whitelist_blacklist:
     post:
       summary: set_whitelist_blacklist
       description: Defines the whitelist and blacklist for a producer node. Takes a JSON object containing whitelist and blacklist information. At least one of actor_whitelist, actor_blacklist, contract_whitelist, contract_blacklist, action_blacklist, and key_blacklist is required. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` take an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
       operationId: set_whitelist_blacklist
-      required: true
       requestBody:
         content:
           application/json:
@@ -267,13 +263,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/OK'
+                $ref: '#/components/schemas/OK'
         "400":
           description: client error
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/Error'
+                $ref: '#/components/schemas/Error'
 
   /producer/create_snapshot:
     post:
@@ -311,7 +307,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/Error'
+                $ref: '#/components/schemas/Error'
 
   /producer/get_integrity_hash:
     post:
@@ -354,13 +350,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/OK'
+                $ref: '#/components/schemas/OK'
         "400":
           description: client error
           content:
             application/json:
               schema:
-                $ref: '#/component/schema/Error'
+                $ref: '#/components/schemas/Error'
 
   /producer/get_supported_protocol_features:
     post:
@@ -437,13 +433,13 @@ paths:
               type: object
               properties:
                 lower_bound:
-                  type: int
+                  type: integer
                   description: lowest account key
                 upper_bound:
-                  type: int
+                  type: integer
                   description: highest account key
                 limit:
-                  type: int
+                  type: integer
                   description: number of rows to scans
                   example: 10
                 reverse:
@@ -457,6 +453,8 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - rows
                 properties:
                   rows:
                     type: array
@@ -465,10 +463,10 @@ paths:
                   more:
                     type: array
                     items:
-                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
-
-component:
-  schema:
+                      - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+components:
+  securitySchemes: {}
+  schemas:
     Error:
       type: object
       properties:

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -7,7 +7,7 @@ info:
     name: MIT
     url: https://opensource.org/licenses/MIT
   contact:
-    url: https://eosnetwork.com
+    url: https://antelope.io
 tags:
   - name: eosio
 servers:
@@ -31,276 +31,181 @@ paths:
   /producer/pause:
     post:
       summary: pause
-      description: Pause producer node
+      description: Pause producer node. Takes no arguments returns no values.
       operationId: pause
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties: {}
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
               schema:
-                type: boolean
-                description: "returns status"
+                $ref: '#/component/schema/OK_PAUSED'
+
   /producer/resume:
     post:
       summary: resume
-      description: Resume producer node
+      description: Resume producer node. Takes no arguments returns no values.
       operationId: resume
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              description: Resumes activity for producer
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
               schema:
-                description: Returns Nothing
+                $ref: '#/component/schema/OK'
+
   /producer/paused:
     post:
       summary: paused
-      description: Retreives paused status for producer node
+      description: Retrieves paused status for producer node. Takes no arguments returns no values.
       operationId: paused
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties: {}
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
               schema:
-                type: boolean
-                description: True if producer is paused, false otherwise
+                $ref: '#/component/schema/OK'
+
   /producer/get_runtime_options:
     post:
       summary: get_runtime_options
-      description: Retreives run time options for producer node
+      description: Retrieves runtime options for producer node. `incoming_defer_ratio` is a floating point number the other return values are integers.
       operationId: get_runtime_options
-      parameters: []
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Runtime_Options'
+
+  /producer/update_runtime_options:
+    post:
+      summary: update_runtime_options
+      description: Update runtime options for producer node. May post any of the runtime options in combination or alone. `incoming_defer_ratio` is a floating point number the other values are integers.
+      operationId: update_runtime_options
       requestBody:
         content:
           application/json:
             schema:
-              type: object
-              properties: {}
+              $ref: '#/component/schema/Runtime_Options'
       responses:
-        "200":
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/OK'
+
+  /producer/get_greylist:
+    post:
+      summary: get_greylist
+      description: Retrieves the greylist for producer node.
+      operationId: get_greylist
+      responses:
+        "201":
           description: OK
           content:
             application/json:
               schema:
                 type: object
-                description: Returns run time options set for the producer
                 properties:
-                  max_transaction_time:
-                    type: integer
-                    description: Max transaction time
-                  max_irreversible_block_age:
-                    type: integer
-                    description: Max irreversible block age
-                  produce_time_offset_us:
-                    type: integer
-                    description: Time offset
-                  last_block_time_offset_us:
-                    type: integer
-                    description: Last block time offset
-                  max_scheduled_transaction_time_per_block_ms:
-                    type: integer
-                    description: Max scheduled transaction time per block in ms
-                  subjective_cpu_leeway_us:
-                    type: integer
-                    description: Subjective CPU leeway
-                  incoming_defer_ratio:
-                    type: integer
-                    description: Incoming defer ration
-  /producer/update_runtime_options:
-    post:
-      summary: update_runtime_options
-      description: Update run time options for producer node
-      operationId: update_runtime_options
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - options
-              properties:
-                options:
-                  type: object
-                  description: Defines the run time options to set for the producer
-                  properties:
-                    max_transaction_time:
-                      type: integer
-                      description: Max transaction time
-                    max_irreversible_block_age:
-                      type: integer
-                      description: Max irreversible block age
-                    produce_time_offset_us:
-                      type: integer
-                      description: Time offset
-                    last_block_time_offset_us:
-                      type: integer
-                      description: Last block time offset
-                    max_scheduled_transaction_time_per_block_ms:
-                      type: integer
-                      description: Max scheduled transaction time per block in ms
-                    subjective_cpu_leeway_us:
-                      type: integer
-                      description: Subjective CPU leeway
-                    incoming_defer_ratio:
-                      type: integer
-                      description: Incoming defer ration
-
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                description: Returns Nothing
-  /producer/get_greylist:
-    post:
-      summary: get_greylist
-      description: Retreives the greylist for producer node
-      operationId: get_greylist
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties: {}
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                description: List of account names stored in the greylist
-                items:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                  accounts:
+                    type: array
+                    description: Array of account names stored in the greylist
+                    items:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
 
   /producer/add_greylist_accounts:
     post:
       summary: add_greylist_accounts
-      description: Adds accounts to grey list for producer node
+      description: Adds accounts to grey list for producer node. At least one account is required.
       operationId: add_greylist_accounts
-      parameters: []
       requestBody:
         content:
           application/json:
             schema:
               type: object
-              required:
-                - params
               properties:
-                params:
-                  type: object
-                  properties:
-                    accounts:
-                      type: array
-                      description: List of account names to add
-                      items:
-                        $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-
+                  accounts:
+                    type: array
+                    description: List of account names to add
+                    items:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
               schema:
-                description: Returns Nothing
+                $ref: '#/component/schema/OK'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Error'
+
   /producer/remove_greylist_accounts:
     post:
       summary: remove_greylist_accounts
-      description: Removes accounts from greylist for producer node
+      description: Removes accounts from greylist for producer node. At least one account is required.
       operationId: remove_greylist_accounts
-      parameters: []
       requestBody:
         content:
           application/json:
             schema:
               type: object
-              required:
-                - params
               properties:
-                params:
-                  type: object
-                  properties:
-                    accounts:
-                      type: array
-                      description: List of account names to remove
-                      items:
-                        $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-
+                accounts:
+                  type: array
+                  description: List of account names to remove
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                description: List of account names stored in the greylist
-                items:
-                  $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                $ref: '#/component/schema/OK'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Error'
 
   /producer/get_whitelist_blacklist:
     post:
       summary: get_whitelist_blacklist
-      description: Retreives the white list and black list for producer node
+      description: Retrieves the whitelist and blacklist for producer node. A JSON object containing whitelist and blacklist information. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` are represented by an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
       operationId: get_whitelist_blacklist
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties: {}
-
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
               schema:
                 type: object
-                description: Defines the actor whitelist and blacklist, the contract whitelist and blacklist, the action blacklist and key blacklist
                 properties:
                   actor_whitelist:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   actor_blacklist:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   contract_whitelist:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   contract_blacklist:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
                   action_blacklist:
                     type: array
                     items:
@@ -308,116 +213,113 @@ paths:
                       description: Array of two string values, the account name as the first and action name as the second
                       items:
                         allOf:
-                          - $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-                          - $ref: "https://eosio.github.io/schemata/v2.0/oas/CppSignature.yaml"
+                          - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                          - $ref: "https://docs.eosnetwork.com/openapi/v2.0/CppSignature.yaml"
                   key_blacklist:
                     type: array
                     items:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/KeyType.yaml"
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/KeyType.yaml"
 
   /producer/set_whitelist_blacklist:
     post:
       summary: set_whitelist_blacklist
-      description: Sets the white list and black list for producer node
+      description: Defines the whitelist and blacklist for a producer node. Takes a JSON object containing whitelist and blacklist information. At least one of actor_whitelist, actor_blacklist, contract_whitelist, contract_blacklist, action_blacklist, and key_blacklist is required. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` take an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
       operationId: set_whitelist_blacklist
-      parameters: []
+      required: true
       requestBody:
         content:
           application/json:
             schema:
               type: object
-              required:
-                - params
               properties:
-                params:
-                  type: object
-                  description: Defines the actor whitelist and blacklist, the contract whitelist and blacklist, the action blacklist and key blacklist
-                  properties:
-                    actor_whitelist:
-                      type: array
-                      items:
-                        $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-                    actor_blacklist:
-                      type: array
-                      items:
-                        $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-                    contract_whitelist:
-                      type: array
-                      items:
-                        $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-                    contract_blacklist:
-                      type: array
-                      items:
-                        $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-                    action_blacklist:
-                      type: array
-                      items:
-                        type: array
-                        description: Array of two string values, the account name as the first and action name as the second
-                        items:
-                          allOf:
-                            - $ref: "https://eosio.github.io/schemata/v2.0/oas/Name.yaml"
-                            - $ref: "https://eosio.github.io/schemata/v2.0/oas/CppSignature.yaml"
-                    key_blacklist:
-                      type: array
-                      items:
-                        $ref: "https://eosio.github.io/schemata/v2.0/oas/KeyType.yaml"
-
+                actor_whitelist:
+                  type: array
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                actor_blacklist:
+                  type: array
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                contract_whitelist:
+                  type: array
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                contract_blacklist:
+                  type: array
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                action_blacklist:
+                  type: array
+                  items:
+                    type: array
+                    description: Array of two string values, the account name as the first and action name as the second
+                    items:
+                      anyOf:
+                        - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+                        - $ref: "https://docs.eosnetwork.com/openapi/v2.0/CppSignature.yaml"
+                key_blacklist:
+                  type: array
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/KeyType.yaml"
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
               schema:
-                description: Returns Nothing
+                $ref: '#/component/schema/OK'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Error'
+
   /producer/create_snapshot:
     post:
       summary: create_snapshot
-      description: Creates a snapshot for producer node
+      description: Creates a snapshot for producer node. Returns error when unable to create snapshot.
       operationId: create_snapshot
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - next
-              properties:
-                next:
-                  type: object
-                  description: Defines the snapshot to be created
-                  properties:
-                    snapshot_name:
-                      type: string
-                      description: The name of the snapshot
-                    head_block_id:
-                      $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
-
-
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
               schema:
-                description: Returns Nothing
+                type: object
+                properties:
+                  head_block_id:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                  head_block_num:
+                    type: integer
+                    descripiton: Highest block number on the chain
+                    example: 5102
+                  head_block_time:
+                    type: string
+                    description: Highest block unix timestamp
+                    example: 2020-11-16T00:00:00.000
+                  version:
+                    type: integer
+                    description: version number
+                    example: 6
+                  snapshot_name:
+                    type: string
+                    description: The path and file name of the snapshot
+                    example: /home/me/nodes/node-name/snapshots/snapshot-0000999f99999f9f999f99f99ff9999f999f9fff99ff99ffff9f9f9fff9f9999.bin
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Error'
 
   /producer/get_integrity_hash:
     post:
       summary: get_integrity_hash
-      description: Retreives the integrity hash for producer node
+      description: Retrieves the integrity hash for producer node
       operationId: get_integrity_hash
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties: {}
-
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
@@ -425,69 +327,61 @@ paths:
                 type: object
                 description: Defines the integrity hash information details
                 properties:
-                  integrity_hash:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
                   head_block_id:
-                    $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                  integrity_hash:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
 
   /producer/schedule_protocol_feature_activations:
     post:
       summary: schedule_protocol_feature_activations
-      description: Schedule protocol feature activation for producer node
+      description: Schedule protocol feature activation for producer node. Note some features may require pre-activation. Will return error for duplicate requests or when feature required pre-activation.
       operationId: schedule_protocol_feature_activations
-      parameters: []
       requestBody:
         content:
           application/json:
             schema:
               type: object
-              required:
-                - schedule
               properties:
-                schedule:
-                  type: object
-                  properties:
-                    protocol_features_to_activate:
-                      type: array
-                      description: List of protocol features to activate
-                      items:
-                        $ref: "https://eosio.github.io/schemata/v2.0/oas/Sha256.yaml"
-
+                protocol_features_to_activate:
+                  type: array
+                  description: List of protocol features to activate
+                  items:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
               schema:
-                description: Returns Nothing
+                $ref: '#/component/schema/OK'
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/component/schema/Error'
 
   /producer/get_supported_protocol_features:
     post:
       summary: get_supported_protocol_features
-      description: Retreives supported protocol features for producer node
+      description: Retrieves supported protocol features for producer node. Pass filters in as part of the request body.
       operationId: get_supported_protocol_features
-      parameters: []
       requestBody:
         content:
           application/json:
             schema:
               type: object
-              required:
-                - params
               properties:
-                params:
-                  type: object
-                  description: Defines filters based on which to return the supported protocol features
-                  properties:
-                    exclude_disabled:
-                      type: boolean
-                      description: Exclude disabled protocol features
-                    exclude_unactivatable:
-                      type: boolean
-                      description: Exclude unactivatable protocol features
-
+                exclude_disabled:
+                  type: boolean
+                  description: Exclude disabled protocol features
+                exclude_unactivatable:
+                  type: boolean
+                  description: Exclude unactivatable protocol features
+                  example: false
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
@@ -495,4 +389,181 @@ paths:
                 type: array
                 description: Variant type, an array of strings with the supported protocol features
                 items:
-                  type: string
+                  type: object
+                  properties:
+                    feature_digest:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                    subjective_restrictions:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                          example: true
+                        preactivation_required:
+                          type: boolean
+                          example: true
+                        earliest_allowed_activation_time:
+                          type: string
+                          example: "1970-01-01T00:00:00.000"
+                        description_digest:
+                          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                        dependancies:
+                          type: array
+                          items:
+                            $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                        protocol_feature_type:
+                          type: string
+                          example: "builtin"
+                        specification:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+
+
+  /producer/get_account_ram_corrections:
+    post:
+      summary: get_account_ram_corrections
+      description: Retrieves accounts with ram corrections.
+      operationId: get_account_ram_corrections
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lower_bound:
+                  type: int
+                  description: lowest account key
+                upper_bound:
+                  type: int
+                  description: highest account key
+                limit:
+                  type: int
+                  description: number of rows to scans
+                  example: 10
+                reverse:
+                  type: boolean
+                  description: direction of search
+                  example: false
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rows:
+                    type: array
+                    items:
+                      type: string
+                  more:
+                    type: array
+                    items:
+                      $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+
+component:
+  schema:
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: http return code
+          example: 400
+        message:
+          type: string
+          description: summary of error
+          example: Invalid Request
+        error:
+          type: object
+          description: details on the error
+          properties:
+            code:
+              type: integer
+              description: internal error code
+              example: 3200006
+            name:
+              type: string
+              description: name of error
+              example: invalid_http_request
+            what:
+              type: string
+              description: prettier version of error name
+              example: invalid http request
+            details:
+              type: array
+              description: list of additional information for debugging
+              items:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: debugging message
+                    example: Unable to parse valid input from POST body
+                  file:
+                    type: string
+                    description: file where error was thrown
+                    example: http_plugin.hpp
+                  line_number:
+                    type: integer
+                    description: line number in file where error was thrown
+                    example: 246
+                  method:
+                    type: string
+                    description: function executed when error occured
+                    example: parse_params
+    OK:
+      type: object
+      properties:
+        result:
+          type: string
+          description: status
+          example: ok
+    OK_PAUSED:
+      type: object
+      properties:
+        json:
+          type: boolean
+          description: true/false indicating paused state
+          example: true
+    Runtime_Options:
+      type: object
+      properties:
+        max_transaction_time:
+          type: integer
+          description: Max transaction time
+          example: 100
+        max_irreversible_block_age:
+          type: integer
+          description: Max irreversible block age
+          example: -1
+        produce_time_offset_us:
+          type: integer
+          description: Time offset
+          example: -100000
+        last_block_time_offset_us:
+          type: integer
+          description: Last block time offset
+          example: -200000
+        max_scheduled_transaction_time_per_block_ms:
+          type: integer
+          description: Max scheduled transaction time per block in ms
+          example: 100
+        subjective_cpu_leeway_us:
+          type: integer
+          description: in micro seconds
+          example: 10
+        incoming_defer_ratio:
+          type: string
+          description: Incoming defer ratio, parsed to double
+          example: "1.00000000000000000"
+        greylist_limit:
+          type: integer
+          description: unsigned int, limit on number of Names supported by greylist
+          example: 1000

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -9,10 +9,8 @@ info:
   contact:
     url: https://antelope.io
 tags:
-  - name: eos
-    description: distributed organization and related software infrastructure supporting EOS
-  - name: antelope
-    description: protocol and framework powering this blockchain
+  - name: Protocol Version 3.1
+    description: The release tag for Leap binaries is also the protocol version
 servers:
   - url: "{protocol}://{host}:{port}/v1"
     variables:

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -86,7 +86,7 @@ paths:
   /producer/get_runtime_options:
     post:
       summary: get_runtime_options
-      description: Retrieves runtime options for producer node. `incoming_defer_ratio` is a floating point number. The other return values are integers.
+      description: Retrieves runtime options for producer node.
       operationId: get_runtime_options
       responses:
         "201":
@@ -105,7 +105,7 @@ paths:
   /producer/update_runtime_options:
     post:
       summary: update_runtime_options
-      description: Update runtime options for producer node. May post any of the runtime options in combination or alone. `incoming_defer_ratio` is a floating point number. The other values are integers.
+      description: Update runtime options for producer node. May post any of the runtime options in combination or alone.
       operationId: update_runtime_options
       requestBody:
         content:
@@ -214,7 +214,7 @@ paths:
   /producer/get_whitelist_blacklist:
     post:
       summary: get_whitelist_blacklist
-      description: Retrieves the whitelist and blacklist for producer node. A JSON object containing whitelist and blacklist information. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` are represented by an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string representing a NamePrivileged or NameBasic or NameBid or NameCatchAll
+      description: Retrieves the whitelist and blacklist for producer node. A JSON object containing whitelist and blacklist information.
       operationId: get_whitelist_blacklist
       responses:
         "201":
@@ -263,7 +263,7 @@ paths:
   /producer/set_whitelist_blacklist:
     post:
       summary: set_whitelist_blacklist
-      description: Defines the whitelist and blacklist for a producer node. Takes a JSON object containing whitelist and blacklist information. At least one of actor_whitelist, actor_blacklist, contract_whitelist, contract_blacklist, action_blacklist, and key_blacklist is required. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` take an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string representing a NamePrivileged or NameBasic or NameBid or NameCatchAll
+      description: Defines the whitelist and blacklist for a producer node. Takes a JSON object containing whitelist and blacklist information.
       operationId: set_whitelist_blacklist
       requestBody:
         content:
@@ -452,7 +452,7 @@ paths:
                           example: "1970-01-01T00:00:00.000"
                         description_digest:
                           $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
-                        dependancies:
+                        dependencies:
                           type: array
                           items:
                             $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
@@ -576,7 +576,7 @@ components:
                     example: 246
                   method:
                     type: string
-                    description: function executed when error occured
+                    description: function executed when error occurred
                     example: parse_params
     OK:
       type: object
@@ -625,5 +625,5 @@ components:
           example: "1.00000000000000000"
         greylist_limit:
           type: integer
-          description: unsigned int, limit on number of Names supported by greylist
+          description: limit on number of Names supported by greylist
           example: 1000

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -263,7 +263,7 @@ paths:
   /producer/set_whitelist_blacklist:
     post:
       summary: set_whitelist_blacklist
-      description: Defines the whitelist and blacklist for a producer node. Takes a JSON object containing whitelist and blacklist information. At least one of actor_whitelist, actor_blacklist, contract_whitelist, contract_blacklist, action_blacklist, and key_blacklist is required. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` take an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
+      description: Defines the whitelist and blacklist for a producer node. Takes a JSON object containing whitelist and blacklist information. At least one of actor_whitelist, actor_blacklist, contract_whitelist, contract_blacklist, action_blacklist, and key_blacklist is required. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` take an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string representing a NamePrivileged or NameBasic or NameBid or NameCatchAll
       operationId: set_whitelist_blacklist
       requestBody:
         content:

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -86,7 +86,7 @@ paths:
   /producer/get_runtime_options:
     post:
       summary: get_runtime_options
-      description: Retrieves runtime options for producer node. `incoming_defer_ratio` is a floating point number the other return values are integers.
+      description: Retrieves runtime options for producer node. `incoming_defer_ratio` is a floating point number. The other return values are integers.
       operationId: get_runtime_options
       responses:
         "201":
@@ -105,7 +105,7 @@ paths:
   /producer/update_runtime_options:
     post:
       summary: update_runtime_options
-      description: Update runtime options for producer node. May post any of the runtime options in combination or alone. `incoming_defer_ratio` is a floating point number the other values are integers.
+      description: Update runtime options for producer node. May post any of the runtime options in combination or alone. `incoming_defer_ratio` is a floating point number. The other values are integers.
       operationId: update_runtime_options
       requestBody:
         content:
@@ -154,7 +154,7 @@ paths:
   /producer/add_greylist_accounts:
     post:
       summary: add_greylist_accounts
-      description: Adds accounts to grey list for producer node. At least one account is required.
+      description: Adds accounts to greylist for producer node. At least one account is required.
       operationId: add_greylist_accounts
       requestBody:
         content:
@@ -214,7 +214,7 @@ paths:
   /producer/get_whitelist_blacklist:
     post:
       summary: get_whitelist_blacklist
-      description: Retrieves the whitelist and blacklist for producer node. A JSON object containing whitelist and blacklist information. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` are represented by an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string represeting a NamePrivileged or NameBasic or NameBid or NameCatchAll
+      description: Retrieves the whitelist and blacklist for producer node. A JSON object containing whitelist and blacklist information. `actor_whitelist`, `actor_blacklist`, `contract_whitelist`, `contract_blacklist` are represented by an array of Names. `action_blacklist` is an array of tuples consisting of Name and Action. `key_blacklist` is an array of Public Keys. Name is a string representing a NamePrivileged or NameBasic or NameBid or NameCatchAll
       operationId: get_whitelist_blacklist
       responses:
         "201":
@@ -317,7 +317,7 @@ paths:
   /producer/create_snapshot:
     post:
       summary: create_snapshot
-      description: Creates a snapshot for producer node. Returns error when unable to create snapshot.
+      description: Creates a snapshot for producer node. Returns error when unable to create a snapshot.
       operationId: create_snapshot
       responses:
         "201":
@@ -495,7 +495,7 @@ paths:
                   description: highest account key
                 limit:
                   type: integer
-                  description: number of rows to scans
+                  description: number of rows to scan
                   example: 10
                 reverse:
                   type: boolean


### PR DESCRIPTION
### Bug Fixes
- spelling fixes
- added `subjective_cpu_leeway_us` to runtime options 
- added `more` option array returned from `get_account_ram_corrections`
- added return boolean to `paused`
- correct `201` return codes 
- `create_snapshot` has return schema previous was *Returns Nothing*
- corrected description for `get_whitelist_blacklist` `set_whitelist_blacklist`

### Schema Alignment
- consolidates to `components` removed hanging `component` section
- moved common schemas to `components` section 
- removed empty `requestBody` 
- added `400` return codes as required by `redocly` linter
- Added version tags to clarify protocol version 

**NOTE** issue #547 will be closed after patching and updating openapi docs in 3.2 and main branches 
Related PR #572 - 3.2 release