### PR TITLE
[PH] Resolve Duplicate Transaction ID Generation in Transaction Generator

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -518,18 +518,18 @@ class Node(object):
         return transIds
 
     def waitForTransactionsInBlockRange(self, transIds, startBlock=2, maxFutureBlocks=0):
-        lastBlockProcessed = startBlock
-        overallFinalBlock = startBlock + maxFutureBlocks
+        nextBlockToProcess = startBlock
+        overallEndBlock = startBlock + maxFutureBlocks
         while len(transIds) > 0:
             currentLoopEndBlock = self.getHeadBlockNum()
-            if currentLoopEndBlock >  overallFinalBlock:
-                currentLoopEndBlock = overallFinalBlock
-            for blockNum in range(currentLoopEndBlock, lastBlockProcessed - 1, -1):
+            if currentLoopEndBlock >  overallEndBlock:
+                currentLoopEndBlock = overallEndBlock
+            for blockNum in range(nextBlockToProcess, currentLoopEndBlock + 1):
                 transIds = self.checkBlockForTransactions(transIds, blockNum)
                 if len(transIds) == 0:
                     return transIds
-            lastBlockProcessed = currentLoopEndBlock
-            if currentLoopEndBlock == overallFinalBlock:
+            nextBlockToProcess = currentLoopEndBlock + 1
+            if currentLoopEndBlock == overallEndBlock:
                 Utils.Print("ERROR: Transactions were missing upon expiration of waitOnblockTransactions")
                 break
             self.waitForHeadToAdvance()

--- a/tests/trx_generator/trx_generator.cpp
+++ b/tests/trx_generator/trx_generator.cpp
@@ -33,7 +33,7 @@ namespace eosio::testing {
          trx.actions.emplace_back(std::move(act));
       }
       trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"),
-         fc::raw::pack(std::to_string(nonce_prefix) + ":" + std::to_string(++nonce) + ":" +
+         fc::raw::pack(std::to_string(_generator_id) + ":" + std::to_string(nonce_prefix) + ":" + std::to_string(++nonce) + ":" +
          fc::time_point::now().time_since_epoch().count())));
 
       trx.sign(priv_key, chain_id);


### PR DESCRIPTION
Duplicate transaction IDs were possible to be generated by two different transaction generators creating transactions at the same time (epoch). This also required the `Action Data` specified to be blank, so it was only affecting the `cpu` and `ram` performance tests. This PR adds the transaction generator's `_generator_id` to the header to prevent collision from happening in the future.

 It also does a little rewrite of a loop to make it more readable.