### PR TITLE
[PH] Capture Full Command Line Argument String in Report

### DIFF
--- a/tests/performance_tests/README.md
+++ b/tests/performance_tests/README.md
@@ -832,69 +832,80 @@ The Performance Test Basic generates, by default, a report that details results 
 ``` json
 {
   "completedRun": true,
-  "testStart": "2023-02-15T22:32:36.946671",
-  "testFinish": "2023-02-15T22:33:41.280861",
+  "testStart": "2023-02-17T22:00:41.305618",
+  "testFinish": "2023-02-17T22:02:21.597430",
   "Analysis": {
     "BlockSize": {
-      "min": 1920,
-      "max": 1920,
-      "avg": 1920.0,
-      "sigma": 0.0,
+      "min": 925248,
+      "max": 1551936,
+      "avg": 1332244.3636363635,
+      "sigma": 144713.34505483133,
       "emptyBlocks": 0,
-      "numBlocks": 7
+      "numBlocks": 44
     },
     "BlocksGuide": {
       "firstBlockNum": 2,
-      "lastBlockNum": 129,
-      "totalBlocks": 128,
-      "testStartBlockNum": 113,
-      "testEndBlockNum": 129,
-      "setupBlocksCnt": 111,
-      "tearDownBlocksCnt": 0,
+      "lastBlockNum": 193,
+      "totalBlocks": 192,
+      "testStartBlockNum": 112,
+      "testEndBlockNum": 160,
+      "setupBlocksCnt": 110,
+      "tearDownBlocksCnt": 33,
       "leadingEmptyBlocksCnt": 1,
-      "trailingEmptyBlocksCnt": 5,
+      "trailingEmptyBlocksCnt": 0,
       "configAddlDropCnt": 2,
-      "testAnalysisBlockCnt": 7
+      "testAnalysisBlockCnt": 44
     },
     "TPS": {
-      "min": 20,
-      "max": 20,
-      "avg": 20.0,
-      "sigma": 0.0,
+      "min": 10265,
+      "max": 15774,
+      "avg": 13882.232558139534,
+      "sigma": 1454.0837894863364,
       "emptyBlocks": 0,
-      "numBlocks": 7,
-      "configTps": 20,
-      "configTestDuration": 5,
+      "numBlocks": 44,
+      "configTps": 50000,
+      "configTestDuration": 10,
       "tpsPerGenerator": [
-        10,
-        10
+        3846,
+        3846,
+        3846,
+        3846,
+        3846,
+        3846,
+        3846,
+        3846,
+        3846,
+        3846,
+        3846,
+        3847,
+        3847
       ],
-      "generatorCount": 2
+      "generatorCount": 13
     },
     "TrxCPU": {
-      "min": 20.0,
-      "max": 141.0,
-      "avg": 72.15,
-      "sigma": 31.078408903932,
-      "samples": 100
+      "min": 6.0,
+      "max": 15292.0,
+      "avg": 25.024962251222377,
+      "sigma": 49.9778703823556,
+      "samples": 322527
     },
     "TrxLatency": {
-      "min": 0.0409998893737793,
-      "max": 0.4419999122619629,
-      "avg": 0.24149999618530274,
-      "sigma": 0.14142224015850113,
-      "samples": 100
+      "min": 0.11500000953674316,
+      "max": 16.91100001335144,
+      "avg": 8.950405516519615,
+      "sigma": 4.844012708597167,
+      "samples": 322527
     },
     "TrxNet": {
       "min": 24.0,
       "max": 24.0,
       "avg": 24.0,
       "sigma": 0.0,
-      "samples": 100
+      "samples": 322527
     },
     "DroppedBlocks": {},
     "DroppedBlocksCount": 0,
-    "DroppedTransactions": 0,
+    "DroppedTransactions": 177473,
     "ProductionWindowsTotal": 0,
     "ProductionWindowsAverageSize": 0,
     "ProductionWindowsMissed": 0,
@@ -902,18 +913,18 @@ The Performance Test Basic generates, by default, a report that details results 
     "ForksCount": 0
   },
   "args": {
-    "rawCmdLine ": "/home/leap/build/tests/performance_tests/performance_test_basic.py -v -p 1 -n 1 --target-tps 20 --tps-limit-per-generator 10 --test-duration-sec 5 --clean-run",
-    "killAll": true,
+    "rawCmdLine ": "tests/performance_tests/performance_test.py --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-producer-threads lmax --calc-chain-threads lmax --calc-net-threads lmax",
+    "killAll": false,
     "dontKill": false,
-    "keepLogs": true,
+    "keepLogs": false,
     "dumpErrorDetails": false,
     "delay": 1,
     "nodesFile": null,
-    "verbose": true,
+    "verbose": false,
     "_killEosInstances": true,
     "_killWallet": true,
     "pnodes": 1,
-    "totalNodes": 1,
+    "totalNodes": 0,
     "topo": "mesh",
     "extraNodeosArgs": {
       "chainPluginArgs": {
@@ -1397,21 +1408,21 @@ The Performance Test Basic generates, by default, a report that details results 
       "1": "--plugin eosio::trace_api_plugin"
     },
     "_totalNodes": 2,
-    "targetTps": 20,
-    "testTrxGenDurationSec": 5,
-    "tpsLimitPerGenerator": 10,
+    "targetTps": 50000,
+    "testTrxGenDurationSec": 10,
+    "tpsLimitPerGenerator": 4000,
     "numAddlBlocksToPrune": 2,
-    "logDirRoot": ".",
-    "delReport": false,
+    "logDirRoot": "p/2023-02-17_22-00-41/pluginThreadOptRunLogs",
+    "delReport": true,
     "quiet": false,
-    "delPerfLogs": false,
-    "expectedTransactionsSent": 100,
+    "delPerfLogs": true,
+    "expectedTransactionsSent": 500000,
     "printMissingTransactions": false,
     "userTrxDataFile": null,
-    "logDirBase": "p",
-    "logDirTimestamp": "2023-02-15_22-32-36",
-    "logDirTimestampedOptSuffix": "-20",
-    "logDirPath": "p/2023-02-15_22-32-36-20"
+    "logDirBase": "p/2023-02-17_22-00-41/pluginThreadOptRunLogs/p",
+    "logDirTimestamp": "2023-02-17_22-00-41",
+    "logDirTimestampedOptSuffix": "-50000",
+    "logDirPath": "p/2023-02-17_22-00-41/pluginThreadOptRunLogs/p/2023-02-17_22-00-41-50000"
   },
   "env": {
     "system": "Linux",

--- a/tests/performance_tests/README.md
+++ b/tests/performance_tests/README.md
@@ -832,8 +832,8 @@ The Performance Test Basic generates, by default, a report that details results 
 ``` json
 {
   "completedRun": true,
-  "testStart": "2023-01-13T18:00:42.465802",
-  "testFinish": "2023-01-13T18:03:11.831277",
+  "testStart": "2023-02-15T22:32:36.946671",
+  "testFinish": "2023-02-15T22:33:41.280861",
   "Analysis": {
     "BlockSize": {
       "min": 1920,
@@ -841,20 +841,20 @@ The Performance Test Basic generates, by default, a report that details results 
       "avg": 1920.0,
       "sigma": 0.0,
       "emptyBlocks": 0,
-      "numBlocks": 177
+      "numBlocks": 7
     },
     "BlocksGuide": {
       "firstBlockNum": 2,
-      "lastBlockNum": 299,
-      "totalBlocks": 298,
-      "testStartBlockNum": 112,
-      "testEndBlockNum": 299,
-      "setupBlocksCnt": 110,
+      "lastBlockNum": 129,
+      "totalBlocks": 128,
+      "testStartBlockNum": 113,
+      "testEndBlockNum": 129,
+      "setupBlocksCnt": 111,
       "tearDownBlocksCnt": 0,
       "leadingEmptyBlocksCnt": 1,
-      "trailingEmptyBlocksCnt": 6,
+      "trailingEmptyBlocksCnt": 5,
       "configAddlDropCnt": 2,
-      "testAnalysisBlockCnt": 177
+      "testAnalysisBlockCnt": 7
     },
     "TPS": {
       "min": 20,
@@ -862,9 +862,9 @@ The Performance Test Basic generates, by default, a report that details results 
       "avg": 20.0,
       "sigma": 0.0,
       "emptyBlocks": 0,
-      "numBlocks": 177,
+      "numBlocks": 7,
       "configTps": 20,
-      "configTestDuration": 90,
+      "configTestDuration": 5,
       "tpsPerGenerator": [
         10,
         10
@@ -872,25 +872,25 @@ The Performance Test Basic generates, by default, a report that details results 
       "generatorCount": 2
     },
     "TrxCPU": {
-      "min": 11.0,
-      "max": 360.0,
-      "avg": 63.10444444444445,
-      "sigma": 33.234456387280126,
-      "samples": 1800
+      "min": 20.0,
+      "max": 141.0,
+      "avg": 72.15,
+      "sigma": 31.078408903932,
+      "samples": 100
     },
     "TrxLatency": {
-      "min": 0.06500005722045898,
-      "max": 0.4679999351501465,
-      "avg": 0.26723387837409973,
-      "sigma": 0.1414459711179884,
-      "samples": 1800
+      "min": 0.0409998893737793,
+      "max": 0.4419999122619629,
+      "avg": 0.24149999618530274,
+      "sigma": 0.14142224015850113,
+      "samples": 100
     },
     "TrxNet": {
       "min": 24.0,
       "max": 24.0,
       "avg": 24.0,
       "sigma": 0.0,
-      "samples": 1800
+      "samples": 100
     },
     "DroppedBlocks": {},
     "DroppedBlocksCount": 0,
@@ -902,6 +902,7 @@ The Performance Test Basic generates, by default, a report that details results 
     "ForksCount": 0
   },
   "args": {
+    "rawCmdLine ": "/home/leap/build/tests/performance_tests/performance_test_basic.py -v -p 1 -n 1 --target-tps 20 --tps-limit-per-generator 10 --test-duration-sec 5 --clean-run",
     "killAll": true,
     "dontKill": false,
     "keepLogs": true,
@@ -1197,8 +1198,8 @@ The Performance Test Basic generates, by default, a report that details results 
         "p2pDedupCacheExpireTimeSec": null,
         "_p2pDedupCacheExpireTimeSecNodeosDefault": 10,
         "_p2pDedupCacheExpireTimeSecNodeosArg": "--p2p-dedup-cache-expire-time-sec",
-        "netThreads": 2,
-        "_netThreadsNodeosDefault": 2,
+        "netThreads": 4,
+        "_netThreadsNodeosDefault": 4,
         "_netThreadsNodeosArg": "--net-threads",
         "syncFetchSpan": null,
         "_syncFetchSpanNodeosDefault": 100,
@@ -1372,10 +1373,21 @@ The Performance Test Basic generates, by default, a report that details results 
         "_traceNoAbisNodeosArg": "--trace-no-abis"
       }
     },
+    "specifiedContract": {
+      "accountName": "eosio",
+      "ownerPrivateKey": "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3",
+      "ownerPublicKey": "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
+      "activePrivateKey": "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3",
+      "activePublicKey": "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
+      "contractDir": "unittests/contracts/eosio.system",
+      "wasmFile": "eosio.system.wasm",
+      "abiFile": "eosio.system.abi"
+    },
     "useBiosBootFile": false,
     "genesisPath": "tests/performance_tests/genesis.json",
     "maximumP2pPerHost": 5000,
     "maximumClients": 0,
+    "loggingLevel": "info",
     "loggingDict": {
       "bios": "off"
     },
@@ -1386,19 +1398,20 @@ The Performance Test Basic generates, by default, a report that details results 
     },
     "_totalNodes": 2,
     "targetTps": 20,
