### PR TITLE
Add absolute value threshold to resource monitor

### DIFF
--- a/plugins/resource_monitor_plugin/include/eosio/resource_monitor_plugin/file_space_handler.hpp
+++ b/plugins/resource_monitor_plugin/include/eosio/resource_monitor_plugin/file_space_handler.hpp
@@ -189,7 +189,7 @@ namespace eosio::resource_monitor {
       bool     output_threshold_warning {true};
 
    private:
-      uint32_t to_gib(uint64_t bytes) {
+      uint64_t to_gib(uint64_t bytes) {
          return bytes/1024/1024/1024;
       }
 

--- a/plugins/resource_monitor_plugin/resource_monitor_plugin.cpp
+++ b/plugins/resource_monitor_plugin/resource_monitor_plugin.cpp
@@ -53,7 +53,8 @@ public:
            "Unless resource-monitor-not-shutdown-on-threshold-exceeded is enabled, a graceful shutdown is initiated if used space is above the threshold. "
            "The value should be between 6 and 99" )
          ( "resource-monitor-space-absolute-gb", bpo::value<uint64_t>(),
-           "Absolute threshold in gibibytes of remaining space. If remaining space is less than value then threshold is considered exceeded."
+           "Absolute threshold in gibibytes of remaining space; applied to each monitored directory. "
+           "If remaining space is less than value for any monitored directories then threshold is considered exceeded."
            "Overrides resource-monitor-space-threshold value.")
          ( "resource-monitor-not-shutdown-on-threshold-exceeded",
            "Used to indicate nodeos will not shutdown when threshold is exceeded." )
@@ -76,7 +77,7 @@ public:
             auto max = std::numeric_limits<uint64_t>::max()/1024/1024/1024;
             EOS_ASSERT(v > 0 && v < max, chain::plugin_config_exception,
                        "\"resource-monitor-space-absolute-gb\" must be greater than 0 GiB and less than max 64 bit value.");
-            uint64_t w = v < 10 ? v+1 : v < 50 ? v+5 : v < 100 ? v+10 : std::min(max, v+25); // set reasonable absolute warning levels
+            uint64_t w = v < 10 ? v+1 : std::min(max, (v + v/10)); // set reasonable absolute warning levels
             space_handler.set_absolute(v*1024*1024*1024, w*1024*1024*1024);
             ilog("Space usage absolute threshold set to ${v} GiB, warning set to ${w} GiB", ("v", v)("w",w));
          } else {
@@ -85,7 +86,7 @@ public:
                "\"resource-monitor-space-threshold\" must be between ${space_threshold_min} and ${space_threshold_max}",
                ("space_threshold_min", space_threshold_min) ("space_threshold_max", space_threshold_max));
             space_handler.set_threshold(threshold, threshold - space_threshold_warning_diff);
