### PR TITLE
Subjectively bill for failed transactions during block production

### DIFF
--- a/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
@@ -15,21 +15,14 @@
 
 namespace eosio {
 
-namespace bmi = boost::multi_index;
-using chain::transaction_id_type;
-using chain::account_name;
-using chain::block_state_ptr;
-using chain::packed_transaction;
-namespace config = chain::config;
-
 class subjective_billing {
 private:
 
    struct trx_cache_entry {
-      transaction_id_type     trx_id;
-      account_name            account;
-      int64_t                 subjective_cpu_bill;
-      fc::time_point          expiry;
+      chain::transaction_id_type trx_id;
+      chain::account_name        account;
+      int64_t                    subjective_cpu_bill = 0;
+      fc::time_point             expiry;
    };
    struct by_id;
    struct by_expiry;
@@ -37,7 +30,7 @@ private:
    using trx_cache_index = bmi::multi_index_container<
          trx_cache_entry,
          indexed_by<
-               bmi::hashed_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER( trx_cache_entry, transaction_id_type, trx_id ) >,
+               bmi::hashed_unique<tag<by_id>, BOOST_MULTI_INDEX_MEMBER( trx_cache_entry, chain::transaction_id_type, trx_id ) >,
                ordered_non_unique<tag<by_expiry>, BOOST_MULTI_INDEX_MEMBER( trx_cache_entry, fc::time_point, expiry ) >
          >
    >;
@@ -45,25 +38,24 @@ private:
    using decaying_accumulator = chain::resource_limits::impl::exponential_decay_accumulator<>;
 
    struct subjective_billing_info {
-      uint64_t              pending_cpu_us;        // tracked cpu us for transactions that may still succeed in a block
+      uint64_t              pending_cpu_us = 0;    // tracked cpu us for transactions that may still succeed in a block
       decaying_accumulator  expired_accumulator;   // accumulator used to account for transactions that have expired
 
-      bool empty(uint32_t time_ordinal, uint32_t expired_accumulator_average_window) {
+      bool empty(uint32_t time_ordinal, uint32_t expired_accumulator_average_window) const {
          return pending_cpu_us == 0 && expired_accumulator.value_at(time_ordinal, expired_accumulator_average_window) == 0;
       }
    };
 
-   using account_subjective_bill_cache = std::map<account_name, subjective_billing_info>;
-   using block_subjective_bill_cache = std::map<account_name, uint64_t>;
+   using account_subjective_bill_cache = std::map<chain::account_name, subjective_billing_info>;
 
    bool                                      _disabled = false;
    trx_cache_index                           _trx_cache_index;
    account_subjective_bill_cache             _account_subjective_bill_cache;
    std::set<chain::account_name>             _disabled_accounts;
-   uint32_t                                  _expired_accumulator_average_window = config::account_cpu_usage_average_window_ms / subjective_time_interval_ms;
+   uint32_t                                  _expired_accumulator_average_window = chain::config::account_cpu_usage_average_window_ms / subjective_time_interval_ms;
 
 private:
-   uint32_t time_ordinal_for( const fc::time_point& t ) const {
+   static uint32_t time_ordinal_for( const fc::time_point& t ) {
       auto ordinal = t.time_since_epoch().count() / (1000U * (uint64_t)subjective_time_interval_ms);
       EOS_ASSERT(ordinal <= std::numeric_limits<uint32_t>::max(), chain::tx_resource_exhaustion, "overflow of quantized time in subjective billing");
       return ordinal;
@@ -87,11 +79,11 @@ private:
       }
    }
 
-   void remove_subjective_billing( const block_state_ptr& bsp, uint32_t time_ordinal ) {
+   void remove_subjective_billing( const chain::block_state_ptr& bsp, uint32_t time_ordinal ) {
       if( !_trx_cache_index.empty() ) {
          for( const auto& receipt : bsp->block->transactions ) {
-            if( std::holds_alternative<packed_transaction>(receipt.trx) ) {
-               const auto& pt = std::get<packed_transaction>(receipt.trx);
+            if( std::holds_alternative<chain::packed_transaction>(receipt.trx) ) {
+               const auto& pt = std::get<chain::packed_transaction>(receipt.trx);
                remove_subjective_billing( pt.id(), time_ordinal );
             }
          }
@@ -101,7 +93,7 @@ private:
 public: // public for tests
    static constexpr uint32_t subjective_time_interval_ms = 5'000;
 
-   void remove_subjective_billing( const transaction_id_type& trx_id, uint32_t time_ordinal ) {
+   void remove_subjective_billing( const chain::transaction_id_type& trx_id, uint32_t time_ordinal ) {
       auto& idx = _trx_cache_index.get<by_id>();
       auto itr = idx.find( trx_id );
       if( itr != idx.end() ) {
@@ -113,10 +105,10 @@ public: // public for tests
 public:
    void disable() { _disabled = true; }
    void disable_account( chain::account_name a ) { _disabled_accounts.emplace( a ); }
-   bool is_account_disabled(const account_name& a ) const { return _disabled || _disabled_accounts.count( a ); }
+   bool is_account_disabled(const chain::account_name& a ) const { return _disabled || _disabled_accounts.count( a ); }
 
-   void subjective_bill( const transaction_id_type& id, const fc::time_point& expire, const account_name& first_auth,
-                         const fc::microseconds& elapsed )
+   void subjective_bill( const chain::transaction_id_type& id, const fc::time_point& expire,
+                         const chain::account_name& first_auth, const fc::microseconds& elapsed )
    {
       if( !_disabled && !_disabled_accounts.count( first_auth ) ) {
          int64_t bill = std::max<int64_t>( 0, elapsed.count() );
@@ -131,7 +123,7 @@ public:
       }
    }
 
-   void subjective_bill_failure( const account_name& first_auth, const fc::microseconds& elapsed, const fc::time_point& now )
+   void subjective_bill_failure( const chain::account_name& first_auth, const fc::microseconds& elapsed, const fc::time_point& now )
    {
       if( !_disabled && !_disabled_accounts.count( first_auth ) ) {
          int64_t bill = std::max<int64_t>( 0, elapsed.count() );
@@ -140,7 +132,7 @@ public:
       }
    }
 
-   int64_t get_subjective_bill( const account_name& first_auth, const fc::time_point& now ) const {
+   int64_t get_subjective_bill( const chain::account_name& first_auth, const fc::time_point& now ) const {
       if( _disabled || _disabled_accounts.count( first_auth ) ) return 0;
       const auto time_ordinal = time_ordinal_for(now);
       const subjective_billing_info* sub_bill_info = nullptr;
@@ -160,7 +152,7 @@ public:
    void abort_block() {
    }
 
-   void on_block( fc::logger& log, const block_state_ptr& bsp, const fc::time_point& now ) {
+   void on_block( fc::logger& log, const chain::block_state_ptr& bsp, const fc::time_point& now ) {
       if( bsp == nullptr || _disabled ) return;
       const auto time_ordinal = time_ordinal_for(now);
       const auto orig_count = _account_subjective_bill_cache.size();

--- a/plugins/producer_plugin/test/test_subjective_billing.cpp
+++ b/plugins/producer_plugin/test/test_subjective_billing.cpp
@@ -36,9 +36,9 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
    {  // Failed transactions remain until expired in subjective billing.
       subjective_billing sub_bill;
 
-      sub_bill.subjective_bill( id1, now, a, fc::microseconds( 13 ), false );
-      sub_bill.subjective_bill( id2, now, a, fc::microseconds( 11 ), false );
-      sub_bill.subjective_bill( id3, now, b, fc::microseconds( 9 ), false );
+      sub_bill.subjective_bill( id1, now, a, fc::microseconds( 13 ) );
+      sub_bill.subjective_bill( id2, now, a, fc::microseconds( 11 ) );
+      sub_bill.subjective_bill( id3, now, b, fc::microseconds( 9 ) );
 
       BOOST_CHECK_EQUAL( 13+11, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 9, sub_bill.get_subjective_bill(b, now) );
@@ -64,9 +64,9 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
    {  // db_read_mode HEAD mode, so transactions are immediately reverted
       subjective_billing sub_bill;
 
-      sub_bill.subjective_bill( id1, now, a, fc::microseconds( 23 ), false );
-      sub_bill.subjective_bill( id2, now, a, fc::microseconds( 19 ), false );
-      sub_bill.subjective_bill( id3, now, b, fc::microseconds( 7 ), false );
+      sub_bill.subjective_bill( id1, now, a, fc::microseconds( 23 ) );
+      sub_bill.subjective_bill( id2, now, a, fc::microseconds( 19 ) );
+      sub_bill.subjective_bill( id3, now, b, fc::microseconds( 7 ) );
 
       BOOST_CHECK_EQUAL( 23+19, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 7, sub_bill.get_subjective_bill(b, now) );
@@ -82,34 +82,6 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
       sub_bill.abort_block();
 
       BOOST_CHECK_EQUAL( 19, sub_bill.get_subjective_bill(a, now) );
-      BOOST_CHECK_EQUAL( 7, sub_bill.get_subjective_bill(b, now) );
-   }
-   {  // db_read_mode SPECULATIVE mode, so transactions are in pending block until aborted
-      subjective_billing sub_bill;
-
-      sub_bill.subjective_bill( id1, now, a, fc::microseconds( 23 ), true );
-      sub_bill.subjective_bill( id2, now, a, fc::microseconds( 19 ), false ); // trx outside of block
-      sub_bill.subjective_bill( id3, now, a, fc::microseconds( 55 ), true );
-      sub_bill.subjective_bill( id4, now, b, fc::microseconds( 3 ), true );
-      sub_bill.subjective_bill( id5, now, b, fc::microseconds( 7 ), true );
-      sub_bill.subjective_bill( id6, now, a, fc::microseconds( 11 ), false ); // trx outside of block
-
-      BOOST_CHECK_EQUAL( 19+11, sub_bill.get_subjective_bill(a, now) ); // should not include what is in the pending block
-      BOOST_CHECK_EQUAL( 0, sub_bill.get_subjective_bill(b, now) );     // should not include what is in the pending block
-      BOOST_CHECK_EQUAL( 0, sub_bill.get_subjective_bill(c, now) );
-
-      sub_bill.on_block(log, {}, now);  // have not seen any of the transactions come back yet
-      sub_bill.abort_block(); // aborts the pending block, so subjective billing needs to include the reverted trxs
-
-      BOOST_CHECK_EQUAL( 23+19+55+11, sub_bill.get_subjective_bill(a, now) );
-      BOOST_CHECK_EQUAL( 3+7, sub_bill.get_subjective_bill(b, now) );
-
-      sub_bill.on_block(log, {}, now);
-      sub_bill.remove_subjective_billing( id3, 0 ); // simulate seeing id3 come back in block (this is what on_block would do)
-      sub_bill.remove_subjective_billing( id4, 0 ); // simulate seeing id4 come back in block (this is what on_block would do)
-      sub_bill.abort_block();
-
-      BOOST_CHECK_EQUAL( 23+19+11, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 7, sub_bill.get_subjective_bill(b, now) );
    }
    { // failed handling logic, decay with repeated failures should be exponential, single failures should be linear
@@ -132,9 +104,9 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
    { // expired handling logic, full billing until expiration then failed/decay logic
       subjective_billing sub_bill;
 
-      sub_bill.subjective_bill( id1, now, a, fc::microseconds( 1024 ), false );
-      sub_bill.subjective_bill( id2, now + fc::microseconds(1), a, fc::microseconds( 1024 ), false );
-      sub_bill.subjective_bill( id3, now, b, fc::microseconds( 1024 ), false );
+      sub_bill.subjective_bill( id1, now, a, fc::microseconds( 1024 ) );
+      sub_bill.subjective_bill( id2, now + fc::microseconds(1), a, fc::microseconds( 1024 ) );
+      sub_bill.subjective_bill( id3, now, b, fc::microseconds( 1024 ) );
       BOOST_CHECK_EQUAL( 1024 + 1024, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 1024, sub_bill.get_subjective_bill(b, now) );
 

--- a/plugins/producer_plugin/test/test_subjective_billing.cpp
+++ b/plugins/producer_plugin/test/test_subjective_billing.cpp
@@ -19,9 +19,6 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
    transaction_id_type id1 = sha256::hash( "1" );
    transaction_id_type id2 = sha256::hash( "2" );
    transaction_id_type id3 = sha256::hash( "3" );
-   transaction_id_type id4 = sha256::hash( "4" );
-   transaction_id_type id5 = sha256::hash( "5" );
-   transaction_id_type id6 = sha256::hash( "6" );
    account_name a = "a"_n;
    account_name b = "b"_n;
    account_name c = "c"_n;


### PR DESCRIPTION
Subjectively bill for failed transactions during block production since failed transaction time not part of objective account cpu billing.
Includes removal of dead-code in `subjective_billing` that should have been removed as part of #414.

Resolves #551 
Related #414 