### PR TITLE
GH-711 Update dependencies to include numpy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Requirements to build:
 - git
 - GMP
 - Python 3
+- python3-numpy
 - zlib
 
 ### Step 1 - Clone

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -3,4 +3,4 @@
 apt-get update
 apt-get update --fix-missing
 DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
-apt-get -y install zip unzip libncurses5 wget git build-essential cmake curl libgmp-dev libssl-dev libzstd-dev time zlib1g-dev libtinfo-dev bzip2 libbz2-dev python3 file
+apt-get -y install zip unzip libncurses5 wget git build-essential cmake curl libgmp-dev libssl-dev libzstd-dev time zlib1g-dev libtinfo-dev bzip2 libbz2-dev python3 python3-numpy file


### PR DESCRIPTION
Was already in unpinned build instructions but missing for pinned builds and overarching requirements in readme.

Fixes: #711 