### PR TITLE
[3.2 -> main] Fix SHiP stability

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -417,7 +417,6 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
          if (ec) {
             fc_elog(_log, "close: ${m}", ("m", ec.message()));
          }
-         socket_stream.reset();
          app().post(priority::high,
                     [self = this->shared_from_this(), plugin=plugin]() { plugin->session_set.erase(self); });
       }


### PR DESCRIPTION
Do not reset `socket_stream` in `close` as it can still be in use until completely closed.
Branch tested and verified stable by @cc32d9. 

Merges `release/3.2` into `main` including #714 

Resolves #669 