### PR TITLE
SHiP do not truncate logs when starting from genesis

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -609,10 +609,6 @@ struct controller_impl {
       }
       initialize_blockchain_state(genesis); // sets head to genesis state
 
-      if( !fork_db.head() ) {
-         fork_db.reset( *head );
-      }
-
       if( blog.head() ) {
          EOS_ASSERT( blog.first_block_num() == 1, block_log_exception,
                      "block log does not start with genesis block"

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -508,12 +508,15 @@ class state_history_log {
       }
 
       auto prune_config = std::get_if<state_history::prune_config>(&config);
-      if (block_num < _end_block)
+      if (block_num < _end_block) {
+         EOS_ASSERT( block_num > 2, chain::plugin_exception, "Existing ship log with ${eb} blocks when starting from genesis block ${b}",
+                     ("eb", _end_block)("b", block_num) );
          truncate(block_num); //truncate is expected to always leave file pointer at the end
-      else if (!prune_config)
+      } else if (!prune_config) {
          log.seek_end(0);
-      else if (prune_config && _begin_block != _end_block)
+      } else if (prune_config && _begin_block != _end_block) {
          log.seek_end(-sizeof(uint32_t));  //overwrite the trailing block count marker on this write
+      }
 
       //if we're operating on a pruned block log and this is the first entry in the log, make note of the feature in the header
       if(prune_config && _begin_block == _end_block)

--- a/plugins/state_history_plugin/tests/session_test.cpp
+++ b/plugins/state_history_plugin/tests/session_test.cpp
@@ -405,6 +405,33 @@ BOOST_AUTO_TEST_CASE(store_read_entry_prune_enabled) {
    store_read_test_case(1024, eosio::state_history::prune_config{.prune_blocks = 100});
 }
 
+BOOST_AUTO_TEST_CASE(store_with_existing) {
+   uint64_t data_size = 512;
+   fc::temp_directory       log_dir;
+   eosio::state_history_log log("ship", log_dir.path(), {});
+
+   eosio::state_history_log_header header;
+   header.block_id     = block_id_for(1);
+   header.payload_size = 0;
+   auto data           = generate_data(data_size);
+
+   log.pack_and_write_entry(header, block_id_for(0),
+                            [&](auto&& buf) { bio::write(buf, (const char*)data.data(), data.size() * sizeof(data[0])); });
+
+   header.block_id     = block_id_for(2);
+   log.pack_and_write_entry(header, block_id_for(1),
+                            [&](auto&& buf) { bio::write(buf, (const char*)data.data(), data.size() * sizeof(data[0])); });
+
+   // Do not allow starting from scratch for existing
+   header.block_id     = block_id_for(1);
+   BOOST_CHECK_EXCEPTION(
+         log.pack_and_write_entry(header, block_id_for(0),
+                                  [&](auto&& buf) { bio::write(buf, (const char*)data.data(), data.size() * sizeof(data[0])); }),
+         eosio::chain::plugin_exception, [](const auto& e) {
+            return e.to_detail_string().find("Existing ship log") != std::string::npos;
+         } );
+}
+
 BOOST_FIXTURE_TEST_CASE(test_session_no_prune, state_history_test_fixture) {
    try {
       // setup block head for the server

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(test_restart_from_block_log) {
    chain.create_account("replay2"_n);
    chain.produce_blocks(1);
    chain.create_account("replay3"_n);
-   chain.produce_blocks(1);
+   chain.produce_blocks(1); // replay3 will be in fork_db.dat
 
    BOOST_REQUIRE_NO_THROW(chain.control->get_account("replay1"_n));
    BOOST_REQUIRE_NO_THROW(chain.control->get_account("replay2"_n));
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_restart_from_block_log) {
    auto               genesis       = chain::block_log::extract_genesis_state(chain.get_config().blocks_dir);
    BOOST_REQUIRE(genesis);
 
-   // remove the state files to make sure we are starting from block log
+   // remove the state files to make sure we are starting from block log & fork_db.dat
    remove_existing_states(copied_config);
 
    tester from_block_log_chain(copied_config, *genesis);


### PR DESCRIPTION
Verify when truncating SHiP logs that truncation is not allowed when starting from genesis.

```
warn  2023-02-22T20:51:14.867 nodeos    controller.cpp:606            startup              ] No existing chain state. Initializing fresh blockchain state.
warn  2023-02-22T20:51:14.867 nodeos    controller.cpp:464            initialize_blockchai ] Initializing new blockchain with genesis state
info  2023-02-22T20:51:14.888 nodeos    controller.cpp:501            replay               ] existing block log, attempting to replay from 2 to 214011 blocks
error 2023-02-22T20:51:14.889 nodeos    state_history_plugin.c:284    on_accepted_block    ] fc::exception: 3110000 plugin_exception: Plugin exception
Existing ship log with 214013 blocks when starting from genesis block 2
    {"eb":214013,"b":2}
    nodeos  log.hpp:513 write_entry

warn  2023-02-22T20:51:14.889 nodeos    controller.cpp:375            emit                 ] controller_emit_signal_exception: 3140002 state_history_write_exception: State history write error
State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process
    {}
    nodeos  state_history_plugin.cpp:292 on_accepted_block

error 2023-02-22T20:51:14.890 nodeos    controller.cpp:2127           apply_block          ] e.to_detail_string(): 3140002 state_history_write_exception: State history write error
State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process
    {}
    nodeos  state_history_plugin.cpp:292 on_accepted_block

warn  2023-02-22T20:51:14.890 nodeos    controller.cpp:2287           replay_push_block    ] 3140002 state_history_write_exception: State history write error
State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process
    {}
    nodeos  state_history_plugin.cpp:292 on_accepted_block

    {}
    nodeos  controller.cpp:2135 apply_block

error 2023-02-22T20:51:14.898 nodeos    main.cpp:162                  main                 ] 3140002 state_history_write_exception: State history write error
State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process
    {}
    nodeos  state_history_plugin.cpp:292 on_accepted_block

    {}
    nodeos  controller.cpp:2135 apply_block
rethrow
    {}
    nodeos  controller.cpp:2287 replay_push_block

    {}
    nodeos  chain_plugin.cpp:1141 plugin_startup
```

Starting from snapshot is allowed:
```
./nodeos --data-dir telos-d --config-dir telos --disable-replay-opts --plugin eosio::chain_api_plugin --plugin eosio::producer_api_plugin --snapshot /home/heifner/ext/leap/cmake-build-debug/bin/telos-d/snapshots/snapshot-0003068e2e7b2030a54466f36af0df3eb47c75d5a7ef4ffe45e702fe07b6884e.bin
```
```
info  2023-02-22T20:53:27.566 nodeos    controller.cpp:571            startup              ] Starting initialization from snapshot, this may take a significant amount of time
info  2023-02-22T20:53:34.702 nodeos    controller.cpp:501            replay               ] existing block log, attempting to replay from 198287 to 214011 blocks
info  2023-02-22T20:53:34.769 nodeos    log.hpp:793                   truncate             ] fork or replay: removed 15726 blocks from trace_history.log
info  2023-02-22T20:53:34.770 nodeos    log.hpp:793                   truncate             ] fork or replay: removed 15726 blocks from chain_state_history.log
info  2023-02-22T20:53:34.943 nodeos    controller.cpp:507            replay               ] 198500 of 214011
```


Resolves #659