### PR TITLE
Move initialization of logging before plugin_initialize

### DIFF
--- a/libraries/libfc/include/fc/log/logger.hpp
+++ b/libraries/libfc/include/fc/log/logger.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include <fc/string.hpp>
 #include <fc/time.hpp>
 #include <fc/log/log_message.hpp>
+#include <string>
 
 #ifndef DEFAULT_LOGGER
 #define DEFAULT_LOGGER "default"
@@ -25,11 +25,11 @@ namespace fc
    class logger 
    {
       public:
-         static logger get( const fc::string& name = DEFAULT_LOGGER );
-         static void update( const fc::string& name, logger& log );
+         static logger get( const std::string& name = DEFAULT_LOGGER );
+         static void update( const std::string& name, logger& log );
 
          logger();
-         logger( const string& name, const logger& parent = nullptr );
+         logger( const std::string& name, const logger& parent = nullptr );
          logger( std::nullptr_t );
          logger( const logger& c );
          logger( logger&& c );
@@ -44,8 +44,8 @@ namespace fc
          logger&    set_parent( const logger& l );
          logger     get_parent()const;
 
-         void  set_name( const fc::string& n );
-         const fc::string& name()const;
+         void  set_name( const std::string& n );
+         std::string get_name()const;
 
          bool is_enabled( log_level e )const;
          void log( log_message m );

--- a/libraries/libfc/src/log/logger.cpp
+++ b/libraries/libfc/src/log/logger.cpp
@@ -3,9 +3,8 @@
 #include <fc/log/appender.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/filesystem.hpp>
-#include <unordered_map>
-#include <string>
 #include <fc/log/logger_config.hpp>
+#include <unordered_map>
 
 namespace fc {
 
@@ -13,7 +12,7 @@ namespace fc {
       public:
          impl()
          :_parent(nullptr),_enabled(true),_additivity(false),_level(log_level::warn){}
-         fc::string       _name;
+         std::string      _name;
          logger           _parent;
          bool             _enabled;
          bool             _additivity;
@@ -28,7 +27,7 @@ namespace fc {
 
     logger::logger(nullptr_t){}
 
-    logger::logger( const string& name, const logger& parent )
+    logger::logger( const std::string& name, const logger& parent )
     :my( new impl() )
     {
        my->_name = name;
@@ -40,7 +39,7 @@ namespace fc {
     :my(l.my){}
 
     logger::logger( logger&& l )
-    :my(fc::move(l.my)){}
+    :my(std::move(l.my)){}
 
     logger::~logger(){}
 
@@ -82,14 +81,14 @@ namespace fc {
        }
     }
 
-    void logger::set_name( const fc::string& n ) { my->_name = n; }
-    const fc::string& logger::name()const { return my->_name; }
+    void logger::set_name( const std::string& n ) { my->_name = n; }
+    std::string logger::get_name()const { return my->_name; }
 
-    logger logger::get( const fc::string& s ) {
+    logger logger::get( const std::string& s ) {
        return log_config::get_logger( s );
     }
 
-    void logger::update( const fc::string& name, logger& log ) {
+    void logger::update( const std::string& name, logger& log ) {
        log_config::update_logger( name, log );
     }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -449,9 +449,10 @@ chain_plugin::do_hard_replay(const variables_map& options) {
 }
 
 void chain_plugin::plugin_initialize(const variables_map& options) {
-   ilog("initializing chain plugin");
-
    try {
+      handle_sighup(); // Sets loggers
+      ilog("initializing chain plugin");
+
       try {
          genesis_state gs; // Check if EOSIO_ROOT_KEY is bad
       } catch ( const std::exception& ) {
@@ -1053,8 +1054,6 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
 void chain_plugin::plugin_startup()
 { try {
-   handle_sighup(); // Sets loggers
-
    EOS_ASSERT( my->chain_config->read_mode != db_read_mode::IRREVERSIBLE || !accept_transactions(), plugin_config_exception,
                "read-mode = irreversible. transactions should not be enabled by enable_accept_transactions" );
    try {

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -456,8 +456,7 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
    }
 
    void http_plugin::handle_sighup() {
-      const std::string name = logger().name(); // copy needed as update can destroy logger impl which holds name
-      fc::logger::update( name, logger() );
+      fc::logger::update( logger().get_name(), logger() );
    }
 
    void http_plugin::plugin_shutdown() {

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -271,6 +271,7 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
 
    void http_plugin::plugin_initialize(const variables_map& options) {
       try {
+         handle_sighup(); // setup logging
          my->plugin_state->max_body_size = options.at( "max-body-size" ).as<uint32_t>();
          verbose_http_errors = options.at( "verbose-http-errors" ).as<bool>();
 
@@ -369,7 +370,6 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
 
    void http_plugin::plugin_startup() {
 
-      handle_sighup(); // setup logging
       app().post(appbase::priority::high, [this] ()
       {
          try {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3662,8 +3662,10 @@ namespace eosio {
    }
 
    void net_plugin::plugin_initialize( const variables_map& options ) {
-      fc_ilog( logger, "Initialize net plugin" );
       try {
+         handle_sighup();
+         fc_ilog( logger, "Initialize net plugin" );
+
          peer_log_format = options.at( "peer-log-format" ).as<string>();
 
          my->sync_master.reset( new sync_manager( options.at( "sync-fetch-span" ).as<uint32_t>()));
@@ -3765,7 +3767,6 @@ namespace eosio {
    }
 
    void net_plugin::plugin_startup() {
-      handle_sighup();
       try {
 
       fc_ilog( logger, "my node_id is ${id}", ("id", my->node_id ));

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -816,6 +816,8 @@ if( options.count(op_name) ) { \
 
 void producer_plugin::plugin_initialize(const boost::program_options::variables_map& options)
 { try {
+   handle_sighup(); // Sets loggers
+
    my->chain_plug = app().find_plugin<chain_plugin>();
    EOS_ASSERT( my->chain_plug, plugin_config_exception, "chain_plugin not found" );
    my->_options = &options;
@@ -990,8 +992,6 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
 
 void producer_plugin::plugin_startup()
 { try {
-   handle_sighup(); // Sets loggers
-
    try {
    ilog("producer plugin:  plugin_startup() begin");
 

--- a/plugins/resource_monitor_plugin/include/eosio/resource_monitor_plugin/file_space_handler.hpp
+++ b/plugins/resource_monitor_plugin/include/eosio/resource_monitor_plugin/file_space_handler.hpp
@@ -93,7 +93,7 @@ namespace eosio::resource_monitor {
          EOS_ASSERT(status == 0, chain::plugin_config_exception,
                     "Failed to run stat on ${path} with status ${status}", ("path", path_name.string())("status", status));
 
-         dlog("${path_name}'s file system to be monitored", ("path_name", path_name.string()));
+         ilog("${path_name}'s file system to be monitored", ("path_name", path_name.string()));
 
          // If the file system containing the path is already
          // in the filesystem list, do not add it again

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -643,6 +643,8 @@ void state_history_plugin::set_program_options(options_description& cli, options
 
 void state_history_plugin::plugin_initialize(const variables_map& options) {
    try {
+      handle_sighup(); // setup logging
+
       EOS_ASSERT(options.at("disable-replay-opts").as<bool>(), plugin_exception,
                  "state_history_plugin requires --disable-replay-opts");
 
@@ -716,8 +718,6 @@ void state_history_plugin::plugin_initialize(const variables_map& options) {
 } // state_history_plugin::plugin_initialize
 
 void state_history_plugin::plugin_startup() {
-   handle_sighup(); // setup logging
-
    try {
       auto bsp = my->chain_plug->chain().head_block_state();
       if( bsp && my->chain_state_log && my->chain_state_log->begin_block() == my->chain_state_log->end_block() ) {
@@ -747,6 +747,8 @@ void state_history_plugin::plugin_shutdown() {
    my->thread_pool.stop();
 }
 
-void state_history_plugin::handle_sighup() { fc::logger::update(logger_name, _log); }
+void state_history_plugin::handle_sighup() {
+   fc::logger::update(logger_name, _log);
+}
 
 } // namespace eosio

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -433,6 +433,8 @@ void trace_api_plugin::set_program_options(appbase::options_description& cli, ap
 }
 
 void trace_api_plugin::plugin_initialize(const appbase::variables_map& options) {
+   handle_sighup(); // setup logging
+
    auto common = std::make_shared<trace_api_common_impl>();
    common->plugin_initialize(options);
 
@@ -444,8 +446,6 @@ void trace_api_plugin::plugin_initialize(const appbase::variables_map& options) 
 }
 
 void trace_api_plugin::plugin_startup() {
-   handle_sighup(); // setup logging
-
    my->plugin_startup();
    rpc->plugin_startup();
 }

--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -87,6 +87,7 @@ int main(int argc, char** argv)
          .server_header = keosd::config::key_store_executable_name + "/" + app->version_string()
       });
       application::register_plugin<wallet_api_plugin>();
+      initialize_logging();
       if(!app->initialize<wallet_plugin, wallet_api_plugin, http_plugin>(argc, argv)) {
          const auto &opts = app->get_options();
          if (opts.count("help") || opts.count("version") || opts.count("full-version") ||
@@ -94,7 +95,6 @@ int main(int argc, char** argv)
             return 0;
          }
       }
-      initialize_logging();
       auto& http = app->get_plugin<http_plugin>();
       http.add_handler("/v1/" + keosd::config::key_store_executable_name + "/stop",
                        [&a=app](string, string, url_response_callback cb) {

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -124,6 +124,7 @@ int main(int argc, char** argv)
          .default_http_port = 8888,
          .server_header = nodeos::config::node_executable_name + "/" + app->version_string()
       });
+      initialize_logging();
       if(!app->initialize<chain_plugin, net_plugin, producer_plugin, resource_monitor_plugin>(argc, argv)) {
          const auto& opts = app->get_options();
          if( opts.count("help") || opts.count("version") || opts.count("full-version") || opts.count("print-default-config") ) {
@@ -137,7 +138,6 @@ int main(int argc, char** argv)
          elog("resource_monitor_plugin failed to initialize");
          return INITIALIZE_FAIL;
       }
-      initialize_logging();
       ilog( "${name} version ${ver} ${fv}",
             ("name", nodeos::config::node_executable_name)("ver", app->version_string())
             ("fv", app->version_string() == app->full_version_string() ? "" : app->full_version_string()) );


### PR DESCRIPTION
During work on #659 the log of `EOS_ASSERT`:
```
error 2023-02-22T20:51:14.889 nodeos    state_history_plugin.c:284    on_accepted_block    ] fc::exception: 3110000 plugin_exception: Plugin exception
Existing ship log with 214013 blocks when starting from genesis block 2
    {"eb":214013,"b":2}
    nodeos  log.hpp:513 write_entry
```
was not logged because it was called before `state_history_plugin::plugin_startup()` where the `state_history` logger is initialized. Some plugins work around this by using the default logger in `plugin_initialize()`. However, there are some logs that never have worked. 
For example, in `net_plugin`:
```
   void net_plugin::plugin_initialize( const variables_map& options ) {
      fc_ilog( logger, "Initialize net plugin" );
```
This never actually logs because the `net_plugin_impl` `logger` has not been initialized.

To avoid this confusion, this PR moves the `initialize_logging()`  of `main` before `app` initialize which is before `plugin_initialize()`. Also any plugin loggers are now initialized in `plugin_initialize` as the first step so that loggers are configured and ready to be used in `plugin_initailize`.

With this change you actually now get:
```
info  2023-02-25T03:29:47.026 nodeos    net_plugin.cpp:3667           plugin_initialize    ] Initialize net plugin
```

See #737
