### PR TITLE
Working to fix nodeos_snapshot_diff_test by sync on trx gen startup

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -120,6 +120,7 @@ class Cluster(object):
         self.defproducerbAccount.ownerPrivateKey=defproducerbPrvtKey
         self.defproducerbAccount.activePrivateKey=defproducerbPrvtKey
 
+        self.trxGenLauncher=None
         self.preExistingFirstTrxFiles=[]
 
         self.useBiosBootFile=False

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -21,7 +21,6 @@ from .testUtils import EnumType
 from .testUtils import addEnum
 from .testUtils import unhandledEnumType
 from .testUtils import ReturnType
-from .launch_transaction_generators import TransactionGeneratorsLauncher, TpsTrxGensConfig
 
 class BlockType(EnumType):
     pass
@@ -1656,21 +1655,3 @@ class Node(object):
             blockAnalysis[specificBlockNum] = { "slot": None, "prod": None}
 
         return blockAnalysis
-
-    def launchTrxGenerators(self, tpsPerGenerator: int, numGenerators: int, durationSec: int, contractOwnerAcctName: str, acctNamesList: list, acctPrivKeysList: list, p2pListenPort: int, waitToComplete:bool=False):
-        Utils.Print("Configure txn generators")
-        info = self.getInfo()
-        chainId = info['chain_id']
-        lib_id = info['last_irreversible_block_id']
-
-        targetTps = tpsPerGenerator*numGenerators
-        tpsLimitPerGenerator=tpsPerGenerator
-
-        tpsTrxGensConfig = TpsTrxGensConfig(targetTps=targetTps, tpsLimitPerGenerator=tpsLimitPerGenerator)
-        trxGenLauncher = TransactionGeneratorsLauncher(chainId=chainId, lastIrreversibleBlockId=lib_id,
-                                                    handlerAcct=contractOwnerAcctName, accts=','.join(map(str, acctNamesList)),
-                                                    privateKeys=','.join(map(str, acctPrivKeysList)), trxGenDurationSec=durationSec,
-                                                    logDir=Utils.DataDir, peerEndpoint=self.host, port=p2pListenPort, tpsTrxGensConfig=tpsTrxGensConfig)
-
-        Utils.Print("Launch txn generators and start generating/sending transactions")
-        trxGenLauncher.launch(waitToComplete=waitToComplete)

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -106,7 +106,7 @@ try:
                                 numGenerators=trxGeneratorCnt, durationSec=testTrxGenDurationSec, waitToComplete=False)
 
     Print("Give txn generator time to spin up and begin producing trxs")
-    cluster.waitForTrxGeneratorsSpinup(nodeId=nonProdNode.nodeId, numGenerators=trxGeneratorCnt)
+    time.sleep(10)
 
     Print("Kill non-producer bridge node")
     testSuccessful = nonProdNode.kill(signal.SIGTERM)

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -116,8 +116,6 @@ try:
         errorExit("Failed to kill the seed node")
 
 finally:
-    if trxGenLauncher is not None:
-        trxGenLauncher.killAll()
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=True, killWallet=True, keepLogs=True, cleanRun=True, dumpErrorDetails=True)
 
 errorCode = 0 if testSuccessful else 1

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -98,7 +98,7 @@ try:
     testSuccessful=False
 
     Print("Configure and launch txn generators")
