### PR TITLE
[3.1 -> 3.2] Attempt connection retry for duplicate connections

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2341,14 +2341,6 @@ namespace eosio {
 
    // called from connection strand
    void connection::connect( const std::shared_ptr<tcp::resolver>& resolver, tcp::resolver::results_type endpoints ) {
-      switch ( no_retry ) {
-         case no_reason:
-         case wrong_version:
-         case benign_other:
-            break;
-         default:
-            return;
-      }
       connecting = true;
       pending_message_buffer.reset();
       buffer_queue.clear_out_queue();


### PR DESCRIPTION
The fix https://github.com/eosnetworkfoundation/mandel/pull/756 did not address that `no_retry` is also redundantly checked in `connect`. This PR removes the duplicate check since `connect` is only called from `resolve_and_connect` where the `no_retry` is already verified.

Resolves #605
Merges #606 into `release/3.2`