### PR TITLE
First cut at a more message based interface between prometheus and instrumented plugins

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -1,6 +1,6 @@
 #include <eosio/chain_api_plugin/chain_api_plugin.hpp>
 #include <eosio/chain/exceptions.hpp>
-
+#include <eosio/http_plugin/macros.hpp>
 #include <fc/io/json.hpp>
 
 namespace eosio {
@@ -23,13 +23,6 @@ chain_api_plugin::~chain_api_plugin(){}
 
 void chain_api_plugin::set_program_options(options_description&, options_description&) {}
 void chain_api_plugin::plugin_initialize(const variables_map&) {}
-
-struct async_result_visitor : public fc::visitor<fc::variant> {
-   template<typename T>
-   fc::variant operator()(const T& v) const {
-      return fc::variant(v);
-   }
-};
 
 // Only want a simple 'Invalid transaction id' if unable to parse the body
 template<>
@@ -61,31 +54,6 @@ parse_params<chain_apis::read_only::get_transaction_status_params, http_params_t
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \
        }}
-
-#define CALL_ASYNC_WITH_400(api_name, api_handle, api_namespace, call_name, call_result, http_response_code, params_type) \
-{std::string("/v1/" #api_name "/" #call_name), \
-   [api_handle](string, string body, url_response_callback cb) mutable { \
-      auto deadline = api_handle.start(); \
-      try { \
-         auto params = parse_params<api_namespace::call_name ## _params, params_type>(body);\
-         FC_CHECK_DEADLINE(deadline);\
-         api_handle.call_name( std::move(params), \
-            [cb, body](const std::variant<fc::exception_ptr, call_result>& result){\
-               if (std::holds_alternative<fc::exception_ptr>(result)) {\
-                  try {\
-                     std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();\
-                  } catch (...) {\
-                     http_plugin::handle_exception(#api_name, #call_name, body, cb);\
-                  }\
-               } else {\
-                  cb(http_response_code, fc::time_point::maximum(), std::visit(async_result_visitor(), result));\
-               }\
-            });\
-      } catch (...) { \
-         http_plugin::handle_exception(#api_name, #call_name, body, cb); \
-      } \
-   }\
-}
 
 #define CHAIN_RO_CALL(call_name, http_response_code, params_type) CALL_WITH_400(chain, ro_api, chain_apis::read_only, call_name, http_response_code, params_type)
 #define CHAIN_RW_CALL(call_name, http_response_code, params_type) CALL_WITH_400(chain, rw_api, chain_apis::read_write, call_name, http_response_code, params_type)

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -30,8 +30,7 @@ namespace eosio { namespace chain { namespace plugin_interface {
    struct plugin_metrics {
       virtual vector<runtime_metric> metrics()=0;
       bool should_post() {
-         fc::time_point now = fc::time_point::now();
-         return ((_listener) && now > (_last_post + fc::milliseconds(_min_post_interval_ms)));
+         return ((_listener) && fc::time_point::now() > (_last_post + fc::milliseconds(_min_post_interval_ms)));
       }
 
       bool post_metrics() {

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -18,20 +18,15 @@ namespace eosio { namespace chain { namespace plugin_interface {
    };
 
    struct runtime_metric {
-      const metric_type type;
-      const std::string family;
-      const std::string label;
-      std::atomic<int64_t> value;
+      const metric_type type = metric_type::gauge;
+      const std::string family = "";
+      const std::string label = "";
+      int64_t value = 0;
+
    };
 
-   struct plugin_metrics {
-      std::vector<std::reference_wrapper<runtime_metric>> metrics;
-      void enable(bool enabled)  {_enabled = enabled; }
-      bool enabled() {return _enabled;}
+   using metrics_listener = std::function<void(std::vector<runtime_metric>)>;
 
-   private:
-      bool _enabled = false;
-   };
    template<typename T>
    using next_function = std::function<void(const std::variant<fc::exception_ptr, T>&)>;
 

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -36,7 +36,7 @@ namespace eosio { namespace chain { namespace plugin_interface {
 
       bool post_metrics() {
          if (should_post()){
-            _listener(std::move(metrics()));
+            _listener(metrics());
             _last_post = fc::time_point::now();
             return true;
          }

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -18,9 +18,9 @@ namespace eosio { namespace chain { namespace plugin_interface {
    };
 
    struct runtime_metric {
-      const metric_type type = metric_type::gauge;
-      const std::string family;
-      const std::string label;
+      metric_type type = metric_type::gauge;
+      std::string family;
+      std::string label;
       int64_t value = 0;
 
    };

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -19,13 +19,42 @@ namespace eosio { namespace chain { namespace plugin_interface {
 
    struct runtime_metric {
       const metric_type type = metric_type::gauge;
-      const std::string family = "";
-      const std::string label = "";
+      const std::string family;
+      const std::string label;
       int64_t value = 0;
 
    };
 
    using metrics_listener = std::function<void(std::vector<runtime_metric>)>;
+
+   struct plugin_metrics {
+      virtual vector<runtime_metric> metrics()=0;
+      bool should_post() {
+         fc::time_point now = fc::time_point::now();
+         return ((_listener) && now > (_last_post + fc::milliseconds(_min_post_interval_ms)));
+      }
+
+      bool post_metrics() {
+         if (should_post()){
+            _listener(std::move(metrics()));
+            _last_post = fc::time_point::now();
+            return true;
+         }
+
+         return false;
+      }
+
+      void register_listener(metrics_listener listener) {
+         _listener = listener;
+      }
+
+      plugin_metrics(int64_t min_post_interval_ms=250) : _min_post_interval_ms(min_post_interval_ms), _listener(nullptr) {}
+
+   private:
+      int64_t _min_post_interval_ms;
+      metrics_listener _listener;
+      fc::time_point _last_post;
+   };
 
    template<typename T>
    using next_function = std::function<void(const std::variant<fc::exception_ptr, T>&)>;

--- a/plugins/http_plugin/include/eosio/http_plugin/macros.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/macros.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+struct async_result_visitor : public fc::visitor<fc::variant> {
+   template<typename T>
+   fc::variant operator()(const T& v) const {
+      return fc::variant(v);
+   }
+};
+
+#define CALL_ASYNC_WITH_400(api_name, api_handle, api_namespace, call_name, call_result, http_response_code, params_type) \
+{std::string("/v1/" #api_name "/" #call_name), \
+   [api_handle](string, string body, url_response_callback cb) mutable { \
+      auto deadline = api_handle.start(); \
+      try { \
+         auto params = parse_params<api_namespace::call_name ## _params, params_type>(body);\
+         FC_CHECK_DEADLINE(deadline);\
+         api_handle.call_name( std::move(params), \
+            [cb, body](const std::variant<fc::exception_ptr, call_result>& result){\
+               if (std::holds_alternative<fc::exception_ptr>(result)) {\
+                  try {\
+                     std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();\
+                  } catch (...) {\
+                     http_plugin::handle_exception(#api_name, #call_name, body, cb);\
+                  }\
+               } else {\
+                  cb(http_response_code, fc::time_point::maximum(), std::visit(async_result_visitor(), result));\
+               }\
+            });\
+      } catch (...) { \
+         http_plugin::handle_exception(#api_name, #call_name, body, cb); \
+      } \
+   }\
+}

--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -15,15 +15,18 @@ namespace eosio {
 
    using namespace plugin_interface;
 
-   struct net_plugin_metrics : plugin_metrics {
+   struct net_plugin_metrics {
       runtime_metric num_peers{metric_type::gauge, "num_peers", "num_peers", 0};
       runtime_metric num_clients{metric_type::gauge, "num_clients", "num_clients", 0};
       runtime_metric dropped_trxs{metric_type::counter, "dropped_trxs", "dropped_trxs", 0};
 
-      net_plugin_metrics() {
-         metrics.emplace_back(std::ref(num_peers));
-         metrics.emplace_back(std::ref(num_clients));
-         metrics.emplace_back(std::ref(dropped_trxs));
+      vector<runtime_metric> metrics() {
+         vector<runtime_metric> metrics;
+         metrics.emplace_back(num_peers);
+         metrics.emplace_back(num_clients);
+         metrics.emplace_back(dropped_trxs);
+
+         return metrics;
       }
    };
 
@@ -46,7 +49,7 @@ namespace eosio {
         std::optional<connection_status>  status( const string& endpoint )const;
         vector<connection_status>         connections()const;
 
-        net_plugin_metrics& metrics();
+        void register_metrics_listener(metrics_listener listener);
 
       private:
         std::shared_ptr<class net_plugin_impl> my;

--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -20,12 +20,12 @@ namespace eosio {
       runtime_metric num_clients{metric_type::gauge, "num_clients", "num_clients", 0};
       runtime_metric dropped_trxs{metric_type::counter, "dropped_trxs", "dropped_trxs", 0};
 
-      virtual vector<runtime_metric> metrics() {
-         vector<runtime_metric> metrics;
-         metrics.reserve(3);
-         metrics.emplace_back(num_peers);
-         metrics.emplace_back(num_clients);
-         metrics.emplace_back(dropped_trxs);
+      vector<runtime_metric> metrics() final {
+         vector<runtime_metric> metrics {
+            num_peers,
+            num_clients,
+            dropped_trxs
+         };
 
          return metrics;
       }

--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -15,13 +15,14 @@ namespace eosio {
 
    using namespace plugin_interface;
 
-   struct net_plugin_metrics {
+   struct net_plugin_metrics : plugin_metrics {
       runtime_metric num_peers{metric_type::gauge, "num_peers", "num_peers", 0};
       runtime_metric num_clients{metric_type::gauge, "num_clients", "num_clients", 0};
       runtime_metric dropped_trxs{metric_type::counter, "dropped_trxs", "dropped_trxs", 0};
 
-      vector<runtime_metric> metrics() {
+      virtual vector<runtime_metric> metrics() {
          vector<runtime_metric> metrics;
+         metrics.reserve(3);
          metrics.emplace_back(num_peers);
          metrics.emplace_back(num_clients);
          metrics.emplace_back(dropped_trxs);

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -26,17 +26,17 @@ struct producer_plugin_metrics : public plugin_metrics {
    runtime_metric scheduled_trxs{metric_type::gauge, "scheduled_trxs", "scheduled_trxs", 0};
 
    virtual vector<runtime_metric> metrics() {
-      vector<runtime_metric> metrics;
-      metrics.reserve(9);
-      metrics.emplace_back(unapplied_transactions);
-      metrics.emplace_back(blacklisted_transactions);
-      metrics.emplace_back(blocks_produced);
-      metrics.emplace_back(trxs_produced);
-      metrics.emplace_back(last_irreversible);
-      metrics.emplace_back(block_num);
-      metrics.emplace_back(subjective_bill_account_size);
-      metrics.emplace_back(subjective_bill_block_size);
-      metrics.emplace_back(scheduled_trxs);
+      vector<runtime_metric> metrics{
+            unapplied_transactions,
+            blacklisted_transactions,
+            blocks_produced,
+            trxs_produced,
+            last_irreversible,
+            block_num,
+            subjective_bill_account_size,
+            subjective_bill_block_size,
+            scheduled_trxs
+      };
 
       return metrics;
    }

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -12,8 +12,9 @@ using boost::signals2::signal;
 using chain::plugin_interface::runtime_metric;
 using chain::plugin_interface::metric_type;
 using chain::plugin_interface::metrics_listener;
+using chain::plugin_interface::plugin_metrics;
 
-struct producer_plugin_metrics {
+struct producer_plugin_metrics : public plugin_metrics {
    runtime_metric unapplied_transactions{metric_type::gauge, "unapplied_transactions", "unapplied_transactions", 0};
    runtime_metric blacklisted_transactions{metric_type::gauge, "blacklisted_transactions", "blacklisted_transactions", 0};
    runtime_metric blocks_produced{metric_type::counter, "blocks_produced", "blocks_produced", 0};
@@ -24,8 +25,9 @@ struct producer_plugin_metrics {
    runtime_metric subjective_bill_block_size{metric_type::gauge, "subjective_bill_block_size", "subjective_bill_block_size", 0};
    runtime_metric scheduled_trxs{metric_type::gauge, "scheduled_trxs", "scheduled_trxs", 0};
 
-   vector<runtime_metric> metrics() {
+   virtual vector<runtime_metric> metrics() {
       vector<runtime_metric> metrics;
+      metrics.reserve(9);
       metrics.emplace_back(unapplied_transactions);
       metrics.emplace_back(blacklisted_transactions);
       metrics.emplace_back(blocks_produced);

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -11,9 +11,9 @@ using boost::signals2::signal;
 
 using chain::plugin_interface::runtime_metric;
 using chain::plugin_interface::metric_type;
-using chain::plugin_interface::plugin_metrics;
+using chain::plugin_interface::metrics_listener;
 
-struct producer_plugin_metrics : public plugin_metrics {
+struct producer_plugin_metrics {
    runtime_metric unapplied_transactions{metric_type::gauge, "unapplied_transactions", "unapplied_transactions", 0};
    runtime_metric blacklisted_transactions{metric_type::gauge, "blacklisted_transactions", "blacklisted_transactions", 0};
    runtime_metric blocks_produced{metric_type::counter, "blocks_produced", "blocks_produced", 0};
@@ -24,16 +24,19 @@ struct producer_plugin_metrics : public plugin_metrics {
    runtime_metric subjective_bill_block_size{metric_type::gauge, "subjective_bill_block_size", "subjective_bill_block_size", 0};
    runtime_metric scheduled_trxs{metric_type::gauge, "scheduled_trxs", "scheduled_trxs", 0};
 
-   producer_plugin_metrics() {
-      metrics.emplace_back(std::ref(unapplied_transactions));
-      metrics.emplace_back(std::ref(blacklisted_transactions));
-      metrics.emplace_back(std::ref(blocks_produced));
-      metrics.emplace_back(std::ref(trxs_produced));
-      metrics.emplace_back(std::ref(last_irreversible));
-      metrics.emplace_back(std::ref(block_num));
-      metrics.emplace_back(std::ref(subjective_bill_account_size));
-      metrics.emplace_back(std::ref(subjective_bill_block_size));
-      metrics.emplace_back(std::ref(scheduled_trxs));
+   vector<runtime_metric> metrics() {
+      vector<runtime_metric> metrics;
+      metrics.emplace_back(unapplied_transactions);
+      metrics.emplace_back(blacklisted_transactions);
+      metrics.emplace_back(blocks_produced);
+      metrics.emplace_back(trxs_produced);
+      metrics.emplace_back(last_irreversible);
+      metrics.emplace_back(block_num);
+      metrics.emplace_back(subjective_bill_account_size);
+      metrics.emplace_back(subjective_bill_block_size);
+      metrics.emplace_back(scheduled_trxs);
+
+      return metrics;
    }
 };
 
@@ -172,6 +175,7 @@ public:
 
    void log_failed_transaction(const transaction_id_type& trx_id, const chain::packed_transaction_ptr& packed_trx_ptr, const char* reason) const;
    producer_plugin_metrics& metrics();
+   void register_metrics_listener(metrics_listener listener);
 
  private:
    std::shared_ptr<class producer_plugin_impl> my;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -424,7 +424,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             _metrics.last_irreversible.value = chain.last_irreversible_block_num();
             _metrics.block_num.value = chain.head_block_num();
 
-            const auto &sch_idx = chain.db().get_index<generated_transaction_multi_index, by_delay>();
+            const auto& sch_idx = chain.db().get_index<generated_transaction_multi_index, by_delay>();
             _metrics.scheduled_trxs.value = sch_idx.size();
 
             _metrics.post_metrics();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -343,16 +343,18 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       std::optional<scoped_connection>                          _irreversible_block_connection;
 
       producer_plugin_metrics                                   _metrics;
-      /*
-       * HACK ALERT
-       * Boost timers can be in a state where a handler has not yet executed but is not abortable.
-       * As this method needs to mutate state handlers depend on for proper functioning to maintain
-       * invariants for other code (namely accepting incoming transactions in a nearly full block)
-       * the handlers capture a corelation ID at the time they are set.  When they are executed
-       * they must check that correlation_id against the global ordinal.  If it does not match that
-       * implies that this method has been called with the handler in the state where it should be
-       * cancelled but wasn't able to be.
-       */
+      metrics_listener                                          _metrics_listener = nullptr;
+
+   /*
+    * HACK ALERT
+    * Boost timers can be in a state where a handler has not yet executed but is not abortable.
+    * As this method needs to mutate state handlers depend on for proper functioning to maintain
+    * invariants for other code (namely accepting incoming transactions in a nearly full block)
+    * the handlers capture a corelation ID at the time they are set.  When they are executed
+    * they must check that correlation_id against the global ordinal.  If it does not match that
+    * implies that this method has been called with the handler in the state where it should be
+    * cancelled but wasn't able to be.
+    */
       uint32_t _timer_corelation_id = 0;
 
       // keep a expected ratio between defer txn and incoming txn
@@ -412,18 +414,22 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       }
 
       void update_block_metrics() {
-         _metrics.unapplied_transactions.value =  _unapplied_transactions.size();
-         _metrics.subjective_bill_account_size.value = _subjective_billing.get_account_cache_size();
-         _metrics.subjective_bill_block_size.value = _subjective_billing.get_block_cache_size();
-         _metrics.blacklisted_transactions.value = _blacklisted_transactions.size();
-         _metrics.unapplied_transactions.value = _unapplied_transactions.size();
+         if (_metrics_listener) {
+            _metrics.unapplied_transactions.value = _unapplied_transactions.size();
+            _metrics.subjective_bill_account_size.value = _subjective_billing.get_account_cache_size();
+            _metrics.subjective_bill_block_size.value = _subjective_billing.get_block_cache_size();
+            _metrics.blacklisted_transactions.value = _blacklisted_transactions.size();
+            _metrics.unapplied_transactions.value = _unapplied_transactions.size();
 
-         auto& chain = chain_plug->chain();
-         _metrics.last_irreversible.value = chain.last_irreversible_block_num();
-         _metrics.block_num.value = chain.head_block_num();
+            auto &chain = chain_plug->chain();
+            _metrics.last_irreversible.value = chain.last_irreversible_block_num();
+            _metrics.block_num.value = chain.head_block_num();
 
-         const auto& sch_idx = chain.db().get_index<generated_transaction_multi_index,by_delay>();
-         _metrics.scheduled_trxs.value = sch_idx.size();
+            const auto &sch_idx = chain.db().get_index<generated_transaction_multi_index, by_delay>();
+            _metrics.scheduled_trxs.value = sch_idx.size();
+
+            _metrics_listener(_metrics.metrics());
+         }
       }
 
       void abort_block() {
@@ -1594,9 +1600,7 @@ fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_po
 
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    chain::controller& chain = chain_plug->chain();
-   if (_metrics.enabled()) {
-      update_block_metrics();
-   }
+   update_block_metrics();
 
    if( !chain_plug->accept_transactions() )
       return start_block_result::waiting_for_block;
@@ -2527,7 +2531,8 @@ void producer_plugin::log_failed_transaction(const transaction_id_type& trx_id, 
             ("entire_trx", packed_trx_ptr ? my->chain_plug->get_log_trx(packed_trx_ptr->get_transaction()) : fc::variant{trx_id}));
 }
 
-producer_plugin_metrics& producer_plugin::metrics() {
-   return my->_metrics;
+void producer_plugin::register_metrics_listener(metrics_listener listener) {
+   my->_metrics_listener = listener;
 }
+
 } // namespace eosio

--- a/plugins/prometheus_plugin/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/prometheus_plugin.cpp
@@ -114,7 +114,7 @@ namespace eosio {
          void update_metrics(std::string plugin_name, vector<runtime_metric> metrics) {
             auto plugin_metrics = _plugin_metrics.find(plugin_name);
             if (plugin_metrics != _plugin_metrics.end()) {
-               plugin_metrics->second = metrics;
+               plugin_metrics->second = std::move(metrics);
             }
          }
 

--- a/plugins/prometheus_plugin/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/prometheus_plugin.cpp
@@ -9,139 +9,138 @@
 #include <eosio/chain/thread_utils.hpp>
 #include <eosio/http_plugin/macros.hpp>
 
-
 namespace eosio {
    using namespace prometheus;
    static appbase::abstract_plugin &_prometheus_plugin = app().register_plugin<prometheus_plugin>();
+   using metric_type=chain::plugin_interface::metric_type;
 
-   struct prometheus_plugin_metrics {
-      Family<Counter>& _bytes_transferred_family;
-      Counter& _bytes_transferred;
-      Family<Counter>& _num_scrapes_family;
-      Counter& _num_scrapes;
-      Family<Summary>& _request_processing_family;
-      Summary& _request_processing;
+   struct prometheus_plugin_metrics : plugin_metrics {
+      runtime_metric bytes_transferred{metric_type::counter, "exposer_transferred_bytes_total", "exposer_transferred_bytes_total"};
+      runtime_metric num_scrapes{metric_type::counter, "exposer_scrapes_total", "exposer_scrapes_total"};
 
-      prometheus_plugin_metrics(Registry& registry) :
-         _bytes_transferred_family(
-         BuildCounter()
-               .Name("exposer_transferred_bytes_total")
-               .Help("Transferred bytes to metrics services")
-               .Register(registry)),
-         _bytes_transferred(_bytes_transferred_family.Add({})),
-         _num_scrapes_family(BuildCounter()
-            .Name("exposer_scrapes_total")
-            .Help("Number of times metrics were scraped")
-            .Register(registry)),
-         _num_scrapes(_num_scrapes_family.Add({})),
-         _request_processing_family(
-         BuildSummary()
-            .Name("request_processing_time")
-            .Help("Processing time of serving scrape requests, in microseconds")
-            .Register(registry)),
-         _request_processing(_request_processing_family.Add(
-            {}, Summary::Quantiles{{0.5, 0.05}, {0.9, 0.01}, {0.99, 0.001}})) {}
-      };
+      std::vector<runtime_metric> metrics() {
+        return std::vector{
+          bytes_transferred,
+          num_scrapes
+        };
+      }
+   };
 
+   struct metrics_model {
+      std::vector<std::shared_ptr<Collectable>> _collectables;
+      std::shared_ptr<Registry> _registry;
+      std::vector<std::reference_wrapper<Family<Gauge>>> _gauges;
+      std::vector<std::reference_wrapper<Family<Counter>>> _counters;
+
+      void add_gauge_metric(const runtime_metric& plugin_metric) {
+         auto& gauge_family = BuildGauge()
+               .Name(plugin_metric.family)
+               .Help("")
+               .Register(*_registry);
+         auto& gauge = gauge_family.Add({});
+         gauge.Set(plugin_metric.value);
+
+         _gauges.push_back(gauge_family);
+
+         ilog("Added gauge metric ${f}:${l}", ("f", plugin_metric.family) ("l", plugin_metric.label));
+      }
+
+      void add_counter_metric(const runtime_metric& plugin_metric) {
+         auto &counter_family = BuildCounter()
+               .Name(plugin_metric.family)
+               .Help("")
+               .Register(*_registry);
+         auto &counter = counter_family.Add({});
+         counter.Increment(plugin_metric.value);
+         _counters.push_back(counter_family);
+
+         ilog("Added counter metric ${f}:${l}", ("f", plugin_metric.family) ("l", plugin_metric.label));
+      }
+
+      void add_runtime_metric(const runtime_metric& plugin_metric) {
+         switch(plugin_metric.type) {
+            case metric_type::gauge:
+               add_gauge_metric(plugin_metric);
+               break;
+            case metric_type::counter:
+               add_counter_metric(plugin_metric);
+               break;
+
+            default:
+               break;
+         }
+      }
+
+      void add_runtime_metrics(std::vector<runtime_metric>& metrics){
+         for (auto const& m : metrics) {
+            add_runtime_metric(m);
+         }
+      }
+
+      metrics_model() {
+         _registry = std::make_shared<Registry>();
+         _collectables.push_back(_registry);
+      }
+
+      std::vector<MetricFamily> collect_metrics() {
+         auto collected_metrics = std::vector<MetricFamily>{};
+
+         for (auto&& collectable : _collectables) {
+
+            auto&& metrics = collectable->Collect();
+            collected_metrics.insert(collected_metrics.end(),
+                                     std::make_move_iterator(metrics.begin()),
+                                     std::make_move_iterator(metrics.end()));
+         }
+
+         return collected_metrics;
+      }
+
+      std::string serialize() {
+         const prometheus::TextSerializer serializer;
+         return serializer.Serialize(collect_metrics());
+      }
+   };
 
       struct prometheus_plugin_impl {
-         std::vector<std::shared_ptr<Collectable>> _collectables;
-         const prometheus::TextSerializer _serializer;
-         std::shared_ptr<Registry> _registry;
          eosio::chain::named_thread_pool _prometheus_thread_pool;
          boost::asio::io_context::strand _prometheus_strand;
+         prometheus_plugin_metrics _metrics;
 
-         std::vector<std::tuple<Family<Gauge>&, Gauge&, const runtime_metric&>> _gauges;
-         std::vector<std::tuple<Family<Counter>&, Counter&, const runtime_metric&>> _counters;
+         map<std::string, vector<runtime_metric>> _plugin_metrics;
 
-         // metrics for prometheus_plugin itself
-         std::unique_ptr<prometheus_plugin_metrics> _metrics;
-
-         // hold onto other plugin metrics
          prometheus_plugin_impl(): _prometheus_thread_pool("prom", 1), _prometheus_strand(_prometheus_thread_pool.get_executor()){ }
 
-         void add_gauge_metric(const runtime_metric& plugin_metric) {
-            auto& gauge_family = BuildGauge()
-                  .Name(plugin_metric.family)
-                  .Help("")
-                  .Register(*_registry);
-            auto& gauge = gauge_family.Add({});
-
-            _gauges.push_back(
-                  std::tuple<Family<Gauge>&, Gauge&, const runtime_metric&>(gauge_family, gauge, plugin_metric));
-
-            ilog("Added gauge metric ${f}:${l}", ("f", plugin_metric.family) ("l", plugin_metric.label));
-         }
-
-         void add_counter_metric(const runtime_metric& plugin_metric) {
-                  auto &counter_family = BuildCounter()
-                        .Name(plugin_metric.family)
-                        .Help("")
-                        .Register(*_registry);
-                  auto &counter = counter_family.Add({});
-                  _counters.push_back(
-                        std::tuple<Family<Counter>&, Counter&, const runtime_metric&>(counter_family, counter, plugin_metric));
-
-            ilog("Added counter metric ${f}:${l}", ("f", plugin_metric.family) ("l", plugin_metric.label));
-         }
-
-         void add_plugin_metric(const runtime_metric& plugin_metric) {
-            switch(plugin_metric.type) {
-               case metric_type::gauge:
-                  add_gauge_metric(plugin_metric);
-                  break;
-               case metric_type::counter:
-                  add_counter_metric(plugin_metric);
-                  break;
-
-               default:
-                  break;
+         void update_metrics(std::string plugin_name, vector<runtime_metric>& metrics) {
+            auto plugin_metrics = _plugin_metrics.find(plugin_name);
+            if (plugin_metrics != _plugin_metrics.end()) {
+               plugin_metrics->second = metrics;
             }
          }
 
-         void update_plugin_metrics() {
-            for (auto& rtm : _gauges) {
-               auto new_val = static_cast<double>(std::get<2>(rtm).value);
-               std::get<1>(rtm).Set(new_val);
-            }
-
-            for (auto& rtm : _counters) {
-               auto new_val = static_cast<double>(std::get<2>(rtm).value);
-               std::get<1>(rtm).Increment(new_val-std::get<1>(rtm).Value());
-            }
-         }
-
-         void update_metrics(vector<runtime_metric> metrics) {
-
-         }
-
-         metrics_listener create_metrics_listener() {
-            return  [self=this] (vector<runtime_metric> metrics) mutable {
+         metrics_listener create_metrics_listener(std::string plugin_name) {
+            return  [plugin_name, self=this] (vector<runtime_metric> metrics) mutable {
                self->_prometheus_strand.post(
-                     [self, metrics=std::move(metrics)]() mutable {
-                        self->update_metrics(metrics);
+                     [self, plugin_name, metrics]() mutable {
+                        self->update_metrics(plugin_name, metrics);
                      }
                );
             };
          }
 
          void initialize_metrics() {
-            _registry = std::make_shared<Registry>();
-            _metrics = std::make_unique<prometheus_plugin_metrics>(*_registry);
-            _collectables.push_back(_registry);
-
-            // this is where we will set up all non-prometheus_plugin metrics
-
             net_plugin* np = app().find_plugin<net_plugin>();
             if (nullptr != np) {
-               np->register_metrics_listener(create_metrics_listener());
+               _plugin_metrics.emplace(std::pair{"net", std::vector<runtime_metric>()});
+               np->register_metrics_listener(create_metrics_listener("net"));
             } else {
                dlog("net_plugin not found -- metrics not added");
             }
 
             producer_plugin* pp = app().find_plugin<producer_plugin>();
             if (nullptr != pp) {
-               pp->register_metrics_listener(create_metrics_listener());
+               _plugin_metrics.emplace(std::pair{"prod", std::vector<runtime_metric>()});
+               pp->register_metrics_listener(create_metrics_listener("prod"));
             } else {
                dlog("producer_plugin not found -- metrics not added");
             }
@@ -149,22 +148,22 @@ namespace eosio {
 
          std::string metrics() {
             auto start_time_of_request = std::chrono::steady_clock::now();
+            metrics_model mm;
+            vector<runtime_metric> prometheus_metrics = _metrics.metrics();
+            mm.add_runtime_metrics(prometheus_metrics);
 
-            update_plugin_metrics();
+            for (auto& pm : _plugin_metrics) {
+               mm.add_runtime_metrics(pm.second);
+            }
 
-            std::vector<prometheus::MetricFamily> metrics;
-
-            metrics = collect_metrics();
-
-            std::string body = _serializer.Serialize(metrics);
+            std::string body = mm.serialize();
 
             auto stop_time_of_request = std::chrono::steady_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
                   stop_time_of_request - start_time_of_request);
-            _metrics->_request_processing.Observe(duration.count());
 
-            _metrics->_bytes_transferred.Increment(body.length());
-            _metrics->_num_scrapes.Increment();
+            _metrics.bytes_transferred.value += body.length();
+            _metrics.num_scrapes.value++;
 
             return body;
          }
@@ -175,19 +174,6 @@ namespace eosio {
             });
          }
 
-         std::vector<MetricFamily> collect_metrics() {
-            auto collected_metrics = std::vector<MetricFamily>{};
-
-            for (auto&& collectable : _collectables) {
-
-               auto&& metrics = collectable->Collect();
-               collected_metrics.insert(collected_metrics.end(),
-                                        std::make_move_iterator(metrics.begin()),
-                                        std::make_move_iterator(metrics.end()));
-            }
-
-            return collected_metrics;
-         }
 
    };
 
@@ -207,8 +193,8 @@ namespace eosio {
 
       prometheus_api(prometheus_plugin_impl& plugin) : _pp(plugin){
       }
-
    };
+
    prometheus_plugin::prometheus_plugin() {
       my.reset(new prometheus_plugin_impl{});
       prometheus_api handle(*my);


### PR DESCRIPTION
New interface between prometheus and instrumented plugins.  

Now, prometheus will register a listener with instrumented plugins.  Instrumented plugins will 'batch' updates and call back the prometheus listener.  

The listener that prometheus passes to the instrumented plugins is a lambda that posts another lambda to a prometheus strand.  The lambda that is posted to the prometheus strand will update the prometheus data model.  The updating of the data model is not implemented in this PR.

One open issue is where can we use 'move' rather than 'copy' semantics.