### PR TITLE
Include additional info in tx_cpu_usage_exceeded exceptions

### DIFF
--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -118,6 +118,8 @@ namespace eosio { namespace chain {
 
          void disallow_transaction_extensions( const char* error_msg )const;
 
+         std::string get_tx_cpu_usage_exceeded_reason_msg(fc::microseconds& limit) const;
+
       /// Fields:
       public:
 
@@ -171,6 +173,16 @@ namespace eosio { namespace chain {
          int64_t                       billing_timer_exception_code = block_cpu_usage_exceeded::code_value;
          fc::time_point                pseudo_start;
          fc::microseconds              billed_time;
+
+         enum class tx_cpu_usage_exceeded_reason {
+            account_cpu_limit, // includes subjective billing
+            on_chain_consensus_max_transaction_cpu_usage,
+            user_specified_trx_max_cpu_usage_ms,
+            node_configured_max_transaction_time,
+            speculative_executed_adjusted_max_transaction_time // prev_billed_cpu_time_us > 0
+         };
+         tx_cpu_usage_exceeded_reason  tx_cpu_usage_reason = tx_cpu_usage_exceeded_reason::account_cpu_limit;
+         fc::microseconds              tx_cpu_usage_amount;
    };
 
 } }

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -166,8 +166,9 @@ void resource_limits_manager::add_transaction_usage(const flat_set<account_name>
 
          EOS_ASSERT( cpu_used_in_window <= max_user_use_in_window,
                      tx_cpu_usage_exceeded,
-                     "authorizing account '${n}' has insufficient cpu resources for this transaction",
-                     ("n", name(a))
+                     "authorizing account '${n}' has insufficient objective cpu resources for this transaction,"
+                     " used in window ${cpu_used_in_window}us, allowed in window ${max_user_use_in_window}us",
+                     ("n", a)
                      ("cpu_used_in_window",cpu_used_in_window)
                      ("max_user_use_in_window",max_user_use_in_window) );
       }
@@ -185,8 +186,9 @@ void resource_limits_manager::add_transaction_usage(const flat_set<account_name>
 
          EOS_ASSERT( net_used_in_window <= max_user_use_in_window,
                      tx_net_usage_exceeded,
-                     "authorizing account '${n}' has insufficient net resources for this transaction",
-                     ("n", name(a))
+                     "authorizing account '${n}' has insufficient net resources for this transaction,"
+                     " used in window ${net_used_in_window}, allowed in window ${max_user_use_in_window}",
+                     ("n", a)
                      ("net_used_in_window",net_used_in_window)
                      ("max_user_use_in_window",max_user_use_in_window) );
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -417,7 +417,8 @@ namespace eosio { namespace chain {
    std::string transaction_context::get_tx_cpu_usage_exceeded_reason_msg(fc::microseconds& limit) const {
       switch( tx_cpu_usage_reason ) {
          case tx_cpu_usage_exceeded_reason::account_cpu_limit:
-            return " reached account cpu limit";
+            limit = objective_duration_limit;
+            return " reached account cpu limit ${limit}us";
          case tx_cpu_usage_exceeded_reason::on_chain_consensus_max_transaction_cpu_usage:
             limit = objective_duration_limit;
             return " reached on chain max_transaction_cpu_usage ${limit}us";
@@ -567,14 +568,14 @@ namespace eosio { namespace chain {
                assert_msg += graylisted ? " greylisted" : "";
                assert_msg += " billable CPU time for the transaction (${billable} us)";
                assert_msg += subjective_billed_us > 0 ? " with a subjective cpu of (${subjective} us)" : "";
-               assert_msg += " reached account cpu limit";
+               assert_msg += " reached account cpu limit ${limit}us";
 
                if( graylisted ) {
                   EOS_ASSERT( false, greylist_cpu_usage_exceeded, std::move(assert_msg),
-                              ("billed", prev_billed_us)("billable", account_limit)("subjective", subjective_billed_us) );
+                              ("billed", prev_billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", account_limit) );
                } else {
                   EOS_ASSERT( false, tx_cpu_usage_exceeded, std::move(assert_msg),
-                              ("billed", prev_billed_us)("billable", account_limit)("subjective", subjective_billed_us) );
+                              ("billed", prev_billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", account_limit) );
                }
             }
          }

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -114,6 +114,7 @@ namespace eosio { namespace chain {
       if( cfg.max_transaction_cpu_usage <= objective_duration_limit.count() ) {
          objective_duration_limit = fc::microseconds(cfg.max_transaction_cpu_usage);
          billing_timer_exception_code = tx_cpu_usage_exceeded::code_value;
+         tx_cpu_usage_reason = tx_cpu_usage_exceeded_reason::on_chain_consensus_max_transaction_cpu_usage;
          _deadline = start + objective_duration_limit;
       }
 
@@ -131,6 +132,7 @@ namespace eosio { namespace chain {
          if( trx_specified_cpu_usage_limit <= objective_duration_limit ) {
             objective_duration_limit = trx_specified_cpu_usage_limit;
             billing_timer_exception_code = tx_cpu_usage_exceeded::code_value;
+            tx_cpu_usage_reason = tx_cpu_usage_exceeded_reason::user_specified_trx_max_cpu_usage_ms;
             _deadline = start + objective_duration_limit;
          }
       }
@@ -181,6 +183,8 @@ namespace eosio { namespace chain {
       // Possibly limit deadline to subjective max_transaction_time
       if( max_transaction_time_subjective != fc::microseconds::maximum() && (start + max_transaction_time_subjective) <= _deadline ) {
          _deadline = start + max_transaction_time_subjective;
+         tx_cpu_usage_reason = billed_cpu_time_us > 0 ? tx_cpu_usage_exceeded_reason::speculative_executed_adjusted_max_transaction_time :
+                                                        tx_cpu_usage_exceeded_reason::node_configured_max_transaction_time;
          billing_timer_exception_code = tx_cpu_usage_exceeded::code_value;
       }
 
@@ -356,6 +360,7 @@ namespace eosio { namespace chain {
          // NOTE: objective_duration_limit may possibly not be objective anymore due to cpu greylisting, but it should still be no greater than the truly objective objective_duration_limit
          objective_duration_limit = fc::microseconds(account_cpu_limit);
          billing_timer_exception_code = tx_cpu_usage_exceeded::code_value;
+         tx_cpu_usage_reason = tx_cpu_usage_exceeded_reason::account_cpu_limit;
       }
 
       net_usage = ((net_usage + 7)/8)*8; // Round up to nearest multiple of word size (8 bytes)
@@ -402,6 +407,26 @@ namespace eosio { namespace chain {
       }
    }
 
+   std::string transaction_context::get_tx_cpu_usage_exceeded_reason_msg(fc::microseconds& limit) const {
+      switch( tx_cpu_usage_reason ) {
+         case tx_cpu_usage_exceeded_reason::account_cpu_limit:
+            return " reached account cpu limit";
+         case tx_cpu_usage_exceeded_reason::on_chain_consensus_max_transaction_cpu_usage:
+            limit = objective_duration_limit;
+            return " reached on chain max_transaction_cpu_usage ${limit}us";
+         case tx_cpu_usage_exceeded_reason::user_specified_trx_max_cpu_usage_ms:
+            limit = objective_duration_limit;
+            return " reached trx specified max_cpu_usage_ms ${limit}us";
+         case tx_cpu_usage_exceeded_reason::node_configured_max_transaction_time:
+            limit = max_transaction_time_subjective;
+            return " reached node configured max-transaction-time ${limit}us";
+         case tx_cpu_usage_exceeded_reason::speculative_executed_adjusted_max_transaction_time:
+            limit = max_transaction_time_subjective;
+            return " reached speculative executed adjusted trx max time ${limit}us";
+      }
+      return "unknown tx_cpu_usage_exceeded";
+   }
+
    void transaction_context::checktime()const {
       if(BOOST_LIKELY(transaction_timer.expired == false))
          return;
@@ -419,15 +444,15 @@ namespace eosio { namespace chain {
          if (subjective_cpu_bill_us > 0) {
             assert_msg += " with a subjective cpu of (${subjective} us)";
          }
+         fc::microseconds limit;
+         assert_msg += get_tx_cpu_usage_exceeded_reason_msg(limit);
          if (cpu_limit_due_to_greylist) {
             assert_msg = "greylisted " + assert_msg;
-            EOS_THROW( greylist_cpu_usage_exceeded,
-                     assert_msg,
-                     ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start)( "subjective", subjective_cpu_bill_us) );
+            EOS_THROW( greylist_cpu_usage_exceeded, assert_msg,
+                     ("billing_timer", now - pseudo_start)("subjective", subjective_cpu_bill_us)("limit", limit) );
          } else {
-            EOS_THROW( tx_cpu_usage_exceeded,
-                     assert_msg,
-                     ("now", now)("deadline", _deadline)("start", start)("billing_timer", now - pseudo_start)("subjective", subjective_cpu_bill_us) );
+            EOS_THROW( tx_cpu_usage_exceeded, assert_msg,
+                     ("billing_timer", now - pseudo_start)("subjective", subjective_cpu_bill_us)("limit", limit) );
          }
       } else if( deadline_exception_code == leeway_deadline_exception::code_value ) {
          EOS_THROW( leeway_deadline_exception,
@@ -490,28 +515,26 @@ namespace eosio { namespace chain {
                         ("billed", billed_us)( "billable", objective_duration_limit.count() )
             );
          } else {
-            auto assert_msg =  [&](bool graylisted, bool subjective) {
-               std::string assert_msg =   "billed CPU time (${billed} us) is greater than the maximum";
-               assert_msg += graylisted ? " greylisted" : "";
-               assert_msg +=              " billable CPU time for the transaction (${billable} us)";
-               assert_msg += subjective ? " with a subjective cpu of (${subjective} us)" : "";
-               return assert_msg;
-            };
             auto graylisted = cpu_limit_due_to_greylist && cpu_limited_by_account;
-            auto subjective =  subjective_billed_us > 0;
             // exceeds trx.max_cpu_usage_ms or cfg.max_transaction_cpu_usage if objective_duration_limit is greater
-            auto limit = graylisted ? account_cpu_limit : (cpu_limited_by_account ? account_cpu_limit : objective_duration_limit.count()); 
-           
-            if (graylisted)
-               EOS_ASSERT( billed_us <= limit,
-                           greylist_cpu_usage_exceeded, 
-                           assert_msg(graylisted, subjective),
-                           ("billed", billed_us)("billable", limit)("subjective", subjective_billed_us));
-            else
-               EOS_ASSERT( billed_us <= limit,
-                           tx_cpu_usage_exceeded,
-                           assert_msg(graylisted, subjective), 
-                           ("billed", billed_us)("billable", limit)("subjective", subjective_billed_us));           
+            auto account_limit = graylisted ? account_cpu_limit : (cpu_limited_by_account ? account_cpu_limit : objective_duration_limit.count());
+
+            if( billed_us > account_limit ) {
+               fc::microseconds tx_limit;
+               std::string assert_msg = "billed CPU time (${billed} us) is greater than the maximum";
+               assert_msg += graylisted ? " greylisted" : "";
+               assert_msg += " billable CPU time for the transaction (${billable} us)";
+               assert_msg += subjective_billed_us > 0 ? " with a subjective cpu of (${subjective} us)" : "";
+               assert_msg += get_tx_cpu_usage_exceeded_reason_msg( tx_limit );
+
+               if( graylisted ) {
+                  EOS_ASSERT( false, greylist_cpu_usage_exceeded, std::move(assert_msg),
+                              ("billed", billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", tx_limit) );
+               } else {
+                  EOS_ASSERT( false, tx_cpu_usage_exceeded, std::move(assert_msg),
+                              ("billed", billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", tx_limit) );
+               }
+            }
          }
       }
    }
@@ -528,28 +551,26 @@ namespace eosio { namespace chain {
                         ("billed", prev_billed_us)( "billable", objective_duration_limit.count() )
             );
          } else {
-            auto assert_msg =  [&](bool graylisted, bool subjective) {
-               std::string assert_msg =   "estimated CPU time (${billed} us) is not less than the maximum";
-               assert_msg += graylisted ? " greylisted" : "";
-               assert_msg +=              " billable CPU time for the transaction (${billable} us)";
-               assert_msg += subjective ? " with a subjective cpu of (${subjective} us)" : "";
-               return assert_msg;
-            };
             auto graylisted = cpu_limit_due_to_greylist && cpu_limited_by_account;
-            auto subjective =  subjective_billed_us > 0;
             // exceeds trx.max_cpu_usage_ms or cfg.max_transaction_cpu_usage if objective_duration_limit is greater
-            auto limit = graylisted ? account_cpu_limit : (cpu_limited_by_account ? account_cpu_limit : objective_duration_limit.count());
-                     
-            if (graylisted)
-               EOS_ASSERT( prev_billed_us < limit,
-                           greylist_cpu_usage_exceeded, 
-                           assert_msg(graylisted, subjective),
-                           ("billed", prev_billed_us)("billable", limit)("subjective", subjective_billed_us));
-            else
-               EOS_ASSERT( prev_billed_us < limit,
-                           tx_cpu_usage_exceeded,
-                           assert_msg(graylisted, subjective),
-                           ("billed", prev_billed_us)("billable", limit)("subjective", subjective_billed_us));          
+            auto account_limit = graylisted ? account_cpu_limit : (cpu_limited_by_account ? account_cpu_limit : objective_duration_limit.count());
+
+            if( prev_billed_us >= account_limit ) {
+               fc::microseconds tx_limit;
+               std::string assert_msg = "estimated CPU time (${billed} us) is not less than the maximum";
+               assert_msg += graylisted ? " greylisted" : "";
+               assert_msg += " billable CPU time for the transaction (${billable} us)";
+               assert_msg += subjective_billed_us > 0 ? " with a subjective cpu of (${subjective} us)" : "";
+               assert_msg += get_tx_cpu_usage_exceeded_reason_msg( tx_limit );
+
+               if( graylisted ) {
+                  EOS_ASSERT( false, greylist_cpu_usage_exceeded, std::move(assert_msg),
+                              ("billed", prev_billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", tx_limit) );
+               } else {
+                  EOS_ASSERT( false, tx_cpu_usage_exceeded, std::move(assert_msg),
+                              ("billed", prev_billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", tx_limit) );
+               }
+            }
          }
       }
    }

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -529,18 +529,20 @@ namespace eosio { namespace chain {
 
             if( billed_us > account_limit ) {
                fc::microseconds tx_limit;
-               std::string assert_msg = "billed CPU time (${billed} us) is greater than the maximum";
+               std::string assert_msg;
+               assert_msg.reserve(1024);
+               assert_msg += "billed CPU time (${billed} us) is greater than the maximum";
                assert_msg += graylisted ? " greylisted" : "";
                assert_msg += " billable CPU time for the transaction (${billable} us)";
                assert_msg += subjective_billed_us > 0 ? " with a subjective cpu of (${subjective} us)" : "";
                assert_msg += get_tx_cpu_usage_exceeded_reason_msg( tx_limit );
 
                if( graylisted ) {
-                  EOS_ASSERT( false, greylist_cpu_usage_exceeded, std::move(assert_msg),
-                              ("billed", billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", tx_limit) );
+                  FC_THROW_EXCEPTION( greylist_cpu_usage_exceeded, std::move(assert_msg),
+                                      ("billed", billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", tx_limit) );
                } else {
-                  EOS_ASSERT( false, tx_cpu_usage_exceeded, std::move(assert_msg),
-                              ("billed", billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", tx_limit) );
+                  FC_THROW_EXCEPTION( tx_cpu_usage_exceeded, std::move(assert_msg),
+                                      ("billed", billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", tx_limit) );
                }
             }
          }
@@ -564,18 +566,20 @@ namespace eosio { namespace chain {
             auto account_limit = graylisted ? account_cpu_limit : (cpu_limited_by_account ? account_cpu_limit : objective_duration_limit.count());
 
             if( prev_billed_us >= account_limit ) {
-               std::string assert_msg = "estimated CPU time (${billed} us) is not less than the maximum";
+               std::string assert_msg;
+               assert_msg.reserve(1024);
+               assert_msg += "estimated CPU time (${billed} us) is not less than the maximum";
                assert_msg += graylisted ? " greylisted" : "";
                assert_msg += " billable CPU time for the transaction (${billable} us)";
                assert_msg += subjective_billed_us > 0 ? " with a subjective cpu of (${subjective} us)" : "";
                assert_msg += " reached account cpu limit ${limit}us";
 
                if( graylisted ) {
-                  EOS_ASSERT( false, greylist_cpu_usage_exceeded, std::move(assert_msg),
-                              ("billed", prev_billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", account_limit) );
+                  FC_THROW_EXCEPTION( greylist_cpu_usage_exceeded, std::move(assert_msg),
+                                      ("billed", prev_billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", account_limit) );
                } else {
-                  EOS_ASSERT( false, tx_cpu_usage_exceeded, std::move(assert_msg),
-                              ("billed", prev_billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", account_limit) );
+                  FC_THROW_EXCEPTION( tx_cpu_usage_exceeded, std::move(assert_msg),
+                                      ("billed", prev_billed_us)("billable", account_limit)("subjective", subjective_billed_us)("limit", account_limit) );
                }
             }
          }

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -679,8 +679,8 @@ namespace eosio { namespace testing {
    * Utility predicate to check whether an fc::exception message contains a given string
    */
   struct fc_exception_message_contains {
-     explicit fc_exception_message_contains( const string& msg )
-           : expected( msg ) {}
+     explicit fc_exception_message_contains( string msg )
+           : expected( std::move(msg) ) {}
 
      bool operator()( const fc::exception& ex );
 

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -676,6 +676,18 @@ namespace eosio { namespace testing {
   };
 
   /**
+   * Utility predicate to check whether an fc::exception message contains a given string
+   */
+  struct fc_exception_message_contains {
+     explicit fc_exception_message_contains( const string& msg )
+           : expected( msg ) {}
+
+     bool operator()( const fc::exception& ex );
+
+     string expected;
+  };
+
+  /**
    * Utility predicate to check whether an fc::assert_exception message is equivalent to a given string
    */
   struct fc_assert_exception_message_is {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1217,6 +1217,15 @@ namespace eosio { namespace testing {
       return match;
    }
 
+   bool fc_exception_message_contains::operator()( const fc::exception& ex ) {
+      auto message = ex.get_log().at( 0 ).get_message();
+      bool match = message.find(expected) != std::string::npos;
+      if( !match ) {
+         BOOST_TEST_MESSAGE( "LOG: expected: " << expected << ", actual: " << message );
+      }
+      return match;
+   }
+
    bool fc_assert_exception_message_is::operator()( const fc::assert_exception& ex ) {
       auto message = ex.get_log().at( 0 ).get_message();
       bool match = false;

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -992,7 +992,7 @@ BOOST_AUTO_TEST_CASE(checktime_fail_tests) { try {
 
    BOOST_CHECK_EXCEPTION( call_test( t, test_api_action<TEST_METHOD("test_checktime", "checktime_failure")>{},
                                      0, 200, 200, fc::raw::pack(10000000000000000000ULL) ),
-                          tx_cpu_usage_exceeded, is_tx_cpu_usage_exceeded );
+                          tx_cpu_usage_exceeded, fc_exception_message_contains("reached on chain max_transaction_cpu_usage") );
 
    uint32_t time_left_in_block_us = config::default_max_block_cpu_usage - config::default_min_transaction_cpu_usage;
    std::string dummy_string = "nonce";
@@ -1046,7 +1046,7 @@ BOOST_AUTO_TEST_CASE(checktime_pause_max_trx_cpu_extended_test) { try {
    auto before = fc::time_point::now();
    BOOST_CHECK_EXCEPTION( call_test( t, test_pause_action<TEST_METHOD("test_checktime", "checktime_failure")>{},
                                      0, 9999, 500, fc::raw::pack(10000000000000000000ULL), "pause"_n ),
-                          tx_cpu_usage_exceeded, is_tx_cpu_usage_exceeded );
+                          tx_cpu_usage_exceeded, fc_exception_message_contains("reached on chain max_transaction_cpu_usage") );
    auto after = fc::time_point::now();
    // Test that it runs longer than specified limit of 24'999 to allow for wasm load time.
    auto dur = (after - before).count();
@@ -1061,7 +1061,7 @@ BOOST_AUTO_TEST_CASE(checktime_pause_max_trx_cpu_extended_test) { try {
    // Test hitting max_transaction_time throws tx_cpu_usage_exceeded
    BOOST_CHECK_EXCEPTION( call_test( t, test_pause_action<TEST_METHOD("test_checktime", "checktime_failure")>{},
                                      0, 5, 50, fc::raw::pack(10000000000000000000ULL), "pause"_n ),
-                          tx_cpu_usage_exceeded, is_tx_cpu_usage_exceeded );
+                          tx_cpu_usage_exceeded, fc_exception_message_contains("reached node configured max-transaction-time") );
 
    // Test hitting block deadline throws deadline_exception
    BOOST_CHECK_EXCEPTION( call_test( t, test_pause_action<TEST_METHOD("test_checktime", "checktime_failure")>{},
@@ -1101,7 +1101,7 @@ BOOST_AUTO_TEST_CASE(checktime_pause_max_trx_extended_test) { try {
    auto before = fc::time_point::now();
    BOOST_CHECK_EXCEPTION( call_test( t, test_pause_action<TEST_METHOD("test_checktime", "checktime_failure")>{},
                                      0, 25, 500, fc::raw::pack(10000000000000000000ULL), "pause"_n ),
-                          tx_cpu_usage_exceeded, is_tx_cpu_usage_exceeded );
+                          tx_cpu_usage_exceeded, fc_exception_message_contains("reached node configured max-transaction-time") );
    auto after = fc::time_point::now();
    // Test that it runs longer than specified limit of 24'999 to allow for wasm load time.
    auto dur = (after - before).count();

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -2050,7 +2050,7 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
    billed_cpu_time_us = EOS_PERCENT( combined_cpu_limit - subjective_cpu_bill_us, 90 * config::percent_1 );
    BOOST_CHECK_EXCEPTION(push_trx( ptrx, fc::time_point::maximum(), billed_cpu_time_us, false, subjective_cpu_bill_us ), tx_cpu_usage_exceeded,
                          [](const tx_cpu_usage_exceeded& e){ fc_exception_message_starts_with starts("estimated");
-                                                             fc_exception_message_contains contains_reached("reached xxx");
+                                                             fc_exception_message_contains contains_reached("reached account cpu limit");
                                                              fc_exception_message_contains contains_subjective("with a subjective cpu of");
                                                              return starts(e) && contains_reached(e) && contains_subjective(e); } );
 
@@ -2058,7 +2058,10 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
    subjective_cpu_bill_us = 0;
    billed_cpu_time_us = EOS_PERCENT( combined_cpu_limit - subjective_cpu_bill_us, 91 * config::percent_1 );
    BOOST_CHECK_EXCEPTION(push_trx( ptrx, fc::time_point::maximum(), billed_cpu_time_us, false, subjective_cpu_bill_us ), tx_cpu_usage_exceeded,
-                         fc_exception_message_starts_with("estimated") );
+                         [](const tx_cpu_usage_exceeded& e){ fc_exception_message_starts_with starts("estimated");
+                                                             fc_exception_message_contains contains_reached("reached account cpu limit");
+                                                             fc_exception_message_contains contains_subjective("with a subjective cpu of");
+                                                             return starts(e) && contains_reached(e) && !contains_subjective(e); } );
 
    // Test when cpu limit is 0
    chain.push_action( config::system_account_name, "setalimits"_n, config::system_account_name, fc::mutable_variant_object()
@@ -2076,7 +2079,9 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
    subjective_cpu_bill_us = 0;
    billed_cpu_time_us = EOS_PERCENT( leeway.count(), 89 *config::percent_1 );
    BOOST_CHECK_EXCEPTION(push_trx( ptrx, fc::time_point::maximum(), billed_cpu_time_us, false, subjective_cpu_bill_us ), tx_cpu_usage_exceeded,
-                         fc_exception_message_starts_with("billed") );
+                         [](const tx_cpu_usage_exceeded& e){ fc_exception_message_starts_with starts("billed");
+                                                             fc_exception_message_contains contains("reached account cpu limit");
+                                                             return starts(e) && contains(e); } );
 
 } FC_LOG_AND_RETHROW()
 


### PR DESCRIPTION
Include in `tx_cpu_usage_exceeded` exception message information on which trx cpu limit was hit.

Includes #562 which should be merged first.
Resolves #330 