### PR TITLE
[3.2 -> main] Fix reporting of dirty db

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3572,7 +3572,11 @@ std::optional<chain_id_type> controller::extract_chain_id_from_db( const path& s
       if (gpo==nullptr) return {};
 
       return gpo->chain_id;
-   } catch (std::system_error &) {} //  do not propagate db_error_code::not_found" for absent db, so it will be created 
+   } catch( const std::system_error& e ) {
+      // do not propagate db_error_code::not_found for absent db, so it will be created
+      if( e.code().value() != chainbase::db_error_code::not_found )
+         throw;
+   }
 
    return {};
 }


### PR DESCRIPTION
Fix issue with dirty db being reported as genesis not found instead of dirty db.

Merges `release/3.2` into `main` including #700 & #708

Resolves #695 
Resolves #565 