### PR TITLE
[3.1 -> 3.2] Test fix: nodeos_forked_chain_lr_test

### DIFF
--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -375,6 +375,8 @@ try:
     if preKillBlockProducer == "defproducerj" or preKillBlockProducer == "defproducerk":
         # wait for defproduceri so there is plenty of time to send kill before defproducerk
         nonProdNode.waitForProducer("defproduceri")
+        preKillBlockNum=nonProdNode.getBlockNum()
+        preKillBlockProducer=nonProdNode.getBlockProducerByNum(preKillBlockNum)
     Print("preKillBlockProducer = {}".format(preKillBlockProducer))
     # kill at last block before defproducerl, since the block it is killed on will get propagated
     killAtProducer="defproducerk"


### PR DESCRIPTION
Fix #533 should have updated `preKillBlockNum` & `preKillBlockProducer` as these are used in the validation calculation.

Ran 20 times without error in CI/CD:
https://github.com/AntelopeIO/leap/actions/runs/4016264242
https://github.com/AntelopeIO/leap/actions/runs/4016267469

Merges #677 into `release/3.2` via merge of `release/3.1`
Resolves #631 