### PR TITLE
Split ship log

### DIFF
--- a/libraries/chain/include/eosio/chain/log_catalog.hpp
+++ b/libraries/chain/include/eosio/chain/log_catalog.hpp
@@ -1,0 +1,283 @@
+#pragma once
+#include <boost/container/flat_map.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/iostreams/device/mapped_file.hpp>
+#include <fc/io/cfile.hpp>
+#include <fc/io/datastream.hpp>
+#include <regex>
+
+namespace eosio {
+namespace chain {
+
+namespace bfs = boost::filesystem;
+
+template <typename Lambda>
+void for_each_file_in_dir_matches(const bfs::path& dir, std::string pattern, Lambda&& lambda) {
+   const std::regex        my_filter(pattern);
+   std::smatch             what;
+   bfs::directory_iterator end_itr; // Default ctor yields past-the-end
+   for (bfs::directory_iterator p(dir); p != end_itr; ++p) {
+      // Skip if not a file
+      if (!bfs::is_regular_file(p->status()))
+         continue;
+      // skip if it does not match the pattern
+      if (!std::regex_match(p->path().filename().string(), what, my_filter))
+         continue;
+      lambda(p->path());
+   }
+}
+
+struct null_verifier {
+   template <typename LogData>
+   void verify(const LogData&, const bfs::path&) {}
+};
+
+template <typename LogData, typename LogIndex, typename LogVerifier = null_verifier>
+struct log_catalog {
+   using block_num_t = uint32_t;
+
+   struct mapped_type {
+      block_num_t last_block_num;
+      bfs::path   filename_base;
+   };
+   using collection_t              = boost::container::flat_map<block_num_t, mapped_type>;
+   using size_type                 = typename collection_t::size_type;
+   static constexpr size_type npos = std::numeric_limits<size_type>::max();
+
+   using mapmode = boost::iostreams::mapped_file::mapmode;
+
+   bfs::path    retained_dir;
+   bfs::path    archive_dir;
+   size_type    max_retained_files = UINT32_MAX;
+   collection_t collection;
+   size_type    active_index = npos;
+   LogData      log_data;
+   LogIndex     log_index;
+   LogVerifier  verifier;
+
+   bool empty() const { return collection.empty(); }
+
+   uint32_t first_block_num() const {
+      if (empty())
+         return 0;
+      return collection.begin()->first;
+   }
+
+   uint32_t last_block_num() const {
+      if (empty())
+         return 0;
+      return collection.rbegin()->second.last_block_num;
+   }
+
+   static bfs::path make_abosolute_dir(const bfs::path& base_dir, bfs::path new_dir) {
+      if (new_dir.is_relative())
+         new_dir = base_dir / new_dir;
+
+      if (!bfs::is_directory(new_dir))
+         bfs::create_directories(new_dir);
+
+      return new_dir;
+   }
+
+   void open(const bfs::path& log_dir, const bfs::path& retained_dir, const bfs::path& archive_dir, const char* name,
+             const char* suffix_pattern = R"(-\d+-\d+\.log)") {
+
+      this->retained_dir = make_abosolute_dir(log_dir, retained_dir.empty() ? log_dir : retained_dir);
+      if (!archive_dir.empty()) {
+         this->archive_dir = make_abosolute_dir(log_dir, archive_dir);
+      }
+
+      for_each_file_in_dir_matches(this->retained_dir, std::string(name) + suffix_pattern, [this](bfs::path path) {
+         auto log_path               = path;
+         auto index_path             = path.replace_extension("index");
+         auto path_without_extension = log_path.parent_path() / log_path.stem().string();
+
+         LogData log(log_path);
+
+         verifier.verify(log, log_path);
+
+         // check if index file matches the log file
+         if (!index_matches_data(index_path, log))
+            log.construct_index(index_path);
+
+         auto existing_itr = collection.find(log.first_block_num());
+         if (existing_itr != collection.end()) {
+            if (log.last_block_num() <= existing_itr->second.last_block_num) {
+               wlog("${log_path} contains the overlapping range with ${existing_path}.log, dropping ${log_path} "
+                    "from catalog",
+                    ("log_path", log_path.string())("existing_path", existing_itr->second.filename_base.string()));
+               return;
+            } else {
+               wlog(
+                   "${log_path} contains the overlapping range with ${existing_path}.log, droping ${existing_path}.log "
+                   "from catelog",
+                   ("log_path", log_path.string())("existing_path", existing_itr->second.filename_base.string()));
+            }
+         }
+
+         collection.insert_or_assign(log.first_block_num(), mapped_type{log.last_block_num(), path_without_extension});
+      });
+   }
+
+   bool index_matches_data(const bfs::path& index_path, const LogData& log) const {
+      if (!bfs::exists(index_path))
+         return false;
+
+      auto num_blocks_in_index = bfs::file_size(index_path) / sizeof(uint64_t);
+      if (num_blocks_in_index != log.num_blocks())
+         return false;
+
+      // make sure the last 8 bytes of index and log matches
+      fc::cfile index_file;
+      index_file.set_file_path(index_path);
+      index_file.open("r");
+      index_file.seek_end(-sizeof(uint64_t));
+      uint64_t pos;
+      index_file.read(reinterpret_cast<char*>(&pos), sizeof(pos));
+      return pos == log.last_block_position();
+   }
+
+   std::optional<uint64_t> get_block_position(uint32_t block_num, mapmode mode = mapmode::readonly) {
+      try {
+         if (active_index != npos) {
+            auto active_item = collection.nth(active_index);
+            if (active_item->first <= block_num && block_num <= active_item->second.last_block_num &&
+                log_data.flags() == mode) {
+               return log_index.nth_block_position(block_num - log_data.first_block_num());
+            }
+         }
+         if (collection.empty() || block_num < collection.begin()->first)
+            return {};
+
+         auto it = --collection.upper_bound(block_num);
+
+         if (block_num <= it->second.last_block_num) {
+            auto name = it->second.filename_base;
+            log_data.open(name.replace_extension("log"), mode);
+            log_index.open(name.replace_extension("index"));
+            this->active_index = collection.index_of(it);
+            return log_index.nth_block_position(block_num - log_data.first_block_num());
+         }
+         return {};
+      } catch (...) {
+         this->active_index = npos;
+         return {};
+      }
+   }
+
+   std::pair<fc::datastream<const char*>, uint32_t> ro_stream_for_block(uint32_t block_num) {
+      auto pos = get_block_position(block_num, mapmode::readonly);
+      if (pos) {
+         return log_data.ro_stream_at(*pos);
+      }
+      return {fc::datastream<const char*>(nullptr, 0), static_cast<uint32_t>(0)};
+   }
+
+   std::pair<fc::datastream<char*>, uint32_t> rw_stream_for_block(uint32_t block_num) {
+      auto pos = get_block_position(block_num, mapmode::readwrite);
+      if (pos) {
+         return log_data.rw_stream_at(*pos);
+      }
+      return {fc::datastream<char*>(nullptr, 0), static_cast<uint32_t>(0)};
+   }
+
+   std::optional<block_id_type> id_for_block(uint32_t block_num) {
+      auto pos = get_block_position(block_num, mapmode::readonly);
+      if (pos) {
+         return log_data.block_id_at(*pos);
+      }
+      return {};
+   }
+
+   static void rename_if_not_exists(bfs::path old_name, bfs::path new_name) {
+      if (!bfs::exists(new_name)) {
+         bfs::rename(old_name, new_name);
+      } else {
+         bfs::remove(old_name);
+         wlog("${new_name} already exists, just removing ${old_name}",
+              ("old_name", old_name.string())("new_name", new_name.string()));
+      }
+   }
+
+   static void rename_bundle(bfs::path orig_path, bfs::path new_path) {
+      rename_if_not_exists(orig_path.replace_extension(".log"), new_path.replace_extension(".log"));
+      rename_if_not_exists(orig_path.replace_extension(".index"), new_path.replace_extension(".index"));
+   }
+
+   /// Add a new entry into the catalog.
+   ///
+   /// Notice that \c start_block_num must be monotonically increasing between the invocations of this function
+   /// so that the new entry would be inserted at the end of the flat_map; otherwise, \c active_index would be
+   /// invalidated and the mapping between the log data their block range would be wrong. This function is only used
+   /// during the splitting of block log. Using this function for other purpose should make sure if the monotonically
+   /// increasing block num guarantee can be met.
+   void add(uint32_t start_block_num, uint32_t end_block_num, const bfs::path& dir, const char* name) {
+
+      const int bufsize = 64;
+      char      buf[bufsize];
+      snprintf(buf, bufsize, "%s-%d-%d", name, start_block_num, end_block_num);
+      bfs::path new_path = retained_dir / buf;
+      rename_bundle(dir / name, new_path);
+      size_type items_to_erase = 0;
+      this->collection.emplace(start_block_num, mapped_type{end_block_num, new_path});
+      if (this->collection.size() >= max_retained_files) {
+         if(max_retained_files < UINT32_MAX){
+            items_to_erase = 
+               max_retained_files > 0 ? this->collection.size() - max_retained_files : this->collection.size();
+         }
+
+         for (auto it = this->collection.begin(); it < this->collection.begin() + items_to_erase; ++it) {
+            auto orig_name = it->second.filename_base;
+            if (archive_dir.empty()) {
+               // delete the old files when no backup dir is specified
+               bfs::remove(orig_name.replace_extension("log"));
+               bfs::remove(orig_name.replace_extension("index"));
+            } else {
+               // move the the archive dir
+               rename_bundle(orig_name, archive_dir / orig_name.filename());
+            }
+         }
+         this->collection.erase(this->collection.begin(), this->collection.begin() + items_to_erase);
+         this->active_index = this->active_index == npos || this->active_index < items_to_erase
+                                  ? npos
+                                  : this->active_index - items_to_erase;
+      }
+   }
+
+   /// Truncate the catalog so that the log/index bundle containing the block with \c block_num
+   /// would be rename to \c new_name; the log/index bundles with blocks strictly higher
+   /// than \c block_num would be deleted, and all the renamed/removed entries would be erased
+   /// from the catalog.
+   ///
+   /// \return if nonzero, it's the starting block number for the log/index bundle being renamed.
+   uint32_t truncate(uint32_t block_num, bfs::path new_name) {
+      if (collection.empty())
+         return 0;
+
+      auto remove_files = [](typename collection_t::const_reference v) {
+         auto name = v.second.filename_base;
+         bfs::remove(name.replace_extension("log"));
+         bfs::remove(name.replace_extension("index"));
+      };
+
+      auto it = collection.upper_bound(block_num);
+
+      if (it == collection.begin() || block_num > (it - 1)->second.last_block_num) {
+         std::for_each(it, collection.end(), remove_files);
+         collection.erase(it, collection.end());
+         return 0;
+      } else {
+         auto truncate_it = --it;
+         auto name        = truncate_it->second.filename_base;
+         bfs::rename(name.replace_extension("log"), new_name.replace_extension("log"));
+         bfs::rename(name.replace_extension("index"), new_name.replace_extension("index"));
+         std::for_each(truncate_it + 1, collection.end(), remove_files);
+         auto result = truncate_it->first;
+         collection.erase(truncate_it, collection.end());
+         return result;
+      }
+   }
+};
+
+} // namespace chain
+} // namespace eosio

