### PR TITLE
Feature bls signatures narrow interface

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "libraries/cli11/cli11"]
 	path = libraries/cli11/cli11
 	url = https://github.com/AntelopeIO/CLI11.git
+[submodule "libraries/libfc/libraries/bls-signatures"]
+        path = libraries/libfc/libraries/bls-signatures
+        url = https://github.com/AntelopeIO/bls-signatures

--- a/benchmark/alt_bn_128.cpp
+++ b/benchmark/alt_bn_128.cpp
@@ -21,7 +21,7 @@ void add_benchmarking() {
 
 
    auto f = [&]() {
-      auto res = bn256::bn256_g1_add(point1, point2, ans);
+      auto res = bn256::g1_add(point1, point2, ans);
       if (res == -1) {
          std::cout << "alt_bn128_add failed" << std::endl;
       }

--- a/benchmark/alt_bn_128.cpp
+++ b/benchmark/alt_bn_128.cpp
@@ -21,7 +21,7 @@ void add_benchmarking() {
 
 
    auto f = [&]() {
-      auto res = bn256::g1_add(point1, point2, ans);
+      auto res = bn256::bn256_g1_add(point1, point2, ans);
       if (res == -1) {
          std::cout << "alt_bn128_add failed" << std::endl;
       }

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -121,6 +121,9 @@ namespace eosio { namespace chain {
 
       built_in_types.emplace("public_key",                pack_unpack_deadline<public_key_type>());
       built_in_types.emplace("signature",                 pack_unpack_deadline<signature_type>());
+      
+      built_in_types.emplace("bls_public_key",            pack_unpack_deadline<bls_public_key_type>());
+      built_in_types.emplace("bls_signature",             pack_unpack_deadline<bls_signature_type>());
 
       built_in_types.emplace("symbol",                    pack_unpack<symbol>());
       built_in_types.emplace("symbol_code",               pack_unpack<symbol_code>());

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -320,6 +320,7 @@ struct controller_impl {
       set_activation_handler<builtin_protocol_feature_t::get_code_hash>();
       set_activation_handler<builtin_protocol_feature_t::get_block_num>();
       set_activation_handler<builtin_protocol_feature_t::crypto_primitives>();
+      set_activation_handler<builtin_protocol_feature_t::aggregate_signatures>();
 
       self.irreversible_block.connect([this](const block_state_ptr& bsp) {
          wasmif.current_lib(bsp->block_num);
@@ -3703,6 +3704,16 @@ void controller_impl::on_activation<builtin_protocol_feature_t::crypto_primitive
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "blake2_f" );
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "sha3" );
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "k1_recover" );
+   } );
+}
+
+template<>
+void controller_impl::on_activation<builtin_protocol_feature_t::aggregate_signatures>() {
+   db.modify( db.get<protocol_state_object>(), [&]( auto& ps ) {
+      add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "bls_verify" );
+      add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "bls_aggregate_pubkeys" );
+      add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "bls_aggregate_sigs" );
+      add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "bls_aggregate_verify" );
    } );
 }
 

--- a/libraries/chain/include/eosio/chain/protocol_feature_manager.hpp
+++ b/libraries/chain/include/eosio/chain/protocol_feature_manager.hpp
@@ -35,6 +35,7 @@ enum class builtin_protocol_feature_t : uint32_t {
    configurable_wasm_limits = 18, // configurable_wasm_limits2,
    crypto_primitives = 19,
    get_block_num = 20,
+   aggregate_signatures = 21,
    reserved_private_fork_protocol_features = 500000,
 };
 

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -16,6 +16,7 @@
 #include <fc/crypto/ripemd160.hpp>
 #include <fc/fixed_string.hpp>
 #include <fc/crypto/private_key.hpp>
+#include <fc/crypto/bls_public_key.hpp>
 
 #include <boost/version.hpp>
 #include <boost/container/deque.hpp>
