### PR TITLE
Move get_block abi serialization off the main thread

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -149,29 +149,29 @@ namespace eosio { namespace chain {
       variants.clear();
       action_results.clear();
 
-      for( auto&& st : abi.structs )
+      for( auto& st : abi.structs )
          structs[st.name] = std::move(st);
 
-      for( auto&& td : abi.types ) {
+      for( auto& td : abi.types ) {
          EOS_ASSERT(!_is_type(td.new_type_name, ctx), duplicate_abi_type_def_exception,
                     "type already exists", ("new_type_name",impl::limit_size(td.new_type_name)));
-         typedefs[td.new_type_name] = std::move(td.type);
+         typedefs[std::move(td.new_type_name)] = std::move(td.type);
       }
 
-      for( auto&& a : abi.actions )
-         actions[a.name] = std::move(a.type);
+      for( auto& a : abi.actions )
+         actions[std::move(a.name)] = std::move(a.type);
 
-      for( auto&& t : abi.tables )
-         tables[t.name] = std::move(t.type);
+      for( auto& t : abi.tables )
+         tables[std::move(t.name)] = std::move(t.type);
 
-      for( auto&& e : abi.error_messages )
-         error_messages[e.error_code] = std::move(e.error_msg);
+      for( auto& e : abi.error_messages )
+         error_messages[std::move(e.error_code)] = std::move(e.error_msg);
 
-      for( auto&& v : abi.variants.value )
-         variants[v.name] = std::move(v);
+      for( auto& v : abi.variants.value )
+         variants[std::move(v.name)] = std::move(v);
 
-      for( auto&& r : abi.action_results.value )
-         action_results[r.name] = std::move(r.result_type);
+      for( auto& r : abi.action_results.value )
+         action_results[std::move(r.name)] = std::move(r.result_type);
 
       /**
        *  The ABI vector may contain duplicates which would make it

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -168,7 +168,7 @@ namespace eosio { namespace chain {
          error_messages[std::move(e.error_code)] = std::move(e.error_msg);
 
       for( auto& v : abi.variants.value )
-         variants[std::move(v.name)] = std::move(v);
+         variants[v.name] = std::move(v);
 
       for( auto& r : abi.action_results.value )
          action_results[std::move(r.name)] = std::move(r.result_type);

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -149,8 +149,11 @@ namespace eosio { namespace chain {
       variants.clear();
       action_results.clear();
 
-      for( auto& st : abi.structs )
-         structs[st.name] = std::move(st);
+      for( auto& st : abi.structs ) {
+         // side effect rules indicate std::move can happen before st.name is accessed.
+         auto n = st.name;
+         structs[std::move(n)] = std::move(st);
+      }
 
       for( auto& td : abi.types ) {
          EOS_ASSERT(!_is_type(td.new_type_name, ctx), duplicate_abi_type_def_exception,
@@ -167,8 +170,11 @@ namespace eosio { namespace chain {
       for( auto& e : abi.error_messages )
          error_messages[std::move(e.error_code)] = std::move(e.error_msg);
 
-      for( auto& v : abi.variants.value )
-         variants[v.name] = std::move(v);
+      for( auto& v : abi.variants.value ) {
+         // Not strictly necessary since trivially copyable, but error on safe side in case name becomes std::string
+         auto n = v.name;
+         variants[std::move(n)] = std::move(v);
+      }
 
       for( auto& r : abi.action_results.value )
          action_results[std::move(r.name)] = std::move(r.result_type);

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -149,11 +149,8 @@ namespace eosio { namespace chain {
       variants.clear();
       action_results.clear();
 
-      for( auto& st : abi.structs ) {
-         // side effect rules indicate std::move can happen before st.name is accessed.
-         auto n = st.name;
-         structs[std::move(n)] = std::move(st);
-      }
+      for( auto& st : abi.structs )
+         structs[st.name] = std::move(st);
 
       for( auto& td : abi.types ) {
          EOS_ASSERT(!_is_type(td.new_type_name, ctx), duplicate_abi_type_def_exception,
@@ -170,11 +167,8 @@ namespace eosio { namespace chain {
       for( auto& e : abi.error_messages )
          error_messages[std::move(e.error_code)] = std::move(e.error_msg);
 
-      for( auto& v : abi.variants.value ) {
-         // Not strictly necessary since trivially copyable, but error on safe side in case name becomes std::string
-         auto n = v.name;
-         variants[std::move(n)] = std::move(v);
-      }
+      for( auto& v : abi.variants.value )
+         variants[v.name] = std::move(v);
 
       for( auto& r : abi.action_results.value )
          action_results[std::move(r.name)] = std::move(r.result_type);

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -70,14 +70,14 @@ namespace eosio { namespace chain {
       );
    }
 
-   abi_serializer::abi_serializer( const abi_def& abi, const yield_function_t& yield ) {
+   abi_serializer::abi_serializer( abi_def&& abi, const yield_function_t& yield ) {
       configure_built_in_types();
-      set_abi(abi, yield);
+      set_abi(std::move(abi), yield);
    }
 
-   abi_serializer::abi_serializer( const abi_def& abi, const fc::microseconds& max_serialization_time) {
+   abi_serializer::abi_serializer( abi_def&& abi, const fc::microseconds& max_serialization_time) {
       configure_built_in_types();
-      set_abi(abi, create_yield_function(max_serialization_time));
+      set_abi(std::move(abi), create_yield_function(max_serialization_time));
    }
 
    void abi_serializer::add_specialized_unpack_pack( const string& name,
@@ -128,10 +128,18 @@ namespace eosio { namespace chain {
       built_in_types.emplace("extended_asset",            pack_unpack<extended_asset>());
    }
 
-   void abi_serializer::set_abi(const abi_def& abi, const yield_function_t& yield) {
+   void abi_serializer::set_abi(abi_def&& abi, const yield_function_t& yield) {
       impl::abi_traverse_context ctx(yield);
 
       EOS_ASSERT(starts_with(abi.version, "eosio::abi/1."), unsupported_abi_version_exception, "ABI has an unsupported version");
+
+      size_t types_size = abi.types.size();
+      size_t structs_size = abi.structs.size();
+      size_t actions_size = abi.actions.size();
+      size_t tables_size = abi.tables.size();
+      size_t error_messages_size = abi.error_messages.size();
+      size_t variants_size = abi.variants.value.size();
+      size_t action_results_size = abi.action_results.value.size();
 
       typedefs.clear();
       structs.clear();
@@ -141,47 +149,47 @@ namespace eosio { namespace chain {
       variants.clear();
       action_results.clear();
 
-      for( const auto& st : abi.structs )
-         structs[st.name] = st;
+      for( auto&& st : abi.structs )
+         structs[st.name] = std::move(st);
 
-      for( const auto& td : abi.types ) {
+      for( auto&& td : abi.types ) {
          EOS_ASSERT(!_is_type(td.new_type_name, ctx), duplicate_abi_type_def_exception,
                     "type already exists", ("new_type_name",impl::limit_size(td.new_type_name)));
-         typedefs[td.new_type_name] = td.type;
+         typedefs[td.new_type_name] = std::move(td.type);
       }
 
-      for( const auto& a : abi.actions )
-         actions[a.name] = a.type;
+      for( auto&& a : abi.actions )
+         actions[a.name] = std::move(a.type);
 
-      for( const auto& t : abi.tables )
-         tables[t.name] = t.type;
+      for( auto&& t : abi.tables )
+         tables[t.name] = std::move(t.type);
 
-      for( const auto& e : abi.error_messages )
-         error_messages[e.error_code] = e.error_msg;
+      for( auto&& e : abi.error_messages )
+         error_messages[e.error_code] = std::move(e.error_msg);
 
-      for( const auto& v : abi.variants.value )
-         variants[v.name] = v;
+      for( auto&& v : abi.variants.value )
+         variants[v.name] = std::move(v);
 
-      for( const auto& r : abi.action_results.value )
-         action_results[r.name] = r.result_type;
+      for( auto&& r : abi.action_results.value )
+         action_results[r.name] = std::move(r.result_type);
 
       /**
        *  The ABI vector may contain duplicates which would make it
        *  an invalid ABI
        */
-      EOS_ASSERT( typedefs.size() == abi.types.size(), duplicate_abi_type_def_exception, "duplicate type definition detected" );
-      EOS_ASSERT( structs.size() == abi.structs.size(), duplicate_abi_struct_def_exception, "duplicate struct definition detected" );
-      EOS_ASSERT( actions.size() == abi.actions.size(), duplicate_abi_action_def_exception, "duplicate action definition detected" );
-      EOS_ASSERT( tables.size() == abi.tables.size(), duplicate_abi_table_def_exception, "duplicate table definition detected" );
-      EOS_ASSERT( error_messages.size() == abi.error_messages.size(), duplicate_abi_err_msg_def_exception, "duplicate error message definition detected" );
-      EOS_ASSERT( variants.size() == abi.variants.value.size(), duplicate_abi_variant_def_exception, "duplicate variant definition detected" );
-      EOS_ASSERT( action_results.size() == abi.action_results.value.size(), duplicate_abi_action_results_def_exception, "duplicate action results definition detected" );
+      EOS_ASSERT( typedefs.size() == types_size, duplicate_abi_type_def_exception, "duplicate type definition detected" );
+      EOS_ASSERT( structs.size() == structs_size, duplicate_abi_struct_def_exception, "duplicate struct definition detected" );
+      EOS_ASSERT( actions.size() == actions_size, duplicate_abi_action_def_exception, "duplicate action definition detected" );
+      EOS_ASSERT( tables.size() == tables_size, duplicate_abi_table_def_exception, "duplicate table definition detected" );
+      EOS_ASSERT( error_messages.size() == error_messages_size, duplicate_abi_err_msg_def_exception, "duplicate error message definition detected" );
+      EOS_ASSERT( variants.size() == variants_size, duplicate_abi_variant_def_exception, "duplicate variant definition detected" );
+      EOS_ASSERT( action_results.size() == action_results_size, duplicate_abi_action_results_def_exception, "duplicate action results definition detected" );
 
       validate(ctx);
    }
 
-   void abi_serializer::set_abi(const abi_def& abi, const fc::microseconds& max_serialization_time) {
-      return set_abi(abi, create_yield_function(max_serialization_time));
+   void abi_serializer::set_abi(abi_def&& abi, const fc::microseconds& max_serialization_time) {
+      return set_abi(std::move(abi), create_yield_function(max_serialization_time));
    }
 
    bool abi_serializer::is_builtin_type(const std::string_view& type)const {

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -35,12 +35,12 @@ struct abi_serializer {
    using yield_function_t = fc::optional_delegate<void(size_t)>;
 
    abi_serializer(){ configure_built_in_types(); }
-   abi_serializer( const abi_def& abi, const yield_function_t& yield );
+   abi_serializer( abi_def&& abi, const yield_function_t& yield );
    [[deprecated("use the overload with yield_function_t[=create_yield_function(max_serialization_time)]")]]
-   abi_serializer( const abi_def& abi, const fc::microseconds& max_serialization_time );
-   void set_abi( const abi_def& abi, const yield_function_t& yield );
+   abi_serializer( abi_def&& abi, const fc::microseconds& max_serialization_time );
+   void set_abi( abi_def&& abi, const yield_function_t& yield );
    [[deprecated("use the overload with yield_function_t[=create_yield_function(max_serialization_time)]")]]
-   void set_abi(const abi_def& abi, const fc::microseconds& max_serialization_time);
+   void set_abi( abi_def&& abi, const fc::microseconds& max_serialization_time);
 
    /// @return string_view of `t` or internal string type
    std::string_view resolve_type(const std::string_view& t)const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -348,8 +348,7 @@ namespace eosio { namespace chain {
             if( n.good() ) {
                try {
                   const auto& a = get_account( n );
-                  abi_def abi;
-                  if( abi_serializer::to_abi( a.abi, abi ))
+                  if( abi_def abi; abi_serializer::to_abi( a.abi, abi ))
                      return abi_serializer( std::move(abi), yield );
                } FC_CAPTURE_AND_LOG((n))
             }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -350,7 +350,7 @@ namespace eosio { namespace chain {
                   const auto& a = get_account( n );
                   abi_def abi;
                   if( abi_serializer::to_abi( a.abi, abi ))
-                     return abi_serializer( abi, yield );
+                     return abi_serializer( std::move(abi), yield );
                } FC_CAPTURE_AND_LOG((n))
             }
             return std::optional<abi_serializer>();

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -343,7 +343,7 @@ namespace eosio { namespace testing {
                   const auto& accnt = control->db().get<account_object, by_name>( name );
                   abi_def abi;
                   if( abi_serializer::to_abi( accnt.abi, abi )) {
-                     return abi_serializer( abi, abi_serializer::create_yield_function( abi_serializer_max_time ) );
+                     return abi_serializer( std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ) );
                   }
                   return std::optional<abi_serializer>();
                } FC_RETHROW_EXCEPTIONS( error, "Failed to find or parse ABI for ${name}", ("name", name))

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -341,8 +341,7 @@ namespace eosio { namespace testing {
             return [this]( const account_name& name ) -> std::optional<abi_serializer> {
                try {
                   const auto& accnt = control->db().get<account_object, by_name>( name );
-                  abi_def abi;
-                  if( abi_serializer::to_abi( accnt.abi, abi )) {
+                  if( abi_def abi; abi_serializer::to_abi( accnt.abi, abi )) {
                      return abi_serializer( std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ) );
                   }
                   return std::optional<abi_serializer>();

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -682,7 +682,7 @@ namespace eosio { namespace testing {
                                    const variant_object& data )const { try {
       const auto& acnt = control->get_account(code);
       auto abi = acnt.get_abi();
-      chain::abi_serializer abis(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+      chain::abi_serializer abis(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
 
       string action_type_name = abis.get_action_type(acttype);
       FC_ASSERT( action_type_name != string(), "unknown action type ${a}", ("a",acttype) );

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -152,7 +152,7 @@ void chain_api_plugin::plugin_startup() {
 
    _http_plugin.add_api({
       { std::string("/v1/chain/get_block"),
-        [ro_api, &chain, &_http_plugin, max_time=std::min(chain.get_abi_serializer_max_time(),max_response_time)]
+        [ro_api, &_http_plugin, max_time=std::min(chain.get_abi_serializer_max_time(),max_response_time)]
               ( string, string body, url_response_callback cb ) mutable {
            auto deadline = ro_api.start();
            try {
@@ -161,50 +161,17 @@ void chain_api_plugin::plugin_startup() {
               FC_CHECK_DEADLINE( deadline );
               chain::signed_block_ptr block = ro_api.get_block( params, deadline );
 
-              auto yield = abi_serializer::create_yield_function( max_time );
-              std::unordered_map<account_name, std::optional<abi_serializer> > abi_cache;
-              auto add_to_cache = [&]( const chain::action& a ) {
-                 auto it = abi_cache.find( a.account );
-                 if( it == abi_cache.end() )
-                    abi_cache.emplace_hint( it, a.account, chain.chain().get_abi_serializer( a.account, yield ) );
-              };
-              for( const auto& receipt: block->transactions ) {
-                 if( std::holds_alternative<chain::packed_transaction>( receipt.trx ) ) {
-                    const auto& pt = std::get<chain::packed_transaction>( receipt.trx );
-                    const auto& t = pt.get_transaction();
-                    for( const auto& a: t.actions )
-                       add_to_cache( a );
-                    for( const auto& a: t.context_free_actions )
-                       add_to_cache( a );
-                 }
-              }
+              auto abi_cache = ro_api.get_block_serializers( block, max_time );
               FC_CHECK_DEADLINE( deadline );
 
               auto post_time = fc::time_point::now();
               auto remaining_time = max_time - (post_time - start);
               _http_plugin.post_http_thread_pool(
-                    [cb, deadline, post_time, remaining_time, abi_cache{std::move(abi_cache)}, block{std::move( block )}]() {
+                    [ro_api, cb, deadline, post_time, remaining_time, abi_cache{std::move(abi_cache)}, block{std::move( block )}]() {
                  try {
                     auto new_deadline = deadline + (fc::time_point::now() - post_time);
 
-                    auto abi_serializer_resolver = [&abi_cache](const account_name& account) -> std::optional<abi_serializer> {
-                       auto it = abi_cache.find( account );
-                       if( it != abi_cache.end() )
-                          return it->second;
-                       return {};
-                    };
-
-                    fc::variant pretty_output;
-                    abi_serializer::to_variant( *block, pretty_output, abi_serializer_resolver,
-                                                abi_serializer::create_yield_function( remaining_time ) );
-
-                    const auto block_id = block->calculate_id();
-                    uint32_t ref_block_prefix = block_id._hash[1];
-
-                    fc::variant result = fc::mutable_variant_object( pretty_output.get_object() )
-                          ( "id", block_id )
-                          ( "block_num", block->block_num() )
-                          ( "ref_block_prefix", ref_block_prefix );
+                    fc::variant result = ro_api.convert_block( block, abi_cache, remaining_time );
 
                     cb( 200, new_deadline, std::move( result ) );
                  } catch( ... ) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -16,7 +16,6 @@
 #include <eosio/chain_plugin/trx_finality_status_processing.hpp>
 #include <eosio/chain/permission_link_object.hpp>
 #include <eosio/chain/global_property_object.hpp>
-#include <eosio/chain/eosio_contract.hpp>
 
 #include <eosio/resource_monitor_plugin/resource_monitor_plugin.hpp>
 
@@ -30,7 +29,6 @@
 
 #include <fc/io/json.hpp>
 #include <fc/variant.hpp>
-#include <signal.h>
 #include <cstdlib>
 
 // reflect chainbase::environment for --print-build-info option
@@ -1881,7 +1879,7 @@ read_only::get_scheduled_transactions( const read_only::get_scheduled_transactio
    return result;
 }
 
-fc::variant read_only::get_block(const read_only::get_block_params& params, const fc::time_point& deadline) const {
+chain::signed_block_ptr read_only::get_block(const read_only::get_block_params& params, const fc::time_point& deadline) const {
    signed_block_ptr block;
    std::optional<uint64_t> block_num;
 
@@ -1903,18 +1901,9 @@ fc::variant read_only::get_block(const read_only::get_block_params& params, cons
    }
 
    EOS_ASSERT( block, unknown_block_exception, "Could not find block: ${block}", ("block", params.block_num_or_id));
+   FC_CHECK_DEADLINE(deadline);
 
-   fc::variant pretty_output;
-   abi_serializer::to_variant(*block, pretty_output, make_resolver(db, abi_serializer::create_yield_function( abi_serializer_max_time )),
-                              abi_serializer::create_yield_function( abi_serializer_max_time ));
-
-   const auto block_id = block->calculate_id();
-   uint32_t ref_block_prefix = block_id._hash[1];
-
-   return fc::mutable_variant_object(pretty_output.get_object())
-           ("id", block_id)
-           ("block_num",block->block_num())
-           ("ref_block_prefix", ref_block_prefix);
+   return block;
 }
 
 fc::variant read_only::get_block_info(const read_only::get_block_info_params& params, const fc::time_point& deadline) const {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2473,8 +2473,7 @@ read_only::get_account_results read_only::get_account( const get_account_params&
 
 static fc::variant action_abi_to_variant( const account_object* code_account, type_name action_type ) {
    fc::variant v;
-   abi_def abi;
-   if( abi_serializer::to_abi(code_account->abi, abi) ) {
+   if( abi_def abi; abi_serializer::to_abi(code_account->abi, abi) ) {
       auto it = std::find_if(abi.structs.begin(), abi.structs.end(), [&](auto& x){return x.name == action_type;});
       if( it != abi.structs.end() )
          to_variant( it->fields,  v );

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -354,7 +354,7 @@ public:
       string block_num_or_id;
    };
 
-   fc::variant get_block(const get_block_params& params, const fc::time_point& deadline) const;
+   chain::signed_block_ptr get_block(const get_block_params& params, const fc::time_point& deadline) const;
 
    struct get_block_info_params {
       uint32_t block_num = 0;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -523,7 +523,7 @@ public:
 
    template <typename IndexType, typename SecKeyType, typename ConvFn>
    read_only::get_table_rows_result get_table_rows_by_seckey( const read_only::get_table_rows_params& p,
-                                                              const abi_def& abi,
+                                                              abi_def&& abi,
                                                               const fc::time_point& deadline,
                                                               ConvFn conv )const {
 
@@ -536,7 +536,7 @@ public:
       name scope{ convert_to_type<uint64_t>(p.scope, "scope") };
 
       abi_serializer abis;
-      abis.set_abi(abi, abi_serializer::create_yield_function( abi_serializer_max_time ) );
+      abis.set_abi(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ) );
       bool primary = false;
       const uint64_t table_with_index = get_table_index_name(p, primary);
       const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(p.code, scope, p.table));
@@ -627,7 +627,7 @@ public:
 
    template <typename IndexType>
    read_only::get_table_rows_result get_table_rows_ex( const read_only::get_table_rows_params& p,
-                                                       const abi_def& abi,
+                                                       abi_def&& abi,
                                                        const fc::time_point& deadline )const {
 
       fc::microseconds params_time_limit = p.time_limit_ms ? fc::milliseconds(*p.time_limit_ms) : fc::milliseconds(10);
@@ -639,7 +639,7 @@ public:
       uint64_t scope = convert_to_type<uint64_t>(p.scope, "scope");
 
       abi_serializer abis;
-      abis.set_abi(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+      abis.set_abi(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
       const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(p.code, name(scope), p.table));
       if( t_id != nullptr ) {
          const auto& idx = d.get_index<IndexType, chain::by_scope_primary>();

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -355,6 +355,13 @@ public:
    };
 
    chain::signed_block_ptr get_block(const get_block_params& params, const fc::time_point& deadline) const;
+   // call from app() thread
+   std::unordered_map<account_name, std::optional<abi_serializer>>
+     get_block_serializers( const chain::signed_block_ptr& block, const fc::microseconds& max_time ) const;
+   // call from any thread
+   fc::variant convert_block( const chain::signed_block_ptr& block,
+                              std::unordered_map<account_name, std::optional<abi_serializer>> abi_cache,
+                              const fc::microseconds& max_time ) const;
 
    struct get_block_info_params {
       uint32_t block_num = 0;

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -490,6 +490,11 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
       my->plugin_state->url_handlers[url] = my->make_http_thread_url_handler(handler);
    }
 
+   void http_plugin::post_http_thread_pool(std::function<void()> f) {
+      if( f )
+         boost::asio::post( my->plugin_state->thread_pool.get_executor(), f );
+   }
+
    void http_plugin::handle_exception( const char *api_name, const char *call_name, const string& body, const url_response_callback& cb) {
       try {
          try {

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -95,6 +95,8 @@ namespace eosio {
         // standard exception handling for api handlers
         static void handle_exception( const char *api_name, const char *call_name, const string& body, const url_response_callback& cb );
 
+        void post_http_thread_pool(std::function<void()> f);
+
         bool is_on_loopback() const;
         bool is_secure() const;
 

--- a/plugins/trace_api_plugin/abi_data_handler.cpp
+++ b/plugins/trace_api_plugin/abi_data_handler.cpp
@@ -3,10 +3,10 @@
 
 namespace eosio::trace_api {
 
-   void abi_data_handler::add_abi( const chain::name& name, const chain::abi_def& abi ) {
+   void abi_data_handler::add_abi( const chain::name& name, chain::abi_def&& abi ) {
       // currently abis are operator provided so no need to protect against abuse
       abi_serializer_by_account.emplace(name,
-            std::make_shared<chain::abi_serializer>(abi, chain::abi_serializer::create_yield_function(fc::microseconds::maximum())));
+            std::make_shared<chain::abi_serializer>(std::move(abi), chain::abi_serializer::create_yield_function(fc::microseconds::maximum())));
    }
 
    std::tuple<fc::variant, std::optional<fc::variant>> abi_data_handler::serialize_to_variant(const std::variant<action_trace_v0, action_trace_v1> & action, const yield_function& yield ) {

--- a/plugins/trace_api_plugin/include/eosio/trace_api/abi_data_handler.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/abi_data_handler.hpp
@@ -28,7 +28,7 @@ namespace eosio {
        * @param name - the name of the account/contract that this ABI belongs to
        * @param abi - the ABI definition of that ABI
        */
-      void add_abi( const chain::name& name, const chain::abi_def& abi );
+      void add_abi( const chain::name& name, chain::abi_def&& abi );
 
       /**
        * Given an action trace, produce a tuple representing the `data` and `return_value` fields in the trace

--- a/plugins/trace_api_plugin/test/test_data_handlers.cpp
+++ b/plugins/trace_api_plugin/test/test_data_handlers.cpp
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       abi.version = "eosio::abi/1.";
 
       abi_data_handler handler(exception_handler{});
-      handler.add_abi("alice"_n, abi);
+      handler.add_abi("alice"_n, std::move(abi));
 
       fc::variant expected = fc::mutable_variant_object()
          ("a", 0)
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       abi.version = "eosio::abi/1.";
 
       abi_data_handler handler(exception_handler{});
-      handler.add_abi("alice"_n, abi);
+      handler.add_abi("alice"_n, std::move(abi));
 
       fc::variant expected = fc::mutable_variant_object()
             ("a", 0)
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       abi.version = "eosio::abi/1.";
 
       abi_data_handler handler(exception_handler{});
-      handler.add_abi("alice"_n, abi);
+      handler.add_abi("alice"_n, std::move(abi));
 
       auto expected = fc::variant();
 
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       abi.version = "eosio::abi/1.";
 
       abi_data_handler handler(exception_handler{});
-      handler.add_abi("alice"_n, abi);
+      handler.add_abi("alice"_n, std::move(abi));
 
       auto expected = fc::variant();
 
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
 
       bool log_called = false;
       abi_data_handler handler([&log_called](const exception_with_context& ){log_called = true;});
-      handler.add_abi("alice"_n, abi);
+      handler.add_abi("alice"_n, std::move(abi));
 
       auto expected = fc::variant();
 

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -213,7 +213,7 @@ struct trace_api_rpc_plugin_impl : public std::enable_shared_from_this<trace_api
                auto kv = parse_kv_pairs(entry);
                auto account = chain::name(kv.first);
                auto abi = abi_def_from_file(kv.second, app().data_dir());
-               data_handler->add_abi(account, abi);
+               data_handler->add_abi(account, std::move(abi));
             } catch (...) {
                elog("Malformed trace-rpc-abi provider: \"${val}\"", ("val", entry));
                throw;

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -93,7 +93,9 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
 
    // block should be decoded successfully
-   std::string block_str = json::to_pretty_string(plugin.get_block(param, fc::time_point::maximum()));
+   auto block = plugin.get_block(param, fc::time_point::maximum());
+   auto abi_cache = plugin.get_block_serializers(block, fc::microseconds::maximum());
+   std::string block_str = json::to_pretty_string(plugin.convert_block(block, abi_cache, fc::microseconds::maximum()));
    BOOST_TEST(block_str.find("procassert") != std::string::npos);
    BOOST_TEST(block_str.find("condition") != std::string::npos);
    BOOST_TEST(block_str.find("Should Not Assert!") != std::string::npos);
@@ -111,7 +113,9 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    BOOST_CHECK_THROW(resolver("asserter"_n), invalid_type_inside_abi);
 
    // get the same block as string, results in decode failed(invalid abi) but not exception
-   std::string block_str2 = json::to_pretty_string(plugin.get_block(param, fc::time_point::maximum()));
+   auto block2 = plugin.get_block(param, fc::time_point::maximum());
+   auto abi_cache2 = plugin.get_block_serializers(block2, fc::microseconds::maximum());
+   std::string block_str2 = json::to_pretty_string(plugin.convert_block(block2, abi_cache2, fc::microseconds::maximum()));
    BOOST_TEST(block_str2.find("procassert") != std::string::npos);
    BOOST_TEST(block_str2.find("condition") == std::string::npos); // decode failed
    BOOST_TEST(block_str2.find("Should Not Assert!") == std::string::npos); // decode failed

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -51,7 +51,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
          const auto& accnt  = this->control->db().get<account_object,by_name>( name );
          abi_def abi;
          if (abi_serializer::to_abi(accnt.abi, abi)) {
-            return abi_serializer(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+            return abi_serializer(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
          }
          return std::optional<abi_serializer>();
       } FC_RETHROW_EXCEPTIONS(error, "resolver failed at chain_plugin_tests::abi_invalid_type");

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -49,8 +49,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    auto resolver = [&,this]( const account_name& name ) -> std::optional<abi_serializer> {
       try {
          const auto& accnt  = this->control->db().get<account_object,by_name>( name );
-         abi_def abi;
-         if (abi_serializer::to_abi(accnt.abi, abi)) {
+         if (abi_def abi; abi_serializer::to_abi(accnt.abi, abi)) {
             return abi_serializer(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
          }
          return std::optional<abi_serializer>();

--- a/tests/test_chain_plugin.cpp
+++ b/tests/test_chain_plugin.cpp
@@ -205,7 +205,7 @@ public:
            const auto& accnt = control->db().get<account_object,by_name>( "eosio.token"_n );
            abi_def abi;
            BOOST_CHECK_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
-           token_abi_ser.set_abi(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+           token_abi_ser.set_abi(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
        }
 
        create_currency( "eosio.token"_n, config::system_account_name, core_from_string("10000000000.0000") );
@@ -224,7 +224,7 @@ public:
            const auto& accnt = control->db().get<account_object,by_name>( config::system_account_name );
            abi_def abi;
            BOOST_CHECK_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
-           abi_ser.set_abi(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+           abi_ser.set_abi(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
        }
 
     }

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -2971,8 +2971,7 @@ BOOST_AUTO_TEST_CASE(abi_to_variant__add_action__good_return_value)
       ]
    })";
    auto abidef = fc::json::from_string(abi).as<abi_def>();
-   auto abidef2 = abidef;
-   abi_serializer abis(std::move(abidef2), abi_serializer::create_yield_function(max_serialization_time));
+   abi_serializer abis(abi_def(abidef), abi_serializer::create_yield_function(max_serialization_time));
 
    mutable_variant_object mvo;
    eosio::chain::impl::abi_traverse_context ctx(abi_serializer::create_yield_function(max_serialization_time));
@@ -2997,8 +2996,7 @@ BOOST_AUTO_TEST_CASE(abi_to_variant__add_action__bad_return_value)
       ]
    })";
    auto abidef = fc::json::from_string(abi).as<abi_def>();
-   auto abidef2 = abidef;
-   abi_serializer abis(std::move(abidef2), abi_serializer::create_yield_function(max_serialization_time));
+   abi_serializer abis(abi_def(abidef), abi_serializer::create_yield_function(max_serialization_time));
 
    mutable_variant_object mvo;
    eosio::chain::impl::abi_traverse_context ctx(abi_serializer::create_yield_function(max_serialization_time));
@@ -3033,8 +3031,7 @@ BOOST_AUTO_TEST_CASE(abi_to_variant__add_action__no_return_value)
       ]
    })";
    auto abidef = fc::json::from_string(abi).as<abi_def>();
-   auto abidef2 = abidef;
-   abi_serializer abis(std::move(abidef2), abi_serializer::create_yield_function(max_serialization_time));
+   abi_serializer abis(abi_def(abidef), abi_serializer::create_yield_function(max_serialization_time));
 
    mutable_variant_object mvo;
    eosio::chain::impl::abi_traverse_context ctx(abi_serializer::create_yield_function(max_serialization_time));

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -551,9 +551,8 @@ BOOST_AUTO_TEST_CASE(general)
 { try {
 
    auto abi = eosio_contract_abi(fc::json::from_string(my_abi).as<abi_def>());
-   auto abi2 = abi;
 
-   abi_serializer abis(std::move(abi), abi_serializer::create_yield_function( max_serialization_time ));
+   abi_serializer abis(abi_def(abi), abi_serializer::create_yield_function( max_serialization_time ));
 
    const char *my_other = R"=====(
     {
@@ -752,7 +751,7 @@ BOOST_AUTO_TEST_CASE(general)
    )=====";
 
    auto var = fc::json::from_string(my_other);
-   verify_byte_round_trip_conversion(abi_serializer{std::move(abi2), abi_serializer::create_yield_function( max_serialization_time )}, "A", var);
+   verify_byte_round_trip_conversion(abi_serializer{std::move(abi), abi_serializer::create_yield_function( max_serialization_time )}, "A", var);
 
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(uint_types)
 
 
    auto var = fc::json::from_string(test_data);
-   verify_byte_round_trip_conversion(abi_serializer{abi, abi_serializer::create_yield_function( max_serialization_time )}, "transfer", var);
+   verify_byte_round_trip_conversion(abi_serializer{std::move(abi), abi_serializer::create_yield_function( max_serialization_time )}, "transfer", var);
 
 } FC_LOG_AND_RETHROW() }
 
@@ -551,8 +551,9 @@ BOOST_AUTO_TEST_CASE(general)
 { try {
 
    auto abi = eosio_contract_abi(fc::json::from_string(my_abi).as<abi_def>());
+   auto abi2 = abi;
 
-   abi_serializer abis(abi, abi_serializer::create_yield_function( max_serialization_time ));
+   abi_serializer abis(std::move(abi), abi_serializer::create_yield_function( max_serialization_time ));
 
    const char *my_other = R"=====(
     {
@@ -751,7 +752,7 @@ BOOST_AUTO_TEST_CASE(general)
    )=====";
 
    auto var = fc::json::from_string(my_other);
-   verify_byte_round_trip_conversion(abi_serializer{abi, abi_serializer::create_yield_function( max_serialization_time )}, "A", var);
+   verify_byte_round_trip_conversion(abi_serializer{std::move(abi2), abi_serializer::create_yield_function( max_serialization_time )}, "A", var);
 
 } FC_LOG_AND_RETHROW() }
 
@@ -802,11 +803,11 @@ BOOST_AUTO_TEST_CASE(abi_cycle)
    auto is_assert_exception = [](const auto& e) -> bool {
       wlog(e.to_string()); return true;
    };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(abi, abi_serializer::create_yield_function( max_serialization_time )), duplicate_abi_type_def_exception, is_assert_exception);
+   BOOST_CHECK_EXCEPTION( abi_serializer abis(std::move(abi), abi_serializer::create_yield_function( max_serialization_time )), duplicate_abi_type_def_exception, is_assert_exception);
 
    abi = fc::json::from_string(struct_cycle_abi).as<abi_def>();
    abi_serializer abis;
-   BOOST_CHECK_EXCEPTION( abis.set_abi(abi, abi_serializer::create_yield_function( max_serialization_time )), abi_circular_def_exception, is_assert_exception );
+   BOOST_CHECK_EXCEPTION( abis.set_abi(std::move(abi), abi_serializer::create_yield_function( max_serialization_time )), abi_circular_def_exception, is_assert_exception );
 
 } FC_LOG_AND_RETHROW() }
 
@@ -1649,7 +1650,7 @@ BOOST_AUTO_TEST_CASE(abi_type_repeat)
 
    auto abi = eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
    auto is_table_exception = [](fc::exception const & e) -> bool { return e.to_detail_string().find("type already exists") != std::string::npos; };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(abi, abi_serializer::create_yield_function( max_serialization_time )), duplicate_abi_type_def_exception, is_table_exception );
+   BOOST_CHECK_EXCEPTION( abi_serializer abis(std::move(abi), abi_serializer::create_yield_function( max_serialization_time )), duplicate_abi_type_def_exception, is_table_exception );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(abi_struct_repeat)
@@ -1706,7 +1707,7 @@ BOOST_AUTO_TEST_CASE(abi_struct_repeat)
    )=====";
 
    auto abi = eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
-   BOOST_CHECK_THROW( abi_serializer abis(abi, abi_serializer::create_yield_function( max_serialization_time )), duplicate_abi_struct_def_exception );
+   BOOST_CHECK_THROW( abi_serializer abis(std::move(abi), abi_serializer::create_yield_function( max_serialization_time )), duplicate_abi_struct_def_exception );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(abi_action_repeat)
@@ -1766,7 +1767,7 @@ BOOST_AUTO_TEST_CASE(abi_action_repeat)
    )=====";
 
    auto abi = eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
-   BOOST_CHECK_THROW( abi_serializer abis(abi, abi_serializer::create_yield_function( max_serialization_time )), duplicate_abi_action_def_exception );
+   BOOST_CHECK_THROW( abi_serializer abis(std::move(abi), abi_serializer::create_yield_function( max_serialization_time )), duplicate_abi_action_def_exception );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(abi_table_repeat)
@@ -1829,7 +1830,7 @@ BOOST_AUTO_TEST_CASE(abi_table_repeat)
    )=====";
 
    auto abi = eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
-   BOOST_CHECK_THROW( abi_serializer abis(abi, abi_serializer::create_yield_function( max_serialization_time )), duplicate_abi_table_def_exception );
+   BOOST_CHECK_THROW( abi_serializer abis(std::move(abi), abi_serializer::create_yield_function( max_serialization_time )), duplicate_abi_table_def_exception );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(abi_type_def)
@@ -2056,7 +2057,7 @@ BOOST_AUTO_TEST_CASE(abi_account_name_in_eosio_abi)
 
    auto abi = eosio_contract_abi(fc::json::from_string(repeat_abi).as<abi_def>());
    auto is_type_exception = [](fc::assert_exception const & e) -> bool { return e.to_detail_string().find("type already exists") != std::string::npos; };
-   BOOST_CHECK_EXCEPTION( abi_serializer abis(abi, abi_serializer::create_yield_function(max_serialization_time )), duplicate_abi_type_def_exception, is_type_exception );
+   BOOST_CHECK_EXCEPTION( abi_serializer abis(std::move(abi), abi_serializer::create_yield_function(max_serialization_time )), duplicate_abi_type_def_exception, is_type_exception );
 
 } FC_LOG_AND_RETHROW() }
 
@@ -2971,7 +2972,8 @@ BOOST_AUTO_TEST_CASE(abi_to_variant__add_action__good_return_value)
       ]
    })";
    auto abidef = fc::json::from_string(abi).as<abi_def>();
-   abi_serializer abis(abidef, abi_serializer::create_yield_function(max_serialization_time));
+   auto abidef2 = abidef;
+   abi_serializer abis(std::move(abidef2), abi_serializer::create_yield_function(max_serialization_time));
 
    mutable_variant_object mvo;
    eosio::chain::impl::abi_traverse_context ctx(abi_serializer::create_yield_function(max_serialization_time));
@@ -2996,7 +2998,8 @@ BOOST_AUTO_TEST_CASE(abi_to_variant__add_action__bad_return_value)
       ]
    })";
    auto abidef = fc::json::from_string(abi).as<abi_def>();
-   abi_serializer abis(abidef, abi_serializer::create_yield_function(max_serialization_time));
+   auto abidef2 = abidef;
+   abi_serializer abis(std::move(abidef2), abi_serializer::create_yield_function(max_serialization_time));
 
    mutable_variant_object mvo;
    eosio::chain::impl::abi_traverse_context ctx(abi_serializer::create_yield_function(max_serialization_time));
@@ -3031,7 +3034,8 @@ BOOST_AUTO_TEST_CASE(abi_to_variant__add_action__no_return_value)
       ]
    })";
    auto abidef = fc::json::from_string(abi).as<abi_def>();
-   abi_serializer abis(abidef, abi_serializer::create_yield_function(max_serialization_time));
+   auto abidef2 = abidef;
+   abi_serializer abis(std::move(abidef2), abi_serializer::create_yield_function(max_serialization_time));
 
    mutable_variant_object mvo;
    eosio::chain::impl::abi_traverse_context ctx(abi_serializer::create_yield_function(max_serialization_time));

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -79,7 +79,7 @@ public:
       const auto& accnt = control->db().get<account_object,by_name>( config::system_account_name );
       abi_def abi;
       BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
-      abi_ser.set_abi(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+      abi_ser.set_abi(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
    }
 
    fc::variant get_global_state() {
@@ -175,7 +175,7 @@ public:
            const auto& accnt = control->db().get<account_object,by_name>( account );
            abi_def abi_definition;
            BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi_definition), true);
-           abi_ser.set_abi(abi_definition, abi_serializer::create_yield_function( abi_serializer_max_time ));
+           abi_ser.set_abi(std::move(abi_definition), abi_serializer::create_yield_function( abi_serializer_max_time ));
         }
         produce_blocks();
     }

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -1684,8 +1684,8 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
 
    // send transfer with delay_sec set to 10
    const auto& acnt = chain.control->db().get<account_object,by_name>("eosio.token"_n);
-   const auto abi = acnt.get_abi();
-   chain::abi_serializer abis(abi, abi_serializer::create_yield_function( chain.abi_serializer_max_time ));
+   auto abi = acnt.get_abi();
+   chain::abi_serializer abis(std::move(abi), abi_serializer::create_yield_function( chain.abi_serializer_max_time ));
    const auto a = chain.control->db().get<account_object,by_name>("eosio.token"_n).get_abi();
 
    string action_type_name = abis.get_action_type(name("transfer"));

--- a/unittests/eosio.token_tests.cpp
+++ b/unittests/eosio.token_tests.cpp
@@ -36,7 +36,7 @@ public:
       const auto& accnt = control->db().get<account_object,by_name>( "eosio.token"_n );
       abi_def abi;
       BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
-      abi_ser.set_abi(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+      abi_ser.set_abi(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
    }
 
    action_result push_action( const account_name& signer, const action_name &name, const variant_object &data ) {

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -48,7 +48,7 @@ public:
          const auto& accnt = control->db().get<account_object,by_name>( "eosio.token"_n );
          abi_def abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
-         token_abi_ser.set_abi(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+         token_abi_ser.set_abi(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
       }
 
       create_currency( "eosio.token"_n, config::system_account_name, core_from_string("10000000000.0000") );
@@ -67,7 +67,7 @@ public:
          const auto& accnt = control->db().get<account_object,by_name>( config::system_account_name );
          abi_def abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
-         abi_ser.set_abi(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+         abi_ser.set_abi(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
       }
 
       produce_blocks();
@@ -429,7 +429,7 @@ public:
          const auto& accnt = control->db().get<account_object,by_name>( "eosio.msig"_n );
          abi_def msig_abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, msig_abi), true);
-         msig_abi_ser.set_abi(msig_abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+         msig_abi_ser.set_abi(std::move(msig_abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
       }
       return msig_abi_ser;
    }

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -183,8 +183,7 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, TESTER ) try {
    auto resolver = [&,this]( const account_name& name ) -> std::optional<abi_serializer> {
       try {
          const auto& accnt  = this->control->db().get<account_object,by_name>( name );
-         abi_def abi;
-         if (abi_serializer::to_abi(accnt.abi, abi)) {
+         if (abi_def abi; abi_serializer::to_abi(accnt.abi, abi)) {
             return abi_serializer(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
          }
          return std::optional<abi_serializer>();

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -185,7 +185,7 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, TESTER ) try {
          const auto& accnt  = this->control->db().get<account_object,by_name>( name );
          abi_def abi;
          if (abi_serializer::to_abi(accnt.abi, abi)) {
-            return abi_serializer(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+            return abi_serializer(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
          }
          return std::optional<abi_serializer>();
       } FC_RETHROW_EXCEPTIONS(error, "Failed to find or parse ABI for ${name}", ("name", name))
@@ -1049,7 +1049,7 @@ BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
    const auto& accnt  = control->db().get<account_object,by_name>("noop"_n);
    abi_def abi;
    BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
-   abi_serializer abi_ser(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+   abi_serializer abi_ser(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
 
    {
       produce_blocks(5);
@@ -1112,7 +1112,7 @@ BOOST_FIXTURE_TEST_CASE(eosio_abi, TESTER) try {
    const auto& accnt  = control->db().get<account_object,by_name>(config::system_account_name);
    abi_def abi;
    BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
-   abi_serializer abi_ser(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
+   abi_serializer abi_ser(std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ));
 
    signed_transaction trx;
    name a = "alice"_n;


### PR DESCRIPTION
Move the abi serialization of `signed_block` for `/v1/chain/get_block` off the main thread. Also the abi cache used in this implementation actually provides a nice performance improvement. See comments on #677. 

This PR also uses the min of `--http-max-response-time-ms` &  `--abi-serializer-max-time-ms` for the deadline of `get_block` instead of running for the full `--abi-serializer-max-time-ms` before checking `--http-max-response-time-ms`.

Also includes reduction of string copies in `abi_serializer`.

Resolves #677 