### PR TITLE
Log exception details for failed transactions

### DIFF
--- a/libraries/libfc/include/fc/exception/exception.hpp
+++ b/libraries/libfc/include/fc/exception/exception.hpp
@@ -64,7 +64,7 @@ namespace fc
             code_value = unspecified_exception_code
          };
 
-         exception( int64_t code = unspecified_exception_code,
+         explicit exception( int64_t code = unspecified_exception_code,
                     const std::string& name_value = "exception",
                     const std::string& what_value = "unspecified");
          exception( log_message&&, int64_t code = unspecified_exception_code,

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2036,7 +2036,7 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
                      ("c", e.code())("a", first_auth)("p", prev_billed_cpu_time_us)
                      ( "r", end - start)("id", trx->id())("e", e) );
             if( !disable_subjective_enforcement )
-               _account_fails.add( first_auth, e.code() );
+               _account_fails.add( first_auth, e );
          }
          if( next ) {
             if( return_failure_trace ) {


### PR DESCRIPTION
Log failed transaction exception details:

For example:
```
debug 2023-02-03T20:52:13.122 nodeos    producer_plugin.cpp:2037      push_transaction     ] Failed 3040000 trx, auth: eosio.wrap, prev billed: 0us, ran: 274us, id: 84ff2165389f800d26f5f47117ed494d30d6e4ebf797edd7ffdda80c07bcaf35, except: {"code":3040000,"name":"transaction_exception","message":"Transaction exception","stack":[{"context":{"level":"error","file":"transaction_context.cpp","line":796,"method":"validate_referenced_accounts","hostname":"","thread_name":"nodeos","timestamp":"2023-02-03T20:52:13.122"},"format":"action's authorizing actor '${account}' does not exist","data":{"account":"eosio.wrap"}}]}
```

Resolves #548