@@ -78,6 +79,10 @@ namespace eosio { namespace chain {
    using public_key_type  = fc::crypto::public_key;
    using private_key_type = fc::crypto::private_key;
    using signature_type   = fc::crypto::signature;
+
+   using bls_public_key_type  = fc::crypto::blslib::bls_public_key;
+   using bls_signature_type   = fc::crypto::blslib::bls_signature;
+
 #if BOOST_VERSION >= 107100
       // configurable boost deque performs much better than std::deque in our use cases
       using block_1024_option_t = boost::container::deque_options< boost::container::block_size<1024u> >::type;

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/intrinsic_mapping.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/intrinsic_mapping.hpp
@@ -267,7 +267,12 @@ inline constexpr auto get_intrinsic_table() {
       "env.sha3",
       "env.blake2_f",
       "env.k1_recover",
-      "env.get_block_num"
+      "env.get_block_num",
+      "env.get_block_num",
+      "env.bls_verify",
+      "env.bls_aggregate_pubkeys",
+      "env.bls_aggregate_sigs",
+      "env.bls_aggregate_verify"
    );
 }
 inline constexpr std::size_t find_intrinsic_index(std::string_view hf) {

--- a/libraries/chain/include/eosio/chain/webassembly/interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/interface.hpp
@@ -1784,6 +1784,24 @@ namespace webassembly {
           * @return -1 if there was an error 0 otherwise.
          */
          int32_t k1_recover( span<const char> signature, span<const char> digest, span<char> pub) const;
+         
+         /**
+          * Verifies that a signature over a message matches the specified public key.
+          *
+          * @ingroup crypto
+          * @param signatue - signature.
+          * @param digest - digest of the message that was signed.
+          * @param[out] pub - output buffer for the public key result.
+          *
+          * @return true if the signature over the message matches the public key, false otherwise.
+         */
+         bool bls_verify( span<const char> signature, span<const char> digest, span<const char> pub) const;
+         
+         int32_t bls_aggregate_pubkeys( span<const char> pubkeys, span<char> aggregate) const;
+
+         int32_t bls_aggregate_sigs( span<const char> signatures, span<char> aggregate) const;
+
+         bool bls_aggregate_verify( span<const char> signature, span<const char> digests, span<const char> pubs) const;
 
          // compiler builtins api
          void __ashlti3(legacy_ptr<int128_t>, uint64_t, uint64_t, uint32_t) const;

--- a/libraries/chain/include/eosio/chain/webassembly/interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/interface.hpp
@@ -1784,17 +1784,7 @@ namespace webassembly {
           * @return -1 if there was an error 0 otherwise.
          */
          int32_t k1_recover( span<const char> signature, span<const char> digest, span<char> pub) const;
-         
-         /**
-          * Verifies that a signature over a message matches the specified public key.
-          *
-          * @ingroup crypto
-          * @param signatue - signature.
-          * @param digest - digest of the message that was signed.
-          * @param[out] pub - output buffer for the public key result.
-          *
-          * @return true if the signature over the message matches the public key, false otherwise.
-         */
+
          bool bls_verify( span<const char> signature, span<const char> digest, span<const char> pub) const;
          
          int32_t bls_aggregate_pubkeys( span<const char> pubkeys, span<char> aggregate) const;

--- a/libraries/chain/protocol_feature_manager.cpp
+++ b/libraries/chain/protocol_feature_manager.cpp
@@ -257,6 +257,16 @@ Adds new cryptographic host functions
 /*
 Builtin protocol feature: GET_BLOCK_NUM
 
+*/
+            {}
+         } )
+         (  builtin_protocol_feature_t::aggregate_signatures, builtin_protocol_feature_spec{
+            "AGGREGATE_SIGNATURES",
+            fc::variant("997de2624c039e38993953ff1091aeb1ecff723d06fe78a5ade08931b0b22896").as<digest_type>(),
+            // SHA256 hash of the raw message below within the comment delimiters (do not modify message below).
+/*
+Builtin protocol feature: AGGREGATE_SIGNATURES
+
 Enables new `get_block_num` intrinsic which returns the current block number.
 */
             {}

--- a/libraries/chain/webassembly/crypto.cpp
+++ b/libraries/chain/webassembly/crypto.cpp
@@ -7,6 +7,7 @@
 #include <fc/crypto/sha3.hpp>
 #include <fc/crypto/k1_recover.hpp>
 #include <bn256/bn256.h>
+#include <fc/crypto/bls_utils.hpp>
 
 namespace {
     uint32_t ceil_log2(uint32_t n)
@@ -19,6 +20,8 @@ namespace {
 }
 
 namespace eosio { namespace chain { namespace webassembly {
+
+   using namespace bn256;
 
    void interface::assert_recover_key( legacy_ptr<const fc::sha256> digest,
                                        legacy_span<const char> sig,
@@ -118,7 +121,7 @@ namespace eosio { namespace chain { namespace webassembly {
 
    int32_t interface::alt_bn128_add(span<const char> op1, span<const char> op2, span<char> result ) const {
       if (op1.size() != 64 ||  op2.size() != 64 ||  result.size() < 64 ||
-         bn256::g1_add({(const uint8_t*)op1.data(), 64}, {(const uint8_t*)op2.data(), 64}, { (uint8_t*)result.data(), 64}) == -1)
+         bn256::bn256_g1_add({(const uint8_t*)op1.data(), 64}, {(const uint8_t*)op2.data(), 64}, { (uint8_t*)result.data(), 64}) == -1)
          return return_code::failure;
       return return_code::success;
    }
@@ -244,6 +247,90 @@ namespace eosio { namespace chain { namespace webassembly {
 
       std::memcpy( pub.data(), res.data(), res.size() );
       return return_code::success;
+   }
+
+   bool interface::bls_verify( span<const char> signature, span<const char> digest, span<const char> pub) const {
+
+
+      fc::crypto::blslib::bls_signature u_sig;
+      fc::crypto::blslib::bls_public_key u_pub;
+      vector<uint8_t> u_digest;
+
+      datastream<const char*> s_sig( signature.data(), signature.size() );
+      datastream<const char*> s_pub( pub.data(), pub.size() );
+      datastream<const char*> s_digest( digest.data(), digest.size() );
+
+      fc::raw::unpack( s_sig, u_sig );
+      fc::raw::unpack( s_pub, u_pub );
+      fc::raw::unpack( s_digest, u_digest );
+
+      std::cerr << u_pub.to_string() << "\n";
+      std::cerr << u_sig.to_string() << "\n";
+
+      bool result = fc::crypto::blslib::verify(u_pub, u_digest, u_sig);
+
+      return result;
+
+   }
+
+   int32_t interface::bls_aggregate_pubkeys( span<const char> pubkeys, span<char> aggregate) const {
+
+      vector<fc::crypto::blslib::bls_public_key> u_pubkeys;
+
+      datastream<const char*> s_pubkeys( pubkeys.data(), pubkeys.size() );
+
+      fc::raw::unpack( s_pubkeys, u_pubkeys );
+
+      fc::crypto::blslib::bls_public_key agg_pubkey = fc::crypto::blslib::aggregate(u_pubkeys);
+
+      auto packed = fc::raw::pack(agg_pubkey);
+
+      auto copy_size = std::min<size_t>(aggregate.size(), packed.size());
+
+      std::memcpy(aggregate.data(), packed.data(), copy_size);
+
+      return packed.size();
+
+   }
+
+   int32_t interface::bls_aggregate_sigs( span<const char> signatures, span<char> aggregate) const {
+
+      vector<fc::crypto::blslib::bls_signature> u_sigs;
+
+      datastream<const char*> s_sigs( signatures.data(), signatures.size() );
+
+      fc::raw::unpack( s_sigs, u_sigs );
+
+      fc::crypto::blslib::bls_signature agg_sig = fc::crypto::blslib::aggregate(u_sigs);
+
+      auto packed = fc::raw::pack(agg_sig);
+
+      auto copy_size = std::min<size_t>(aggregate.size(), packed.size());
+
+      std::memcpy(aggregate.data(), packed.data(), copy_size);
+
+      return packed.size();
+
+   }
+
+   bool interface::bls_aggregate_verify( span<const char> signature, span<const char> digests, span<const char> pubs) const {
+
+      fc::crypto::blslib::bls_signature u_sig;
+      vector<fc::crypto::blslib::bls_public_key> u_pubs;
+      vector<vector<uint8_t>> u_digests;
+
+      datastream<const char*> s_sig( signature.data(), signature.size() );
+      datastream<const char*> s_pubs( pubs.data(), pubs.size() );
+      datastream<const char*> s_digests( digests.data(), digests.size() );
+
+      fc::raw::unpack( s_sig, u_sig );
+      fc::raw::unpack( s_pubs, u_pubs );
+      fc::raw::unpack( s_digests, u_digests );
+
+      bool result = fc::crypto::blslib::aggregate_verify(u_pubs, u_digests, u_sig);
+
+      return result;
+
    }
 
 }}} // ns eosio::chain::webassembly

--- a/libraries/chain/webassembly/crypto.cpp
+++ b/libraries/chain/webassembly/crypto.cpp
@@ -121,7 +121,7 @@ namespace eosio { namespace chain { namespace webassembly {
 
    int32_t interface::alt_bn128_add(span<const char> op1, span<const char> op2, span<char> result ) const {
       if (op1.size() != 64 ||  op2.size() != 64 ||  result.size() < 64 ||
-         bn256::bn256_g1_add({(const uint8_t*)op1.data(), 64}, {(const uint8_t*)op2.data(), 64}, { (uint8_t*)result.data(), 64}) == -1)
+         bn256::g1_add({(const uint8_t*)op1.data(), 64}, {(const uint8_t*)op2.data(), 64}, { (uint8_t*)result.data(), 64}) == -1)
          return return_code::failure;
       return return_code::success;
    }
@@ -267,7 +267,7 @@ namespace eosio { namespace chain { namespace webassembly {
       std::cerr << u_pub.to_string() << "\n";
       std::cerr << u_sig.to_string() << "\n";
 
-      bool result = fc::crypto::blslib::verify(u_pub, u_digest, u_sig);
+      bool result = fc::crypto::blslib::bls_utils::verify(u_pub, u_digest, u_sig);
 
       return result;
 
@@ -281,7 +281,7 @@ namespace eosio { namespace chain { namespace webassembly {
 
       fc::raw::unpack( s_pubkeys, u_pubkeys );
 
-      fc::crypto::blslib::bls_public_key agg_pubkey = fc::crypto::blslib::aggregate(u_pubkeys);
+      fc::crypto::blslib::bls_public_key agg_pubkey = fc::crypto::blslib::bls_utils::aggregate(u_pubkeys);
 
       auto packed = fc::raw::pack(agg_pubkey);
 
@@ -301,7 +301,7 @@ namespace eosio { namespace chain { namespace webassembly {
 
       fc::raw::unpack( s_sigs, u_sigs );
 
-      fc::crypto::blslib::bls_signature agg_sig = fc::crypto::blslib::aggregate(u_sigs);
+      fc::crypto::blslib::bls_signature agg_sig = fc::crypto::blslib::bls_utils::aggregate(u_sigs);
 
       auto packed = fc::raw::pack(agg_sig);
 
@@ -327,7 +327,7 @@ namespace eosio { namespace chain { namespace webassembly {
       fc::raw::unpack( s_pubs, u_pubs );
       fc::raw::unpack( s_digests, u_digests );
 
-      bool result = fc::crypto::blslib::aggregate_verify(u_pubs, u_digests, u_sig);
+      bool result = fc::crypto::blslib::bls_utils::aggregate_verify(u_pubs, u_digests, u_sig);
 
       return result;
 

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -629,6 +629,12 @@ REGISTER_CF_HOST_FUNCTION( blake2_f );
 REGISTER_CF_HOST_FUNCTION( sha3 );
 REGISTER_CF_HOST_FUNCTION( k1_recover );
 
+// aggregate_signatures protocol feature
+REGISTER_CF_HOST_FUNCTION( bls_verify );
+REGISTER_CF_HOST_FUNCTION( bls_aggregate_pubkeys );
+REGISTER_CF_HOST_FUNCTION( bls_aggregate_sigs );
+REGISTER_CF_HOST_FUNCTION( bls_aggregate_verify );
+
 } // namespace webassembly
 } // namespace chain
 } // namespace eosio

--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -57,6 +57,7 @@ set( fc_sources
      src/crypto/bls_private_key.cpp
      src/crypto/bls_public_key.cpp
      src/crypto/bls_signature.cpp
+     src/crypto/bls_utils.cpp
      src/crypto/modular_arithmetic.cpp
      src/crypto/blake2.cpp
      src/crypto/k1_recover.cpp

--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory( secp256k1 )
 add_subdirectory( libraries/bn256/src )
+add_subdirectory( libraries/bls-signatures )
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
@@ -53,6 +54,9 @@ set( fc_sources
      src/crypto/public_key.cpp
      src/crypto/private_key.cpp
      src/crypto/signature.cpp
+     src/crypto/bls_private_key.cpp
+     src/crypto/bls_public_key.cpp
+     src/crypto/bls_signature.cpp
      src/crypto/modular_arithmetic.cpp
      src/crypto/blake2.cpp
      src/crypto/k1_recover.cpp
@@ -140,7 +144,7 @@ if(APPLE)
   find_library(security_framework Security)
   find_library(corefoundation_framework CoreFoundation)
 endif()
-target_link_libraries( fc PUBLIC Boost::date_time Boost::filesystem Boost::chrono Boost::iostreams Threads::Threads
+target_link_libraries( fc PUBLIC bls Boost::date_time Boost::filesystem Boost::chrono Boost::iostreams Threads::Threads
                                  OpenSSL::Crypto OpenSSL::SSL ZLIB::ZLIB ${PLATFORM_SPECIFIC_LIBS} ${CMAKE_DL_LIBS} secp256k1 ${security_framework} ${corefoundation_framework})
 
 # Critically, this ensures that OpenSSL 1.1 & 3.0 both have a variant of BN_zero() with void return value. But it also allows access

--- a/libraries/libfc/include/fc/crypto/bls_private_key.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_private_key.hpp
@@ -6,11 +6,11 @@
 #include <fc/reflect/reflect.hpp>
 #include <fc/reflect/variant.hpp>
 #include <fc/static_variant.hpp>
-#include <bls.hpp>
 
 namespace fc { namespace crypto { namespace blslib {
 
-   using namespace bls;
+
+   //using namespace bls;
 
    class bls_private_key
    {
@@ -21,12 +21,12 @@ namespace fc { namespace crypto { namespace blslib {
          bls_private_key( const bls_private_key& ) = default;
          bls_private_key& operator= (const bls_private_key& ) = default;
 
-         bls_private_key( vector<uint8_t> seed ){
+         bls_private_key( std::vector<uint8_t> seed ){
             _seed = seed;
          }
 
          bls_public_key     get_public_key() const;
-         bls_signature      sign( vector<uint8_t> message ) const;
+         bls_signature      sign( std::vector<uint8_t> message ) const;
          sha512         generate_shared_secret( const bls_public_key& pub ) const;
 
          std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
@@ -37,12 +37,12 @@ namespace fc { namespace crypto { namespace blslib {
 
             rand_bytes(r, 32);
 
-            vector<uint8_t> v(r, r+32);
+            std::vector<uint8_t> v(r, r+32);
 
             return bls_private_key(v);
          }
 
-         static bls_private_key regenerate( vector<uint8_t> seed ) {
+         static bls_private_key regenerate( std::vector<uint8_t> seed ) {
             return bls_private_key(seed);
          }
 
@@ -52,7 +52,7 @@ namespace fc { namespace crypto { namespace blslib {
          std::string serialize();
 
       private:
-         vector<uint8_t> _seed;
+         std::vector<uint8_t> _seed;
 
          friend bool operator == ( const bls_private_key& p1, const bls_private_key& p2);
          friend bool operator != ( const bls_private_key& p1, const bls_private_key& p2);

--- a/libraries/libfc/include/fc/crypto/bls_private_key.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_private_key.hpp
@@ -1,0 +1,76 @@
+#pragma once
+#include <fc/crypto/elliptic.hpp>
+#include <fc/crypto/elliptic_r1.hpp>
+#include <fc/crypto/bls_public_key.hpp>
+#include <fc/crypto/rand.hpp>
+#include <fc/reflect/reflect.hpp>
+#include <fc/reflect/variant.hpp>
+#include <fc/static_variant.hpp>
+#include <bls.hpp>
+
+namespace fc { namespace crypto { namespace blslib {
+
+   using namespace bls;
+
+/*   namespace config {
+      constexpr const char* bls_private_key_base_prefix = "PVT";
+      constexpr const char* bls_private_key_prefix = "BLS";
+   };*/
+
+   class bls_private_key
+   {
+      public:
+
+         bls_private_key() = default;
+         bls_private_key( bls_private_key&& ) = default;
+         bls_private_key( const bls_private_key& ) = default;
+         bls_private_key& operator= (const bls_private_key& ) = default;
+
+         bls_private_key( vector<uint8_t> seed ){
+            _seed = seed;
+         }
+
+         bls_public_key     get_public_key() const;
+         bls_signature      sign( vector<uint8_t> message ) const;
+         sha512         generate_shared_secret( const bls_public_key& pub ) const;
+
+         std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
+
+         static bls_private_key generate() {
+
+            char* r = (char*) malloc(32);
+
+            rand_bytes(r, 32);
+
+            vector<uint8_t> v(r, r+32);
+
+            return bls_private_key(v);
+         }
+
+         static bls_private_key regenerate( vector<uint8_t> seed ) {
+            return bls_private_key(seed);
+         }
+
+         // serialize to/from string
+         explicit bls_private_key(const string& base58str);
+
+         std::string serialize();
+
+      private:
+         vector<uint8_t> _seed;
+
+         friend bool operator == ( const bls_private_key& p1, const bls_private_key& p2);
+         friend bool operator != ( const bls_private_key& p1, const bls_private_key& p2);
+         friend bool operator < ( const bls_private_key& p1, const bls_private_key& p2);
+         friend struct reflector<bls_private_key>;
+   }; // bls_private_key
+
+} } }  // fc::crypto::blslib
+
+namespace fc {
+   void to_variant(const crypto::blslib::bls_private_key& var, variant& vo, const fc::yield_function_t& yield = fc::yield_function_t());
+
+   void from_variant(const variant& var, crypto::blslib::bls_private_key& vo);
+} // namespace fc
+
+FC_REFLECT(fc::crypto::blslib::bls_private_key, (_seed) )

--- a/libraries/libfc/include/fc/crypto/bls_private_key.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_private_key.hpp
@@ -12,11 +12,6 @@ namespace fc { namespace crypto { namespace blslib {
 
    using namespace bls;
 
-/*   namespace config {
-      constexpr const char* bls_private_key_base_prefix = "PVT";
-      constexpr const char* bls_private_key_prefix = "BLS";
-   };*/
-
    class bls_private_key
    {
       public:

--- a/libraries/libfc/include/fc/crypto/bls_public_key.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_public_key.hpp
@@ -1,0 +1,79 @@
+#pragma once
+#include <fc/crypto/elliptic.hpp>
+#include <fc/crypto/elliptic_r1.hpp>
+#include <fc/crypto/elliptic_webauthn.hpp>
+#include <fc/crypto/bls_signature.hpp>
+#include <fc/reflect/reflect.hpp>
+#include <fc/reflect/variant.hpp>
+#include <fc/static_variant.hpp>
+//#include <bls.hpp>
+
+namespace fc { namespace crypto { namespace blslib {
+
+   using namespace std;
+/*
+   namespace config {
+      constexpr const char* bls_public_key_legacy_prefix = "EOS";
+      constexpr const char* bls_public_key_base_prefix = "PUB";
+      constexpr const char* bls_public_key_prefix = "BLS";
+
+   };*/
+
+   class bls_public_key
+   {
+      public:
+
+         bls_public_key() = default;
+         bls_public_key( bls_public_key&& ) = default;
+         bls_public_key( const bls_public_key& ) = default;
+         bls_public_key& operator= (const bls_public_key& ) = default;
+
+         bls_public_key( std::vector<uint8_t> pkey ){
+            _pkey = pkey;
+         }
+
+/*         bls_public_key( G1Element pkey ){
+            _pkey = pkey.Serialize();
+         }
+*/
+         //bls_public_key( const bls_signature& c, const sha256& digest, bool check_canonical = true );
+
+/*         bls_public_key( storage_type&& other_storage )
+         :_storage(forward<storage_type>(other_storage))
+         {}
+*/
+         bool valid()const;
+
+         size_t which()const;
+
+         // serialize to/from string
+         explicit bls_public_key(const string& base58str);
+         //std::string to_string() const;
+         //std::string to_string() ;
+
+         std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
+
+         //storage_type _storage;
+
+         std::vector<uint8_t> _pkey;
+
+      private:
+
+
+         friend std::ostream& operator<< (std::ostream& s, const bls_public_key& k);
+         //friend bool operator == ( const bls_public_key& p1, const bls_public_key& p2);
+         //friend bool operator != ( const bls_public_key& p1, const bls_public_key& p2);
+         //friend bool operator < ( const bls_public_key& p1, const bls_public_key& p2);
+         friend struct reflector<bls_public_key>;
+         friend class bls_private_key;
+   }; // bls_public_key
+
+} } }  // fc::crypto::blslib
+
+namespace fc {
+   void to_variant(const crypto::blslib::bls_public_key& var, variant& vo, const fc::yield_function_t& yield = fc::yield_function_t());
+
+   void from_variant(const variant& var, crypto::blslib::bls_public_key& vo);
+} // namespace fc
+
+FC_REFLECT(fc::crypto::blslib::bls_public_key, (_pkey) )

--- a/libraries/libfc/include/fc/crypto/bls_public_key.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_public_key.hpp
@@ -10,15 +10,6 @@
 
 namespace fc { namespace crypto { namespace blslib {
 
-   using namespace std;
-/*
-   namespace config {
-      constexpr const char* bls_public_key_legacy_prefix = "EOS";
-      constexpr const char* bls_public_key_base_prefix = "PUB";
-      constexpr const char* bls_public_key_prefix = "BLS";
-
-   };*/
-
    class bls_public_key
    {
       public:
@@ -38,12 +29,9 @@ namespace fc { namespace crypto { namespace blslib {
 
          // serialize to/from string
          explicit bls_public_key(const string& base58str);
-         //std::string to_string() const;
-         //std::string to_string() ;
 
          std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
 
-         //storage_type _storage;
 
          std::vector<uint8_t> _pkey;
 

--- a/libraries/libfc/include/fc/crypto/bls_public_key.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_public_key.hpp
@@ -32,16 +32,6 @@ namespace fc { namespace crypto { namespace blslib {
             _pkey = pkey;
          }
 
-/*         bls_public_key( G1Element pkey ){
-            _pkey = pkey.Serialize();
-         }
-*/
-         //bls_public_key( const bls_signature& c, const sha256& digest, bool check_canonical = true );
-
-/*         bls_public_key( storage_type&& other_storage )
-         :_storage(forward<storage_type>(other_storage))
-         {}
-*/
          bool valid()const;
 
          size_t which()const;
@@ -61,9 +51,7 @@ namespace fc { namespace crypto { namespace blslib {
 
 
          friend std::ostream& operator<< (std::ostream& s, const bls_public_key& k);
-         //friend bool operator == ( const bls_public_key& p1, const bls_public_key& p2);
-         //friend bool operator != ( const bls_public_key& p1, const bls_public_key& p2);
-         //friend bool operator < ( const bls_public_key& p1, const bls_public_key& p2);
+
          friend struct reflector<bls_public_key>;
          friend class bls_private_key;
    }; // bls_public_key

--- a/libraries/libfc/include/fc/crypto/bls_signature.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_signature.hpp
@@ -12,15 +12,9 @@ namespace fc { namespace crypto { namespace blslib {
 
    using namespace std;
 
-/*   namespace config {
-      constexpr const char* bls_signature_base_prefix = "SIG";
-      constexpr const char* bls_signature_prefix = "BLS";
-   };
-*/
    class bls_signature
    {
       public:
-         //using storage_type = ecc::signature_shim;//std::variant<ecc::signature_shim, r1::signature_shim, webauthn::signature>;
 
          bls_signature() = default;
          bls_signature( bls_signature&& ) = default;
@@ -31,10 +25,6 @@ namespace fc { namespace crypto { namespace blslib {
             _sig = sig;
          }
 
-/*         bls_signature( G2Element sig ){
-            _sig = sig.Serialize();
-         }
-*/
          // serialize to/from string
          explicit bls_signature(const string& base58str);
          std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
@@ -48,22 +38,11 @@ namespace fc { namespace crypto { namespace blslib {
 
       private:
 
-         //storage_type _storage;
-
-/*         bls_signature( storage_type&& other_storage )
-         :_storage(std::forward<storage_type>(other_storage))
-         {}
-*/
-         //friend bool operator == ( const bls_signature& p1, const bls_signature& p2);
-         //friend bool operator != ( const bls_signature& p1, const bls_signature& p2);
-        //friend bool operator < ( const bls_signature& p1, const bls_signature& p2);
          friend std::size_t hash_value(const bls_signature& b); //not cryptographic; for containers
          friend struct reflector<bls_signature>;
          friend class bls_private_key;
          friend class bls_public_key;
    }; // bls_public_key
-
-   //size_t hash_value(const bls_signature& b);
 
 } } }  // fc::crypto::blslib
 
@@ -73,12 +52,12 @@ namespace fc {
    void from_variant(const variant& var, crypto::blslib::bls_signature& vo);
 } // namespace fc
 
-namespace std {
+/*namespace std {
    template <> struct hash<fc::crypto::blslib::bls_signature> {
       std::size_t operator()(const fc::crypto::blslib::bls_signature& k) const {
          //return fc::crypto::hash_value(k);
       }
    };
 } // std
-
+*/
 FC_REFLECT(fc::crypto::blslib::bls_signature, (_sig) )

--- a/libraries/libfc/include/fc/crypto/bls_signature.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_signature.hpp
@@ -10,7 +10,7 @@
 
 namespace fc { namespace crypto { namespace blslib {
 
-   using namespace std;
+   //using namespace std;
 
    class bls_signature
    {
@@ -28,8 +28,6 @@ namespace fc { namespace crypto { namespace blslib {
          // serialize to/from string
          explicit bls_signature(const string& base58str);
          std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
-
-         size_t which() const;
 
          size_t variable_size() const;
 
@@ -52,12 +50,4 @@ namespace fc {
    void from_variant(const variant& var, crypto::blslib::bls_signature& vo);
 } // namespace fc
 
-/*namespace std {
-   template <> struct hash<fc::crypto::blslib::bls_signature> {
-      std::size_t operator()(const fc::crypto::blslib::bls_signature& k) const {
-         //return fc::crypto::hash_value(k);
-      }
-   };
-} // std
-*/
 FC_REFLECT(fc::crypto::blslib::bls_signature, (_sig) )

--- a/libraries/libfc/include/fc/crypto/bls_signature.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_signature.hpp
@@ -1,0 +1,84 @@
+#pragma once
+#include <fc/static_variant.hpp>
+#include <fc/crypto/elliptic.hpp>
+#include <fc/crypto/elliptic_r1.hpp>
+#include <fc/crypto/elliptic_webauthn.hpp>
+#include <fc/crypto/bls_public_key.hpp>
+#include <fc/reflect/reflect.hpp>
+#include <fc/reflect/variant.hpp>
+//#include <bls.hpp>
+
+namespace fc { namespace crypto { namespace blslib {
+
+   using namespace std;
+
+/*   namespace config {
+      constexpr const char* bls_signature_base_prefix = "SIG";
+      constexpr const char* bls_signature_prefix = "BLS";
+   };
+*/
+   class bls_signature
+   {
+      public:
+         //using storage_type = ecc::signature_shim;//std::variant<ecc::signature_shim, r1::signature_shim, webauthn::signature>;
+
+         bls_signature() = default;
+         bls_signature( bls_signature&& ) = default;
+         bls_signature( const bls_signature& ) = default;
+         bls_signature& operator= (const bls_signature& ) = default;
+
+         bls_signature( std::vector<uint8_t> sig ){
+            _sig = sig;
+         }
+
+/*         bls_signature( G2Element sig ){
+            _sig = sig.Serialize();
+         }
+*/
+         // serialize to/from string
+         explicit bls_signature(const string& base58str);
+         std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
+
+         size_t which() const;
+
+         size_t variable_size() const;
+
+
+         std::vector<uint8_t> _sig;
+
+      private:
+
+         //storage_type _storage;
+
+/*         bls_signature( storage_type&& other_storage )
+         :_storage(std::forward<storage_type>(other_storage))
+         {}
+*/
+         //friend bool operator == ( const bls_signature& p1, const bls_signature& p2);
+         //friend bool operator != ( const bls_signature& p1, const bls_signature& p2);
+        //friend bool operator < ( const bls_signature& p1, const bls_signature& p2);
+         friend std::size_t hash_value(const bls_signature& b); //not cryptographic; for containers
+         friend struct reflector<bls_signature>;
+         friend class bls_private_key;
+         friend class bls_public_key;
+   }; // bls_public_key
+
+   //size_t hash_value(const bls_signature& b);
+
+} } }  // fc::crypto::blslib
+
+namespace fc {
+   void to_variant(const crypto::blslib::bls_signature& var, variant& vo, const fc::yield_function_t& yield = fc::yield_function_t());
+
+   void from_variant(const variant& var, crypto::blslib::bls_signature& vo);
+} // namespace fc
+
+namespace std {
+   template <> struct hash<fc::crypto::blslib::bls_signature> {
+      std::size_t operator()(const fc::crypto::blslib::bls_signature& k) const {
+         //return fc::crypto::hash_value(k);
+      }
+   };
+} // std
+
+FC_REFLECT(fc::crypto::blslib::bls_signature, (_sig) )

--- a/libraries/libfc/include/fc/crypto/bls_utils.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_utils.hpp
@@ -1,66 +1,21 @@
 #pragma once
 #include <fc/crypto/bls_private_key.hpp>
-//#include <fc/crypto/bls_public_key.hpp>
-//#include <fc/crypto/bls_signature.hpp>
 #include <fc/crypto/rand.hpp>
-//#include <bls.hpp>
 
-namespace fc { namespace crypto { namespace blslib {
+namespace fc { namespace crypto { namespace blslib { namespace bls_utils {
 
-   static bls_private_key generate() {
+   bls_private_key generate();
 
-     char* r = (char*) malloc(32);
+   bool verify( const bls_public_key &pubkey,
+                  const std::vector<uint8_t> &message,
+                  const bls_signature &signature);
 
-     rand_bytes(r, 32);
+   bls_public_key aggregate( const std::vector<bls_public_key> &keys);
 
-     vector<uint8_t> v(r, r+32);
+   bls_signature aggregate( const std::vector<bls_signature> &signatures);
 
-     return bls_private_key(v);
+   bool aggregate_verify( const std::vector<bls_public_key> &pubkeys,
+                  const std::vector<std::vector<uint8_t>> &messages,
+                  const bls_signature &signature);
 
-   }
-
-   static bool verify( const bls_public_key &pubkey,
-                  const vector<uint8_t> &message,
-                  const bls_signature &signature){
-
-      return PopSchemeMPL().Verify(pubkey._pkey, message, signature._sig);
-
-   };
-
-   static bls_public_key aggregate( const vector<bls_public_key> &keys){
-
-      G1Element aggKey;
-
-      for (size_t i = 0 ; i < keys.size(); i++){
-         aggKey += G1Element::FromByteVector(keys[i]._pkey);
-      }
-
-      return bls_public_key(aggKey.Serialize());
-
-   };
-
-   static bls_signature aggregate( const vector<bls_signature> &signatures){
-
-      vector<vector<uint8_t>> v_sigs;
-
-      for (size_t i = 0 ; i < signatures.size(); i++)
-         v_sigs.push_back(signatures[i]._sig);
-
-      return bls_signature(PopSchemeMPL().Aggregate(v_sigs));
-
-   };
-
-   static bool aggregate_verify( const vector<bls_public_key> &pubkeys,
-                  const vector<vector<uint8_t>> &messages,
-                  const bls_signature &signature){
-
-      vector<vector<uint8_t>> v_pubkeys;
-
-      for (size_t i = 0 ; i < pubkeys.size(); i++)
-         v_pubkeys.push_back(pubkeys[i]._pkey);
-
-      return PopSchemeMPL().AggregateVerify(v_pubkeys, messages, signature._sig);
-
-   };
-
-} } }  // fc::crypto::blslib
+} } } }  // fc::crypto::blslib:bls_utils

--- a/libraries/libfc/include/fc/crypto/bls_utils.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_utils.hpp
@@ -1,0 +1,66 @@
+#pragma once
+#include <fc/crypto/bls_private_key.hpp>
+//#include <fc/crypto/bls_public_key.hpp>
+//#include <fc/crypto/bls_signature.hpp>
+#include <fc/crypto/rand.hpp>
+//#include <bls.hpp>
+
+namespace fc { namespace crypto { namespace blslib {
+
+   static bls_private_key generate() {
+
+     char* r = (char*) malloc(32);
+
+     rand_bytes(r, 32);
+
+     vector<uint8_t> v(r, r+32);
+
+     return bls_private_key(v);
+
+   }
+
+   static bool verify( const bls_public_key &pubkey,
+                  const vector<uint8_t> &message,
+                  const bls_signature &signature){
+
+      return PopSchemeMPL().Verify(pubkey._pkey, message, signature._sig);
+
+   };
+
+   static bls_public_key aggregate( const vector<bls_public_key> &keys){
+
+      G1Element aggKey;
+
+      for (size_t i = 0 ; i < keys.size(); i++){
+         aggKey += G1Element::FromByteVector(keys[i]._pkey);
+      }
+
+      return bls_public_key(aggKey.Serialize());
+
+   };
+
+   static bls_signature aggregate( const vector<bls_signature> &signatures){
+
+      vector<vector<uint8_t>> v_sigs;
+
+      for (size_t i = 0 ; i < signatures.size(); i++)
+         v_sigs.push_back(signatures[i]._sig);
+
+      return bls_signature(PopSchemeMPL().Aggregate(v_sigs));
+
+   };
+
+   static bool aggregate_verify( const vector<bls_public_key> &pubkeys,
+                  const vector<vector<uint8_t>> &messages,
+                  const bls_signature &signature){
+
+      vector<vector<uint8_t>> v_pubkeys;
+
+      for (size_t i = 0 ; i < pubkeys.size(); i++)
+         v_pubkeys.push_back(pubkeys[i]._pkey);
+
+      return PopSchemeMPL().AggregateVerify(v_pubkeys, messages, signature._sig);
+
+   };
+
+} } }  // fc::crypto::blslib

--- a/libraries/libfc/src/crypto/bls_private_key.cpp
+++ b/libraries/libfc/src/crypto/bls_private_key.cpp
@@ -1,0 +1,151 @@
+#include <fc/crypto/bls_private_key.hpp>
+#include <fc/utility.hpp>
+#include <fc/exception/exception.hpp>
+
+namespace fc { namespace crypto { namespace blslib {
+
+   using namespace std;
+
+   bls_public_key bls_private_key::get_public_key() const
+   {  
+      G1Element pk = AugSchemeMPL().KeyGen(_seed).GetG1Element();
+
+      return bls_public_key(pk.Serialize());
+   }
+
+   bls_signature bls_private_key::sign( vector<uint8_t> message ) const
+   {  
+
+   PrivateKey sk = AugSchemeMPL().KeyGen(_seed);
+
+      G2Element s = PopSchemeMPL().Sign(sk, message);
+      return bls_signature(s.Serialize());
+   }
+
+   /*struct public_key_visitor : visitor<bls_public_key::storage_type> {
+      template<typename KeyType>
+      bls_public_key::storage_type operator()(const KeyType& key) const
+      {
+        //return bls_public_key::storage_type(key.get_public_key());
+      }
+   };
+   struct sign_visitor : visitor<bls_signature::storage_type> {
+      sign_visitor( const sha256& digest, bool require_canonical )
+      :_digest(digest)
+      ,_require_canonical(require_canonical)
+      {}
+      template<typename KeyType>
+      bls_signature::storage_type operator()(const KeyType& key) const
+      {
+         return bls_signature::storage_type(key.sign(_digest, _require_canonical));
+      }
+      const sha256&  _digest;
+      bool           _require_canonical;
+   };
+   bls_signature bls_private_key::sign( vector<uint8_t> message ) const
+   {
+      //return bls_signature(std::visit(sign_visitor(digest, require_canonical), _seed));
+   }
+   struct generate_shared_secret_visitor : visitor<sha512> {
+      generate_shared_secret_visitor( const bls_public_key::storage_type& pub_storage )
+      :_pub_storage(pub_storage)
+      {}
+      template<typename KeyType>
+      sha512 operator()(const KeyType& key) const
+      {
+         using PublicKeyType = typename KeyType::public_key_type;
+         return key.generate_shared_secret(std::template get<PublicKeyType>(_pub_storage));
+      }
+      const bls_public_key::storage_type&  _pub_storage;
+   };
+   sha512 bls_private_key::generate_shared_secret( const bls_public_key& pub ) const
+   template<typename Data>
+   string to_wif( const Data& secret, const fc::yield_function_t& yield )
+   {
+   {
+      return std::visit(generate_shared_secret_visitor(pub._storage), _seed);
+   }*/
+  /*    const size_t size_of_data_to_hash = sizeof(typename Data::data_type) + 1;
+      const size_t size_of_hash_bytes = 4;
+      char data[size_of_data_to_hash + size_of_hash_bytes];
+      data[0] = (char)0x80; // this is the Bitcoin MainNet code
+      memcpy(&data[1], (const char*)&secret.serialize(), sizeof(typename Data::data_type));
+      sha256 digest = sha256::hash(data, size_of_data_to_hash);
+      digest = sha256::hash(digest);
+      memcpy(data + size_of_data_to_hash, (char*)&digest, size_of_hash_bytes);
+      return to_base58(data, sizeof(data), yield);
+   }
+*/
+
+   /*template<typename Data>
+   Data from_wif( const string& wif_key )
+   {
+      auto wif_bytes = from_base58(wif_key);
+      FC_ASSERT(wif_bytes.size() >= 5);
+      auto key_bytes = vector<char>(wif_bytes.begin() + 1, wif_bytes.end() - 4);
+      fc::sha256 check = fc::sha256::hash(wif_bytes.data(), wif_bytes.size() - 4);
+      fc::sha256 check2 = fc::sha256::hash(check);
+      FC_ASSERT(memcmp( (char*)&check, wif_bytes.data() + wif_bytes.size() - 4, 4 ) == 0 ||
+                memcmp( (char*)&check2, wif_bytes.data() + wif_bytes.size() - 4, 4 ) == 0 );
+      return Data(fc::variant(key_bytes).as<typename Data::data_type>());
+   }*/
+
+/*   static vector<uint8_t> priv_parse_base58(const string& base58str)
+   {
+      const auto pivot = base58str.find('_');
+      if (pivot == std::string::npos) {
+         // wif import
+         using default_type = std::variant_alternative_t<0, bls_private_key::storage_type>;
+         return bls_private_key::storage_type(from_wif<default_type>(base58str));
+      } else {
+         constexpr auto prefix = config::private_key_base_prefix;
+         const auto prefix_str = base58str.substr(0, pivot);
+         FC_ASSERT(prefix == prefix_str, "Private Key has invalid prefix: ${str}", ("str", base58str)("prefix_str", prefix_str));
+         auto data_str = base58str.substr(pivot + 1);
+         FC_ASSERT(!data_str.empty(), "Private Key has no data: ${str}", ("str", base58str));
+         return base58_str_parser<bls_private_key::storage_type, config::private_key_prefix>::apply(data_str);
+      }
+   }*/
+
+   bls_private_key::bls_private_key(const std::string& base58str){}
+
+   std::string bls_private_key::to_string(const fc::yield_function_t& yield) const
+   {
+
+      PrivateKey pk = AugSchemeMPL().KeyGen(_seed);
+      vector<uint8_t> pkBytes = pk.Serialize();
+      auto data_str = Util::HexStr(pkBytes);
+      return data_str;/**/
+   }
+
+/*   std::string bls_private_key::serialize(){
+      PrivateKey sk = AugSchemeMPL().KeyGen(_seed);
+      return Util::HexStr(sk.Serialize());
+   }*/
+
+   std::ostream& operator<<(std::ostream& s, const bls_private_key& k) {
+      s << "bls_private_key(" << k.to_string() << ')';
+      return s;
+   }
+/*
+   bool operator == ( const bls_private_key& p1, const bls_private_key& p2) {
+      return eq_comparator<vector<char>>::apply(p1._seed, p2._seed);
+   }
+   bool operator < ( const bls_private_key& p1, const bls_private_key& p2){
+      return less_comparator<vector<char>>::apply(p1._seed, p2._seed);
+   }*/
+} } }  // fc::crypto::blslib
+
+namespace fc
+{
+   void to_variant(const fc::crypto::blslib::bls_private_key& var, variant& vo, const fc::yield_function_t& yield)
+   {
+      vo = var.to_string(yield);
+   }
+
+   void from_variant(const variant& var, fc::crypto::blslib::bls_private_key& vo)
+   {
+      vo = fc::crypto::blslib::bls_private_key(var.as_string());
+   }
+
+} // fc

--- a/libraries/libfc/src/crypto/bls_private_key.cpp
+++ b/libraries/libfc/src/crypto/bls_private_key.cpp
@@ -22,91 +22,6 @@ namespace fc { namespace crypto { namespace blslib {
       return bls_signature(s.Serialize());
    }
 
-   /*struct public_key_visitor : visitor<bls_public_key::storage_type> {
-      template<typename KeyType>
-      bls_public_key::storage_type operator()(const KeyType& key) const
-      {
-        //return bls_public_key::storage_type(key.get_public_key());
-      }
-   };
-   struct sign_visitor : visitor<bls_signature::storage_type> {
-      sign_visitor( const sha256& digest, bool require_canonical )
-      :_digest(digest)
-      ,_require_canonical(require_canonical)
-      {}
-      template<typename KeyType>
-      bls_signature::storage_type operator()(const KeyType& key) const
-      {
-         return bls_signature::storage_type(key.sign(_digest, _require_canonical));
-      }
-      const sha256&  _digest;
-      bool           _require_canonical;
-   };
-   bls_signature bls_private_key::sign( vector<uint8_t> message ) const
-   {
-      //return bls_signature(std::visit(sign_visitor(digest, require_canonical), _seed));
-   }
-   struct generate_shared_secret_visitor : visitor<sha512> {
-      generate_shared_secret_visitor( const bls_public_key::storage_type& pub_storage )
-      :_pub_storage(pub_storage)
-      {}
-      template<typename KeyType>
-      sha512 operator()(const KeyType& key) const
-      {
-         using PublicKeyType = typename KeyType::public_key_type;
-         return key.generate_shared_secret(std::template get<PublicKeyType>(_pub_storage));
-      }
-      const bls_public_key::storage_type&  _pub_storage;
-   };
-   sha512 bls_private_key::generate_shared_secret( const bls_public_key& pub ) const
-   template<typename Data>
-   string to_wif( const Data& secret, const fc::yield_function_t& yield )
-   {
-   {
-      return std::visit(generate_shared_secret_visitor(pub._storage), _seed);
-   }*/
-  /*    const size_t size_of_data_to_hash = sizeof(typename Data::data_type) + 1;
-      const size_t size_of_hash_bytes = 4;
-      char data[size_of_data_to_hash + size_of_hash_bytes];
-      data[0] = (char)0x80; // this is the Bitcoin MainNet code
-      memcpy(&data[1], (const char*)&secret.serialize(), sizeof(typename Data::data_type));
-      sha256 digest = sha256::hash(data, size_of_data_to_hash);
-      digest = sha256::hash(digest);
-      memcpy(data + size_of_data_to_hash, (char*)&digest, size_of_hash_bytes);
-      return to_base58(data, sizeof(data), yield);
-   }
-*/
-
-   /*template<typename Data>
-   Data from_wif( const string& wif_key )
-   {
-      auto wif_bytes = from_base58(wif_key);
-      FC_ASSERT(wif_bytes.size() >= 5);
-      auto key_bytes = vector<char>(wif_bytes.begin() + 1, wif_bytes.end() - 4);
-      fc::sha256 check = fc::sha256::hash(wif_bytes.data(), wif_bytes.size() - 4);
-      fc::sha256 check2 = fc::sha256::hash(check);
-      FC_ASSERT(memcmp( (char*)&check, wif_bytes.data() + wif_bytes.size() - 4, 4 ) == 0 ||
-                memcmp( (char*)&check2, wif_bytes.data() + wif_bytes.size() - 4, 4 ) == 0 );
-      return Data(fc::variant(key_bytes).as<typename Data::data_type>());
-   }*/
-
-/*   static vector<uint8_t> priv_parse_base58(const string& base58str)
-   {
-      const auto pivot = base58str.find('_');
-      if (pivot == std::string::npos) {
-         // wif import
-         using default_type = std::variant_alternative_t<0, bls_private_key::storage_type>;
-         return bls_private_key::storage_type(from_wif<default_type>(base58str));
-      } else {
-         constexpr auto prefix = config::private_key_base_prefix;
-         const auto prefix_str = base58str.substr(0, pivot);
-         FC_ASSERT(prefix == prefix_str, "Private Key has invalid prefix: ${str}", ("str", base58str)("prefix_str", prefix_str));
-         auto data_str = base58str.substr(pivot + 1);
-         FC_ASSERT(!data_str.empty(), "Private Key has no data: ${str}", ("str", base58str));
-         return base58_str_parser<bls_private_key::storage_type, config::private_key_prefix>::apply(data_str);
-      }
-   }*/
-
    bls_private_key::bls_private_key(const std::string& base58str){}
 
    std::string bls_private_key::to_string(const fc::yield_function_t& yield) const
@@ -118,22 +33,11 @@ namespace fc { namespace crypto { namespace blslib {
       return data_str;/**/
    }
 
-/*   std::string bls_private_key::serialize(){
-      PrivateKey sk = AugSchemeMPL().KeyGen(_seed);
-      return Util::HexStr(sk.Serialize());
-   }*/
-
    std::ostream& operator<<(std::ostream& s, const bls_private_key& k) {
       s << "bls_private_key(" << k.to_string() << ')';
       return s;
    }
-/*
-   bool operator == ( const bls_private_key& p1, const bls_private_key& p2) {
-      return eq_comparator<vector<char>>::apply(p1._seed, p2._seed);
-   }
-   bool operator < ( const bls_private_key& p1, const bls_private_key& p2){
-      return less_comparator<vector<char>>::apply(p1._seed, p2._seed);
-   }*/
+
 } } }  // fc::crypto::blslib
 
 namespace fc

--- a/libraries/libfc/src/crypto/bls_private_key.cpp
+++ b/libraries/libfc/src/crypto/bls_private_key.cpp
@@ -1,14 +1,15 @@
 #include <fc/crypto/bls_private_key.hpp>
 #include <fc/utility.hpp>
 #include <fc/exception/exception.hpp>
+#include <bls.hpp>
 
 namespace fc { namespace crypto { namespace blslib {
 
-   using namespace std;
+   //using namespace std;
 
    bls_public_key bls_private_key::get_public_key() const
    {  
-      G1Element pk = AugSchemeMPL().KeyGen(_seed).GetG1Element();
+      bls::G1Element pk = bls::AugSchemeMPL().KeyGen(_seed).GetG1Element();
 
       return bls_public_key(pk.Serialize());
    }
@@ -16,9 +17,9 @@ namespace fc { namespace crypto { namespace blslib {
    bls_signature bls_private_key::sign( vector<uint8_t> message ) const
    {  
 
-   PrivateKey sk = AugSchemeMPL().KeyGen(_seed);
+   bls::PrivateKey sk = bls::AugSchemeMPL().KeyGen(_seed);
 
-      G2Element s = PopSchemeMPL().Sign(sk, message);
+      bls::G2Element s = bls::PopSchemeMPL().Sign(sk, message);
       return bls_signature(s.Serialize());
    }
 
@@ -27,9 +28,9 @@ namespace fc { namespace crypto { namespace blslib {
    std::string bls_private_key::to_string(const fc::yield_function_t& yield) const
    {
 
-      PrivateKey pk = AugSchemeMPL().KeyGen(_seed);
+      bls::PrivateKey pk = bls::AugSchemeMPL().KeyGen(_seed);
       vector<uint8_t> pkBytes = pk.Serialize();
-      auto data_str = Util::HexStr(pkBytes);
+      auto data_str = bls::Util::HexStr(pkBytes);
       return data_str;/**/
    }
 

--- a/libraries/libfc/src/crypto/bls_public_key.cpp
+++ b/libraries/libfc/src/crypto/bls_public_key.cpp
@@ -1,10 +1,11 @@
 #include <fc/crypto/bls_public_key.hpp>
 #include <fc/crypto/common.hpp>
 #include <fc/exception/exception.hpp>
+#include <bls.hpp>
 
 namespace fc { namespace crypto { namespace blslib {
 
-   static vector<uint8_t> parse_base58(const std::string& base58str)
+   static std::vector<uint8_t> parse_base58(const std::string& base58str)
    {  
 
       std::vector<char> v1 = fc::from_base58(base58str);

--- a/libraries/libfc/src/crypto/bls_public_key.cpp
+++ b/libraries/libfc/src/crypto/bls_public_key.cpp
@@ -1,0 +1,87 @@
+#include <fc/crypto/bls_public_key.hpp>
+#include <fc/crypto/common.hpp>
+#include <fc/exception/exception.hpp>
+
+namespace fc { namespace crypto { namespace blslib {
+
+  /* struct recovery_visitor : fc::visitor<bls_public_key::storage_type> {
+      recovery_visitor(const sha256& digest, bool check_canonical)
+      :_digest(digest)
+      ,_check_canonical(check_canonical)
+      {}
+      template<typename SignatureType>
+      bls_public_key::storage_type operator()(const SignatureType& s) const {
+         return bls_public_key::storage_type(s.recover(_digest, _check_canonical));
+      }
+      const sha256& _digest;
+      bool _check_canonical;
+   };
+   bls_public_key::bls_public_key( const bls_signature& c, const sha256& digest, bool check_canonical )
+   :_storage(std::visit(recovery_visitor(digest, check_canonical), c._storage))
+   {
+   }
+   size_t bls_public_key::which() const {
+      return _storage.index();
+   }*/
+
+   static vector<uint8_t> parse_base58(const std::string& base58str)
+   {  
+
+/*      constexpr auto prefix = config::bls_public_key_base_prefix;
+      const auto pivot = base58str.find('_');
+      const auto prefix_str = base58str.substr(0, pivot);
+      auto data_str = base58str.substr(pivot + 1);
+*/
+      std::vector<char> v1 = fc::from_base58(base58str);
+
+      std::vector<uint8_t> v2;
+      std::copy(v1.begin(), v1.end(), std::back_inserter(v2));
+
+      return v2;
+
+   }
+
+   bls_public_key::bls_public_key(const std::string& base58str)
+   :_pkey(parse_base58(base58str))
+   {}
+
+
+/*   bool bls_public_key::valid()const
+   {
+      //return std::visit(is_valid_visitor(), _storage);
+   }*/
+
+
+   std::string bls_public_key::to_string(const fc::yield_function_t& yield)const {
+
+      std::vector<char> v2;
+      std::copy(_pkey.begin(), _pkey.end(), std::back_inserter(v2));
+
+      std::string data_str = fc::to_base58(v2, yield);
+
+      //std::string data_str = Util::HexStr(_pkey);
+
+      return data_str;
+
+   }
+
+   std::ostream& operator<<(std::ostream& s, const bls_public_key& k) {
+      s << "bls_public_key(" << k.to_string() << ')';
+      return s;
+   }
+
+} } }  // fc::crypto::blslib
+
+namespace fc
+{
+   using namespace std;
+   void to_variant(const fc::crypto::blslib::bls_public_key& var, fc::variant& vo, const fc::yield_function_t& yield)
+   {
+      vo = var.to_string(yield);
+   }
+
+   void from_variant(const fc::variant& var, fc::crypto::blslib::bls_public_key& vo)
+   {
+      vo = fc::crypto::blslib::bls_public_key(var.as_string());
+   }
+} // fc

--- a/libraries/libfc/src/crypto/bls_public_key.cpp
+++ b/libraries/libfc/src/crypto/bls_public_key.cpp
@@ -4,34 +4,9 @@
 
 namespace fc { namespace crypto { namespace blslib {
 
-  /* struct recovery_visitor : fc::visitor<bls_public_key::storage_type> {
-      recovery_visitor(const sha256& digest, bool check_canonical)
-      :_digest(digest)
-      ,_check_canonical(check_canonical)
-      {}
-      template<typename SignatureType>
-      bls_public_key::storage_type operator()(const SignatureType& s) const {
-         return bls_public_key::storage_type(s.recover(_digest, _check_canonical));
-      }
-      const sha256& _digest;
-      bool _check_canonical;
-   };
-   bls_public_key::bls_public_key( const bls_signature& c, const sha256& digest, bool check_canonical )
-   :_storage(std::visit(recovery_visitor(digest, check_canonical), c._storage))
-   {
-   }
-   size_t bls_public_key::which() const {
-      return _storage.index();
-   }*/
-
    static vector<uint8_t> parse_base58(const std::string& base58str)
    {  
 
-/*      constexpr auto prefix = config::bls_public_key_base_prefix;
-      const auto pivot = base58str.find('_');
-      const auto prefix_str = base58str.substr(0, pivot);
-      auto data_str = base58str.substr(pivot + 1);
-*/
       std::vector<char> v1 = fc::from_base58(base58str);
 
       std::vector<uint8_t> v2;
@@ -44,12 +19,6 @@ namespace fc { namespace crypto { namespace blslib {
    bls_public_key::bls_public_key(const std::string& base58str)
    :_pkey(parse_base58(base58str))
    {}
-
-
-/*   bool bls_public_key::valid()const
-   {
-      //return std::visit(is_valid_visitor(), _storage);
-   }*/
 
 
    std::string bls_public_key::to_string(const fc::yield_function_t& yield)const {

--- a/libraries/libfc/src/crypto/bls_signature.cpp
+++ b/libraries/libfc/src/crypto/bls_signature.cpp
@@ -4,26 +4,8 @@
 
 namespace fc { namespace crypto { namespace blslib {
 
-  /* struct hash_visitor : public fc::visitor<size_t> {
-      template<typename SigType>
-      size_t operator()(const SigType& sig) const {
-         static_assert(sizeof(sig._data.data) == 65, "sig size is expected to be 65");
-         //signatures are two bignums: r & s. Just add up least significant digits of the two
-         return *(size_t*)&sig._data.data[32-sizeof(size_t)] + *(size_t*)&sig._data.data[64-sizeof(size_t)];
-      }
-      size_t operator()(const webauthn::bls_signature& sig) const {
-         return sig.get_hash();
-      }
-   };*/
-
    static vector<uint8_t> sig_parse_base58(const std::string& base58str)
    { try {
-
-
-/*      const auto pivot = base58str.find('_');
-      auto base_str = base58str.substr(pivot + 1);
-      const auto pivot2 = base_str.find('_');
-      auto data_str = base_str.substr(pivot2 + 1);*/
 
       std::vector<char> v1 = fc::from_base58(base58str);
 
@@ -42,21 +24,6 @@ namespace fc { namespace crypto { namespace blslib {
       //return _storage.index();
    }
 
-
-   //template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-   //template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
-
-   /*size_t bls_signature::variable_size() const {
-      return std::visit(overloaded {
-         [&](const auto& k1r1) {
-            return static_cast<size_t>(0);
-         },
-         [&](const webauthn::bls_signature& wa) {
-            return static_cast<size_t>(wa.variable_size());
-         }
-      }, _storage);
-   }*/
-
    std::string bls_signature::to_string(const fc::yield_function_t& yield) const
    {
 
@@ -73,21 +40,7 @@ namespace fc { namespace crypto { namespace blslib {
       s << "bls_signature(" << k.to_string() << ')';
       return s;
    }
-/*
-   bool operator == ( const bls_signature& p1, const bls_signature& p2) {
-      return eq_comparator<bls_signature::storage_type>::apply(p1._storage, p2._storage);
-   }
-   bool operator != ( const bls_signature& p1, const bls_signature& p2) {
-      return !eq_comparator<bls_signature::storage_type>::apply(p1._storage, p2._storage);
-   }
-   bool operator < ( const bls_signature& p1, const bls_signature& p2)
-   {
-      return less_comparator<bls_signature::storage_type>::apply(p1._storage, p2._storage);
-   }
-*/
-/*   size_t hash_value(const bls_signature& b) {
-     //  return std::visit(hash_visitor(), b._storage);
-   }*/
+
 } } }  // fc::crypto::blslib
 
 namespace fc

--- a/libraries/libfc/src/crypto/bls_signature.cpp
+++ b/libraries/libfc/src/crypto/bls_signature.cpp
@@ -1,0 +1,104 @@
+#include <fc/crypto/bls_signature.hpp>
+#include <fc/crypto/common.hpp>
+#include <fc/exception/exception.hpp>
+
+namespace fc { namespace crypto { namespace blslib {
+
+  /* struct hash_visitor : public fc::visitor<size_t> {
+      template<typename SigType>
+      size_t operator()(const SigType& sig) const {
+         static_assert(sizeof(sig._data.data) == 65, "sig size is expected to be 65");
+         //signatures are two bignums: r & s. Just add up least significant digits of the two
+         return *(size_t*)&sig._data.data[32-sizeof(size_t)] + *(size_t*)&sig._data.data[64-sizeof(size_t)];
+      }
+      size_t operator()(const webauthn::bls_signature& sig) const {
+         return sig.get_hash();
+      }
+   };*/
+
+   static vector<uint8_t> sig_parse_base58(const std::string& base58str)
+   { try {
+
+
+/*      const auto pivot = base58str.find('_');
+      auto base_str = base58str.substr(pivot + 1);
+      const auto pivot2 = base_str.find('_');
+      auto data_str = base_str.substr(pivot2 + 1);*/
+
+      std::vector<char> v1 = fc::from_base58(base58str);
+
+      std::vector<uint8_t> v2;
+      std::copy(v1.begin(), v1.end(), std::back_inserter(v2));
+
+      return v2;
+
+   } FC_RETHROW_EXCEPTIONS( warn, "error parsing bls_signature", ("str", base58str ) ) }
+
+   bls_signature::bls_signature(const std::string& base58str)
+     :_sig(sig_parse_base58(base58str))
+   {}
+
+   size_t bls_signature::which() const {
+      //return _storage.index();
+   }
+
+
+   //template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+   //template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+   /*size_t bls_signature::variable_size() const {
+      return std::visit(overloaded {
+         [&](const auto& k1r1) {
+            return static_cast<size_t>(0);
+         },
+         [&](const webauthn::bls_signature& wa) {
+            return static_cast<size_t>(wa.variable_size());
+         }
+      }, _storage);
+   }*/
+
+   std::string bls_signature::to_string(const fc::yield_function_t& yield) const
+   {
+
+      std::vector<char> v2;
+      std::copy(_sig.begin(), _sig.end(), std::back_inserter(v2));
+
+      std::string data_str = fc::to_base58(v2, yield);
+
+      return data_str;
+
+   }
+
+   std::ostream& operator<<(std::ostream& s, const bls_signature& k) {
+      s << "bls_signature(" << k.to_string() << ')';
+      return s;
+   }
+/*
+   bool operator == ( const bls_signature& p1, const bls_signature& p2) {
+      return eq_comparator<bls_signature::storage_type>::apply(p1._storage, p2._storage);
+   }
+   bool operator != ( const bls_signature& p1, const bls_signature& p2) {
+      return !eq_comparator<bls_signature::storage_type>::apply(p1._storage, p2._storage);
+   }
+   bool operator < ( const bls_signature& p1, const bls_signature& p2)
+   {
+      return less_comparator<bls_signature::storage_type>::apply(p1._storage, p2._storage);
+   }
+*/
+/*   size_t hash_value(const bls_signature& b) {
+     //  return std::visit(hash_visitor(), b._storage);
+   }*/
+} } }  // fc::crypto::blslib
+
+namespace fc
+{
+   void to_variant(const fc::crypto::blslib::bls_signature& var, fc::variant& vo, const fc::yield_function_t& yield)
+   {
+      vo = var.to_string(yield);
+   }
+
+   void from_variant(const fc::variant& var, fc::crypto::blslib::bls_signature& vo)
+   {
+      vo = fc::crypto::blslib::bls_signature(var.as_string());
+   }
+} // fc

--- a/libraries/libfc/src/crypto/bls_signature.cpp
+++ b/libraries/libfc/src/crypto/bls_signature.cpp
@@ -4,7 +4,7 @@
 
 namespace fc { namespace crypto { namespace blslib {
 
-   static vector<uint8_t> sig_parse_base58(const std::string& base58str)
+   static std::vector<uint8_t> sig_parse_base58(const std::string& base58str)
    { try {
 
       std::vector<char> v1 = fc::from_base58(base58str);
@@ -19,10 +19,6 @@ namespace fc { namespace crypto { namespace blslib {
    bls_signature::bls_signature(const std::string& base58str)
      :_sig(sig_parse_base58(base58str))
    {}
-
-   size_t bls_signature::which() const {
-      //return _storage.index();
-   }
 
    std::string bls_signature::to_string(const fc::yield_function_t& yield) const
    {

--- a/libraries/libfc/src/crypto/bls_utils.cpp
+++ b/libraries/libfc/src/crypto/bls_utils.cpp
@@ -1,0 +1,66 @@
+#include <fc/crypto/bls_utils.hpp>
+#include <fc/crypto/common.hpp>
+#include <fc/exception/exception.hpp>
+#include <bls.hpp>
+
+namespace fc { namespace crypto { namespace blslib { namespace bls_utils {
+
+   using namespace bls;
+
+   bls_private_key generate() {
+
+     char* r = (char*) malloc(32);
+
+     rand_bytes(r, 32);
+
+     std::vector<uint8_t> v(r, r+32);
+
+     return bls_private_key(v);
+
+   }
+
+   bool verify( const bls_public_key &pubkey,
+                  const std::vector<uint8_t> &message,
+                  const bls_signature &signature){
+
+      return bls::PopSchemeMPL().Verify(pubkey._pkey, message, signature._sig);
+
+   };
+
+   bls_public_key aggregate( const std::vector<bls_public_key> &keys){
+
+      bls::G1Element aggKey;
+
+      for (size_t i = 0 ; i < keys.size(); i++){
+         aggKey += bls::G1Element::FromByteVector(keys[i]._pkey);
+      }
+
+      return bls_public_key(aggKey.Serialize());
+
+   };
+
+   bls_signature aggregate( const std::vector<bls_signature> &signatures){
+
+      std::vector<std::vector<uint8_t>> v_sigs;
+
+      for (size_t i = 0 ; i < signatures.size(); i++)
+         v_sigs.push_back(signatures[i]._sig);
+
+      return bls_signature(bls::PopSchemeMPL().Aggregate(v_sigs));
+
+   };
+
+   bool aggregate_verify( const std::vector<bls_public_key> &pubkeys,
+                  const std::vector<std::vector<uint8_t>> &messages,
+                  const bls_signature &signature){
+
+      vector<vector<uint8_t>> v_pubkeys;
+
+      for (size_t i = 0 ; i < pubkeys.size(); i++)
+         v_pubkeys.push_back(pubkeys[i]._pkey);
+
+      return bls::PopSchemeMPL().AggregateVerify(v_pubkeys, messages, signature._sig);
+
+   };
+
+} } } }  // fc::crypto::blslib::bls_utils

--- a/libraries/libfc/test/CMakeLists.txt
+++ b/libraries/libfc/test/CMakeLists.txt
@@ -15,3 +15,8 @@ add_executable( test_filesystem test_filesystem.cpp )
 target_link_libraries( test_filesystem fc )
 
 add_test(NAME test_filesystem COMMAND test_filesystem WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_executable( test_bls test_bls.cpp )
+target_link_libraries( test_bls fc )
+
+add_test(NAME test_bls COMMAND libraries/libfc/test/test_bls WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/libraries/libfc/test/CMakeLists.txt
+++ b/libraries/libfc/test/CMakeLists.txt
@@ -19,4 +19,4 @@ add_test(NAME test_filesystem COMMAND test_filesystem WORKING_DIRECTORY ${CMAKE_
 add_executable( test_bls test_bls.cpp )
 target_link_libraries( test_bls fc )
 
-add_test(NAME test_bls COMMAND libraries/libfc/test/test_bls WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME test_bls COMMAND test_bls WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/libraries/libfc/test/test_bls.cpp
+++ b/libraries/libfc/test/test_bls.cpp
@@ -1,0 +1,192 @@
+#define BOOST_TEST_MODULE bls
+
+#include <boost/test/included/unit_test.hpp>
+
+#include <fc/crypto/bls_private_key.hpp>
+#include <fc/crypto/bls_public_key.hpp>
+#include <fc/crypto/bls_signature.hpp>
+
+#include <fc/crypto/bls_utils.hpp>
+
+#include <fc/exception/exception.hpp>
+
+using std::cout;
+
+//using namespace fc;
+using namespace fc::crypto::blslib;
+
+BOOST_AUTO_TEST_SUITE(bls)
+
+// can we use BLS stuff?
+
+// Example seed, used to generate private key. Always use
+// a secure RNG with sufficient entropy to generate a seed (at least 32 bytes).
+std::vector<uint8_t> seed_1 = {  0,  50, 6,  244, 24,  199, 1,  25,  52,  88,  192,
+                            19, 18, 12, 89,  6,   220, 18, 102, 58,  209, 82,
+                            12, 62, 89, 110, 182, 9,   44, 20,  254, 22};
+
+std::vector<uint8_t> seed_2 = {  6,  51, 22,  89, 11,  15, 4,  61,  127,  241,  79,
+                            26, 88, 52, 1,  6,   18, 79, 10, 8, 36, 182,
+                            154, 35, 75, 156, 215, 41,   29, 90,  125, 233};
+
+std::vector<uint8_t> message_1 = { 51, 23, 56, 93, 212, 129, 128, 27, 
+                            251, 12, 42, 129, 210, 9, 34, 98};  // Message is passed in as a byte vector
+
+
+std::vector<uint8_t> message_2 = { 16, 38, 54, 125, 71, 214, 217, 78, 
+                            73, 23, 127, 235, 8, 94, 41, 53};  // Message is passed in as a byte vector
+
+
+//test a single key signature + verification
+BOOST_AUTO_TEST_CASE(bls_sig_verif) try {
+
+  bls_private_key sk = bls_private_key(seed_1);
+  bls_public_key pk = sk.get_public_key();
+
+  bls_signature signature = sk.sign(message_1);
+
+  //cout << "pk : " << pk.to_string() << "\n";
+  //cout << "signature : " << signature.to_string() << "\n";
+
+  // Verify the signature
+  bool ok = verify(pk, message_1, signature);
+
+  BOOST_CHECK_EQUAL(ok, true);
+
+} FC_LOG_AND_RETHROW();
+
+
+//test serialization / deserialization of private key, public key and signature
+BOOST_AUTO_TEST_CASE(bls_serialization_test) try {
+
+  bls_private_key sk = bls_private_key(seed_1);
+  bls_public_key pk = sk.get_public_key();
+
+  bls_signature signature = sk.sign(message_1);
+
+  std::string pk_string = pk.to_string();
+  std::string signature_string = signature.to_string();
+
+  //cout << pk_string << "\n";
+  //cout << signature_string << "\n";
+
+  bls_public_key pk2 = bls_public_key(pk_string);
+  bls_signature signature2 = bls_signature(signature_string);
+
+  //cout << pk2.to_string() << "\n";
+  //cout << signature2.to_string() << "\n";
+
+  bool ok = verify(pk2, message_1, signature2);
+
+  BOOST_CHECK_EQUAL(ok, true);
+
+} FC_LOG_AND_RETHROW();
+
+//test public keys + signatures aggregation + verification
+BOOST_AUTO_TEST_CASE(bls_agg_sig_verif) try {
+
+  bls_private_key sk1 = bls_private_key(seed_1);
+  bls_public_key pk1 = sk1.get_public_key();
+
+  bls_signature sig1 = sk1.sign(message_1);
+
+  //cout << "pk1 : " << pk1.to_string() << "\n";
+  //cout << "sig1 : " << sig1.to_string() << "\n";
+
+  bls_private_key sk2 = bls_private_key(seed_2);
+  bls_public_key pk2 = sk2.get_public_key();
+
+  bls_signature sig2 = sk2.sign(message_1);
+
+  //cout << "pk2 : "  << pk2.to_string() << "\n";
+  //cout << "sig2 : "  << sig2.to_string() << "\n";
+
+  bls_public_key aggKey = aggregate({pk1, pk2});
+  bls_signature aggSig = aggregate({sig1, sig2});
+
+ // cout << "aggKey : "  << aggKey.to_string() << "\n";
+  //cout << "aggSig : "  << aggSig.to_string() << "\n";
+
+  // Verify the signature
+  bool ok = verify(aggKey, message_1, aggSig);
+
+  BOOST_CHECK_EQUAL(ok, true);
+
+} FC_LOG_AND_RETHROW();
+
+
+//test signature aggregation + aggregate tree verification
+BOOST_AUTO_TEST_CASE(bls_agg_tree_verif) try {
+
+  bls_private_key sk1 = bls_private_key(seed_1);
+  bls_public_key pk1 = sk1.get_public_key();
+
+  bls_signature sig1 = sk1.sign(message_1);
+
+  //cout << "pk1 : " << pk1.to_string() << "\n";
+  //cout << "sig1 : " << sig1.to_string() << "\n";
+
+  bls_private_key sk2 = bls_private_key(seed_2);
+  bls_public_key pk2 = sk2.get_public_key();
+
+  bls_signature sig2 = sk2.sign(message_2);
+
+  //cout << "pk2 : "  << pk2.to_string() << "\n";
+  //cout << "sig2 : "  << sig2.to_string() << "\n";
+
+  bls_signature aggSig = aggregate({sig1, sig2});
+
+  //cout << "aggSig : "  << aggSig.to_string() << "\n";
+
+  vector<bls_public_key> pubkeys = {pk1, pk2};
+  vector<vector<uint8_t>> messages = {message_1, message_2};
+
+  // Verify the signature
+  bool ok = aggregate_verify(pubkeys, messages, aggSig);
+
+  BOOST_CHECK_EQUAL(ok, true);
+
+} FC_LOG_AND_RETHROW();
+
+
+//test random key generation, signature + verification
+BOOST_AUTO_TEST_CASE(bls_key_gen) try {
+
+  bls_private_key sk = generate();
+  bls_public_key pk = sk.get_public_key();
+
+  bls_signature signature = sk.sign(message_1);
+
+  // Verify the signature
+  bool ok = verify(pk, message_1, signature);
+
+  BOOST_CHECK_EQUAL(ok, true);
+
+} FC_LOG_AND_RETHROW();
+
+
+//test wrong key and wrong signature
+BOOST_AUTO_TEST_CASE(bls_bad_sig_verif) try {
+
+  bls_private_key sk1 = bls_private_key(seed_1);
+  bls_public_key pk1 = sk1.get_public_key();
+
+  bls_signature sig1 = sk1.sign(message_1);
+
+  bls_private_key sk2 = bls_private_key(seed_2);
+  bls_public_key pk2 = sk2.get_public_key();
+
+  bls_signature sig2 = sk2.sign(message_1);
+
+  // Verify the signature
+  bool ok1 = verify(pk1, message_1, sig2); //verify wrong key / signature
+  bool ok2 = verify(pk2, message_1, sig1); //verify wrong key / signature
+
+  BOOST_CHECK_EQUAL(ok1, false);
+  BOOST_CHECK_EQUAL(ok2, false);
+
+
+} FC_LOG_AND_RETHROW();
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libraries/libfc/test/test_bls.cpp
+++ b/libraries/libfc/test/test_bls.cpp
@@ -14,6 +14,7 @@ using std::cout;
 
 //using namespace fc;
 using namespace fc::crypto::blslib;
+using namespace fc::crypto::blslib::bls_utils;
 
 BOOST_AUTO_TEST_SUITE(bls)
 
@@ -138,8 +139,8 @@ BOOST_AUTO_TEST_CASE(bls_agg_tree_verif) try {
 
   //cout << "aggSig : "  << aggSig.to_string() << "\n";
 
-  vector<bls_public_key> pubkeys = {pk1, pk2};
-  vector<vector<uint8_t>> messages = {message_1, message_2};
+  std::vector<bls_public_key> pubkeys = {pk1, pk2};
+  std::vector<std::vector<uint8_t>> messages = {message_1, message_2};
 
   // Verify the signature
   bool ok = aggregate_verify(pubkeys, messages, aggSig);


### PR DESCRIPTION
This pull request introduces aggregate signatures (BLS signature scheme) as a protocol feature. It uses Chia's BLS-signatures library, which in turn depends on the Relic toolkit.

It defines the following new host functions :

bls_verify
bls_aggregate_pubkeys
bls_aggregate_sigs
bls_aggregate_verify

as well as new built-in types :

bls_public_key
bls_signature

Unit tests are included in libraries/libfc/test/test_bls.cpp

Corresponding pull request on cdt is available here : https://github.com/AntelopeIO/cdt/pull/92

A smart contract that can be used to test the new functionalities can be found here : https://github.com/systemzax/agg-sig-tests-contract