### PR TITLE
named_thread_pool description for debugger

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -301,7 +301,7 @@ struct controller_impl {
     conf( cfg ),
     chain_id( chain_id ),
     read_mode( cfg.read_mode ),
-    thread_pool( "chain" )
+    thread_pool( "chain"_n )
    {
       fork_db.open( [this]( block_timestamp_type timestamp,
                             const flat_set<digest_type>& cur_features,

--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <eosio/chain/name.hpp>
 #include <fc/exception/exception.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
@@ -21,7 +22,7 @@ namespace eosio { namespace chain {
       /// @param name_prefix is name appended with -## of thread.
       ///                    A short name_prefix (6 chars or under) is recommended as console_appender uses 9 chars
       ///                    for the thread name.
-      explicit named_thread_pool( std::string name_prefix );
+      explicit named_thread_pool( eosio::chain::name name_prefix );
 
       /// calls stop()
       ~named_thread_pool();
@@ -42,7 +43,7 @@ namespace eosio { namespace chain {
    private:
       using ioc_work_t = boost::asio::executor_work_guard<boost::asio::io_context::executor_type>;
 
-      std::string                    _name_prefix;
+      eosio::chain::name             _name_prefix;
       boost::asio::io_context        _ioc;
       std::vector<std::thread>       _thread_pool;
       std::optional<ioc_work_t>      _ioc_work;

--- a/libraries/chain/thread_utils.cpp
+++ b/libraries/chain/thread_utils.cpp
@@ -21,14 +21,14 @@ void named_thread_pool::start( size_t num_threads, on_except_t on_except ) {
    _ioc.restart();
    _thread_pool.reserve( num_threads );
 
-   // capture name since name_prefix is invalid in debugger, use abieos/tools/num2name to get name
+   // capture eosio::name desc since name_prefix is invalid in debugger, use abieos/tools/num2name to get string name
    std::string sanitized_name = fc::to_lower(_name_prefix);
    sanitized_name = sanitized_name.substr(0, 12);
    name desc(string_to_uint64_t(sanitized_name));
 
    for( size_t i = 0; i < num_threads; ++i ) {
       _thread_pool.emplace_back( [desc, &ioc = _ioc, &name_prefix = _name_prefix, on_except, i]() {
-         (void)desc;
+         (void)desc; // see comment above
          std::string tn = name_prefix + "-" + std::to_string( i );
          try {
             fc::set_os_thread_name( tn );

--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -115,7 +115,7 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test_multi_threaded, TESTER) { try {
    produce_block();
    create_account(tester_account);
 
-   named_thread_pool thread_pool( "test" );
+   named_thread_pool thread_pool( "test"_n );
    thread_pool.start( 5, {} );
 
    for( size_t i = 0; i < 100; ++i ) {

--- a/plugins/http_plugin/include/eosio/http_plugin/common.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/common.hpp
@@ -129,7 +129,7 @@ struct http_plugin_state {
    bool keep_alive = false;
 
    uint16_t thread_pool_size = 2;
-   eosio::chain::named_thread_pool thread_pool{ "http" };
+   eosio::chain::named_thread_pool thread_pool{ eosio::chain::name("http") };
 
    fc::logger& logger;
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -281,7 +281,7 @@ namespace eosio {
       compat::channels::transaction_ack::channel_type::handle  incoming_transaction_ack_subscription;
 
       uint16_t                              thread_pool_size = 4;
-      eosio::chain::named_thread_pool       thread_pool{ "net" };
+      eosio::chain::named_thread_pool       thread_pool{ "net"_n };
 
       boost::asio::deadline_timer           accept_error_timer{thread_pool.get_executor()};
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -307,7 +307,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       pending_block_mode                                        _pending_block_mode = pending_block_mode::speculating;
       unapplied_transaction_queue                               _unapplied_transactions;
       size_t                                                    _thread_pool_size = config::default_controller_thread_pool_size;
-      named_thread_pool                                         _thread_pool{ "prod" };
+      named_thread_pool                                         _thread_pool{ "prod"_n };
 
       std::atomic<int32_t>                                      _max_transaction_time_ms; // modified by app thread, read by net_plugin thread pool
       std::atomic<bool>                                         _received_block{false}; // modified by net_plugin thread pool and app thread

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -87,7 +87,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
    using acceptor_type = std::variant<std::unique_ptr<tcp::acceptor>, std::unique_ptr<unixs::acceptor>>;
    std::set<acceptor_type>          acceptors;
 
-   named_thread_pool                thread_pool{"SHiP"};
+   named_thread_pool                thread_pool{"ship"_n};
 
    static void get_log_entry(state_history_log& log, uint32_t block_num, std::optional<bytes>& result) {
       if (block_num < log.begin_block() || block_num >= log.end_block())

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -910,7 +910,7 @@ BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
       BOOST_CHECK_EQUAL(trx.id(), ptrx->id());
       BOOST_CHECK_EQUAL(trx.id(), ptrx2->id());
 
-      named_thread_pool thread_pool( "misc" );
+      named_thread_pool thread_pool( "misc"_n );
       thread_pool.start( 5, {} );
 
       auto fut = transaction_metadata::start_recover_keys( ptrx, thread_pool.get_executor(), test.control->get_chain_id(), fc::microseconds::maximum(), transaction_metadata::trx_type::input );
@@ -1202,7 +1202,7 @@ BOOST_AUTO_TEST_CASE(bad_alloc_test) {
 
 BOOST_AUTO_TEST_CASE(named_thread_pool_test) {
    {
-      named_thread_pool thread_pool( "misc" );
+      named_thread_pool thread_pool( "misc"_n );
       thread_pool.start( 5, {} );
 
       std::promise<void> p;
@@ -1213,7 +1213,7 @@ BOOST_AUTO_TEST_CASE(named_thread_pool_test) {
       BOOST_TEST( (f.wait_for( 100ms ) == std::future_status::ready) );
    }
    { // delayed start
-      named_thread_pool thread_pool( "misc" );
+      named_thread_pool thread_pool( "misc"_n );
 
       std::promise<void> p;
       auto f = p.get_future();
@@ -1227,7 +1227,7 @@ BOOST_AUTO_TEST_CASE(named_thread_pool_test) {
    { // exception
       std::promise<fc::exception> ep;
       auto ef = ep.get_future();
-      named_thread_pool thread_pool( "misc" );
+      named_thread_pool thread_pool( "misc"_n );
       thread_pool.start( 5, [&ep](const fc::exception& e) { ep.set_value(e); } );
 
       boost::asio::post( thread_pool.get_executor(), [](){


### PR DESCRIPTION
I found this useful for recent debugging of crashes and deadlocks, decided would be nice to just have it always baked in.

Add `eosio::name` description to `named_thread_pool` lambda to assist in determining which thread pool is active for a given thread stack trace from a `core` file.

I tried capturing `name_prefix` by value in the lambda but the debugger still showed it as invalid.
Another option, #687,  makes `named_thread_pool` a template instantiated with `eosio::name` so the value would be in the symbol name. 

Release builds with clang11 and lldb.
Before:
```
<snip>
[Inlined] boost::asio::io_context::run() io_context.ipp:63
$_0::operator()() const thread_utils.cpp:27
<unknown> 0x00007f2b3dbcede4
start_thread 0x00007f2b3de6d609
__clone 0x00007f2b3da0a133
```
```
0x926dc68 = {int} 153541736
this = {const (unnamed class) *} 0x5133c28 
 ioc = {boost::asio::io_context &} 
 name_prefix = {std::basic_string<> &} 
   = invalid value
 on_except = {eosio::chain::named_thread_pool::on_except_t} 
 i = {size_t} 1
tn = {std::string} error: summary string parsing error
```

After:
```
<snip>
[Inlined] boost::asio::io_context::run() io_context.ipp:63
$_0::operator()() const thread_utils.cpp:30
<unknown> 0x00007fea901e6de4
start_thread 0x00007fea90485609
__clone 0x00007fea90022133```
```
```
0x926dc68 = {int} 153541736
this = {const (unnamed class) *} 0x436ebb8 
 name_prefix = {eosio::chain::name} 
  value = {uint64_t} 4849507634736267264
 ioc = {boost::asio::io_context &} 
 on_except = {eosio::chain::named_thread_pool::on_except_t} 
 i = {size_t} 1
tn = {std::string} error: summary string parsing error
```
```
 ../../tests/abieos/tools/tools/num2name 4849507634736267264
chain
```