### PR TITLE
[4.0] [PH] enable compatibility for 2.0 and 2.1 nodeos on performance tests.

### DIFF
--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -418,6 +418,7 @@ struct launcher_def {
    bool nogen;
    bool boot;
    bool add_enable_stale_production = false;
+   bool old_nodeos = false;
    string launch_name;
    string launch_time;
    server_identities servers;
@@ -510,6 +511,7 @@ launcher_def::set_options (bpo::options_description &cfg) {
     ("max-transaction-cpu-usage",bpo::value<uint32_t>(),"Provide the \"max-transaction-cpu-usage\" value to use in the genesis.json file")
     ("logging-level",bpo::value<string>(),"Provide the \"level\" value to use in the logging.json file ")
     ("logging-level-map",bpo::value<string>(),"String of a dict which specifies \"level\" value to use in the logging.json file for specific nodes, matching based on node number. Ex: {\"bios\":\"off\",\"00\":\"info\"}")
+    ("old-nodeos", bpo::bool_switch(&old_nodeos)->default_value(false), "Toggles old nodeos compatibility")
         ;
 }
 
@@ -1639,7 +1641,11 @@ launcher_def::launch (eosd_def &instance, string &gts) {
 
   //Always enable the trace_api_plugin on the bios node
   if (instance.name == "bios") {
-    eosdcmd += "--plugin eosio::trace_api_plugin ";
+    if (old_nodeos) {
+      eosdcmd += "--plugin eosio::history_api_plugin  --filter-on \"*\"";
+    } else {
+      eosdcmd += "--plugin eosio::trace_api_plugin ";
+    }
   }
 
   if( add_enable_stale_production ) {

--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -418,7 +418,7 @@ struct launcher_def {
    bool nogen;
    bool boot;
    bool add_enable_stale_production = false;
-   bool old_nodeos = false;
+   bool is_nodeos_v2 = false;
    string launch_name;
    string launch_time;
    server_identities servers;
@@ -511,7 +511,7 @@ launcher_def::set_options (bpo::options_description &cfg) {
     ("max-transaction-cpu-usage",bpo::value<uint32_t>(),"Provide the \"max-transaction-cpu-usage\" value to use in the genesis.json file")
     ("logging-level",bpo::value<string>(),"Provide the \"level\" value to use in the logging.json file ")
     ("logging-level-map",bpo::value<string>(),"String of a dict which specifies \"level\" value to use in the logging.json file for specific nodes, matching based on node number. Ex: {\"bios\":\"off\",\"00\":\"info\"}")
-    ("old-nodeos", bpo::bool_switch(&old_nodeos)->default_value(false), "Toggles old nodeos compatibility")
+    ("is-nodeos-v2", bpo::bool_switch(&is_nodeos_v2)->default_value(false), "Toggles old nodeos compatibility")
         ;
 }
 
@@ -1641,7 +1641,7 @@ launcher_def::launch (eosd_def &instance, string &gts) {
 
   //Always enable the trace_api_plugin on the bios node
   if (instance.name == "bios") {
-    if (old_nodeos) {
+    if (is_nodeos_v2) {
       eosdcmd += "--plugin eosio::history_api_plugin  --filter-on \"*\"";
     } else {
       eosdcmd += "--plugin eosio::trace_api_plugin ";

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -16,6 +16,7 @@ from core_symbol import CORE_SYMBOL
 from .testUtils import Utils
 from .testUtils import Account
 from .testUtils import BlockLogAction
+from .Node import NodeosVersion
 from .Node import BlockType
 from .Node import Node
 from .WalletMgr import WalletMgr
@@ -82,7 +83,7 @@ class Cluster(object):
     # pylint: disable=too-many-arguments
     # walletd [True|False] Is keosd running. If not load the wallet plugin
     def __init__(self, walletd=False, localCluster=True, host="localhost", port=8888, walletHost="localhost", walletPort=9899
-                 , defproduceraPrvtKey=None, defproducerbPrvtKey=None, staging=False, loggingLevel="debug", loggingLevelDict={}, isNodeosv2=False):
+                 , defproduceraPrvtKey=None, defproducerbPrvtKey=None, staging=False, loggingLevel="debug", loggingLevelDict={}, nodeosVers=NodeosVersion.v3):
         """Cluster container.
         walletd [True|False] Is wallet keosd running. If not load the wallet plugin
         localCluster [True|False] Is cluster local to host.
@@ -122,7 +123,7 @@ class Cluster(object):
         self.filesToCleanup=[]
         self.alternateVersionLabels=Cluster.__defaultAlternateVersionLabels()
         self.biosNode = None
-        self.isNodeosv2=isNodeosv2
+        self.nodeosVers=nodeosVers
 
 
     def setChainStrategy(self, chainSyncStrategy=Utils.SyncReplayTag):
@@ -529,7 +530,7 @@ class Cluster(object):
         port=Cluster.__BiosPort if onlyBios else self.port
         host=Cluster.__BiosHost if onlyBios else self.host
         nodeNum="bios" if onlyBios else 0
-        node=Node(host, port, nodeNum, walletMgr=self.walletMgr, isNodeosv2=self.isNodeosv2)
+        node=Node(host, port, nodeNum, walletMgr=self.walletMgr, nodeosVers=self.nodeosVers)
         if Utils.Debug: Utils.Print("Node: %s", str(node))
 
         node.checkPulse(exitOnError=True)
@@ -568,7 +569,7 @@ class Cluster(object):
         for n in nArr:
             port=n["port"]
             host=n["host"]
-            node=Node(host, port, nodeId=len(nodes), walletMgr=self.walletMgr, isNodeosv2=self.isNodeosv2)
+            node=Node(host, port, nodeId=len(nodes), walletMgr=self.walletMgr, nodeosVers=self.nodeosVers)
             if Utils.Debug: Utils.Print("Node:", node)
 
             node.checkPulse(exitOnError=True)
@@ -1427,7 +1428,7 @@ class Cluster(object):
         if m is None:
             Utils.Print("ERROR: Failed to find %s pid. Pattern %s" % (Utils.EosServerName, pattern))
             return None
-        instance=Node(self.host, self.port + nodeNum, nodeNum, pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr, isNodeosv2=self.isNodeosv2)
+        instance=Node(self.host, self.port + nodeNum, nodeNum, pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr, nodeosVers=self.nodeosVers)
         if Utils.Debug: Utils.Print("Node>", instance)
         return instance
 
@@ -1440,7 +1441,7 @@ class Cluster(object):
             Utils.Print("ERROR: Failed to find %s pid. Pattern %s" % (Utils.EosServerName, pattern))
             return None
         else:
-            return Node(Cluster.__BiosHost, Cluster.__BiosPort, "bios", pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr, isNodeosv2=self.isNodeosv2)
+            return Node(Cluster.__BiosHost, Cluster.__BiosPort, "bios", pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr, nodeosVers=self.nodeosVers)
 
     # Kills a percentange of Eos instances starting from the tail and update eosInstanceInfos state
     def killSomeEosInstances(self, killCount, killSignalStr=Utils.SigKillTag):
@@ -1606,7 +1607,7 @@ class Cluster(object):
         with open(startFile, 'r') as file:
             cmd=file.read()
             Utils.Print("unstarted local node cmd: %s" % (cmd))
-        instance=Node(self.host, port=self.port+nodeId, nodeId=nodeId, pid=None, cmd=cmd, walletMgr=self.walletMgr, isNodeosv2=self.isNodeosv2)
+        instance=Node(self.host, port=self.port+nodeId, nodeId=nodeId, pid=None, cmd=cmd, walletMgr=self.walletMgr, nodeosVers=self.nodeosVers)
         if Utils.Debug: Utils.Print("Unstarted Node>", instance)
         return instance
 

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -82,7 +82,7 @@ class Cluster(object):
     # pylint: disable=too-many-arguments
     # walletd [True|False] Is keosd running. If not load the wallet plugin
     def __init__(self, walletd=False, localCluster=True, host="localhost", port=8888, walletHost="localhost", walletPort=9899
-                 , defproduceraPrvtKey=None, defproducerbPrvtKey=None, staging=False, loggingLevel="debug", loggingLevelDict={}, oldNodeos=False):
+                 , defproduceraPrvtKey=None, defproducerbPrvtKey=None, staging=False, loggingLevel="debug", loggingLevelDict={}, isNodeosv2=False):
         """Cluster container.
         walletd [True|False] Is wallet keosd running. If not load the wallet plugin
         localCluster [True|False] Is cluster local to host.
@@ -122,7 +122,7 @@ class Cluster(object):
         self.filesToCleanup=[]
         self.alternateVersionLabels=Cluster.__defaultAlternateVersionLabels()
         self.biosNode = None
-        self.oldNodeos=oldNodeos
+        self.isNodeosv2=isNodeosv2
 
 
     def setChainStrategy(self, chainSyncStrategy=Utils.SyncReplayTag):
@@ -433,7 +433,7 @@ class Cluster(object):
 
         for args in specificExtraNodeosArgs.values():
             if "--plugin eosio::history_api_plugin" in args:
-                cmdArr.append("--old-nodeos")
+                cmdArr.append("--is-nodeos-v2")
                 break
         Cluster.__LauncherCmdArr = cmdArr.copy()
 
@@ -528,7 +528,7 @@ class Cluster(object):
         port=Cluster.__BiosPort if onlyBios else self.port
         host=Cluster.__BiosHost if onlyBios else self.host
         nodeNum="bios" if onlyBios else 0
-        node=Node(host, port, nodeNum, walletMgr=self.walletMgr, oldNodeos=self.oldNodeos)
+        node=Node(host, port, nodeNum, walletMgr=self.walletMgr, isNodeosv2=self.isNodeosv2)
         if Utils.Debug: Utils.Print("Node: %s", str(node))
 
         node.checkPulse(exitOnError=True)
@@ -567,7 +567,7 @@ class Cluster(object):
         for n in nArr:
             port=n["port"]
             host=n["host"]
-            node=Node(host, port, nodeId=len(nodes), walletMgr=self.walletMgr, oldNodeos=self.oldNodeos)
+            node=Node(host, port, nodeId=len(nodes), walletMgr=self.walletMgr, isNodeosv2=self.isNodeosv2)
             if Utils.Debug: Utils.Print("Node:", node)
 
             node.checkPulse(exitOnError=True)
@@ -1426,7 +1426,7 @@ class Cluster(object):
         if m is None:
             Utils.Print("ERROR: Failed to find %s pid. Pattern %s" % (Utils.EosServerName, pattern))
             return None
-        instance=Node(self.host, self.port + nodeNum, nodeNum, pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr, oldNodeos=self.oldNodeos)
+        instance=Node(self.host, self.port + nodeNum, nodeNum, pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr, isNodeosv2=self.isNodeosv2)
         if Utils.Debug: Utils.Print("Node>", instance)
         return instance
 
@@ -1439,7 +1439,7 @@ class Cluster(object):
             Utils.Print("ERROR: Failed to find %s pid. Pattern %s" % (Utils.EosServerName, pattern))
             return None
         else:
-            return Node(Cluster.__BiosHost, Cluster.__BiosPort, "bios", pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr, oldNodeos=self.oldNodeos)
+            return Node(Cluster.__BiosHost, Cluster.__BiosPort, "bios", pid=int(m.group(1)), cmd=m.group(2), walletMgr=self.walletMgr, isNodeosv2=self.isNodeosv2)
 
     # Kills a percentange of Eos instances starting from the tail and update eosInstanceInfos state
     def killSomeEosInstances(self, killCount, killSignalStr=Utils.SigKillTag):
@@ -1605,7 +1605,7 @@ class Cluster(object):
         with open(startFile, 'r') as file:
             cmd=file.read()
             Utils.Print("unstarted local node cmd: %s" % (cmd))
-        instance=Node(self.host, port=self.port+nodeId, nodeId=nodeId, pid=None, cmd=cmd, walletMgr=self.walletMgr, oldNodeos=self.oldNodeos)
+        instance=Node(self.host, port=self.port+nodeId, nodeId=nodeId, pid=None, cmd=cmd, walletMgr=self.walletMgr, isNodeosv2=self.isNodeosv2)
         if Utils.Debug: Utils.Print("Unstarted Node>", instance)
         return instance
 

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -431,10 +431,11 @@ class Cluster(object):
             cmdArr.append("--shape")
             cmdArr.append(topo)
 
-        for args in specificExtraNodeosArgs.values():
-            if "--plugin eosio::history_api_plugin" in args:
-                cmdArr.append("--is-nodeos-v2")
-                break
+        if type(specificExtraNodeosArgs) is dict:
+            for args in specificExtraNodeosArgs.values():
+                if "--plugin eosio::history_api_plugin" in args:
+                    cmdArr.append("--is-nodeos-v2")
+                    break
         Cluster.__LauncherCmdArr = cmdArr.copy()
 
         s=" ".join([("'{0}'".format(element) if (' ' in element) else element) for element in cmdArr.copy()])

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -16,7 +16,6 @@ from core_symbol import CORE_SYMBOL
 from .testUtils import Utils
 from .testUtils import Account
 from .testUtils import BlockLogAction
-from .Node import NodeosVersion
 from .Node import BlockType
 from .Node import Node
 from .WalletMgr import WalletMgr
@@ -83,7 +82,7 @@ class Cluster(object):
     # pylint: disable=too-many-arguments
     # walletd [True|False] Is keosd running. If not load the wallet plugin
     def __init__(self, walletd=False, localCluster=True, host="localhost", port=8888, walletHost="localhost", walletPort=9899
-                 , defproduceraPrvtKey=None, defproducerbPrvtKey=None, staging=False, loggingLevel="debug", loggingLevelDict={}, nodeosVers=NodeosVersion.v3):
+                 , defproduceraPrvtKey=None, defproducerbPrvtKey=None, staging=False, loggingLevel="debug", loggingLevelDict={}, nodeosVers=""):
         """Cluster container.
         walletd [True|False] Is wallet keosd running. If not load the wallet plugin
         localCluster [True|False] Is cluster local to host.

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -22,12 +22,6 @@ from .testUtils import addEnum
 from .testUtils import unhandledEnumType
 from .testUtils import ReturnType
 
-class NodeosVersion(EnumType):
-    v1 = 1
-    v2 = 2
-    v3 = 3
-    v4 = 4
-
 class BlockType(EnumType):
     pass
 
@@ -39,7 +33,7 @@ class Node(object):
 
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-many-arguments
-    def __init__(self, host, port, nodeId, pid=None, cmd=None, walletMgr=None, nodeosVers=NodeosVersion.v3):
+    def __init__(self, host, port, nodeId, pid=None, cmd=None, walletMgr=None, nodeosVers=""):
         self.host=host
         self.port=port
         self.pid=pid
@@ -61,7 +55,7 @@ class Node(object):
         self.popenProc=None           # initial process is started by launcher, this will only be set on relaunch
         self.lastTrackedTransactionId=None
         self.nodeosVers=nodeosVers
-        if self.nodeosVers==NodeosVersion.v2:
+        if self.nodeosVers=="v2":
             self.fetchTransactionCommand = lambda: "get transaction"
             self.fetchTransactionFromTrace = lambda trx: trx['trx']['id']
             self.fetchBlock = lambda blockNum: self.processUrllibRequest("chain", "get_block", {"block_num_or_id":blockNum}, silentErrors=False, exitOnError=True)

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -22,6 +22,12 @@ from .testUtils import addEnum
 from .testUtils import unhandledEnumType
 from .testUtils import ReturnType
 
+class NodeosVersion(EnumType):
+    v1 = 1
+    v2 = 2
+    v3 = 3
+    v4 = 4
+
 class BlockType(EnumType):
     pass
 
@@ -33,7 +39,7 @@ class Node(object):
 
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-many-arguments
-    def __init__(self, host, port, nodeId, pid=None, cmd=None, walletMgr=None, isNodeosv2=False):
+    def __init__(self, host, port, nodeId, pid=None, cmd=None, walletMgr=None, nodeosVers=NodeosVersion.v3):
         self.host=host
         self.port=port
         self.pid=pid
@@ -54,8 +60,8 @@ class Node(object):
         self.missingTransaction=False
         self.popenProc=None           # initial process is started by launcher, this will only be set on relaunch
         self.lastTrackedTransactionId=None
-        self.isNodeosv2=isNodeosv2
-        if isNodeosv2:
+        self.nodeosVers=nodeosVers
+        if self.nodeosVers==NodeosVersion.v2:
             self.fetchTransactionCommand = lambda: "get transaction"
             self.fetchTransactionFromTrace = lambda trx: trx['trx']['id']
             self.fetchBlock = lambda blockNum: self.processUrllibRequest("chain", "get_block", {"block_num_or_id":blockNum}, silentErrors=False, exitOnError=True)

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -33,7 +33,7 @@ class Node(object):
 
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-many-arguments
-    def __init__(self, host, port, nodeId, pid=None, cmd=None, walletMgr=None, oldNodeos=False):
+    def __init__(self, host, port, nodeId, pid=None, cmd=None, walletMgr=None, isNodeosv2=False):
         self.host=host
         self.port=port
         self.pid=pid
@@ -54,7 +54,7 @@ class Node(object):
         self.missingTransaction=False
         self.popenProc=None           # initial process is started by launcher, this will only be set on relaunch
         self.lastTrackedTransactionId=None
-        self.oldNodeos=oldNodeos
+        self.isNodeosv2=isNodeosv2
 
     def eosClientArgs(self):
         walletArgs=" " + self.walletMgr.getWalletEndpointArgs() if self.walletMgr is not None else ""
@@ -281,7 +281,7 @@ class Node(object):
         assert(isinstance(transId, str))
         exitOnErrorForDelayed=not delayedRetry and exitOnError
         timeout=3
-        if self.oldNodeos:
+        if self.isNodeosv2:
             cmdDesc="get transaction"
         else:
             cmdDesc="get transaction_trace"
@@ -337,7 +337,7 @@ class Node(object):
         refBlockNum=None
         key=""
         try:
-            if self.oldNodeos:
+            if self.isNodeosv2:
                 key="[trx][trx][ref_block_num]"
                 refBlockNum=trans["trx"]["trx"]["ref_block_num"]
             else:
@@ -503,13 +503,13 @@ class Node(object):
         return ret
 
     def checkBlockForTransactions(self, transIds, blockNum):
-        if self.oldNodeos:
+        if self.isNodeosv2:
             block = self.processUrllibRequest("chain", "get_block", {"block_num_or_id":blockNum}, silentErrors=False, exitOnError=True)
         else:
             block = self.processUrllibRequest("trace_api", "get_block", {"block_num":blockNum}, silentErrors=False, exitOnError=True)
         if block['payload']['transactions']:
             for trx in block['payload']['transactions']:
-                if self.oldNodeos:
+                if self.isNodeosv2:
                     if trx['trx']['id'] in transIds:
                         transIds.pop(trx['trx']['id'])
                 else:

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -55,6 +55,18 @@ class Node(object):
         self.popenProc=None           # initial process is started by launcher, this will only be set on relaunch
         self.lastTrackedTransactionId=None
         self.isNodeosv2=isNodeosv2
+        if isNodeosv2:
+            self.fetchTransactionCommand = lambda: "get transaction"
+            self.fetchTransactionFromTrace = lambda trx: trx['trx']['id']
+            self.fetchBlock = lambda blockNum: self.processUrllibRequest("chain", "get_block", {"block_num_or_id":blockNum}, silentErrors=False, exitOnError=True)
+            self.fetchKeyCommand = lambda: "[trx][trx][ref_block_num]"
+            self.fetchRefBlock = lambda trans: trans["trx"]["trx"]["ref_block_num"]
+        else:
+            self.fetchTransactionCommand = lambda: "get transaction_trace"
+            self.fetchTransactionFromTrace = lambda trx: trx['id']
+            self.fetchBlock = lambda blockNum: self.processUrllibRequest("trace_api", "get_block", {"block_num":blockNum}, silentErrors=False, exitOnError=True)
+            self.fetchKeyCommand = lambda: "[transaction][transaction_header][ref_block_num]"
+            self.fetchRefBlock = lambda trans: trans["transaction_header"]["ref_block_num"]
 
     def eosClientArgs(self):
         walletArgs=" " + self.walletMgr.getWalletEndpointArgs() if self.walletMgr is not None else ""
@@ -281,10 +293,7 @@ class Node(object):
         assert(isinstance(transId, str))
         exitOnErrorForDelayed=not delayedRetry and exitOnError
         timeout=3
-        if self.isNodeosv2:
-            cmdDesc="get transaction"
-        else:
-            cmdDesc="get transaction_trace"
+        cmdDesc=self.fetchTransactionCommand()
         cmd="%s %s" % (cmdDesc, transId)
         msg="(transaction id=%s)" % (transId);
         for i in range(0,(int(60/timeout) - 1)):
@@ -337,12 +346,8 @@ class Node(object):
         refBlockNum=None
         key=""
         try:
-            if self.isNodeosv2:
-                key="[trx][trx][ref_block_num]"
-                refBlockNum=trans["trx"]["trx"]["ref_block_num"]
-            else:
-                key="[transaction][transaction_header][ref_block_num]"
-                refBlockNum=trans["transaction_header"]["ref_block_num"]
+            key = self.fetchKeyCommand()
+            refBlockNum = self.fetchRefBlock(trans)
             refBlockNum=int(refBlockNum)+1
         except (TypeError, ValueError, KeyError) as _:
             Utils.Print("transaction%s not found. Transaction: %s" % (key, trans))
@@ -503,18 +508,11 @@ class Node(object):
         return ret
 
     def checkBlockForTransactions(self, transIds, blockNum):
-        if self.isNodeosv2:
-            block = self.processUrllibRequest("chain", "get_block", {"block_num_or_id":blockNum}, silentErrors=False, exitOnError=True)
-        else:
-            block = self.processUrllibRequest("trace_api", "get_block", {"block_num":blockNum}, silentErrors=False, exitOnError=True)
+        block = self.fetchBlock(blockNum)
         if block['payload']['transactions']:
             for trx in block['payload']['transactions']:
-                if self.isNodeosv2:
-                    if trx['trx']['id'] in transIds:
-                        transIds.pop(trx['trx']['id'])
-                else:
-                    if trx['id'] in transIds:
-                        transIds.pop(trx['id'])
+                if self.fetchTransactionFromTrace(trx) in transIds:
+                    transIds.pop(self.fetchTransactionFromTrace(trx))
         return transIds
 
     def waitForTransactionsInBlockRange(self, transIds, startBlock=2, maxFutureBlocks=0):

--- a/tests/performance_tests/README.md
+++ b/tests/performance_tests/README.md
@@ -14,7 +14,7 @@ Please refer to [Leap: Build and Install from Source](https://github.com/Antelop
 
 ## Steps
 
-1. Build Leap. For complete instructions on building from source please refer to [Leap: Build and Install from Source](https://github.com/AntelopeIO/leap/#build-and-install-from-source)
+1. Build Leap. For complete instructions on building from source please refer to [Leap: Build and Install from Source](https://github.com/AntelopeIO/leap/#build-and-install-from-source) For older compatible nodeos versions, such as 2.X, the following binaries need to be replaced with the older version: `build/programs/nodeos/nodeos`, `build/programs/cleos/cleos`, `bin/nodeos`, and `bin/cleos`.
 2. Run Performance Tests
     1. Full Performance Harness Test Run (Standard):
         ``` bash

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -54,8 +54,6 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
     maxTpsAchieved = 0
     maxTpsReport = {}
     searchResults = []
-    if Utils.getNodeosVersion().split('.')[0] == "v2":
-        isNodeosv2 = True
 
     while ceiling >= floor:
         print(f"Running scenario: floor {floor} binSearchTarget {binSearchTarget} ceiling {ceiling}")
@@ -64,7 +62,7 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
 
         myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=binSearchTarget,
                                     testTrxGenDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
-                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs, isNodeosv2=isNodeosv2)
+                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs)
         testSuccessful = myTest.runTest()
         if evaluateSuccess(myTest, testSuccessful, ptbResult):
             maxTpsAchieved = binSearchTarget
@@ -97,8 +95,6 @@ def performPtbReverseLinearSearch(tpsInitial: int, step: int, testHelperConfig: 
     maxTpsReport = {}
     searchResults = []
     maxFound = False
-    if Utils.getNodeosVersion().split('.')[0] == "v2":
-        isNodeosv2 = True
 
     while not maxFound:
         print(f"Running scenario: floor {absFloor} searchTarget {searchTarget} ceiling {absCeiling}")
@@ -107,7 +103,7 @@ def performPtbReverseLinearSearch(tpsInitial: int, step: int, testHelperConfig: 
 
         myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=searchTarget,
                                     testTrxGenDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
-                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs, isNodeosv2=isNodeosv2)
+                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs)
         testSuccessful = myTest.runTest()
         if evaluateSuccess(myTest, testSuccessful, ptbResult):
             maxTpsAchieved = searchTarget
@@ -284,7 +280,7 @@ def main():
                 lastBlockCpuEffortPercent=args.last_block_cpu_effort_percent)
     extraNodeosHttpPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosHttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
     extraNodeosArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs(chainPluginArgs=extraNodeosChainPluginArgs, httpPluginArgs=extraNodeosHttpPluginArgs, producerPluginArgs=extraNodeosProducerPluginArgs)
-    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=pnodes, totalNodes=totalNodes, topo=topo, genesisPath=genesisPath, prodsEnableTraceApi=prodsEnableTraceApi, extraNodeosArgs=extraNodeosArgs)
+    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=pnodes, totalNodes=totalNodes, topo=topo, genesisPath=genesisPath, prodsEnableTraceApi=prodsEnableTraceApi, extraNodeosArgs=extraNodeosArgs, isNodeosv2=Utils.getNodeosVersion().split('.')[0] == "v2")
 
     argsDict = prepArgsDict(testDurationSec=testDurationSec, finalDurationSec=finalDurationSec, logsDir=testTimeStampDirPath,
                         maxTpsToTest=maxTpsToTest, testIterationMinStep=testIterationMinStep, tpsLimitPerGenerator=tpsLimitPerGenerator,

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -54,6 +54,8 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
     maxTpsAchieved = 0
     maxTpsReport = {}
     searchResults = []
+    if Utils.getNodeosVersion().split('.')[0] == "v2":
+        oldNodeos = True
 
     while ceiling >= floor:
         print(f"Running scenario: floor {floor} binSearchTarget {binSearchTarget} ceiling {ceiling}")
@@ -62,7 +64,7 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
 
         myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=binSearchTarget,
                                     testTrxGenDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
-                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs)
+                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs, oldNodeos=oldNodeos)
         testSuccessful = myTest.runTest()
         if evaluateSuccess(myTest, testSuccessful, ptbResult):
             maxTpsAchieved = binSearchTarget
@@ -95,6 +97,8 @@ def performPtbReverseLinearSearch(tpsInitial: int, step: int, testHelperConfig: 
     maxTpsReport = {}
     searchResults = []
     maxFound = False
+    if Utils.getNodeosVersion().split('.')[0] == "v2":
+        oldNodeos = True
 
     while not maxFound:
         print(f"Running scenario: floor {absFloor} searchTarget {searchTarget} ceiling {absCeiling}")
@@ -103,7 +107,7 @@ def performPtbReverseLinearSearch(tpsInitial: int, step: int, testHelperConfig: 
 
         myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=searchTarget,
                                     testTrxGenDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
-                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs)
+                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs, oldNodeos=oldNodeos)
         testSuccessful = myTest.runTest()
         if evaluateSuccess(myTest, testSuccessful, ptbResult):
             maxTpsAchieved = searchTarget

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -11,7 +11,6 @@ sys.path.append(harnessPath)
 
 from TestHarness import TestHelper, Utils
 from TestHarness.TestHelper import AppArgs
-from TestHarness.Node import NodeosVersion
 from performance_test_basic import PerformanceBasicTest
 from platform import release, system
 from dataclasses import dataclass, asdict, field
@@ -281,11 +280,7 @@ def main():
                 lastBlockCpuEffortPercent=args.last_block_cpu_effort_percent)
     extraNodeosHttpPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosHttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
     extraNodeosArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs(chainPluginArgs=extraNodeosChainPluginArgs, httpPluginArgs=extraNodeosHttpPluginArgs, producerPluginArgs=extraNodeosProducerPluginArgs)
-    if Utils.getNodeosVersion().split('.')[0] == "v2":
-        nodeosVers = NodeosVersion.v2
-    else:
-        nodeosVers = NodeosVersion.v3
-    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=pnodes, totalNodes=totalNodes, topo=topo, genesisPath=genesisPath, prodsEnableTraceApi=prodsEnableTraceApi, extraNodeosArgs=extraNodeosArgs, nodeosVers=nodeosVers)
+    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=pnodes, totalNodes=totalNodes, topo=topo, genesisPath=genesisPath, prodsEnableTraceApi=prodsEnableTraceApi, extraNodeosArgs=extraNodeosArgs, nodeosVers=Utils.getNodeosVersion().split('.')[0])
 
     argsDict = prepArgsDict(testDurationSec=testDurationSec, finalDurationSec=finalDurationSec, logsDir=testTimeStampDirPath,
                         maxTpsToTest=maxTpsToTest, testIterationMinStep=testIterationMinStep, tpsLimitPerGenerator=tpsLimitPerGenerator,

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -11,6 +11,7 @@ sys.path.append(harnessPath)
 
 from TestHarness import TestHelper, Utils
 from TestHarness.TestHelper import AppArgs
+from TestHarness.Node import NodeosVersion
 from performance_test_basic import PerformanceBasicTest
 from platform import release, system
 from dataclasses import dataclass, asdict, field
@@ -280,7 +281,11 @@ def main():
                 lastBlockCpuEffortPercent=args.last_block_cpu_effort_percent)
     extraNodeosHttpPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosHttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
     extraNodeosArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs(chainPluginArgs=extraNodeosChainPluginArgs, httpPluginArgs=extraNodeosHttpPluginArgs, producerPluginArgs=extraNodeosProducerPluginArgs)
-    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=pnodes, totalNodes=totalNodes, topo=topo, genesisPath=genesisPath, prodsEnableTraceApi=prodsEnableTraceApi, extraNodeosArgs=extraNodeosArgs, isNodeosv2=Utils.getNodeosVersion().split('.')[0] == "v2")
+    if Utils.getNodeosVersion().split('.')[0] == "v2":
+        nodeosVers = NodeosVersion.v2
+    else:
+        nodeosVers = NodeosVersion.v3
+    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=pnodes, totalNodes=totalNodes, topo=topo, genesisPath=genesisPath, prodsEnableTraceApi=prodsEnableTraceApi, extraNodeosArgs=extraNodeosArgs, nodeosVers=nodeosVers)
 
     argsDict = prepArgsDict(testDurationSec=testDurationSec, finalDurationSec=finalDurationSec, logsDir=testTimeStampDirPath,
                         maxTpsToTest=maxTpsToTest, testIterationMinStep=testIterationMinStep, tpsLimitPerGenerator=tpsLimitPerGenerator,

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -55,7 +55,7 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
     maxTpsReport = {}
     searchResults = []
     if Utils.getNodeosVersion().split('.')[0] == "v2":
-        oldNodeos = True
+        isNodeosv2 = True
 
     while ceiling >= floor:
         print(f"Running scenario: floor {floor} binSearchTarget {binSearchTarget} ceiling {ceiling}")
@@ -64,7 +64,7 @@ def performPtbBinarySearch(tpsTestFloor: int, tpsTestCeiling: int, minStep: int,
 
         myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=binSearchTarget,
                                     testTrxGenDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
-                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs, oldNodeos=oldNodeos)
+                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs, isNodeosv2=isNodeosv2)
         testSuccessful = myTest.runTest()
         if evaluateSuccess(myTest, testSuccessful, ptbResult):
             maxTpsAchieved = binSearchTarget
@@ -98,7 +98,7 @@ def performPtbReverseLinearSearch(tpsInitial: int, step: int, testHelperConfig: 
     searchResults = []
     maxFound = False
     if Utils.getNodeosVersion().split('.')[0] == "v2":
-        oldNodeos = True
+        isNodeosv2 = True
 
     while not maxFound:
         print(f"Running scenario: floor {absFloor} searchTarget {searchTarget} ceiling {absCeiling}")
@@ -107,7 +107,7 @@ def performPtbReverseLinearSearch(tpsInitial: int, step: int, testHelperConfig: 
 
         myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=searchTarget,
                                     testTrxGenDurationSec=testDurationSec, tpsLimitPerGenerator=tpsLimitPerGenerator,
-                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs, oldNodeos=oldNodeos)
+                                    numAddlBlocksToPrune=numAddlBlocksToPrune, rootLogDir=testLogDir, delReport=delReport, quiet=quiet, delPerfLogs=delPerfLogs, isNodeosv2=isNodeosv2)
         testSuccessful = myTest.runTest()
         if evaluateSuccess(myTest, testSuccessful, ptbResult):
             maxTpsAchieved = searchTarget

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -15,7 +15,6 @@ sys.path.append(harnessPath)
 
 from TestHarness import Cluster, TestHelper, Utils, WalletMgr
 from TestHarness.TestHelper import AppArgs
-from TestHarness.Node import NodeosVersion
 from dataclasses import dataclass, asdict, field
 from datetime import datetime
 from math import ceil
@@ -95,7 +94,7 @@ class PerformanceBasicTest:
         maximumClients: int = 0
         loggingDict: dict = field(default_factory=lambda: { "bios": "off" })
         prodsEnableTraceApi: bool = False
-        nodeosVers: NodeosVersion = NodeosVersion.v3
+        nodeosVers: str = ""
         specificExtraNodeosArgs: dict = field(default_factory=dict)
         _totalNodes: int = 2
 
@@ -103,17 +102,18 @@ class PerformanceBasicTest:
             self._totalNodes = self.pnodes + 1 if self.totalNodes <= self.pnodes else self.totalNodes
             if not self.prodsEnableTraceApi:
                 self.specificExtraNodeosArgs.update({f"{node}" : "--plugin eosio::trace_api_plugin" for node in range(self.pnodes, self._totalNodes)})
-            if self.nodeosVers == NodeosVersion.v2:
+            assert self.nodeosVers != "v1" and self.nodeosVers != "v0", f"nodeos version {Utils.getNodeosVersion().split('.')[0]} is unsupported by performance test"
+            if self.nodeosVers == "v2":
                 self.fetchBlock = lambda node, blockNum: node.processUrllibRequest("chain", "get_block", {"block_num_or_id":blockNum}, silentErrors=False, exitOnError=True)
                 self.writeTrx = lambda trxDataFile, block, blockNum: [trxDataFile.write(f"{trx['trx']['id']},{blockNum},{trx['cpu_usage_us']},{trx['net_usage_words']}\n") for trx in block['payload']['transactions'] if block['payload']['transactions']]
                 self.writeBlock = lambda blockDataFile, block: blockDataFile.write(f"{block['payload']['block_num']},{block['payload']['id']},{block['payload']['producer']},{block['payload']['confirmed']},{block['payload']['timestamp']}\n")
-                self.fetchBlock2 = lambda node, headBlock: node.processUrllibRequest("chain", "get_block", {"block_num_or_id":headBlock}, silentErrors=False, exitOnError=True)
+                self.fetchHeadBlock = lambda node, headBlock: node.processUrllibRequest("chain", "get_block", {"block_num_or_id":headBlock}, silentErrors=False, exitOnError=True)
                 self.specificExtraNodeosArgs.update({f"{node}" : '--plugin eosio::history_api_plugin --filter-on "*"' for node in range(self.pnodes, self._totalNodes)})
             else:
                 self.fetchBlock = lambda node, blockNum: node.processUrllibRequest("trace_api", "get_block", {"block_num":blockNum}, silentErrors=False, exitOnError=True)
                 self.writeTrx = lambda trxDataFile, block, blockNum: [trxDataFile.write(f"{trx['id']},{trx['block_num']},{trx['cpu_usage_us']},{trx['net_usage_words']}\n") for trx in block['payload']['transactions'] if block['payload']['transactions']]
                 self.writeBlock = lambda blockDataFile, block: blockDataFile.write(f"{block['payload']['number']},{block['payload']['id']},{block['payload']['producer']},{block['payload']['status']},{block['payload']['timestamp']}\n")
-                self.fetchBlock2 = lambda node, headBlock: node.processUrllibRequest("chain", "get_block_info", {"block_num":headBlock}, silentErrors=False, exitOnError=True)
+                self.fetchHeadBlock = lambda node, headBlock: node.processUrllibRequest("chain", "get_block_info", {"block_num":headBlock}, silentErrors=False, exitOnError=True)
 
     def __init__(self, testHelperConfig: TestHelperConfig=TestHelperConfig(), clusterConfig: ClusterConfig=ClusterConfig(), targetTps: int=8000,
                  testTrxGenDurationSec: int=30, tpsLimitPerGenerator: int=4000, numAddlBlocksToPrune: int=2,
@@ -231,7 +231,7 @@ class PerformanceBasicTest:
         emptyBlocks = 0
         while emptyBlocks < numEmptyToWaitOn:
             headBlock = node.getHeadBlockNum()
-            block = self.clusterConfig.fetchBlock2(node, headBlock)
+            block = self.clusterConfig.fetchHeadBlock(node, headBlock)
             node.waitForHeadToAdvance()
             if block['payload']['transaction_mroot'] == "0000000000000000000000000000000000000000000000000000000000000000":
                 emptyBlocks += 1
@@ -457,11 +457,7 @@ def main():
     extraNodeosHttpPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosHttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
     extraNodeosArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs(chainPluginArgs=extraNodeosChainPluginArgs, httpPluginArgs=extraNodeosHttpPluginArgs, producerPluginArgs=extraNodeosProducerPluginArgs)
 
-    if Utils.getNodeosVersion().split('.')[0] == "v2":
-        nodeosVers = NodeosVersion.v2
-    else:
-        nodeosVers = NodeosVersion.v3
-    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis, prodsEnableTraceApi=args.prods_enable_trace_api, extraNodeosArgs=extraNodeosArgs, nodeosVers=nodeosVers)
+    testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis, prodsEnableTraceApi=args.prods_enable_trace_api, extraNodeosArgs=extraNodeosArgs, nodeosVers=Utils.getNodeosVersion().split('.')[0])
 
     myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=args.target_tps,
                                   testTrxGenDurationSec=args.test_duration_sec, tpsLimitPerGenerator=args.tps_limit_per_generator,

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -440,7 +440,6 @@ def parseArgs():
     appArgs.add_bool(flag="--del-report", help="Whether to delete overarching performance run report.")
     appArgs.add_bool(flag="--quiet", help="Whether to quiet printing intermediate results and reports to stdout")
     appArgs.add_bool(flag="--prods-enable-trace-api", help="Determines whether producer nodes should have eosio::trace_api_plugin enabled")
-    appArgs.add_bool(flag="--old-nodeos", help="If running 2.0 nodeos and cleos, set to true")
     args=TestHelper.parse_args({"-p","-n","-d","-s","--nodes-file"
                                 ,"--dump-error-details","-v","--leave-running"
                                 ,"--clean-run"}, applicationSpecificArgs=appArgs)

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -94,6 +94,7 @@ class PerformanceBasicTest:
         maximumClients: int = 0
         loggingDict: dict = field(default_factory=lambda: { "bios": "off" })
         prodsEnableTraceApi: bool = False
+        oldNodeos: bool = False
         specificExtraNodeosArgs: dict = field(default_factory=dict)
         _totalNodes: int = 2
 
@@ -104,7 +105,7 @@ class PerformanceBasicTest:
 
     def __init__(self, testHelperConfig: TestHelperConfig=TestHelperConfig(), clusterConfig: ClusterConfig=ClusterConfig(), targetTps: int=8000,
                  testTrxGenDurationSec: int=30, tpsLimitPerGenerator: int=4000, numAddlBlocksToPrune: int=2,
-                 rootLogDir: str=".", delReport: bool=False, quiet: bool=False, delPerfLogs: bool=False):
+                 rootLogDir: str=".", delReport: bool=False, quiet: bool=False, delPerfLogs: bool=False, oldNodeos: bool=False):
         self.testHelperConfig = testHelperConfig
         self.clusterConfig = clusterConfig
         self.targetTps = targetTps
@@ -115,7 +116,7 @@ class PerformanceBasicTest:
         self.delReport = delReport
         self.quiet = quiet
         self.delPerfLogs=delPerfLogs
-
+        self.clusterConfig.oldNodeos=oldNodeos
         self.testHelperConfig.keepLogs = not self.delPerfLogs
 
         Utils.Debug = self.testHelperConfig.verbose
@@ -146,7 +147,7 @@ class PerformanceBasicTest:
 
         # Setup cluster and its wallet manager
         self.walletMgr=WalletMgr(True)
-        self.cluster=Cluster(walletd=True, loggingLevel="info", loggingLevelDict=self.clusterConfig.loggingDict)
+        self.cluster=Cluster(walletd=True, loggingLevel="info", loggingLevelDict=self.clusterConfig.loggingDict, oldNodeos=oldNodeos)
         self.cluster.setWalletMgr(self.walletMgr)
 
     def cleanupOldClusters(self):
@@ -204,22 +205,34 @@ class PerformanceBasicTest:
 
     def queryBlockTrxData(self, node, blockDataPath, blockTrxDataPath, startBlockNum, endBlockNum):
         for blockNum in range(startBlockNum, endBlockNum):
-            block = node.processUrllibRequest("trace_api", "get_block", {"block_num":blockNum}, silentErrors=False, exitOnError=True)
+            if self.clusterConfig.oldNodeos:
+                block = node.processUrllibRequest("chain", "get_block", {"block_num_or_id":blockNum}, silentErrors=False, exitOnError=True)
+            else:
+                block = node.processUrllibRequest("trace_api", "get_block", {"block_num":blockNum}, silentErrors=False, exitOnError=True)
             btdf_append_write = self.fileOpenMode(blockTrxDataPath)
             with open(blockTrxDataPath, btdf_append_write) as trxDataFile:
-                [trxDataFile.write(f"{trx['id']},{trx['block_num']},{trx['cpu_usage_us']},{trx['net_usage_words']}\n") for trx in block['payload']['transactions'] if block['payload']['transactions']]
+                if self.clusterConfig.oldNodeos:
+                    [trxDataFile.write(f"{trx['trx']['id']},{blockNum},{trx['cpu_usage_us']},{trx['net_usage_words']}\n") for trx in block['payload']['transactions'] if block['payload']['transactions']]
+                else:
+                    [trxDataFile.write(f"{trx['id']},{trx['block_num']},{trx['cpu_usage_us']},{trx['net_usage_words']}\n") for trx in block['payload']['transactions'] if block['payload']['transactions']]
             trxDataFile.close()
 
             bdf_append_write = self.fileOpenMode(blockDataPath)
             with open(blockDataPath, bdf_append_write) as blockDataFile:
-                blockDataFile.write(f"{block['payload']['number']},{block['payload']['id']},{block['payload']['producer']},{block['payload']['status']},{block['payload']['timestamp']}\n")
+                if self.clusterConfig.oldNodeos:
+                    blockDataFile.write(f"{block['payload']['block_num']},{block['payload']['id']},{block['payload']['producer']},{block['payload']['confirmed']},{block['payload']['timestamp']}\n")
+                else:
+                    blockDataFile.write(f"{block['payload']['number']},{block['payload']['id']},{block['payload']['producer']},{block['payload']['status']},{block['payload']['timestamp']}\n")
             blockDataFile.close()
 
     def waitForEmptyBlocks(self, node, numEmptyToWaitOn):
         emptyBlocks = 0
         while emptyBlocks < numEmptyToWaitOn:
             headBlock = node.getHeadBlockNum()
-            block = node.processUrllibRequest("chain", "get_block_info", {"block_num":headBlock}, silentErrors=False, exitOnError=True)
+            if self.clusterConfig.oldNodeos:
+                block = node.processUrllibRequest("chain", "get_block", {"block_num_or_id":headBlock}, silentErrors=False, exitOnError=True)
+            else:
+                block = node.processUrllibRequest("chain", "get_block_info", {"block_num":headBlock}, silentErrors=False, exitOnError=True)
             node.waitForHeadToAdvance()
             if block['payload']['transaction_mroot'] == "0000000000000000000000000000000000000000000000000000000000000000":
                 emptyBlocks += 1
@@ -228,6 +241,8 @@ class PerformanceBasicTest:
         return node.getHeadBlockNum()
 
     def launchCluster(self):
+        if self.clusterConfig.oldNodeos:
+            self.clusterConfig.specificExtraNodeosArgs.update({f"{node}" : "--plugin eosio::history_api_plugin --filter-on \"*\"" for node in range(self.clusterConfig.pnodes, self.clusterConfig._totalNodes)})
         return self.cluster.launch(
             pnodes=self.clusterConfig.pnodes,
             totalNodes=self.clusterConfig._totalNodes,
@@ -425,6 +440,7 @@ def parseArgs():
     appArgs.add_bool(flag="--del-report", help="Whether to delete overarching performance run report.")
     appArgs.add_bool(flag="--quiet", help="Whether to quiet printing intermediate results and reports to stdout")
     appArgs.add_bool(flag="--prods-enable-trace-api", help="Determines whether producer nodes should have eosio::trace_api_plugin enabled")
+    appArgs.add_bool(flag="--old-nodeos", help="If running 2.0 nodeos and cleos, set to true")
     args=TestHelper.parse_args({"-p","-n","-d","-s","--nodes-file"
                                 ,"--dump-error-details","-v","--leave-running"
                                 ,"--clean-run"}, applicationSpecificArgs=appArgs)
@@ -445,11 +461,14 @@ def main():
     extraNodeosHttpPluginArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs.ExtraNodeosHttpPluginArgs(httpMaxResponseTimeMs=args.http_max_response_time_ms)
     extraNodeosArgs = PerformanceBasicTest.ClusterConfig.ExtraNodeosArgs(chainPluginArgs=extraNodeosChainPluginArgs, httpPluginArgs=extraNodeosHttpPluginArgs, producerPluginArgs=extraNodeosProducerPluginArgs)
     testClusterConfig = PerformanceBasicTest.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis, prodsEnableTraceApi=args.prods_enable_trace_api, extraNodeosArgs=extraNodeosArgs)
+    oldNodeos = False
 
+    if Utils.getNodeosVersion().split('.')[0] == "v2":
+        oldNodeos = True
     myTest = PerformanceBasicTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, targetTps=args.target_tps,
                                   testTrxGenDurationSec=args.test_duration_sec, tpsLimitPerGenerator=args.tps_limit_per_generator,
                                   numAddlBlocksToPrune=args.num_blocks_to_prune, delReport=args.del_report, quiet=args.quiet,
-                                  delPerfLogs=args.del_perf_logs)
+                                  delPerfLogs=args.del_perf_logs, oldNodeos=oldNodeos)
     testSuccessful = myTest.runTest()
 
     exitCode = 0 if testSuccessful else 1


### PR DESCRIPTION
In an effort to benchmark 2.0 and 2.1 nodeos some changes had to be made to accommodate the differences such as history_api_plugin being removed.