-    "testTrxGenDurationSec": 90,
+    "testTrxGenDurationSec": 5,
     "tpsLimitPerGenerator": 10,
     "numAddlBlocksToPrune": 2,
     "logDirRoot": ".",
     "delReport": false,
     "quiet": false,
     "delPerfLogs": false,
-    "expectedTransactionsSent": 1800,
+    "expectedTransactionsSent": 100,
     "printMissingTransactions": false,
+    "userTrxDataFile": null,
     "logDirBase": "p",
-    "logDirTimestamp": "2023-01-13_18-00-42",
+    "logDirTimestamp": "2023-02-15_22-32-36",
     "logDirTimestampedOptSuffix": "-20",
-    "logDirPath": "p/2023-01-13_18-00-42-20"
+    "logDirPath": "p/2023-02-15_22-32-36-20"
   },
   "env": {
     "system": "Linux",

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -341,6 +341,7 @@ class PerformanceTest:
 
     def prepArgsDict(self) -> dict:
         argsDict = {}
+        argsDict.update({"rawCmdLine ": ' '.join(sys.argv[0:])})
         argsDict.update(asdict(self.testHelperConfig))
         argsDict.update(asdict(self.clusterConfig))
         argsDict.update(asdict(self.ptConfig))

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -131,7 +131,6 @@ class PerformanceTestBasic:
         expectedTransactionsSent: int = field(default_factory=int, init=False)
         printMissingTransactions: bool=False
         userTrxDataFile: Path=None
-        argsString: str=""
 
         def __post_init__(self):
             self.expectedTransactionsSent = self.testTrxGenDurationSec * self.targetTps
@@ -398,6 +397,7 @@ class PerformanceTestBasic:
 
     def prepArgs(self) -> dict:
         args = {}
+        args.update({"rawCmdLine ": ' '.join(sys.argv[0:])})
         args.update(asdict(self.testHelperConfig))
         args.update(asdict(self.clusterConfig))
         args.update(asdict(self.ptbConfig))
@@ -617,7 +617,7 @@ def main():
     ptbConfig = PerformanceTestBasic.PtbConfig(targetTps=args.target_tps, testTrxGenDurationSec=args.test_duration_sec, tpsLimitPerGenerator=args.tps_limit_per_generator,
                                   numAddlBlocksToPrune=args.num_blocks_to_prune, logDirRoot=".", delReport=args.del_report, quiet=args.quiet, delPerfLogs=args.del_perf_logs,
                                   printMissingTransactions=args.print_missing_transactions,
-                                  userTrxDataFile=Path(args.user_trx_data_file) if args.user_trx_data_file is not None else None, argsString=' '.join(sys.argv[1:]))
+                                  userTrxDataFile=Path(args.user_trx_data_file) if args.user_trx_data_file is not None else None)
     myTest = PerformanceTestBasic(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, ptbConfig=ptbConfig)
 
     testSuccessful = myTest.runTest()

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -131,6 +131,7 @@ class PerformanceTestBasic:
         expectedTransactionsSent: int = field(default_factory=int, init=False)
         printMissingTransactions: bool=False
         userTrxDataFile: Path=None
