### PR TITLE
[3.2] SHiP do not truncate logs when starting from genesis

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -216,12 +216,15 @@ class state_history_log {
          }
       }
 
-      if (block_num < _end_block)
+      if (block_num < _end_block) {
+         EOS_ASSERT( block_num > 2, chain::plugin_exception, "Existing ship log with ${eb} blocks when starting from genesis block ${b}",
+                     ("eb", _end_block)("b", block_num) );
          truncate(block_num); //truncate is expected to always leave file pointer at the end
-      else if (!prune_config)
+      } else if (!prune_config) {
          log.seek_end(0);
-      else if (prune_config && _begin_block != _end_block)
+      } else if (prune_config && _begin_block != _end_block) {
          log.seek_end(-sizeof(uint32_t));  //overwrite the trailing block count marker on this write
+      }
 
       //if we're operating on a pruned block log and this is the first entry in the log, make note of the feature in the header
       if(prune_config && _begin_block == _end_block)

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -220,7 +220,7 @@ class state_history_log {
          static uint32_t start_block_num = block_num;
          EOS_ASSERT( block_num > 2, chain::plugin_exception, "Existing ship log with ${eb} blocks when starting from genesis block ${b}",
                      ("eb", _end_block)("b", block_num) );
-         if ( get_block_id_i(block_num) != header.block_id ) {
+         if ( block_num < _begin_block || get_block_id_i(block_num) != header.block_id ) {
             truncate(block_num); //truncate is expected to always leave file pointer at the end
          } else {
             if (start_block_num == block_num || block_num % 1000 == 0 )

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -217,9 +217,13 @@ class state_history_log {
       }
 
       if (block_num < _end_block) {
+         // This is typically because of a fork, and we need to truncate the log back to the beginning of the fork.
          static uint32_t start_block_num = block_num;
+         // Guard agaisnt accidently starting a fresh chain with an existing ship log, require manual removal of ship logs.
          EOS_ASSERT( block_num > 2, chain::plugin_exception, "Existing ship log with ${eb} blocks when starting from genesis block ${b}",
                      ("eb", _end_block)("b", block_num) );
+         // block_num < _begin_block = pruned log, need to call truncate() to reset
+         // get_block_id_i check is an optimization to avoid writing a block that is already in the log (snapshot or replay)
          if ( block_num < _begin_block || get_block_id_i(block_num) != header.block_id ) {
             truncate(block_num); //truncate is expected to always leave file pointer at the end
          } else {

--- a/tests/ship_log.cpp
+++ b/tests/ship_log.cpp
@@ -18,21 +18,21 @@ struct ship_log_fixture {
       bounce();
    }
 
-   void add(uint32_t index, size_t size, char fillchar) {
+   void add(uint32_t index, size_t size, char fillchar, char prevchar) {
       std::vector<char> a;
       a.assign(size, fillchar);
 
-      auto block_for_id = [](const uint32_t bnum) {
-         fc::sha256 m = fc::sha256::hash(fc::sha256::hash(std::to_string(bnum)));
+      auto block_for_id = [](const uint32_t bnum, const char fillc) {
+         fc::sha256 m = fc::sha256::hash(fc::sha256::hash(std::to_string(bnum)+fillc));
          m._hash[0] = fc::endian_reverse_u32(bnum);
          return m;
       };
 
       eosio::state_history_log_header header;
-      header.block_id = block_for_id(index);
+      header.block_id = block_for_id(index, fillchar);
       header.payload_size = a.size();
 
-      log->write_entry(header, block_for_id(index-1), [&](auto& f) {
+      log->write_entry(header, block_for_id(index-1, prevchar), [&](auto& f) {
          f.write(a.data(), a.size());
       });
 
@@ -125,25 +125,25 @@ BOOST_DATA_TEST_CASE(basic_prune_test, bdata::xrange(2) * bdata::xrange(2) * bda
 
    //we'll start at 2 here, since that's what you'd get from starting from genesis, but it really doesn't matter
    // one way or another for the ship log logic
-   t.add(2, payload_size, 'A');
-   t.add(3, payload_size, 'B');
-   t.add(4, payload_size, 'C');
+   t.add(2, payload_size, 'A', 'A');
+   t.add(3, payload_size, 'B', 'A');
+   t.add(4, payload_size, 'C', 'B');
    t.check_n_bounce([&]() {
       t.check_range_present(2, 4);
    });
 
-   t.add(5, payload_size, 'D');
+   t.add(5, payload_size, 'D', 'C');
    t.check_n_bounce([&]() {
       t.check_range_present(2, 5);
    });
 
-   t.add(6, payload_size, 'E');
+   t.add(6, payload_size, 'E', 'D');
    t.check_n_bounce([&]() {
       t.check_not_present(2);
       t.check_range_present(3, 6);
    });
 
-   t.add(7, payload_size, 'F');
+   t.add(7, payload_size, 'F', 'E');
    t.check_n_bounce([&]() {
       t.check_not_present(2);
       t.check_not_present(3);
@@ -151,7 +151,7 @@ BOOST_DATA_TEST_CASE(basic_prune_test, bdata::xrange(2) * bdata::xrange(2) * bda
    });
 
    //undo 6 & 7 and reapply 6
-   t.add(6, payload_size, 'G');
+   t.add(6, payload_size, 'G', 'D');
    t.check_n_bounce([&]() {
       t.check_not_present(2);
       t.check_not_present(3);
@@ -159,32 +159,32 @@ BOOST_DATA_TEST_CASE(basic_prune_test, bdata::xrange(2) * bdata::xrange(2) * bda
       t.check_range_present(4, 6);
    });
 
-   t.add(7, payload_size, 'H');
+   t.add(7, payload_size, 'H', 'G');
    t.check_n_bounce([&]() {
       t.check_not_present(2);
       t.check_not_present(3);
       t.check_range_present(4, 7);
    });
 
-   t.add(8, payload_size, 'I');
-   t.add(9, payload_size, 'J');
-   t.add(10, payload_size, 'K');
+   t.add(8, payload_size, 'I', 'H');
+   t.add(9, payload_size, 'J', 'I');
+   t.add(10, payload_size, 'K', 'J');
    t.check_n_bounce([&]() {
       t.check_range_present(7, 10);
    });
 
    //undo back to the first stored block
-   t.add(7, payload_size, 'L');
+   t.add(7, payload_size, 'L', 'G');
    t.check_n_bounce([&]() {
       t.check_range_present(7, 7);
       t.check_not_present(6);
       t.check_not_present(8);
    });
 
-   t.add(8, payload_size, 'L');
-   t.add(9, payload_size, 'M');
-   t.add(10, payload_size, 'N');
-   t.add(11, payload_size, 'O');
+   t.add(8, payload_size, 'M', 'L');
+   t.add(9, payload_size, 'N', 'M');
+   t.add(10, payload_size, 'O', 'N');
+   t.add(11, payload_size, 'P', 'O');
    t.check_n_bounce([&]() {
       t.check_range_present(8, 11);
       t.check_not_present(6);
@@ -192,7 +192,7 @@ BOOST_DATA_TEST_CASE(basic_prune_test, bdata::xrange(2) * bdata::xrange(2) * bda
    });
 
    //undo past the first stored
-   t.add(6, payload_size, 'P');
+   t.add(6, payload_size, 'Q', 'D');
    t.check_n_bounce([&]() {
       t.check_range_present(6, 6);
       t.check_not_present(7);
@@ -200,22 +200,32 @@ BOOST_DATA_TEST_CASE(basic_prune_test, bdata::xrange(2) * bdata::xrange(2) * bda
    });
 
    //pile up a lot
-   t.add(7, payload_size, 'Q');
-   t.add(8, payload_size, 'R');
-   t.add(9, payload_size, 'S');
-   t.add(10, payload_size, 'T');
-   t.add(11, payload_size, 'U');
-   t.add(12, payload_size, 'V');
-   t.add(13, payload_size, 'W');
-   t.add(14, payload_size, 'X');
-   t.add(15, payload_size, 'W');
-   t.add(16, payload_size, 'Z');
+   t.add(7, payload_size, 'R', 'Q');
+   t.add(8, payload_size, 'S', 'R');
+   t.add(9, payload_size, 'T', 'S');
+   t.add(10, payload_size, 'U', 'T');
+   t.add(11, payload_size, 'V', 'U');
+   t.add(12, payload_size, 'W', 'V');
+   t.add(13, payload_size, 'X', 'W');
+   t.add(14, payload_size, 'Y', 'X');
+   t.add(15, payload_size, 'Z', 'Y');
+   t.add(16, payload_size, '1', 'Z');
    t.check_n_bounce([&]() {
       t.check_range_present(13, 16);
       t.check_not_present(12);
       t.check_not_present(17);
    });
 
+   //invalid fork, previous should be 'X'
+   BOOST_REQUIRE_EXCEPTION(t.add(14, payload_size, '*', 'W' ), eosio::chain::plugin_exception, [](const eosio::chain::plugin_exception& e) {
+      return e.to_detail_string().find("missed a fork change") != std::string::npos;
+   });
+
+   //start from genesis not allowed
+   BOOST_REQUIRE_EXCEPTION(t.add(2, payload_size, 'A', 'A');, eosio::chain::plugin_exception, [](const eosio::chain::plugin_exception& e) {
+      std::string err = e.to_detail_string();
+      return err.find("Existing ship log") != std::string::npos && err.find("when starting from genesis block") != std::string::npos;
+   });
 
 } FC_LOG_AND_RETHROW() }
 
@@ -226,30 +236,30 @@ BOOST_DATA_TEST_CASE(basic_test, bdata::xrange(2) * bdata::xrange(2) * bdata::xr
    size_t payload_size = larger_than_tmpfile_blocksize();
 
    //we'll start off with a high number; but it really doesn't matter for ship's logs
-   t.add(200, payload_size, 'A');
-   t.add(201, payload_size, 'B');
-   t.add(202, payload_size, 'C');
+   t.add(200, payload_size, 'A', 'A');
+   t.add(201, payload_size, 'B', 'A');
+   t.add(202, payload_size, 'C', 'B');
    t.check_n_bounce([&]() {
       t.check_range_present(200, 202);
    });
-   t.add(203, payload_size, 'D');
-   t.add(204, payload_size, 'E');
-   t.add(205, payload_size, 'F');
-   t.add(206, payload_size, 'G');
-   t.add(207, payload_size, 'H');
+   t.add(203, payload_size, 'D', 'C');
+   t.add(204, payload_size, 'E', 'D');
+   t.add(205, payload_size, 'F', 'E');
+   t.add(206, payload_size, 'G', 'F');
+   t.add(207, payload_size, 'H', 'G');
    t.check_n_bounce([&]() {
       t.check_range_present(200, 207);
    });
 
    //fork off G & H
-   t.add(206, payload_size, 'I');
-   t.add(207, payload_size, 'J');
+   t.add(206, payload_size, 'I', 'F');
+   t.add(207, payload_size, 'J', 'I');
    t.check_n_bounce([&]() {
       t.check_range_present(200, 207);
    });
 
-   t.add(208, payload_size, 'K');
-   t.add(209, payload_size, 'L');
+   t.add(208, payload_size, 'K', 'J');
+   t.add(209, payload_size, 'L', 'K');
    t.check_n_bounce([&]() {
       t.check_range_present(200, 209);
       t.check_not_present(199);
@@ -311,14 +321,14 @@ BOOST_DATA_TEST_CASE(non_prune_to_prune, bdata::xrange(2) * bdata::xrange(2), en
    t.check_empty();
    size_t payload_size = larger_than_tmpfile_blocksize();
 
-   t.add(2, payload_size, 'A');
-   t.add(3, payload_size, 'B');
-   t.add(4, payload_size, 'C');
-   t.add(5, payload_size, 'D');
-   t.add(6, payload_size, 'E');
-   t.add(7, payload_size, 'F');
-   t.add(8, payload_size, 'G');
-   t.add(9, payload_size, 'H');
+   t.add(2, payload_size, 'A', 'A');
+   t.add(3, payload_size, 'B', 'A');
+   t.add(4, payload_size, 'C', 'B');
+   t.add(5, payload_size, 'D', 'C');
+   t.add(6, payload_size, 'E', 'D');
+   t.add(7, payload_size, 'F', 'E');
+   t.add(8, payload_size, 'G', 'F');
+   t.add(9, payload_size, 'H', 'G');
    t.check_n_bounce([&]() {
       t.check_range_present(2, 9);
    });
@@ -330,10 +340,10 @@ BOOST_DATA_TEST_CASE(non_prune_to_prune, bdata::xrange(2) * bdata::xrange(2), en
    t.check_n_bounce([&]() {
       t.check_range_present(6, 9);
    });
-   t.add(10, payload_size, 'I');
-   t.add(11, payload_size, 'J');
-   t.add(12, payload_size, 'K');
-   t.add(13, payload_size, 'L');
+   t.add(10, payload_size, 'I', 'H');
+   t.add(11, payload_size, 'J', 'I');
+   t.add(12, payload_size, 'K', 'J');
+   t.add(13, payload_size, 'L', 'K');
    t.check_n_bounce([&]() {
       t.check_range_present(10, 13);
    });
@@ -346,14 +356,14 @@ BOOST_DATA_TEST_CASE(prune_to_non_prune, bdata::xrange(2) * bdata::xrange(2), en
    t.check_empty();
    size_t payload_size = larger_than_tmpfile_blocksize();
 
-   t.add(2, payload_size, 'A');
-   t.add(3, payload_size, 'B');
-   t.add(4, payload_size, 'C');
-   t.add(5, payload_size, 'D');
-   t.add(6, payload_size, 'E');
-   t.add(7, payload_size, 'F');
-   t.add(8, payload_size, 'G');
-   t.add(9, payload_size, 'H');
+   t.add(2, payload_size, 'A', 'X');
+   t.add(3, payload_size, 'B', 'A');
+   t.add(4, payload_size, 'C', 'B');
+   t.add(5, payload_size, 'D', 'C');
+   t.add(6, payload_size, 'E', 'D');
+   t.add(7, payload_size, 'F', 'E');
+   t.add(8, payload_size, 'G', 'F');
+   t.add(9, payload_size, 'H', 'G');
    t.check_n_bounce([&]() {
       t.check_range_present(6, 9);
    });
@@ -365,12 +375,12 @@ BOOST_DATA_TEST_CASE(prune_to_non_prune, bdata::xrange(2) * bdata::xrange(2), en
    t.check_n_bounce([&]() {
       t.check_range_present(6, 9);
    });
-   t.add(10, payload_size, 'I');
-   t.add(11, payload_size, 'J');
-   t.add(12, payload_size, 'K');
-   t.add(13, payload_size, 'L');
-   t.add(14, payload_size, 'M');
-   t.add(15, payload_size, 'N');
+   t.add(10, payload_size, 'I', 'H');
+   t.add(11, payload_size, 'J', 'I');
+   t.add(12, payload_size, 'K', 'J');
+   t.add(13, payload_size, 'L', 'K');
+   t.add(14, payload_size, 'M', 'L');
+   t.add(15, payload_size, 'N', 'M');
    t.check_n_bounce([&]() {
       t.check_range_present(6, 15);
    });

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(test_restart_from_block_log) {
    chain.create_account("replay2"_n);
    chain.produce_blocks(1);
    chain.create_account("replay3"_n);
-   chain.produce_blocks(1);
+   chain.produce_blocks(1); // replay3 will be in fork_db.dat
 
    BOOST_REQUIRE_NO_THROW(chain.control->get_account("replay1"_n));
    BOOST_REQUIRE_NO_THROW(chain.control->get_account("replay2"_n));
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_restart_from_block_log) {
    auto               genesis       = chain::block_log::extract_genesis_state(chain.get_config().blocks_dir);
    BOOST_REQUIRE(genesis);
 
-   // remove the state files to make sure we are starting from block log
+   // remove the state files to make sure we are starting from block log & fork_db.dat
    remove_existing_states(copied_config);
 
    tester from_block_log_chain(copied_config, *genesis);


### PR DESCRIPTION
Verify when truncating SHiP logs that truncation is not allowed when starting from genesis.

```
warn  2023-02-22T20:51:14.867 nodeos    controller.cpp:606            startup              ] No existing chain state. Initializing fresh blockchain state.
warn  2023-02-22T20:51:14.867 nodeos    controller.cpp:464            initialize_blockchai ] Initializing new blockchain with genesis state
info  2023-02-22T20:51:14.888 nodeos    controller.cpp:501            replay               ] existing block log, attempting to replay from 2 to 214011 blocks
error 2023-02-22T20:51:14.889 nodeos    state_history_plugin.c:284    on_accepted_block    ] fc::exception: 3110000 plugin_exception: Plugin exception
Existing ship log with 214013 blocks when starting from genesis block 2
    {"eb":214013,"b":2}
    nodeos  log.hpp:513 write_entry

warn  2023-02-22T20:51:14.889 nodeos    controller.cpp:375            emit                 ] controller_emit_signal_exception: 3140002 state_history_write_exception: State history write error
State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process
    {}
    nodeos  state_history_plugin.cpp:292 on_accepted_block

error 2023-02-22T20:51:14.890 nodeos    controller.cpp:2127           apply_block          ] e.to_detail_string(): 3140002 state_history_write_exception: State history write error
State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process
    {}
    nodeos  state_history_plugin.cpp:292 on_accepted_block

warn  2023-02-22T20:51:14.890 nodeos    controller.cpp:2287           replay_push_block    ] 3140002 state_history_write_exception: State history write error
State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process
    {}
    nodeos  state_history_plugin.cpp:292 on_accepted_block

    {}
    nodeos  controller.cpp:2135 apply_block

error 2023-02-22T20:51:14.898 nodeos    main.cpp:162                  main                 ] 3140002 state_history_write_exception: State history write error
State history encountered an Error which it cannot recover from.  Please resolve the error and relaunch the process
    {}
    nodeos  state_history_plugin.cpp:292 on_accepted_block

    {}
    nodeos  controller.cpp:2135 apply_block
rethrow
    {}
    nodeos  controller.cpp:2287 replay_push_block

    {}
    nodeos  chain_plugin.cpp:1141 plugin_startup
```

Starting from snapshot is allowed:
```
./nodeos --data-dir telos-d --config-dir telos --disable-replay-opts --plugin eosio::chain_api_plugin --plugin eosio::producer_api_plugin --snapshot /home/heifner/ext/leap/cmake-build-debug/bin/telos-d/snapshots/snapshot-0003068e2e7b2030a54466f36af0df3eb47c75d5a7ef4ffe45e702fe07b6884e.bin
```
```
info  2023-02-22T20:53:27.566 nodeos    controller.cpp:571            startup              ] Starting initialization from snapshot, this may take a significant amount of time
info  2023-02-22T20:53:34.702 nodeos    controller.cpp:501            replay               ] existing block log, attempting to replay from 198287 to 214011 blocks
info  2023-02-22T20:53:34.769 nodeos    log.hpp:793                   truncate             ] fork or replay: removed 15726 blocks from trace_history.log
info  2023-02-22T20:53:34.770 nodeos    log.hpp:793                   truncate             ] fork or replay: removed 15726 blocks from chain_state_history.log
info  2023-02-22T20:53:34.943 nodeos    controller.cpp:507            replay               ] 198500 of 214011
```

Test added to `main` branch, see #736 

Resolves #659