### PR TITLE
[3.1 -> 3.2] keosd - Exit program if keosd fails to aquire wallet lock (GH #513)

### DIFF
--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -71,6 +71,17 @@ bfs::path determine_home_directory()
    return home;
 }
 
+enum return_codes {
+   OTHER_FAIL        = -2,
+   INITIALIZE_FAIL   = -1,
+   SUCCESS           = 0,
+   BAD_ALLOC         = 1,
+   DATABASE_DIRTY    = 2,
+   FIXED_REVERSIBLE  = SUCCESS,
+   EXTRACTED_GENESIS = SUCCESS,
+   NODE_MANAGEMENT_SUCCESS = 5
+};
+
 int main(int argc, char** argv)
 {
    try {
@@ -91,6 +102,7 @@ int main(int argc, char** argv)
              opts.count("print-default-config")) {
             return 0;
          }
+         return INITIALIZE_FAIL;
       }
       initialize_logging();
       auto& http = app().get_plugin<http_plugin>();


### PR DESCRIPTION
Resolves https://github.com/AntelopeIO/leap/issues/513.

Add missing return statement when app. initialization fails.