+        argsString: str=""
 
         def __post_init__(self):
             self.expectedTransactionsSent = self.testTrxGenDurationSec * self.targetTps
@@ -616,7 +617,7 @@ def main():
     ptbConfig = PerformanceTestBasic.PtbConfig(targetTps=args.target_tps, testTrxGenDurationSec=args.test_duration_sec, tpsLimitPerGenerator=args.tps_limit_per_generator,
                                   numAddlBlocksToPrune=args.num_blocks_to_prune, logDirRoot=".", delReport=args.del_report, quiet=args.quiet, delPerfLogs=args.del_perf_logs,
                                   printMissingTransactions=args.print_missing_transactions,
-                                  userTrxDataFile=Path(args.user_trx_data_file) if args.user_trx_data_file is not None else None)
+                                  userTrxDataFile=Path(args.user_trx_data_file) if args.user_trx_data_file is not None else None, argsString=' '.join(sys.argv[1:]))
     myTest = PerformanceTestBasic(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, ptbConfig=ptbConfig)
 
     testSuccessful = myTest.runTest()


### PR DESCRIPTION
Log `rawCmdLine ` using `' '.join(sys.argv[0:])` in order to capture the command line used to start the test run
`"rawCmdLine ": "tests/performance_tests/performance_test.py --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-producer-threads lmax --calc-chain-threads lmax --calc-net-threads lmax"`