### PR TITLE
Optimize json parsing

### DIFF
--- a/libraries/libfc/include/fc/io/json.hpp
+++ b/libraries/libfc/include/fc/io/json.hpp
@@ -35,7 +35,6 @@ namespace fc
          static constexpr uint64_t max_length_limit = std::numeric_limits<uint64_t>::max();
          static constexpr size_t escape_string_yield_check_count = 128;
          static variant  from_string( const string& utf8_str, const parse_type ptype = parse_type::legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
-         static variants variants_from_string( const string& utf8_str, const parse_type ptype = parse_type::legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
          static string   to_string( const variant& v, const yield_function_t& yield, const output_formatting format = output_formatting::stringify_large_ints_and_doubles);
          static string   to_pretty_string( const variant& v, const yield_function_t& yield, const output_formatting format = output_formatting::stringify_large_ints_and_doubles );
 

--- a/libraries/libfc/src/io/json.cpp
+++ b/libraries/libfc/src/io/json.cpp
@@ -293,7 +293,8 @@ namespace fc
               default:
                  if( isalnum( c ) )
                  {
-                    return s + stringFromToken( in );
+                    s += stringFromToken( in );
+                    return s;
                  }
                 done = true;
                 break;

--- a/libraries/libfc/src/io/json.cpp
+++ b/libraries/libfc/src/io/json.cpp
@@ -443,17 +443,18 @@ namespace fc
 
    variant json::from_string( const std::string& utf8_str, const json::parse_type ptype, const uint32_t max_depth )
    { try {
-      boost::iostreams::stream<boost::iostreams::array_source> in(utf8_str.c_str(), utf8_str.size());
+      using stream_t = boost::iostreams::stream<boost::iostreams::array_source>;
+      stream_t in(utf8_str.c_str(), utf8_str.size());
       switch( ptype )
       {
           case parse_type::legacy_parser:
-             return variant_from_stream<boost::iostreams::stream<boost::iostreams::array_source>, json::parse_type::legacy_parser>( in, max_depth );
+             return variant_from_stream<stream_t, json::parse_type::legacy_parser>( in, max_depth );
           case parse_type::legacy_parser_with_string_doubles:
-              return variant_from_stream<boost::iostreams::stream<boost::iostreams::array_source>, json::parse_type::legacy_parser_with_string_doubles>( in, max_depth );
+              return variant_from_stream<stream_t, json::parse_type::legacy_parser_with_string_doubles>( in, max_depth );
           case parse_type::strict_parser:
-              return json_relaxed::variant_from_stream<boost::iostreams::stream<boost::iostreams::array_source>, true>( in, max_depth );
+              return json_relaxed::variant_from_stream<stream_t, true>( in, max_depth );
           case parse_type::relaxed_parser:
-              return json_relaxed::variant_from_stream<boost::iostreams::stream<boost::iostreams::array_source>, false>( in, max_depth );
+              return json_relaxed::variant_from_stream<stream_t, false>( in, max_depth );
           default:
               FC_ASSERT( false, "Unknown JSON parser type {ptype}", ("ptype", static_cast<int>(ptype)) );
       }


### PR DESCRIPTION
Some low hanging fruit optimizations to JSON parsing until https://github.com/AntelopeIO/leap/issues/299 can be worked.
* Use boost stream and `std::string` instead of `std::stringstream`
* One test case of `setcode` of the `eosio.system` contract time for parsing the incoming JSON went from 3.5ms to 1.4ms.
