### PR TITLE
Change INCBIN to INCTXT for abi in tests to fix invalid read

### DIFF
--- a/libraries/testing/contracts.cpp.in
+++ b/libraries/testing/contracts.cpp.in
@@ -12,10 +12,10 @@ INCBIN(eosio_testing_contract_ ## CN ## _abi,  "${CMAKE_BINARY_DIR}/libraries/te
                                                                                                                                                                               \
 namespace eosio::testing {                                                                                                                                                    \
    std::vector<std::uint8_t> contracts:: CN ## _wasm() {                                                                                                                      \
-      return std::vector<std::uint8_t>(geosio_testing_contract_ ## CN ## _wasm_data, geosio_testing_contract_ ## CN ## _wasm_data + geosio_testing_contract_ ## CN ## _wasm_size); \
+      return std::vector<std::uint8_t>(geosio_testing_contract_ ## CN ## _wasm_data, geosio_testing_contract_ ## CN ## _wasm_data + geosio_testing_contract_ ## CN ## _wasm_size + 1); \
    }                                                                                                                                                                          \
    std::vector<char> contracts:: CN ## _abi() {                                                                                                                               \
-      return std::vector<char>(geosio_testing_contract_ ## CN ## _abi_data, geosio_testing_contract_ ## CN ## _abi_data + geosio_testing_contract_ ## CN ## _abi_size);       \
+      return std::vector<char>(geosio_testing_contract_ ## CN ## _abi_data, geosio_testing_contract_ ## CN ## _abi_data + geosio_testing_contract_ ## CN ## _abi_size + 1);       \
    }                                                                                                                                                                          \
 }
 

--- a/libraries/testing/contracts.cpp.in
+++ b/libraries/testing/contracts.cpp.in
@@ -8,14 +8,14 @@
 
 #define MAKE_EMBEDDED_WASM_ABI(CN,C, D)                                                                                                                                       \
 INCBIN(eosio_testing_contract_ ## CN ## _wasm, "${CMAKE_BINARY_DIR}/libraries/testing/" #D "/" #C "/" #C ".wasm");                                                            \
-INCBIN(eosio_testing_contract_ ## CN ## _abi,  "${CMAKE_BINARY_DIR}/libraries/testing/" #D "/" #C "/" #C ".abi");                                                             \
+INCTXT(eosio_testing_contract_ ## CN ## _abi,  "${CMAKE_BINARY_DIR}/libraries/testing/" #D "/" #C "/" #C ".abi");                                                             \
                                                                                                                                                                               \
 namespace eosio::testing {                                                                                                                                                    \
    std::vector<std::uint8_t> contracts:: CN ## _wasm() {                                                                                                                      \
-      return std::vector<std::uint8_t>(geosio_testing_contract_ ## CN ## _wasm_data, geosio_testing_contract_ ## CN ## _wasm_data + geosio_testing_contract_ ## CN ## _wasm_size + 1); \
+      return std::vector<std::uint8_t>(geosio_testing_contract_ ## CN ## _wasm_data, geosio_testing_contract_ ## CN ## _wasm_data + geosio_testing_contract_ ## CN ## _wasm_size); \
    }                                                                                                                                                                          \
    std::vector<char> contracts:: CN ## _abi() {                                                                                                                               \
-      return std::vector<char>(geosio_testing_contract_ ## CN ## _abi_data, geosio_testing_contract_ ## CN ## _abi_data + geosio_testing_contract_ ## CN ## _abi_size + 1);       \
+      return std::vector<char>(geosio_testing_contract_ ## CN ## _abi_data, geosio_testing_contract_ ## CN ## _abi_data + geosio_testing_contract_ ## CN ## _abi_size);       \
    }                                                                                                                                                                          \
 }
 


### PR DESCRIPTION
Fixes issue 2 from https://github.com/AntelopeIO/leap/issues/494

**Issue 2**: `std::char_traits::length` was looking for null terminator in the abi vector, which wasn't there, causing an invalid read. Switching from INCBIN to INCTXT helped.

**Issue 1**:
I think it is false positive and can be ignored.

What happens in unit test:
1. Blockchain is initialized.
2. It is written to a memory mapped file (shared_memory.bin) and saved.
3. File with blockchain is loaded again (in tester.cpp:283) to a memory mapped file.
4. Exception is thrown because of failed transaction and blockchain is flushed again to shared_memory.bin.
5. At this point valgrind warns there is uninitialized data in the blockchain which is being dumped to a file.

Why I think it is false positive?
Because all the data is initialized to 0 at the address pointed by valgrind. Additionally I found what is at address pointed by valgrind and it should be initialized.
Like in below example valgrind points to 0x77e2504 for an uinitialized byte. During debugging I found that 0x77e2000 is a `block_header_state` (printed below).
As you can see below "uninitialized byte" seem to be 0, together with block_header_state. 504 byte after 0x77e2000 seem to be `_storage` (part of `block_header_state`).
Note: debugging was made on a code, where I explicitly zero'ed all the memory in block_header_state, but valgrind was still showing an issue.

```
==101357== Syscall param msync(start) points to uninitialised byte(s)
(...)
==101357==  Address 0x77e2504 is in a rw- mapped file /tmp/4db8-bc8f-775c-3b39/state/shared_memory.bin segment


(gdb) p (char*)0x77e2504
$39 = 0x77e2504 ""
(gdb) p (char*)0x77e2505
$40 = 0x77e2505 ""
(gdb) p (char*)0x77e2506
$41 = 0x77e2506 ""
(gdb) p (char*)0x77e2507
$42 = 0x77e2507 ""
(gdb) p (char*)0x77e2508
$43 = 0x77e2508 ""
(gdb) p (char*)0x77e2509
$44 = 0x77e2509 ""

(gdb) p sizeof(eosio::chain::block_header_state)
$56 = 688

(gdb) p *(eosio::chain::block_header_state*)0x77e2000
$58 = {<eosio::chain::detail::block_header_state_common> = {block_num = 1230196549, dpos_proposed_irreversible_blocknum = 843203663, 
    dpos_irreversible_blocknum = 257, active_schedule = {version = 0, producers = std::vector of length 0, capacity 0}, 
    blockroot_merkle = {_node_count = 0, _active_nodes = std::vector of length 0, capacity 0}, producer_to_last_produced = {
      m_flat_tree = {
        m_data = {<boost::container::dtl::flat_tree_value_compare<std::less<eosio::chain::name>, boost::container::dtl::pair<eosio::chain::name, unsigned int>, boost::container::dtl::select1st<eosio::chain::name> >> = {<std::less<eosio::chain::name>> = {<std::binary_function<eosio::chain::name, eosio::chain::name, bool>> = {<No data fields>}, <No data fields>}, <No data fields>}, m_seq = {
            m_holder = {<boost::container::new_allocator<boost::container::dtl::pair<eosio::chain::name, unsigned int> >> = {<No data fields>}, m_start = 0x0, m_size = 0, m_capacity = 0}}}, static has_stored_allocator_type = true}}, producer_to_last_implied_irb = {
      m_flat_tree = {
        m_data = {<boost::container::dtl::flat_tree_value_compare<std::less<eosio::chain::name>, boost::container::dtl::pair<eosio::chain::name, unsigned int>, boost::container::dtl::select1st<eosio::chain::name> >> = {<std::less<eosio::chain::name>> = {<std::binary_function<eosio::chain::name, eosio::chain::name, bool>> = {<No data fields>}, <No data fields>}, <No data fields>}, m_seq = {
            m_holder = {<boost::container::new_allocator<boost::container::dtl::pair<eosio::chain::name, unsigned int> >> = {<No data fields>}, m_start = 0x0, m_size = 0, m_capacity = 0}}}, static has_stored_allocator_type = true}}, 
    valid_block_signing_authority = std::variant<eosio::chain::block_signing_authority_v0> [index 0] = {{threshold = 0, 
        keys = std::vector of length 0, capacity 0}}, confirm_count = std::vector of length 0, capacity 0}, id = {_hash = {0, 0, 0, 
      0}}, header = {<eosio::chain::block_header> = {timestamp = {slot = 0}, producer = {value = 0}, confirmed = 0, previous = {
        _hash = {0, 0, 0, 0}}, transaction_mroot = {_hash = {0, 0, 0, 0}}, action_mroot = {_hash = {0, 0, 0, 0}}, 
      schedule_version = 0, new_producers = std::optional<eosio::chain::legacy::producer_schedule_type> [no contained value], 
      header_extensions = std::vector of length 0, capacity 0}, producer_signature = {
      _storage = std::variant<fc::ecc::signature_shim, fc::crypto::r1::signature_shim, fc::crypto::webauthn::signature> [index 0] = {
        {<fc::crypto::shim<fc::array<unsigned char, 65> >> = {_data = {data = '\000' <repeats 64 times>}}, <No data fields>}}}}, 
  pending_schedule = {schedule_lib_num = 0, schedule_hash = {_hash = {0, 0, 0, 0}}, schedule = {version = 0, 
      producers = std::vector of length 0, capacity 0}}, 
  activated_protocol_features = std::shared_ptr<eosio::chain::protocol_feature_activation_set> (empty) = {get() = 0x0}, 
  additional_signatures = std::vector of length 0, capacity 0, header_exts = {m_flat_tree = {
      m_data = {<boost::container::dtl::flat_tree_value_compare<std::less<unsigned short>, boost::container::dtl::pair<unsigned short, std::variant<eosio::chain::protocol_feature_activation, eosio::chain::producer_schedule_change_extension> >, boost::container::dtl::select1st<unsigned short> >> = {<std::less<unsigned short>> = {<std::binary_function<unsigned short, unsigned short, bool>> = {<No data fields>}, <No data fields>}, <No data fields>}, m_seq = {
          m_holder = {<boost::container::new_allocator<boost::container::dtl::pair<unsigned short, std::variant<eosio::chain::protocol_feature_activation, eosio::chain::producer_schedule_change_extension> > >> = {<No data fields>}, m_start = 0x0, m_size = 0, 
            m_capacity = 0}}}, static has_stored_allocator_type = true}}}
```