--- a/libraries/chain/include/eosio/chain/log_catalog.hpp
+++ b/libraries/chain/include/eosio/chain/log_catalog.hpp
@@ -173,11 +173,11 @@ struct log_catalog {
       return {fc::datastream<const char*>(nullptr, 0), static_cast<uint32_t>(0)};
    }
 
-   template <typename Result>
-   auto ro_stream_for_block(uint32_t block_num, Result& result) -> std::optional<decltype( std::declval<LogData>().ro_stream_at(0, result))> {
+   template <typename ...Rest>
+   auto ro_stream_for_block(uint32_t block_num, Rest&& ...rest) -> std::optional<decltype( std::declval<LogData>().ro_stream_at(0, std::forward<Rest&&>(rest)...))> {
       auto pos = get_block_position(block_num, mapmode::readonly);
       if (pos) {
-         return log_data.ro_stream_at(*pos, result);
+         return log_data.ro_stream_at(*pos, std::forward<Rest&&>(rest)...);
       }
       return {};
    }

--- a/libraries/chain/include/eosio/chain/log_catalog.hpp
+++ b/libraries/chain/include/eosio/chain/log_catalog.hpp
@@ -173,6 +173,15 @@ struct log_catalog {
       return {fc::datastream<const char*>(nullptr, 0), static_cast<uint32_t>(0)};
    }
 
+   template <typename Result>
+   auto ro_stream_for_block(uint32_t block_num, Result& result) -> std::optional<decltype( std::declval<LogData>().ro_stream_at(0, result))> {
+      auto pos = get_block_position(block_num, mapmode::readonly);
+      if (pos) {
+         return log_data.ro_stream_at(*pos, result);
+      }
+      return {};
+   }
+
    std::pair<fc::datastream<char*>, uint32_t> rw_stream_for_block(uint32_t block_num) {
       auto pos = get_block_position(block_num, mapmode::readwrite);
       if (pos) {
@@ -222,7 +231,7 @@ struct log_catalog {
       this->collection.emplace(start_block_num, mapped_type{end_block_num, new_path});
       if (this->collection.size() >= max_retained_files) {
          if(max_retained_files < UINT32_MAX){
-            items_to_erase = 
+            items_to_erase =
                max_retained_files > 0 ? this->collection.size() - max_retained_files : this->collection.size();
          }
 

--- a/libraries/chain/include/eosio/chain/log_data_base.hpp
+++ b/libraries/chain/include/eosio/chain/log_data_base.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#include <boost/iostreams/device/mapped_file.hpp>
+
+namespace eosio {
+namespace chain {
+
+template <typename T>
+T read_buffer(const char* buf) {
+   T result;
+   memcpy(&result, buf, sizeof(T));
+   return result;
+}
+
+template <typename Derived>
+class log_data_base {
+ protected:
+   boost::iostreams::mapped_file file;
+
+   const Derived* self() const { return static_cast<const Derived*>(this); }
+
+ public:
+   using mapmode = boost::iostreams::mapped_file::mapmode;
+
+   log_data_base() = default;
+
+   void    close() { file.close(); }
+   bool    is_open() const { return file.is_open(); }
+   mapmode flags() const { return file.flags(); }
+
+   const char* data() const { return file.const_data(); }
+   uint64_t    size() const { return file.size(); }
+   uint32_t    last_block_num() const { return self()->block_num_at(last_block_position()); }
+   uint64_t    last_block_position() const {
+      uint32_t offset = sizeof(uint64_t);
+      if (self()->is_currently_pruned())
+         offset += sizeof(uint32_t);
+      return read_buffer<uint64_t>(data() + size() - offset);
+   }
+
+   uint32_t num_blocks() const {
+      if (self()->first_block_position() == file.size())
+         return 0;
+      else if (self()->is_currently_pruned())
+         return read_buffer<uint32_t>(data() + size() - sizeof(uint32_t));
+      return last_block_num() - self()->first_block_num() + 1;
+   }
+};
+} // namespace chain
+} // namespace eosio

--- a/libraries/chain/include/eosio/chain/log_index.hpp
+++ b/libraries/chain/include/eosio/chain/log_index.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <boost/filesystem/path.hpp>
+#include <boost/iostreams/device/mapped_file.hpp>
+
+namespace eosio {
+namespace chain {
+
+template <typename Exception>
+class log_index {
+   boost::iostreams::mapped_file_source file;
+
+ public:
+   log_index() = default;
+   log_index(const boost::filesystem::path& path) { open(path); }
+
+   void open(const boost::filesystem::path& path) {
+      if (file.is_open())
+         file.close();
+      file.open(path.generic_string());
+      EOS_ASSERT(file.size() % sizeof(uint64_t) == 0, Exception,
+                 "The size of ${file} is not a multiple of sizeof(uint64_t)", ("file", path.generic_string()));
+   }
+
+   bool is_open() const { return file.is_open(); }
+
+   using iterator = const uint64_t*;
+   iterator begin() const { return reinterpret_cast<iterator>(file.data()); }
+   iterator end() const { return reinterpret_cast<iterator>(file.data() + file.size()); }
+
+   /// @pre file.size() > 0
+   uint64_t back() const { return *(this->end() - 1); }
+   int      num_blocks() const { return file.size() / sizeof(uint64_t); }
+   uint64_t nth_block_position(uint32_t n) const { return *(begin() + n); }
+
+   const char* data() const { return file.data(); }
+};
+
+} // namespace chain
+} // namespace eosio

--- a/libraries/state_history/compression.cpp
+++ b/libraries/state_history/compression.cpp
@@ -18,15 +18,17 @@ bytes zlib_compress_bytes(const bytes& in) {
    return out;
 }
 
-bytes zlib_decompress(const bytes& in) {
+bytes zlib_decompress(const char* data, uint64_t data_size) {
    bytes                  out;
    bio::filtering_ostream decomp;
    decomp.push(bio::zlib_decompressor());
    decomp.push(bio::back_inserter(out));
-   bio::write(decomp, in.data(), in.size());
+   bio::write(decomp, data, data_size);
    bio::close(decomp);
    return out;
 }
+
+
 
 } // namespace state_history
 } // namespace eosio

--- a/libraries/state_history/include/eosio/state_history/compression.hpp
+++ b/libraries/state_history/include/eosio/state_history/compression.hpp
@@ -8,7 +8,7 @@ namespace state_history {
 using chain::bytes;
 
 bytes zlib_compress_bytes(const bytes& in);
-bytes zlib_decompress(const bytes& in);
+bytes zlib_decompress(const char* data, uint64_t data_size);
 
 } // namespace state_history
 } // namespace eosio

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -488,6 +488,9 @@ namespace eosio { namespace testing {
          }
       }
 
+      tester(const std::function<void(controller&)>& control_setup, setup_policy policy = setup_policy::full,
+             db_read_mode read_mode = db_read_mode::HEAD);
+
       using base_tester::produce_block;
 
       signed_block_ptr produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms) )override {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1199,6 +1199,20 @@ namespace eosio { namespace testing {
       preactivate_protocol_features( preactivations );
    }
 
+   tester::tester(const std::function<void(controller&)>& control_setup, setup_policy policy, db_read_mode read_mode) {
+      auto def_conf            = default_config(tempdir);
+      def_conf.first.read_mode = read_mode;
+      cfg                      = def_conf.first;
+
+      base_tester::open(make_protocol_feature_set(), def_conf.second.compute_chain_id(),
+                        [&genesis = def_conf.second, &control = this->control, &control_setup]() {
+                           control_setup(*control);
+                           control->startup([]() {}, []() { return false; }, genesis);
+                        });
+
+      execute_setup_policy(policy);
+   }
+
    bool fc_exception_message_is::operator()( const fc::exception& ex ) {
       auto message = ex.get_log().at( 0 ).get_message();
       bool match = (message == expected);

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -194,8 +194,11 @@ struct session : session_base, std::enable_shared_from_this<session<Plugin, Sock
    void send() {
       if (sending)
          return;
-      if (send_queue.empty())
-         return send_update();
+      if (send_queue.empty()) {
+         plugin->post_task(
+             [self = this->shared_from_this()]() { self->send_update(); });
+         return;
+      }
       sending = true;
       socket_stream.binary(sent_abi);
       sent_abi = true;

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -43,7 +43,7 @@ template <typename Session>
 class blocks_result_send_queue_entry : public send_queue_entry_base<Session> {
    eosio::state_history::get_blocks_result_v0                      r;
    std::vector<char>                                               data;
-   eosio::log_entry_type                                buf;
+   std::variant<std::vector<char>, locked_decompress_stream> buf;
 
    template <typename Next>
    void async_send(Session* s, bool fin, const std::vector<char>& d, Next&& next) {
@@ -55,7 +55,7 @@ class blocks_result_send_queue_entry : public send_queue_entry_base<Session> {
    }
 
    template <typename Next>
-   void async_send(Session* s, bool fin, maybe_locked_decompress_stream& locked_strm, Next&& next) {
+   void async_send(Session* s, bool fin, locked_decompress_stream& locked_strm, Next&& next) {
       data.resize(s->default_frame_size);
       auto size = bio::read(locked_strm.buf, data.data(), s->default_frame_size);
       data.resize(size);
@@ -74,15 +74,6 @@ class blocks_result_send_queue_entry : public send_queue_entry_base<Session> {
                    async_send(s.get(), fin, locked_strm, std::move(next));
                 }
              });
-          });
-   }
-
-   template <typename Next>
-   void async_send(Session* s, bool fin, const std::shared_ptr<std::vector<char>>& d, Next&& next) {
-      s->socket_stream.async_write_some(
-          fin, boost::asio::buffer(*d),
-          [s = s->shared_from_this(), next = std::forward<Next>(next)](boost::system::error_code ec, size_t) mutable {
-             s->callback(ec, "async_write", [s, next = std::move(next)]() mutable { next(s.get()); });
           });
    }
 
@@ -244,13 +235,15 @@ struct session : session_base, std::enable_shared_from_this<session<Plugin, Sock
       send();
    }
 
-   uint64_t get_trace_log_entry(const eosio::state_history::get_blocks_result_v0& result, eosio::log_entry_type& buf) {
+   uint64_t get_trace_log_entry(const eosio::state_history::get_blocks_result_v0&              result,
+                                std::variant<std::vector<char>, locked_decompress_stream>& buf) {
       if (result.traces.has_value())
          return plugin->get_trace_log()->get_unpacked_entry(result.this_block->block_num, buf);
       return 0;
    }
 
-   uint64_t get_delta_log_entry(const eosio::state_history::get_blocks_result_v0& result, eosio::log_entry_type& buf) {
+   uint64_t get_delta_log_entry(const eosio::state_history::get_blocks_result_v0&              result,
+                                std::variant<std::vector<char>, locked_decompress_stream>& buf) {
       if (result.deltas.has_value())
          return plugin->get_chain_state_log()->get_unpacked_entry(result.this_block->block_num, buf);
       return 0;

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -18,6 +18,7 @@ using unixs   = boost::asio::local::stream_protocol;
 namespace ws  = boost::beast::websocket;
 namespace bio = boost::iostreams;
 
+
 template <typename Session>
 struct send_queue_entry_base {
    virtual ~send_queue_entry_base() {}

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -301,7 +301,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
       state_history_log_header header{.magic        = ship_magic(ship_current_version, 0),
                                       .block_id     = block_state->id,
                                       .payload_size = 0};
-      trace_log->pack_and_async_write_entry(header, block_state->block->previous, [this, &block_state](auto&& buf) {
+      trace_log->pack_and_write_entry(header, block_state->block->previous, [this, &block_state](auto&& buf) {
          trace_converter.pack(buf, chain_plug->chain().db(), trace_debug_mode, block_state);
       });
    }
@@ -315,15 +315,9 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
 
       state_history_log_header header{
           .magic = ship_magic(ship_current_version, 0), .block_id = block_state->id, .payload_size = 0};
-      if (fresh) {
-         chain_state_log->pack_and_write_entry(header, block_state->header.previous, [this](auto&& buf) {
-            pack_deltas(buf, chain_plug->chain().db(), true);
-         });
-      } else {
-         chain_state_log->pack_and_async_write_entry(header, block_state->header.previous, [this](auto&& buf) {
-            pack_deltas(buf, chain_plug->chain().db(), false);
-         });
-      }
+      chain_state_log->pack_and_write_entry(header, block_state->header.previous, [this, fresh](auto&& buf) {
+         pack_deltas(buf, chain_plug->chain().db(), fresh);
+      });
    } // store_chain_state
 };   // state_history_plugin_impl
 

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -331,11 +331,10 @@ void state_history_plugin::set_program_options(options_description& cli, options
    options("state-history-dir", bpo::value<bfs::path>()->default_value("state-history"),
            "the location of the state-history directory (absolute path or relative to application data dir)");
    options("state-history-retained-dir", bpo::value<bfs::path>(),
-           "the location of the state history retained directory (absolute path or relative to state-history dir).\n"
-           "If the value is empty, it is set to the value of state-history directory.");
+           "the location of the state history retained directory (absolute path or relative to state-history dir).");
    options("state-history-archive-dir", bpo::value<bfs::path>(),
            "the location of the state history archive directory (absolute path or relative to state-history dir).\n"
-           "If the value is empty, blocks files beyond the retained limit will be deleted.\n"
+           "If the value is empty string, blocks files beyond the retained limit will be deleted.\n"
            "All files in the archive directory are completely under user's control, i.e. they won't be accessed by nodeos anymore.");
    options("state-history-stride", bpo::value<uint32_t>(),
          "split the state history log files when the block number is the multiple of the stride\n"

--- a/plugins/state_history_plugin/tests/session_test.cpp
+++ b/plugins/state_history_plugin/tests/session_test.cpp
@@ -364,16 +364,53 @@ void store_read_test_case(uint64_t data_size, eosio::state_history_log_config co
    BOOST_REQUIRE_EQUAL(log.get_log_file().tellp(), pos);
 
 
-   std::variant<std::vector<char>, eosio::maybe_locked_decompress_stream> buf;
+   auto same_data = [](const std::vector<int32_t>& lhs, std::vector<char>& rhs) -> bool {
+      return (lhs.size() * sizeof(int32_t) == rhs.size()) && std::equal(rhs.begin(), rhs.end(), (const char*)lhs.data());
+   };
+
+
+   eosio::log_entry_type buf;
    log.get_unpacked_entry(1, buf);
 
-   std::vector<char> decompressed;
-   auto& locked_strm = std::get<eosio::maybe_locked_decompress_stream>(buf);
-   BOOST_CHECK(locked_strm.lock.has_value() == std::holds_alternative<eosio::state_history::prune_config>(config));
-   bio::copy(locked_strm.buf, bio::back_inserter(decompressed));
+   {
+      std::vector<char> decompressed;
+      auto locked_strm_ptr = std::get_if<eosio::maybe_locked_decompress_stream>(&buf);
+      BOOST_REQUIRE(locked_strm_ptr);
+      BOOST_CHECK(locked_strm_ptr->lock.has_value() == std::holds_alternative<eosio::state_history::prune_config>(config));
+      bio::copy(locked_strm_ptr->buf, bio::back_inserter(decompressed));
+      BOOST_CHECK(same_data(data, decompressed));
+   }
 
-   BOOST_CHECK_EQUAL(data.size() * sizeof(data[0]), decompressed.size());
-   BOOST_CHECK(std::equal(decompressed.begin(), decompressed.end(), (const char*)data.data()));
+   data = generate_data(data_size);
+
+   header.block_id     = block_id_for(2);
+   log.pack_and_async_write_entry(header, block_id_for(1),
+      [&](auto&& buf) { bio::write(buf, (const char*)data.data(), data.size() * sizeof(data[0])); });
+
+   // in this case, we should get the cached value
+   {
+      log.get_unpacked_entry(2, buf);
+      auto decompressed = std::get_if<std::shared_ptr<eosio::chain::bytes>>(&buf);
+      BOOST_REQUIRE(decompressed);
+      BOOST_CHECK( same_data(data, *decompressed->get()));
+   }
+
+   {
+      // let's wait until the index has been writeen
+      while (boost::filesystem::file_size( log_dir.path()/"ship.index" ) < 2*sizeof(uint64_t)) {
+         using namespace std::chrono_literals;
+         std::this_thread::sleep_for(200ms);
+      };
+
+      log.clear_cache(); // clear the cache so we can read the entry directly from disk
+      log.get_unpacked_entry(2, buf);
+      auto locked_strm_ptr = std::get_if<eosio::maybe_locked_decompress_stream>(&buf);
+      BOOST_REQUIRE(locked_strm_ptr);
+      std::vector<char> decompressed;
+      bio::copy(locked_strm_ptr->buf, bio::back_inserter(decompressed));
+      BOOST_CHECK(same_data(data, decompressed));
+   }
+
 }
 
 BOOST_AUTO_TEST_CASE(store_read_entry_no_prune) {

--- a/tests/ship_log.cpp
+++ b/tests/ship_log.cpp
@@ -50,10 +50,11 @@ struct ship_log_fixture {
       BOOST_REQUIRE_EQUAL(log->end_block()-1, last);
       if(enable_read) {
          for(auto i = first; i <= last; i++) {
-            std::variant<std::vector<char>, eosio::maybe_locked_decompress_stream> result;
+            eosio::log_entry_type result;
             log->get_unpacked_entry(i, result);
             std::visit(eosio::chain::overloaded{
                [&](std::vector<char>& buff) { BOOST_REQUIRE(buff == written_data.at(i)); },
+               [&](std::shared_ptr<std::vector<char>>& buff) { BOOST_REQUIRE(*buff == written_data.at(i)); },
                [&](eosio::maybe_locked_decompress_stream& strm) {
                   std::vector<char> buff;
                   boost::iostreams::copy(strm.buf, boost::iostreams::back_inserter(buff));
@@ -64,7 +65,7 @@ struct ship_log_fixture {
    }
 
    void check_not_present(uint32_t index) {
-      std::variant<std::vector<char>, eosio::maybe_locked_decompress_stream> result;
+      eosio::log_entry_type result;
       BOOST_REQUIRE_EQUAL(log->get_unpacked_entry(index, result), 0);
    }
 

--- a/tests/ship_log.cpp
+++ b/tests/ship_log.cpp
@@ -50,12 +50,11 @@ struct ship_log_fixture {
       BOOST_REQUIRE_EQUAL(log->end_block()-1, last);
       if(enable_read) {
          for(auto i = first; i <= last; i++) {
-            eosio::log_entry_type result;
+            std::variant<std::vector<char>, eosio::locked_decompress_stream> result;
             log->get_unpacked_entry(i, result);
             std::visit(eosio::chain::overloaded{
                [&](std::vector<char>& buff) { BOOST_REQUIRE(buff == written_data.at(i)); },
-               [&](std::shared_ptr<std::vector<char>>& buff) { BOOST_REQUIRE(*buff == written_data.at(i)); },
-               [&](eosio::maybe_locked_decompress_stream& strm) {
+               [&](eosio::locked_decompress_stream& strm) {
                   std::vector<char> buff;
                   boost::iostreams::copy(strm.buf, boost::iostreams::back_inserter(buff));
                   BOOST_REQUIRE(buff == written_data.at(i));
@@ -65,7 +64,7 @@ struct ship_log_fixture {
    }
 
    void check_not_present(uint32_t index) {
-      eosio::log_entry_type result;
+      std::variant<std::vector<char>, eosio::locked_decompress_stream> result;
       BOOST_REQUIRE_EQUAL(log->get_unpacked_entry(index, result), 0);
    }
 

--- a/tests/ship_log.cpp
+++ b/tests/ship_log.cpp
@@ -7,14 +7,18 @@
 #include <fc/bitutil.hpp>
 
 #include <eosio/state_history/log.hpp>
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/device/back_inserter.hpp>
+
 
 namespace bdata = boost::unit_test::data;
 
 struct ship_log_fixture {
    ship_log_fixture(bool enable_read, bool reopen_on_mark, bool remove_index_on_reopen, bool vacuum_on_exit_if_small, std::optional<uint32_t> prune_blocks) :
      enable_read(enable_read), reopen_on_mark(reopen_on_mark),
-     remove_index_on_reopen(remove_index_on_reopen), vacuum_on_exit_if_small(vacuum_on_exit_if_small),
-     prune_blocks(prune_blocks) {
+     remove_index_on_reopen(remove_index_on_reopen), vacuum_on_exit_if_small(vacuum_on_exit_if_small){
+      if (prune_blocks)
+         conf = eosio::state_history::prune_config{ .prune_blocks = *prune_blocks };
       bounce();
    }
 
@@ -30,10 +34,10 @@ struct ship_log_fixture {
 
       eosio::state_history_log_header header;
       header.block_id = block_for_id(index);
-      header.payload_size = a.size();
+      header.payload_size = 0;
 
-      log->write_entry(header, block_for_id(index-1), [&](auto& f) {
-         f.write(a.data(), a.size());
+      log->pack_and_write_entry(header, block_for_id(index-1), [&](auto& f) {
+         boost::iostreams::write(f, a.data(), a.size());
       });
 
       if(index + 1 > written_data.size())
@@ -46,21 +50,22 @@ struct ship_log_fixture {
       BOOST_REQUIRE_EQUAL(log->end_block()-1, last);
       if(enable_read) {
          for(auto i = first; i <= last; i++) {
-            std::vector<char> buff;
-            buff.resize(written_data.at(i).size());
-            eosio::state_history_log_header header;
-            fc::cfile& cf = log->get_entry(i, header);
-            cf.read(buff.data(), written_data.at(i).size());
-            BOOST_REQUIRE(buff == written_data.at(i));
+            std::variant<std::vector<char>, eosio::maybe_locked_decompress_stream> result;
+            log->get_unpacked_entry(i, result);
+            std::visit(eosio::chain::overloaded{
+               [&](std::vector<char>& buff) { BOOST_REQUIRE(buff == written_data.at(i)); },
+               [&](eosio::maybe_locked_decompress_stream& strm) {
+                  std::vector<char> buff;
+                  boost::iostreams::copy(strm.buf, boost::iostreams::back_inserter(buff));
+                  BOOST_REQUIRE(buff == written_data.at(i));
+               }} , result);
          }
       }
    }
 
    void check_not_present(uint32_t index) {
-      eosio::state_history_log_header header;
-      BOOST_REQUIRE_EXCEPTION(log->get_entry(index, header), eosio::chain::plugin_exception, [](const eosio::chain::plugin_exception& e) {
-          return e.to_detail_string().find("read non-existing block in") != std::string::npos;
-      });
+      std::variant<std::vector<char>, eosio::maybe_locked_decompress_stream> result;
+      BOOST_REQUIRE_EQUAL(log->get_unpacked_entry(index, result), 0);
    }
 
    void check_empty() {
@@ -78,9 +83,8 @@ struct ship_log_fixture {
    }
 
    bool enable_read, reopen_on_mark, remove_index_on_reopen, vacuum_on_exit_if_small;
-   std::optional<uint32_t> prune_blocks;
-   fc::temp_file log_file;
-   fc::temp_file index_file;
+   eosio::state_history_log_config conf;
+   fc::temp_directory log_dir;
 
    std::optional<eosio::state_history_log> log;
 
@@ -90,16 +94,14 @@ private:
    void bounce() {
       log.reset();
       if(remove_index_on_reopen)
-         fc::remove(index_file.path());
-      std::optional<eosio::state_history_log_prune_config> prune_conf;
-      if(prune_blocks) {
-         prune_conf.emplace();
-         prune_conf->prune_blocks = *prune_blocks;
+         fc::remove(log_dir.path()/ (std::string("shipit") + ".index"));
+      auto prune_conf = std::get_if<eosio::state_history::prune_config>(&conf);
+      if(prune_conf) {
          prune_conf->prune_threshold = 8; //every 8 bytes check in and see if to prune. should make it always check after each entry for us
          if(vacuum_on_exit_if_small)
             prune_conf->vacuum_on_close = 1024*1024*1024; //something large: always vacuum on close for these tests
       }
-      log.emplace("shipit", log_file.path().string(), index_file.path().string(), prune_conf);
+      log.emplace("shipit", log_dir.path(), conf);
    }
 };
 
@@ -259,50 +261,52 @@ BOOST_DATA_TEST_CASE(basic_test, bdata::xrange(2) * bdata::xrange(2) * bdata::xr
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(empty) { try {
-   fc::temp_file log_file;
-   fc::temp_file index_file;
+   fc::temp_directory log_dir;
 
    {
-      eosio::state_history_log log("empty", log_file.path().string(), index_file.path().string());
+      eosio::state_history_log log("empty", log_dir.path());
       BOOST_REQUIRE_EQUAL(log.begin_block(), log.end_block());
    }
    //reopen
    {
-      eosio::state_history_log log("empty", log_file.path().string(), index_file.path().string());
+      eosio::state_history_log log("empty", log_dir.path());
       BOOST_REQUIRE_EQUAL(log.begin_block(), log.end_block());
    }
    //reopen but prunned set
-   const eosio::state_history_log_prune_config simple_prune_conf = {
+   const eosio::state_history::prune_config simple_prune_conf = {
       .prune_blocks = 4
    };
    {
-      eosio::state_history_log log("empty", log_file.path().string(), index_file.path().string(), simple_prune_conf);
+      eosio::state_history_log log("empty", log_dir.path(), simple_prune_conf);
       BOOST_REQUIRE_EQUAL(log.begin_block(), log.end_block());
    }
    {
-      eosio::state_history_log log("empty", log_file.path().string(), index_file.path().string(), simple_prune_conf);
+      eosio::state_history_log log("empty", log_dir.path(), simple_prune_conf);
       BOOST_REQUIRE_EQUAL(log.begin_block(), log.end_block());
    }
    //back to non pruned
    {
-      eosio::state_history_log log("empty", log_file.path().string(), index_file.path().string());
+      eosio::state_history_log log("empty", log_dir.path());
       BOOST_REQUIRE_EQUAL(log.begin_block(), log.end_block());
    }
    {
-      eosio::state_history_log log("empty", log_file.path().string(), index_file.path().string());
+      eosio::state_history_log log("empty", log_dir.path());
       BOOST_REQUIRE_EQUAL(log.begin_block(), log.end_block());
    }
 
-   BOOST_REQUIRE(fc::file_size(log_file.path()) == 0);
-   BOOST_REQUIRE(fc::file_size(index_file.path()) == 0);
+   auto log_file = (log_dir.path()/ (std::string("empty") + ".log")).string();
+   auto index_file = (log_dir.path()/ (std::string("empty") + ".index")).string();
+
+   BOOST_REQUIRE(fc::file_size(log_file.c_str()) == 0);
+   BOOST_REQUIRE(fc::file_size(index_file.c_str()) == 0);
 
    //one more time to pruned, just to make sure
    {
-      eosio::state_history_log log("empty", log_file.path().string(), index_file.path().string(), simple_prune_conf);
+      eosio::state_history_log log("empty", log_dir.path(), simple_prune_conf);
       BOOST_REQUIRE_EQUAL(log.begin_block(), log.end_block());
    }
-   BOOST_REQUIRE(fc::file_size(log_file.path()) == 0);
-   BOOST_REQUIRE(fc::file_size(index_file.path()) == 0);
+   BOOST_REQUIRE(fc::file_size(log_file.c_str()) == 0);
+   BOOST_REQUIRE(fc::file_size(index_file.c_str()) == 0);
 }  FC_LOG_AND_RETHROW() }
 
 BOOST_DATA_TEST_CASE(non_prune_to_prune, bdata::xrange(2) * bdata::xrange(2), enable_read, remove_index_on_reopen)  { try {
@@ -324,7 +328,7 @@ BOOST_DATA_TEST_CASE(non_prune_to_prune, bdata::xrange(2) * bdata::xrange(2), en
    });
 
    //upgrade to pruned...
-   t.prune_blocks = 4;
+   t.conf = eosio::state_history::prune_config{ .prune_blocks = 4 };
    t.template check_n_bounce([]() {});
 
    t.check_n_bounce([&]() {
@@ -359,7 +363,7 @@ BOOST_DATA_TEST_CASE(prune_to_non_prune, bdata::xrange(2) * bdata::xrange(2), en
    });
 
    //no more pruned
-   t.prune_blocks.reset();
+   t.conf = std::monostate{};
    t.template check_n_bounce([]() {});
 
    t.check_n_bounce([&]() {
@@ -376,5 +380,46 @@ BOOST_DATA_TEST_CASE(prune_to_non_prune, bdata::xrange(2) * bdata::xrange(2), en
    });
 
 } FC_LOG_AND_RETHROW() }
+
+BOOST_DATA_TEST_CASE(prune_to_partitioned, bdata::xrange(2) * bdata::xrange(2), enable_read, remove_index_on_reopen)  { try {
+   ship_log_fixture t(enable_read, true, remove_index_on_reopen, false, 4);
+
+   t.check_empty();
+   size_t payload_size = larger_than_tmpfile_blocksize();
+
+   t.add(2, payload_size, 'A');
+   t.add(3, payload_size, 'B');
+   t.add(4, payload_size, 'C');
+   t.add(5, payload_size, 'D');
+   t.add(6, payload_size, 'E');
+   t.add(7, payload_size, 'F');
+   t.add(8, payload_size, 'G');
+   t.add(9, payload_size, 'H');
+   t.check_n_bounce([&]() {
+      t.check_range_present(6, 9);
+   });
+
+   //no more pruned
+   t.conf = eosio::state_history::partition_config{
+       .stride  = 5
+   };
+
+   t.template check_n_bounce([]() {});
+
+   t.check_n_bounce([&]() {
+      t.check_range_present(6, 9);
+   });
+   t.add(10, payload_size, 'I');
+   t.add(11, payload_size, 'J');
+   t.add(12, payload_size, 'K');
+   t.add(13, payload_size, 'L');
+   t.add(14, payload_size, 'M');
+   t.add(15, payload_size, 'N');
+   t.check_n_bounce([&]() {
+      t.check_range_present(6, 15);
+   });
+
+} FC_LOG_AND_RETHROW() }
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/ship_streamer.cpp
+++ b/tests/ship_streamer.cpp
@@ -116,10 +116,6 @@ int main(int argc, char* argv[]) {
          boost::beast::flat_buffer buffer;
          stream.read(buffer);
 
-         FILE* f = fopen("last_result.bin", "wb");
-         fwrite((const char*)buffer.data().data(), buffer.data().size(), 1, f);
-         fclose(f);
-
          eosio::input_stream is((const char*)buffer.data().data(), buffer.data().size());
          rapidjson::Document result_doucment;
          result_doucment.Parse(result_type.bin_to_json(is).c_str());

--- a/tests/ship_streamer.cpp
+++ b/tests/ship_streamer.cpp
@@ -109,11 +109,16 @@ int main(int argc, char* argv[]) {
 
       stream.binary(true);
       stream.write(boost::asio::buffer(request_type.json_to_bin(request_sb.GetString(), [](){})));
+      stream.read_message_max(0);
 
       bool is_first = true;
       for(;;) {
          boost::beast::flat_buffer buffer;
          stream.read(buffer);
+
+         FILE* f = fopen("last_result.bin", "wb");
+         fwrite((const char*)buffer.data().data(), buffer.data().size(), 1, f);
+         fclose(f);
 
          eosio::input_stream is((const char*)buffer.data().data(), buffer.data().size());
          rapidjson::Document result_doucment;

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -641,11 +641,14 @@ struct state_history_tester : state_history_tester_logs, tester {
 };
 
 static std::vector<char> get_decompressed_entry(eosio::state_history_log& log, block_num_type block_num) {
-   std::variant<std::vector<char>, eosio::maybe_locked_decompress_stream> buf;
+   eosio::log_entry_type buf;
    log.get_unpacked_entry(block_num, buf);
    namespace bio = boost::iostreams;
    return std::visit(eosio::chain::overloaded{ [](std::vector<char>& bytes) {
                                                  return bytes;
+                                              },
+                                              [](std::shared_ptr<std::vector<char>>& bytes) {
+                                                 return *bytes;
                                               },
                                                [](eosio::maybe_locked_decompress_stream& strm) {
                                                   std::vector<char> bytes;

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -641,16 +641,13 @@ struct state_history_tester : state_history_tester_logs, tester {
 };
 
 static std::vector<char> get_decompressed_entry(eosio::state_history_log& log, block_num_type block_num) {
-   eosio::log_entry_type buf;
+   std::variant<std::vector<char>, eosio::locked_decompress_stream> buf;
    log.get_unpacked_entry(block_num, buf);
    namespace bio = boost::iostreams;
    return std::visit(eosio::chain::overloaded{ [](std::vector<char>& bytes) {
                                                  return bytes;
                                               },
-                                              [](std::shared_ptr<std::vector<char>>& bytes) {
-                                                 return *bytes;
-                                              },
-                                               [](eosio::maybe_locked_decompress_stream& strm) {
+                                               [](eosio::locked_decompress_stream& strm) {
                                                   std::vector<char> bytes;
                                                   bio::copy(strm.buf, bio::back_inserter(bytes));
                                                   return bytes;

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -15,6 +15,7 @@
 #include <eosio/stream.hpp>
 #include <eosio/ship_protocol.hpp>
 #include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/copy.hpp>
 
 using namespace eosio::chain;
 using namespace eosio::testing;
@@ -599,5 +600,246 @@ BOOST_AUTO_TEST_CASE(test_deltas_resources_history) {
       BOOST_CHECK(std::any_of(partial_txns.begin(), partial_txns.end(), contains_transaction_extensions));
    }
 
+
+struct state_history_tester_logs  {
+   state_history_tester_logs(const fc::path& dir, const eosio::state_history_log_config& config)
+      : traces_log("trace_history",dir, config) , chain_state_log("chain_state_history", dir, config) {}
+
+   eosio::state_history_log traces_log;
+   eosio::state_history_log chain_state_log;
+   eosio::state_history::trace_converter trace_converter;
+};
+
+struct state_history_tester : state_history_tester_logs, tester {
+
+
+   state_history_tester(const fc::path& dir, const eosio::state_history_log_config& config)
+   : state_history_tester_logs(dir, config), tester ([this](eosio::chain::controller& control) {
+      control.applied_transaction.connect(
+       [&](std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> t) {
+          trace_converter.add_transaction(std::get<0>(t), std::get<1>(t));
+       });
+
+      control.accepted_block.connect([&](const block_state_ptr& block_state) {
+         eosio::state_history_log_header header{.magic        = eosio::ship_magic(eosio::ship_current_version, 0),
+                                      .block_id     = block_state->id,
+                                      .payload_size = 0};
+
+         traces_log.pack_and_write_entry(header, block_state->block->previous, [this, &control, &block_state](auto&& buf) {
+            trace_converter.pack(buf, control.db(), false, block_state);
+         });
+
+         chain_state_log.pack_and_write_entry(header, block_state->header.previous, [&control](auto&& buf) {
+            eosio::state_history::pack_deltas(buf, control.db(), true);
+         });
+      });
+      control.block_start.connect([this](uint32_t block_num) {
+         trace_converter.cached_traces.clear();
+         trace_converter.onblock_trace.reset();
+      });
+   }) {}
+};
+
+static std::vector<char> get_decompressed_entry(eosio::state_history_log& log, block_num_type block_num) {
+   std::variant<std::vector<char>, eosio::maybe_locked_decompress_stream> buf;
+   log.get_unpacked_entry(block_num, buf);
+   namespace bio = boost::iostreams;
+   return std::visit(eosio::chain::overloaded{ [](std::vector<char>& bytes) {
+                                                 return bytes;
+                                              },
+                                               [](eosio::maybe_locked_decompress_stream& strm) {
+                                                  std::vector<char> bytes;
+                                                  bio::copy(strm.buf, bio::back_inserter(bytes));
+                                                  return bytes;
+                                               } },
+                     buf);
+}
+
+static std::vector<eosio::ship_protocol::transaction_trace> get_traces(eosio::state_history_log& log,
+                                                                       block_num_type            block_num) {
+   auto                                                          entry = get_decompressed_entry(log, block_num);
+   std::vector<eosio::ship_protocol::transaction_trace>          traces;
+
+   if (entry.size()) {
+      eosio::input_stream traces_bin{ entry.data(), entry.data() + entry.size() };
+      BOOST_REQUIRE_NO_THROW(from_bin(traces, traces_bin));
+   }
+   return traces;
+}
+
+BOOST_AUTO_TEST_CASE(test_splitted_log) {
+   namespace bfs = boost::filesystem;
+
+   fc::temp_directory state_history_dir;
+
+   eosio::state_history::partition_config config{
+      .retained_dir = "retained",
+      .archive_dir = "archive",
+      .stride  = 20,
+      .max_retained_files = 5
+   };
+
+   state_history_tester chain(state_history_dir.path(), config);
+   chain.produce_blocks(50);
+
+   deploy_test_api(chain);
+   auto cfd_trace = push_test_cfd_transaction(chain);
+
+   chain.produce_blocks(100);
+
+   auto log_dir = state_history_dir.path();
+   auto archive_dir  = log_dir / "archive";
+   auto retained_dir = log_dir / "retained";
+
+   BOOST_CHECK(bfs::exists( archive_dir / "trace_history-2-20.log" ));
+   BOOST_CHECK(bfs::exists( archive_dir / "trace_history-2-20.index" ));
+   BOOST_CHECK(bfs::exists( archive_dir / "trace_history-21-40.log" ));
+   BOOST_CHECK(bfs::exists( archive_dir / "trace_history-21-40.index" ));
+
+   BOOST_CHECK(bfs::exists( archive_dir / "chain_state_history-2-20.log" ));
+   BOOST_CHECK(bfs::exists( archive_dir / "chain_state_history-2-20.index" ));
+   BOOST_CHECK(bfs::exists( archive_dir / "chain_state_history-21-40.log" ));
+   BOOST_CHECK(bfs::exists( archive_dir / "chain_state_history-21-40.index" ));
+
+   BOOST_CHECK(bfs::exists( retained_dir / "trace_history-41-60.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "trace_history-41-60.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "trace_history-61-80.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "trace_history-61-80.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "trace_history-81-100.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "trace_history-81-100.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "trace_history-101-120.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "trace_history-101-120.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "trace_history-121-140.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "trace_history-121-140.index" ));
+
+   BOOST_CHECK_EQUAL(chain.traces_log.begin_block(), 41);
+
+   BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-41-60.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-41-60.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-61-80.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-61-80.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-81-100.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-81-100.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-101-120.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-101-120.index" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-121-140.log" ));
+   BOOST_CHECK(bfs::exists( retained_dir / "chain_state_history-121-140.index" ));
+
+   BOOST_CHECK_EQUAL(chain.chain_state_log.begin_block(), 41);
+
+   BOOST_CHECK(get_traces(chain.traces_log, 10).empty());
+   BOOST_CHECK(get_traces(chain.traces_log, 100).size());
+   BOOST_CHECK(get_traces(chain.traces_log, 140).size());
+   BOOST_CHECK(get_traces(chain.traces_log, 150).size());
+   BOOST_CHECK(get_traces(chain.traces_log, 160).empty());
+
+   BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 10).empty());
+   BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 100).size());
+   BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 140).size());
+   BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 150).size());
+   BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 160).empty());
+}
+
+void push_blocks( tester& from, tester& to ) {
+   while( to.control->fork_db_pending_head_block_num()
+            < from.control->fork_db_pending_head_block_num() )
+   {
+      auto fb = from.control->fetch_block_by_number( to.control->fork_db_pending_head_block_num()+1 );
+      to.push_block( fb );
+   }
+}
+
+bool test_fork(uint32_t stride, uint32_t max_retained_files) {
+   namespace bfs = boost::filesystem;
+
+   fc::temp_directory state_history_dir;
+
+   eosio::state_history::partition_config config{
+      .retained_dir = "retained",
+      .archive_dir = "archive",
+      .stride  = stride,
+      .max_retained_files = max_retained_files
+   };
+
+   state_history_tester chain1(state_history_dir.path(), config);
+   chain1.produce_blocks(2);
+
+   chain1.create_accounts( {"dan"_n,"sam"_n,"pam"_n} );
+   chain1.produce_block();
+   chain1.set_producers( {"dan"_n,"sam"_n,"pam"_n} );
+   chain1.produce_blocks(30);
+
+   tester chain2(setup_policy::none);
+   push_blocks(chain1, chain2);
+
+   auto fork_block_num = chain1.control->head_block_num();
+
+   chain1.produce_blocks(12);
+   auto create_account_traces = chain2.create_accounts( {"adam"_n} );
+   auto create_account_trace_id = create_account_traces[0]->id;
+
+   auto b = chain2.produce_block();
+   chain2.produce_blocks(11+12);
+
+   for( uint32_t start = fork_block_num + 1, end = chain2.control->head_block_num(); start <= end; ++start ) {
+      auto fb = chain2.control->fetch_block_by_number( start );
+      chain1.push_block( fb );
+   }
+   auto traces = get_traces(chain1.traces_log, b->block_num());
+
+   bool trace_found = std::find_if(traces.begin(), traces.end(), [create_account_trace_id](const auto& v) {
+                         return std::get<eosio::ship_protocol::transaction_trace_v0>(v).id == create_account_trace_id;
+                      }) != traces.end();
+
+   return trace_found;
+}
+
+BOOST_AUTO_TEST_CASE(test_fork_no_stride) {
+   // In this case, the chain fork would NOT trunk the trace log across the stride boundary.
+   BOOST_CHECK(test_fork(UINT32_MAX, 10));
+}
+BOOST_AUTO_TEST_CASE(test_fork_with_stride1) {
+   // In this case, the chain fork would trunk the trace log across the stride boundary.
+   // However, there are still some traces remains after the truncation.
+   BOOST_CHECK(test_fork(10, 10));
+}
+BOOST_AUTO_TEST_CASE(test_fork_with_stride2) {
+   // In this case, the chain fork would trunk the trace log across the stride boundary.
+   // However, no existing trace remain after the truncation. Because we only keep a very
+   // short history, the create_account_trace is not available to be found. We just need
+   // to make sure no exception is throw.
+   BOOST_CHECK_NO_THROW(test_fork(5, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_corrupted_log_recovery) {
+  namespace bfs = boost::filesystem;
+
+   fc::temp_directory state_history_dir;
+
+   eosio::state_history::partition_config config{
+      .archive_dir = "archive",
+      .stride  = 100,
+      .max_retained_files = 5
+   };
+
+   state_history_tester chain(state_history_dir.path(), config);
+   chain.produce_blocks(50);
+   chain.close();
+
+   // write a few random bytes to block log indicating the last block entry is incomplete
+   fc::cfile logfile;
+   logfile.set_file_path(state_history_dir.path() / "trace_history.log");
+   logfile.open("ab");
+   const char random_data[] = "12345678901231876983271649837";
+   logfile.write(random_data, sizeof(random_data));
+
+   bfs::remove_all(chain.get_config().blocks_dir/"reversible");
+
+   state_history_tester new_chain(state_history_dir.path(), config);
+   new_chain.produce_blocks(50);
+
+   BOOST_CHECK(get_traces(new_chain.traces_log, 10).size());
+   BOOST_CHECK(get_decompressed_entry(new_chain.chain_state_log,10).size());
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR backports https://github.com/EOSIO/eos/pull/9277 and https://github.com/EOSIO/eos/pull/9821 to support supports the trace and chain state log spliting in state history plugin. 

Some new options for state history plugin are added:

- state-history-stride: split the state history log files when the block number is the multiple of the stride. When the stride is reached, the current history log and index will be renamed '*-history--.log/index' and a new current history log and index will be created with the most recent blocks. All files following this format will be used to construct an extended history log.
- max-retained-history-files: the maximum number of state history log file groups to retain so that the blocks in those files can be queried. When the number is reached, the oldest log files would be moved to archive dir or deleted if the archive dir is empty. The retained log files should not be manipulated by users.
- state-history-retained-dir: the location of the state history retained directory (absolute path or relative to state-history dir). 
- state-history-archive-dir: the location of the state history archive directory (absolute path or relative to state-history dir). If the value is empty string, log files beyond the retained limit will be deleted. All files in the archive directory are completely under user's control, i.e. they won't be accessed by nodeos anymore.