### PR TITLE
Small Misc python test improvements

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -821,8 +821,9 @@ class Node(object):
         except subprocess.CalledProcessError as ex:
             if not shouldFail:
                 end=time.perf_counter()
+                out=ex.output.decode("utf-8")
                 msg=ex.stderr.decode("utf-8")
-                Utils.Print("ERROR: Exception during set contract.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
+                Utils.Print("ERROR: Exception during set contract. stderr: %s.  stdout: %s.  cmd Duration: %.3f sec." % (msg, out, end-start))
                 return None
             else:
                 retMap={}
@@ -905,13 +906,15 @@ class Node(object):
             return (False, msg)
 
     # returns tuple with transaction execution status and transaction
-    def pushMessage(self, account, action, data, opts, silentErrors=False, signatures=None, expectTrxTrace=True):
+    def pushMessage(self, account, action, data, opts, silentErrors=False, signatures=None, expectTrxTrace=True, force=False):
         cmd="%s %s push action -j %s %s" % (Utils.EosClientPath, self.eosClientArgs(), account, action)
         cmdArr=cmd.split()
         # not using __sign_str, since cmdArr messes up the string
         if signatures is not None:
             cmdArr.append("--sign-with")
             cmdArr.append("[ \"%s\" ]" % ("\", \"".join(signatures)))
+        if force:
+            cmdArr.append("-f")
         if data is not None:
             cmdArr.append(data)
         if opts is not None:
@@ -927,9 +930,10 @@ class Node(object):
             return (Node.getTransStatus(trans) == 'executed' if expectTrxTrace else True, trans)
         except subprocess.CalledProcessError as ex:
             msg=ex.stderr.decode("utf-8")
+            output=ex.output.decode("utf-8")
             if not silentErrors:
                 end=time.perf_counter()
-                Utils.Print("ERROR: Exception during push message.  cmd Duration=%.3f sec.  %s" % (end - start, msg))
+                Utils.Print("ERROR: Exception during push message. stderr: %s. stdout: %s.  cmd Duration=%.3f sec." % (msg, output, end - start))
             return (False, msg)
 
     @staticmethod
@@ -1027,8 +1031,9 @@ class Node(object):
         except subprocess.CalledProcessError as ex:
             if not silentErrors:
                 end=time.perf_counter()
+                out=ex.output.decode("utf-8")
                 msg=ex.stderr.decode("utf-8")
-                errorMsg="Exception during \"%s\". Exception message: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, end-start, exitMsg)
+                errorMsg="Exception during \"%s\". Exception message: %s.  stdout: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, out, end-start, exitMsg)
                 if exitOnError:
                     Utils.cmdError(errorMsg)
                     Utils.errorExit(errorMsg)

--- a/tests/TestHarness/WalletMgr.py
+++ b/tests/TestHarness/WalletMgr.py
@@ -80,7 +80,7 @@ class WalletMgr(object):
                     statusMsg+=" port %d is NOT available." % (self.port)
                 Utils.Print("Launching %s, note similar processes running. %s" % (Utils.EosWalletName, statusMsg))
 
-        cmd="%s --data-dir %s --config-dir %s --http-server-address=%s:%d --http-max-response-time-ms 99999 --verbose-http-errors" % (
+        cmd="%s --data-dir %s --config-dir %s --unlock-timeout=999999 --http-server-address=%s:%d --http-max-response-time-ms 99999 --verbose-http-errors" % (
             Utils.EosWalletPath, WalletMgr.__walletDataDir, WalletMgr.__walletDataDir, self.host, self.port)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         with open(WalletMgr.__walletLogOutFile, 'w') as sout, open(WalletMgr.__walletLogErrFile, 'w') as serr:


### PR DESCRIPTION
- Adds better error output on failures.
- Adds `-f` force option to `pushMessage`
- Sets `keosd` to have very large timeout so when `--keep-running` is used the wallet doesn't auto-lock.