### PR TITLE
Add a named_thread class that includes a strand

### DIFF
--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -3,6 +3,7 @@
 #include <eosio/chain/name.hpp>
 #include <fc/exception/exception.hpp>
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/strand.hpp>
 #include <boost/asio/post.hpp>
 #include <future>
 #include <memory>
@@ -27,7 +28,7 @@ namespace eosio { namespace chain {
       /// calls stop()
       ~named_thread_pool();
 
-      boost::asio::io_context& get_executor() { return _ioc; }
+      auto& get_executor() { return _ioc; }
 
       /// Spawn threads, can be re-started after stop().
       /// Assumes start()/stop() called from the same thread or externally protected.
@@ -47,6 +48,34 @@ namespace eosio { namespace chain {
       boost::asio::io_context        _ioc;
       std::vector<std::thread>       _thread_pool;
       std::optional<ioc_work_t>      _ioc_work;
+   };
+
+   class named_thread {
+   public:
+      /// @param name_prefix is name appended with -1 for thread name.
+      ///                    A short name_prefix (6 chars or under) is recommended as console_appender uses 9 chars
+      ///                    for the thread name.
+      explicit named_thread( eosio::chain::name name_prefix )
+      : _pool( name_prefix ) {}
+
+      /// stop before destroying strand
+      ~named_thread() { stop(); }
+
+      auto& get_executor() { return _strand; }
+
+      /// Spawn thread, can be re-started after stop().
+      /// Assumes start()/stop() called from the same thread or externally protected.
+      /// @param on_except is the function to call if io_context throws an exception, is called from thread pool thread.
+      ///                  if an empty function then logs and rethrows exception on thread which will terminate.
+      /// @throw assert_exception if already started and not stopped.
+      void start( named_thread_pool::on_except_t on_except ) { _pool.start( 1, std::move(on_except) ); }
+
+      /// destroy work guard, stop io_context, join thread_pool
+      void stop() { _pool.stop(); }
+
+   private:
+      named_thread_pool _pool;
+      boost::asio::io_context::strand _strand{_pool.get_executor()};
    };
 
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -1250,6 +1250,56 @@ BOOST_AUTO_TEST_CASE(named_thread_pool_test) {
    }
 }
 
+BOOST_AUTO_TEST_CASE(named_thread_test) {
+   {
+      named_thread thread( "misc"_n );
+      thread.start( {} );
+
+      std::promise<void> p;
+      auto f = p.get_future();
+      boost::asio::post( thread.get_executor(), [&p](){
+         p.set_value();
+      });
+      BOOST_TEST( (f.wait_for( 100ms ) == std::future_status::ready) );
+   }
+   { // delayed start
+      named_thread thread( "misc"_n );
+
+      std::promise<void> p;
+      auto f = p.get_future();
+      boost::asio::post( thread.get_executor(), [&p](){
+         p.set_value();
+      });
+      BOOST_TEST( (f.wait_for( 10ms ) == std::future_status::timeout) );
+      thread.start( {} );
+      BOOST_TEST( (f.wait_for( 100ms ) == std::future_status::ready) );
+   }
+   { // exception
+      std::promise<fc::exception> ep;
+      auto ef = ep.get_future();
+      named_thread thread( "misc"_n );
+      thread.start( [&ep](const fc::exception& e) { ep.set_value(e); } );
+
+      boost::asio::post( thread.get_executor(), [](){
+         FC_ASSERT( false, "oops throw on thread" );
+      });
+      BOOST_TEST( (ef.wait_for( 100ms ) == std::future_status::ready) );
+      BOOST_TEST( ef.get().to_detail_string().find("oops throw on thread") != std::string::npos );
+
+      // we can restart, after a stop
+      BOOST_REQUIRE_THROW( thread.start( [&ep](const fc::exception& e) { ep.set_value(e); } ), fc::assert_exception );
+      thread.stop();
+
+      std::promise<void> p;
+      auto f = p.get_future();
+      boost::asio::post( thread.get_executor(), [&p](){
+         p.set_value();
+      });
+      thread.start( [&ep](const fc::exception& e) { ep.set_value(e); } );
+      BOOST_TEST( (f.wait_for( 100ms ) == std::future_status::ready) );
+   }
+}
+
 BOOST_AUTO_TEST_CASE(public_key_from_hash) {
    auto private_key_string = std::string("5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3");
    auto expected_public_key = std::string("EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV");


### PR DESCRIPTION
Create a dedicated class for the use of one named thread. Use a strand for the executor type. Will be useful for the `state_history_plugin` and `prometheus_plugin`.