### PR TITLE
Revert interface change of abi_serializer for tester

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -70,14 +70,14 @@ namespace eosio { namespace chain {
       );
    }
 
-   abi_serializer::abi_serializer( abi_def&& abi, const yield_function_t& yield ) {
+   abi_serializer::abi_serializer( abi_def abi, const yield_function_t& yield ) {
       configure_built_in_types();
       set_abi(std::move(abi), yield);
    }
 
-   abi_serializer::abi_serializer( abi_def&& abi, const fc::microseconds& max_serialization_time) {
+   abi_serializer::abi_serializer( const abi_def& abi, const fc::microseconds& max_serialization_time) {
       configure_built_in_types();
-      set_abi(std::move(abi), create_yield_function(max_serialization_time));
+      set_abi(abi, create_yield_function(max_serialization_time));
    }
 
    void abi_serializer::add_specialized_unpack_pack( const string& name,
@@ -128,7 +128,7 @@ namespace eosio { namespace chain {
       built_in_types.emplace("extended_asset",            pack_unpack<extended_asset>());
    }
 
-   void abi_serializer::set_abi(abi_def&& abi, const yield_function_t& yield) {
+   void abi_serializer::set_abi(abi_def abi, const yield_function_t& yield) {
       impl::abi_traverse_context ctx(yield);
 
       EOS_ASSERT(starts_with(abi.version, "eosio::abi/1."), unsupported_abi_version_exception, "ABI has an unsupported version");
@@ -188,8 +188,8 @@ namespace eosio { namespace chain {
       validate(ctx);
    }
 
-   void abi_serializer::set_abi(abi_def&& abi, const fc::microseconds& max_serialization_time) {
-      return set_abi(std::move(abi), create_yield_function(max_serialization_time));
+   void abi_serializer::set_abi(const abi_def& abi, const fc::microseconds& max_serialization_time) {
+      return set_abi(abi, create_yield_function(max_serialization_time));
    }
 
    bool abi_serializer::is_builtin_type(const std::string_view& type)const {

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -35,12 +35,12 @@ struct abi_serializer {
    using yield_function_t = fc::optional_delegate<void(size_t)>;
 
    abi_serializer(){ configure_built_in_types(); }
-   abi_serializer( abi_def&& abi, const yield_function_t& yield );
+   abi_serializer( abi_def abi, const yield_function_t& yield );
    [[deprecated("use the overload with yield_function_t[=create_yield_function(max_serialization_time)]")]]
-   abi_serializer( abi_def&& abi, const fc::microseconds& max_serialization_time );
-   void set_abi( abi_def&& abi, const yield_function_t& yield );
+   abi_serializer( const abi_def& abi, const fc::microseconds& max_serialization_time );
+   void set_abi( abi_def abi, const yield_function_t& yield );
    [[deprecated("use the overload with yield_function_t[=create_yield_function(max_serialization_time)]")]]
-   void set_abi( abi_def&& abi, const fc::microseconds& max_serialization_time);
+   void set_abi(const abi_def& abi, const fc::microseconds& max_serialization_time);
 
    /// @return string_view of `t` or internal string type
    std::string_view resolve_type(const std::string_view& t)const;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1697,7 +1697,7 @@ read_only::get_producers_result
 read_only::get_producers( const read_only::get_producers_params& params, const fc::time_point& deadline ) const try {
    abi_def abi = eosio::chain_apis::get_abi(db, config::system_account_name);
    const auto table_type = get_table_type(abi, "producers"_n);
-   const abi_serializer abis{ std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ) };
+   const abi_serializer abis{ abi_def(abi), abi_serializer::create_yield_function( abi_serializer_max_time ) };
    EOS_ASSERT(table_type == KEYi64, chain::contract_table_query_exception, "Invalid table type ${type} for table producers", ("type",table_type));
 
    const auto& d = db.db();


### PR DESCRIPTION
The recent change to `abi_serializer` https://github.com/AntelopeIO/leap/pull/696 Specifically the change https://github.com/AntelopeIO/leap/pull/696/commits/62903c04ab510784e255e4e38d67fd7cb5e27ba6 caused existing test cases that use contract tester to not compile.

This PR reverts the changes to `abi_serializer` deprecated methods and changes `abi_serializer` constructor and `set_abi` to take `abi_def` by value instead of rvalue reference. This should allow existing users of contract tester to not have to update their test code.

Resolves #741 