### PR TITLE
[3.2] Fixes Producer Plugin Schema Fixes and Better Alignment with OpenAPI spec

### DIFF
--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -527,7 +527,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /producer/producer/get_unapplied_transactions:
+  /producer/get_unapplied_transactions:
     post:
       summary: get_unapplied_transactions
       description: Get Unapplied Transactions. No required parameters.

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -9,7 +9,7 @@ info:
   contact:
     url: https://antelope.io
 tags:
-  - name: Protocol Version 3.1
+  - name: Protocol Version 3.2
     description: The release tag for Leap binaries is also the protocol version
 servers:
   - url: "{protocol}://{host}:{port}/v1"
@@ -421,6 +421,7 @@ paths:
                 exclude_disabled:
                   type: boolean
                   description: Exclude disabled protocol features
+                  example: false
                 exclude_unactivatable:
                   type: boolean
                   description: Exclude unactivatable protocol features
@@ -519,6 +520,81 @@ paths:
                     type: array
                     items:
                       - $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
+        "400":
+          description: client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /producer/producer/get_unapplied_transactions:
+    post:
+      summary: get_unapplied_transactions
+      description: Get Unapplied Transactions. No required parameters.
+      operationId: get_unapplied_transactions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                limit:
+                  type: integer
+                  description: limit number of transactions to return
+                  example: 2
+                lower_bound:
+                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                time_limit_ms:
+                  type: integer
+                  description: defaults to 10ms
+                  example: 10
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  size:
+                    type: integer
+                    example: 12428
+                  incoming_size:
+                    type: integer
+                    example: 4475
+                  trxs:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        trx_id:
+                          $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
+                        expiration:
+                          type: string
+                          example: "2022-09-17T16:30:16"
+                        trx_type:
+                          type: string
+                          example: "aborted"
+                        first_auth:
+                          type: string
+                          example: "jkbsg.wam"
+                        first_receiver:
+                          type: string
+                          example: "m.federation"
+                        first_action:
+                          type: string
+                          example: "mine"
+                        total_actions:
+                          type: integer
+                          example: 1
+                        billed_cpu_time_us:
+                          type: integer
+                          example: 504
+                        size:
+                          type: integer
+                          example: 934
+                  more:
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
         "400":
           description: client error
           content:

--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -73,9 +73,11 @@ paths:
         "201":
           description: OK
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/OK_PAUSED'
+                description: true or false
+                type: string
+                example: false
         "400":
           description: client error
           content:
@@ -661,13 +663,6 @@ components:
           type: string
           description: status
           example: ok
-    OK_PAUSED:
-      type: object
-      properties:
-        json:
-          type: boolean
-          description: true/false indicating paused state
-          example: true
     Runtime_Options:
       type: object
       properties:


### PR DESCRIPTION
## Bug Fixes
- spelling fixes
- added subjective_cpu_leeway_us to runtime options
- added more option array returned from get_account_ram_corrections
- added return boolean to paused
- set text/plain return type for paused return code
- correct 201 return codes
- create_snapshot has return schema previous was Returns Nothing
- corrected description for get_whitelist_blacklist set_whitelist_blacklist

## Schema Alignment
- consolidates to components removed hanging component section
- moved common schemas to components section
- removed empty requestBody
- added 400 return codes as required by redocly linter
- Added version tags to clarify protocol version

**NOTE** issue https://github.com/AntelopeIO/leap/issues/547 will be closed after patching and updating openapi docs in 3.2 and main branches
Related PR https://github.com/AntelopeIO/leap/pull/569 - 3.1 release