-            ilog("Space usage threshold set to ${threshold}", ("threshold", threshold));
+            ilog("Space usage threshold set to ${threshold}%", ("threshold", threshold));
          }
 
          if (options.count("resource-monitor-not-shutdown-on-threshold-exceeded")) {

--- a/plugins/resource_monitor_plugin/test/CMakeLists.txt
+++ b/plugins/resource_monitor_plugin/test/CMakeLists.txt
@@ -1,22 +1,4 @@
-add_executable( test_threshold test_threshold.cpp )
-target_link_libraries( test_threshold resource_monitor_plugin )
-target_include_directories( test_threshold PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test(NAME test_threshold COMMAND plugins/resource_monitor_plugin/test/test_threshold WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_monitor_loop test_monitor_loop.cpp )
-target_link_libraries( test_monitor_loop resource_monitor_plugin )
-target_include_directories( test_monitor_loop PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test(NAME test_monitor_loop COMMAND plugins/resource_monitor_plugin/test/test_monitor_loop WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_add_file_system test_add_file_system.cpp )
-target_link_libraries( test_add_file_system resource_monitor_plugin )
-target_include_directories( test_add_file_system PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test(NAME test_add_file_system COMMAND plugins/resource_monitor_plugin/test/test_add_file_system WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_resmon_plugin test_resmon_plugin.cpp )
+add_executable( test_resmon_plugin test_resmon_plugin.cpp test_add_file_system.cpp test_monitor_loop.cpp test_threshold.cpp )
 target_link_libraries( test_resmon_plugin resource_monitor_plugin )
 target_include_directories( test_resmon_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 add_test(NAME test_resmon_plugin COMMAND plugins/resource_monitor_plugin/test/test_resmon_plugin WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/plugins/resource_monitor_plugin/test/test_add_file_system.cpp
+++ b/plugins/resource_monitor_plugin/test/test_add_file_system.cpp
@@ -1,7 +1,4 @@
-#define BOOST_TEST_MODULE add_file_system
-#include <boost/test/included/unit_test.hpp>
-
-#include <fc/variant_object.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <eosio/resource_monitor_plugin/file_space_handler.hpp>
 
@@ -11,7 +8,7 @@ using namespace boost::system;
 
 struct add_file_system_fixture {
    struct mock_space_provider {
-      mock_space_provider(add_file_system_fixture& fixture)
+      explicit mock_space_provider(add_file_system_fixture& fixture)
       :fixture(fixture)
       {}
 
@@ -50,7 +47,7 @@ struct add_file_system_fixture {
       mock_get_space = [ i = 0, capacity, available ]( const bfs::path& p, boost::system::error_code& ec) mutable -> bfs::space_info {
          ec = boost::system::errc::make_error_code(errc::success);
 
-         bfs::space_info rc;
+         bfs::space_info rc{};
          rc.capacity  = capacity[i];
          rc.available = available[i];
          i++;
@@ -93,7 +90,7 @@ BOOST_AUTO_TEST_SUITE(space_handler_tests)
    {
       mock_get_space = []( const bfs::path& p, boost::system::error_code& ec) -> bfs::space_info {
          ec = boost::system::errc::make_error_code(errc::no_such_file_or_directory);
-         bfs::space_info rc;
+         bfs::space_info rc{};
          return rc;
       };
 

--- a/plugins/resource_monitor_plugin/test/test_monitor_loop.cpp
+++ b/plugins/resource_monitor_plugin/test/test_monitor_loop.cpp
@@ -1,7 +1,4 @@
-#define BOOST_TEST_MODULE monitor_loop
-#include <boost/test/included/unit_test.hpp>
-
-#include <fc/variant_object.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <eosio/resource_monitor_plugin/file_space_handler.hpp>
 
@@ -11,7 +8,7 @@ using namespace boost::system;
 
 struct space_handler_fixture {
    struct mock_space_provider {
-      mock_space_provider(space_handler_fixture& fixture)
+      explicit mock_space_provider(space_handler_fixture& fixture)
       :fixture(fixture)
       {}
 
@@ -63,7 +60,7 @@ struct space_handler_fixture {
       mock_get_space = [ i = 0, num_loops ]( const bfs::path& p, boost::system::error_code& ec) mutable -> bfs::space_info {
          ec = boost::system::errc::make_error_code(errc::success);
 
-         bfs::space_info rc;
+         bfs::space_info rc{};
          rc.capacity  = 1000000;
 
          if ( i < num_loops + 1 ) {  // "+ 1" for the get_space in add_file_system
@@ -146,14 +143,9 @@ BOOST_AUTO_TEST_SUITE(monitor_loop_tests)
       BOOST_TEST( test_loop_common(2, 5) );
    }
 
-   BOOST_FIXTURE_TEST_CASE(ten_loops_5_sec_interval, space_handler_fixture)
+   BOOST_FIXTURE_TEST_CASE(five_loops_5_sec_interval, space_handler_fixture)
    {
-      BOOST_TEST( test_loop_common(10, 5) );
-   }
-
-   BOOST_FIXTURE_TEST_CASE(one_hundred_twenty_loops_1_sec_interval, space_handler_fixture)
-   {
-      BOOST_TEST( test_loop_common(120, 1) );
+      BOOST_TEST( test_loop_common(5, 5) );
    }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/plugins/resource_monitor_plugin/test/test_resmon_plugin.cpp
+++ b/plugins/resource_monitor_plugin/test/test_resmon_plugin.cpp
@@ -113,6 +113,31 @@ BOOST_AUTO_TEST_SUITE(resmon_plugin_tests)
       BOOST_REQUIRE_NO_THROW(set_options({"--resource-monitor-space-threshold=99"}));
    }
 
+   BOOST_FIXTURE_TEST_CASE(absoluteTooBig, resmon_fixture)
+   {
+      BOOST_REQUIRE_THROW(set_options({"--resource-monitor-space-absolute-gb=17179869183"}), chain::plugin_config_exception);
+   }
+
+   BOOST_FIXTURE_TEST_CASE(absoluteTooSmall, resmon_fixture)
+   {
+      BOOST_REQUIRE_THROW(set_options({"--resource-monitor-space-absolute-gb=0"}), chain::plugin_config_exception);
+   }
+
+   BOOST_FIXTURE_TEST_CASE(absoluteLowBound, resmon_fixture)
+   {
+      BOOST_REQUIRE_NO_THROW(set_options({"--resource-monitor-space-absolute-gb=1"}));
+   }
+
+   BOOST_FIXTURE_TEST_CASE(absoluteMiddle, resmon_fixture)
+   {
+      BOOST_REQUIRE_NO_THROW(set_options({"--resource-monitor-space-absolute-gb=1024"}));
+   }
+
+   BOOST_FIXTURE_TEST_CASE(absoluteHighBound, resmon_fixture)
+   {
+      BOOST_REQUIRE_NO_THROW(set_options({"--resource-monitor-space-absolute-gb=17179869182"}));
+   }
+
    BOOST_FIXTURE_TEST_CASE(noShutdown, resmon_fixture)
    {
       BOOST_REQUIRE_NO_THROW(set_options({"--resource-monitor-not-shutdown-on-threshold-exceeded"}));
@@ -142,7 +167,7 @@ BOOST_AUTO_TEST_SUITE(resmon_plugin_tests)
 
    BOOST_FIXTURE_TEST_CASE(startupLongRun, resmon_fixture)
    {
-      BOOST_REQUIRE_NO_THROW( plugin_startup({"/tmp"}, 120));
+      BOOST_REQUIRE_NO_THROW( plugin_startup({"/tmp"}, 5));
    }
 
    BOOST_FIXTURE_TEST_CASE(warningIntervalTooBig, resmon_fixture)

--- a/plugins/resource_monitor_plugin/test/test_threshold.cpp
+++ b/plugins/resource_monitor_plugin/test/test_threshold.cpp
@@ -1,7 +1,4 @@
-#define BOOST_TEST_MODULE threshold
-#include <boost/test/included/unit_test.hpp>
-
-#include <fc/variant_object.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <eosio/resource_monitor_plugin/file_space_handler.hpp>
 
@@ -11,7 +8,7 @@ using namespace boost::system;
 
 struct threshold_fixture {
    struct mock_space_provider {
-      mock_space_provider(threshold_fixture& fixture)
+      explicit mock_space_provider(threshold_fixture& fixture)
       :fixture(fixture)
       {}
 
@@ -30,33 +27,44 @@ struct threshold_fixture {
 
    using file_space_handler_t = file_space_handler<mock_space_provider>;
    threshold_fixture()
-   : space_handler(mock_space_provider(*this), ctx)
+   : space_handler(std::make_unique<file_space_handler_t>(mock_space_provider(*this), ctx))
    {
    }
 
    void add_file_system(const bfs::path& path_name) {
-      space_handler.add_file_system(path_name);
+      space_handler->add_file_system(path_name);
    }
 
    void set_threshold(uint32_t threshold, uint32_t warning_threshold) {
-      space_handler.set_threshold(threshold, warning_threshold);
+      space_handler->set_threshold(threshold, warning_threshold);
    }
 
    bool is_threshold_exceeded() {
-      return space_handler.is_threshold_exceeded();
+      return space_handler->is_threshold_exceeded();
    }
 
    void set_shutdown_on_exceeded(bool shutdown_on_exceeded) {
-      space_handler.set_shutdown_on_exceeded(shutdown_on_exceeded);
+      space_handler->set_shutdown_on_exceeded(shutdown_on_exceeded);
    }
 
-   bool test_threshold_common(std::map<bfs::path, uintmax_t>& available, std::map<bfs::path, int>& dev, uint32_t warning_threshold=75)
+   bool test_threshold_common(std::map<bfs::path, uintmax_t>& available, std::map<bfs::path, int>& dev, uint32_t warning_threshold=75) {
+      bool first = test_threshold_common_(available, dev, warning_threshold);
+      space_handler = std::make_unique<file_space_handler_t>(mock_space_provider(*this), ctx);
+
+      test_absolute = true;
+      bool second = test_threshold_common_(available, dev, warning_threshold);
+      BOOST_TEST(first == second);
+      return second;
+   }
+
+   bool test_threshold_common_(std::map<bfs::path, uintmax_t>& available, std::map<bfs::path, int>& dev, uint32_t warning_threshold=75)
    {
+      const uint32_t capacity = 1000000;
       mock_get_space = [available]( const bfs::path& p, boost::system::error_code& ec) mutable -> bfs::space_info {
          ec = boost::system::errc::make_error_code(errc::success);
 
-         bfs::space_info rc;
-         rc.capacity  = 1000000;
+         bfs::space_info rc{};
+         rc.capacity  = capacity;
          rc.available = available[p];
 
          return rc;
@@ -69,7 +77,11 @@ struct threshold_fixture {
          return 0;
       };
 
-      set_threshold(80, warning_threshold);
+      if (test_absolute) {
+         space_handler->set_absolute(.20*capacity, ((100-warning_threshold)/100.0)*capacity);
+      } else {
+         set_threshold(80, warning_threshold);
+      }
       set_shutdown_on_exceeded(true);
 
       for (size_t i = 0; i < available.size(); i++) {
@@ -83,10 +95,11 @@ struct threshold_fixture {
    std::function<bfs::space_info(const bfs::path& p, boost::system::error_code& ec)> mock_get_space;
    std::function<int(const char *path, struct stat *buf)> mock_get_stat;
 
-   file_space_handler_t space_handler;
+   std::unique_ptr<file_space_handler_t> space_handler;
+   bool test_absolute = false;
 };
 
-BOOST_AUTO_TEST_SUITE(threshol_tests)
+BOOST_AUTO_TEST_SUITE(threshold_tests)
    BOOST_FIXTURE_TEST_CASE(equal_to_threshold, threshold_fixture)
    {
       std::map<bfs::path, uintmax_t> availables {{"/test0", 200000}};
@@ -264,7 +277,7 @@ BOOST_AUTO_TEST_SUITE(threshol_tests)
             ec = boost::system::errc::make_error_code(errc::success);
          }
 
-         bfs::space_info rc;
+         bfs::space_info rc{};
          rc.capacity  = 1000000;
          rc.available = 200500;
 


### PR DESCRIPTION
Add new option to `resource_monitor_plugin`
* `--resource-monitor-space-absolute-gb` - "Absolute threshold in gibibytes of remaining space; applied to each monitored directory. If remaining space is less than value for any monitored directories then threshold is considered exceeded. Overrides resource-monitor-space-threshold value."
* Log space threshold warning on shutdown when exceeded.
```
error 2023-02-10T15:23:54.009 resmon    file_space_handler.hpp:74     is_threshold_exceede ] Space usage warning: /home/heifner/ext/leap/cmake-build-debug/bin/t/blocks's file system exceeded threshold 240 GiB, available: 237 GiB, Capacity: 1006 GiB, shutdown_available: 240 GiB
error 2023-02-10T15:23:54.010 resmon    file_space_handler.hpp:135    space_monitor_loop   ] Gracefully shutting down, exceeded file system configured threshold.
info  2023-02-10T15:23:54.010 nodeos    resource_monitor_plugi:143    plugin_shutdown      ] shutdown...
```
* Includes a fix so that invalid plugin configuration options are logged.

* Includes some cleanup to the resource monitor unittests to make them run much quicker and to combine them into one executable.

Resolves #395 