### PR TITLE
[3.2 -> main] Avoid logging errors when client disconnects after request (GH #530)

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -253,8 +253,11 @@ public:
                 std::size_t bytes_transferred) {
       boost::ignore_unused(bytes_transferred);
 
-      // This means they closed the connection
-      if(ec == http::error::end_of_stream)
+      // By default, http_plugin runs in keep_alive mode (persistent connections)
+      // hence respecting the http 1.1 standard. So after sending a response, we wait
+      // on another read. If the client disconnects, we may get
+      // http::error::end_of_stream or asio::error::connection_reset.
+      if(ec == http::error::end_of_stream || ec == asio::error::connection_reset)
          return derived().do_eof();
 
       if(ec) {


### PR DESCRIPTION
Resolves #530.

These messages are showing up in leap 3.2 is because the implementation of the http_server changed in leap 3.2, including adding support for HTTP 1.1 Keep-Alive, which allows HTTP connections to persist for more than one request.

As a result, when the client closes the connection, the server is busy performing a read (waiting for the next request) which end with a Connection reset by peer error. This was reported as an error by mistake. This PR makes the http_plugin silently close its side of the connection.