### PR TITLE
remove unused boost/bind.hpp include that generates a warning

### DIFF
--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -23,7 +23,6 @@
 #include <softfloat.hpp>
 #include <compiler_builtins.hpp>
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
 #include <fstream>
 #include <string.h>
 


### PR DESCRIPTION
Just including this header on modern boost versions gives a warning

> #pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.

just remove this include: it's unused.