-    targetTpsPerGenerator = 500
+    targetTpsPerGenerator = 100
     testTrxGenDurationSec=60
     trxGeneratorCnt=1
     cluster.launchTrxGenerators(contractOwnerAcctName=cluster.eosioAccount.name, acctNamesList=[accounts[0].name,accounts[1].name],
@@ -107,7 +107,6 @@ try:
 
     Print("Give txn generator time to spin up and begin producing trxs")
     cluster.waitForTrxGeneratorsSpinup(nodeId=nonProdNode.nodeId, numGenerators=trxGeneratorCnt)
-    time.sleep(5)
 
     Print("Kill non-producer bridge node")
     testSuccessful = nonProdNode.kill(signal.SIGTERM)

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -98,16 +98,16 @@ try:
     testSuccessful=False
 
     Print("Configure and launch txn generators")
-    nonProducerP2pPort = cluster.getNodeP2pPort(nonProdNode.nodeId)
     targetTpsPerGenerator = 500
     testTrxGenDurationSec=60
     trxGeneratorCnt=1
-    nonProdNode.launchTrxGenerators(tpsPerGenerator=targetTpsPerGenerator, numGenerators=trxGeneratorCnt, durationSec=testTrxGenDurationSec,
-                                    contractOwnerAcctName=cluster.eosioAccount.name, acctNamesList=[accounts[0].name,accounts[1].name],
-                                    acctPrivKeysList=[account1PrivKey,account2PrivKey], p2pListenPort=nonProducerP2pPort, waitToComplete=False)
+    cluster.launchTrxGenerators(contractOwnerAcctName=cluster.eosioAccount.name, acctNamesList=[accounts[0].name,accounts[1].name],
+                                acctPrivKeysList=[account1PrivKey,account2PrivKey], nodeId=nonProdNode.nodeId, tpsPerGenerator=targetTpsPerGenerator,
+                                numGenerators=trxGeneratorCnt, durationSec=testTrxGenDurationSec, waitToComplete=False)
 
     Print("Give txn generator time to spin up and begin producing trxs")
-    time.sleep(10)
+    cluster.waitForTrxGeneratorsSpinup(nodeId=nonProdNode.nodeId, numGenerators=trxGeneratorCnt)
+    time.sleep(5)
 
     Print("Kill non-producer bridge node")
     testSuccessful = nonProdNode.kill(signal.SIGTERM)

--- a/tests/nodeos_snapshot_diff_test.py
+++ b/tests/nodeos_snapshot_diff_test.py
@@ -199,8 +199,6 @@ try:
     testSuccessful=True
 
 finally:
-    if trxGenLauncher is not None:
-        trxGenLauncher.killAll()
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
 exitCode = 0 if testSuccessful else 1

--- a/tests/nodeos_snapshot_diff_test.py
+++ b/tests/nodeos_snapshot_diff_test.py
@@ -107,9 +107,9 @@ try:
             libBlockNum=info["last_irreversible_block_num"]
             Utils.errorExit("Failed to get to %s block number %d. Last had head block number %d and lib %d" % (blockType, blockNum, headBlockNum, libBlockNum))
 
-    node0=cluster.getNode(0)
 
     snapshotNodeId = 0
+    node0=cluster.getNode(snapshotNodeId)
     irrNodeId = snapshotNodeId+1
 
     nodeSnap=cluster.getNode(snapshotNodeId)
@@ -120,12 +120,13 @@ try:
     waitForBlock(node0, blockNum, blockType=BlockType.lib)
 
     Print("Configure and launch txn generators")
-    producerP2pPort = cluster.getNodeP2pPort(snapshotNodeId)
     targetTpsPerGenerator = 667
     testTrxGenDurationSec=60*30
-    node0.launchTrxGenerators(tpsPerGenerator=targetTpsPerGenerator, numGenerators=trxGeneratorCnt, durationSec=testTrxGenDurationSec,
-                              contractOwnerAcctName=cluster.eosioAccount.name, acctNamesList=[account1Name, account2Name],
-                              acctPrivKeysList=[account1PrivKey,account2PrivKey], p2pListenPort=producerP2pPort, waitToComplete=False)
+    cluster.launchTrxGenerators(contractOwnerAcctName=cluster.eosioAccount.name, acctNamesList=[account1Name, account2Name],
+                                acctPrivKeysList=[account1PrivKey,account2PrivKey], nodeId=snapshotNodeId, tpsPerGenerator=targetTpsPerGenerator,
+                                numGenerators=trxGeneratorCnt, durationSec=testTrxGenDurationSec, waitToComplete=False)
+
+    cluster.waitForTrxGeneratorsSpinup(nodeId=snapshotNodeId, numGenerators=trxGeneratorCnt)
 
     blockNum=node0.getBlockNum(BlockType.head)
     timePerBlock=500

--- a/tests/nodeos_snapshot_diff_test.py
+++ b/tests/nodeos_snapshot_diff_test.py
@@ -120,7 +120,7 @@ try:
     waitForBlock(node0, blockNum, blockType=BlockType.lib)
 
     Print("Configure and launch txn generators")
-    targetTpsPerGenerator = 667
+    targetTpsPerGenerator = 10
     testTrxGenDurationSec=60*30
     cluster.launchTrxGenerators(contractOwnerAcctName=cluster.eosioAccount.name, acctNamesList=[account1Name, account2Name],
                                 acctPrivKeysList=[account1PrivKey,account2PrivKey], nodeId=snapshotNodeId, tpsPerGenerator=targetTpsPerGenerator,

--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -113,12 +113,14 @@ try:
     waitForBlock(node0, blockNum, blockType=BlockType.lib)
 
     Print("Configure and launch txn generators")
-    producerP2pPort = cluster.getNodeP2pPort(node0.nodeId)
     targetTpsPerGenerator = 100
     testTrxGenDurationSec=60*60
-    node0.launchTrxGenerators(tpsPerGenerator=targetTpsPerGenerator, numGenerators=trxGeneratorCnt, durationSec=testTrxGenDurationSec,
-                              contractOwnerAcctName=cluster.eosioAccount.name, acctNamesList=[account1Name, account2Name],
-                              acctPrivKeysList=[account1PrivKey,account2PrivKey], p2pListenPort=producerP2pPort, waitToComplete=False)
+    cluster.launchTrxGenerators(contractOwnerAcctName=cluster.eosioAccount.name, acctNamesList=[account1Name, account2Name],
+                                acctPrivKeysList=[account1PrivKey,account2PrivKey], nodeId=node0.nodeId,
+                                tpsPerGenerator=targetTpsPerGenerator, numGenerators=trxGeneratorCnt, durationSec=testTrxGenDurationSec,
+                                waitToComplete=False)
+
+    cluster.waitForTrxGeneratorsSpinup(nodeId=node0.nodeId, numGenerators=trxGeneratorCnt)
 
     blockNum=head(node0)
     timePerBlock=500

--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -201,8 +201,6 @@ try:
     testSuccessful=True
 
 finally:
-    if trxGenLauncher is not None:
-        trxGenLauncher.killAll()
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
 exitCode = 0 if testSuccessful else 1

--- a/tests/trx_generator/trx_generator.cpp
+++ b/tests/trx_generator/trx_generator.cpp
@@ -97,8 +97,21 @@ namespace eosio::testing {
       _stop_on_trx_failed(stop_on_trx_failed) {
    }
 
+   void log_first_trx(const std::string& log_dir, const chain::signed_transaction& trx) {
+      std::ostringstream fileName;
+      fileName << log_dir << "/first_trx_" << getpid() << ".txt";
+      std::ofstream out(fileName.str());
+
+      out << fc::string(trx.id()) << "\n";
+      out.close();
+   }
+
    void transfer_trx_generator::push_transaction(p2p_trx_provider& provider, signed_transaction_w_signer& trx, uint64_t& nonce_prefix, uint64_t& nonce, const fc::microseconds& trx_expiration, const chain_id_type& chain_id, const block_id_type& last_irr_block_id) {
       update_resign_transaction(trx._trx, trx._signer, ++nonce_prefix, nonce, trx_expiration, chain_id, last_irr_block_id);
+      if (_txcount == 0)
+      {
+         log_first_trx(_log_dir, trx._trx);
+      }
       provider.send(trx._trx);
    }
 

--- a/tests/trx_generator/trx_generator.cpp
+++ b/tests/trx_generator/trx_generator.cpp
@@ -108,8 +108,7 @@ namespace eosio::testing {
 
    void transfer_trx_generator::push_transaction(p2p_trx_provider& provider, signed_transaction_w_signer& trx, uint64_t& nonce_prefix, uint64_t& nonce, const fc::microseconds& trx_expiration, const chain_id_type& chain_id, const block_id_type& last_irr_block_id) {
       update_resign_transaction(trx._trx, trx._signer, ++nonce_prefix, nonce, trx_expiration, chain_id, last_irr_block_id);
-      if (_txcount == 0)
-      {
+      if (_txcount == 0) {
          log_first_trx(_log_dir, trx._trx);
       }
       provider.send(trx._trx);


### PR DESCRIPTION
Refactor - move `launchTrxGenerators` from `Node.py` to `Cluster.py` where it fits better.

Add `waitForTrxGeneratorsSpinup` function which allows tests to wait for initial trx from each generator to appear in a block.  This allows the tests to sync on the trx generators spinning up and knowing that trxs are flowing before proceeding with tests.

Update tests that used `launchTrxGenerators` for the refactor and to use the `waitForTrxGeneratorsSpinup` function.

`trx_generator` now logs first transaction it is preparing to send right before sending it to allow synchronization by tests without influencing its generation rate since it occurs prior only on initial trx and prior to initial trx send.

Resolves: #637