### PR TITLE
[PH] expose --user-trx-data-file to performance test

### DIFF
--- a/tests/performance_tests/README.md
+++ b/tests/performance_tests/README.md
@@ -433,6 +433,8 @@ Performance Test Basic Base:
 * `--wasm-file WASM_FILE`
                           WASM file name for contract (default: eosio.system.wasm)
 * `--abi-file ABI_FILE`   ABI file name for contract (default: eosio.system.abi)
+* `--user-trx-data-file USER_TRX_DATA_FILE`
+                          Path to transaction data JSON file (default: None)
 * `--wasm-runtime RUNTIME`
                           Override default WASM runtime ("eos-vm-jit", "eos-vm")
                           "eos-vm-jit" : A WebAssembly runtime that compiles WebAssembly code to native x86 code prior to
@@ -459,8 +461,6 @@ Performance Test Basic Single Test:
                           The target transfers per second to send during test (default: 8000)
 * `--test-duration-sec TEST_DURATION_SEC`
                           The duration of transfer trx generation for the test in seconds (default: 90)
-* `--user-trx-data-file USER_TRX_DATA_FILE`
-                          Path to transaction data JSON file (default: None)
 </details>
 
 #### Launch Transaction Generators (TestHarness)

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -102,7 +102,7 @@ class PerformanceTest:
         self.loggingConfig = PerformanceTest.LoggingConfig(logDirBase=Path(self.ptConfig.logDirRoot)/PurePath(PurePath(__file__).name).stem[0],
                                                            logDirTimestamp=f"{self.testsStart.strftime('%Y-%m-%d_%H-%M-%S')}")
 
-    def performPtbBinarySearch(self, clusterConfig: PerformanceTestBasic.ClusterConfig, logDirRoot: Path, delReport: bool, quiet: bool, delPerfLogs: bool, userTrxDataFile: Path) -> TpsTestResult.PerfTestSearchResults:
+    def performPtbBinarySearch(self, clusterConfig: PerformanceTestBasic.ClusterConfig, logDirRoot: Path, delReport: bool, quiet: bool, delPerfLogs: bool) -> TpsTestResult.PerfTestSearchResults:
         floor = 0
         ceiling = self.ptConfig.maxTpsToTest
         binSearchTarget = self.ptConfig.maxTpsToTest
@@ -118,7 +118,7 @@ class PerformanceTest:
             scenarioResult = PerformanceTest.PerfTestSearchIndivResult(success=False, searchTarget=binSearchTarget, searchFloor=floor, searchCeiling=ceiling, basicTestResult=ptbResult)
             ptbConfig = PerformanceTestBasic.PtbConfig(targetTps=binSearchTarget, testTrxGenDurationSec=self.ptConfig.testDurationSec, tpsLimitPerGenerator=self.ptConfig.tpsLimitPerGenerator,
                                                        numAddlBlocksToPrune=self.ptConfig.numAddlBlocksToPrune, logDirRoot=logDirRoot, delReport=delReport,
-                                                       quiet=quiet, userTrxDataFile=userTrxDataFile)
+                                                       quiet=quiet, userTrxDataFile=self.ptConfig.userTrxDataFile)
 
             myTest = PerformanceTestBasic(testHelperConfig=self.testHelperConfig, clusterConfig=clusterConfig, ptbConfig=ptbConfig)
             testSuccessful = myTest.runTest()
@@ -234,7 +234,7 @@ class PerformanceTest:
             setattr(getattr(clusterConfig.extraNodeosArgs, optPlugin.value + 'PluginArgs'), f"{optPlugin.value}Threads", threadCount)
 
             binSearchResults = self.performPtbBinarySearch(clusterConfig=clusterConfig, logDirRoot=self.loggingConfig.pluginThreadOptLogsDirPath,
-                                                            delReport=True, quiet=False, delPerfLogs=True, userTrxDataFile=self.ptConfig.userTrxDataFile)
+                                                            delReport=True, quiet=False, delPerfLogs=True)
 
             threadToMaxTpsDict[threadCount] = binSearchResults.maxTpsAchieved
             if not self.ptConfig.quiet:
@@ -354,7 +354,7 @@ class PerformanceTest:
         perfRunSuccessful = False
 
         binSearchResults = self.performPtbBinarySearch(clusterConfig=self.clusterConfig, logDirRoot=self.loggingConfig.ptbLogsDirPath,
-                                                            delReport=self.ptConfig.delReport, quiet=self.ptConfig.quiet, delPerfLogs=self.ptConfig.delPerfLogs, userTrxDataFile=self.ptConfig.userTrxDataFile)
+                                                            delReport=self.ptConfig.delReport, quiet=self.ptConfig.quiet, delPerfLogs=self.ptConfig.delPerfLogs)
 
         print(f"Successful rate of: {binSearchResults.maxTpsAchieved}")
 

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -61,6 +61,7 @@ class PerformanceTest:
         calcProducerThreads: str="none"
         calcChainThreads: str="none"
         calcNetThreads: str="none"
+        userTrxDataFile: Path=None
 
 
     @dataclass
@@ -101,7 +102,7 @@ class PerformanceTest:
         self.loggingConfig = PerformanceTest.LoggingConfig(logDirBase=Path(self.ptConfig.logDirRoot)/PurePath(PurePath(__file__).name).stem[0],
                                                            logDirTimestamp=f"{self.testsStart.strftime('%Y-%m-%d_%H-%M-%S')}")
 
-    def performPtbBinarySearch(self, clusterConfig: PerformanceTestBasic.ClusterConfig, logDirRoot: Path, delReport: bool, quiet: bool, delPerfLogs: bool) -> TpsTestResult.PerfTestSearchResults:
+    def performPtbBinarySearch(self, clusterConfig: PerformanceTestBasic.ClusterConfig, logDirRoot: Path, delReport: bool, quiet: bool, delPerfLogs: bool, userTrxDataFile: Path) -> TpsTestResult.PerfTestSearchResults:
         floor = 0
         ceiling = self.ptConfig.maxTpsToTest
         binSearchTarget = self.ptConfig.maxTpsToTest
@@ -117,7 +118,7 @@ class PerformanceTest:
             scenarioResult = PerformanceTest.PerfTestSearchIndivResult(success=False, searchTarget=binSearchTarget, searchFloor=floor, searchCeiling=ceiling, basicTestResult=ptbResult)
             ptbConfig = PerformanceTestBasic.PtbConfig(targetTps=binSearchTarget, testTrxGenDurationSec=self.ptConfig.testDurationSec, tpsLimitPerGenerator=self.ptConfig.tpsLimitPerGenerator,
                                                        numAddlBlocksToPrune=self.ptConfig.numAddlBlocksToPrune, logDirRoot=logDirRoot, delReport=delReport,
-                                                       quiet=quiet, delPerfLogs=delPerfLogs)
+                                                       quiet=quiet, userTrxDataFile=userTrxDataFile)
 
             myTest = PerformanceTestBasic(testHelperConfig=self.testHelperConfig, clusterConfig=clusterConfig, ptbConfig=ptbConfig)
             testSuccessful = myTest.runTest()
@@ -233,7 +234,7 @@ class PerformanceTest:
             setattr(getattr(clusterConfig.extraNodeosArgs, optPlugin.value + 'PluginArgs'), f"{optPlugin.value}Threads", threadCount)
 
             binSearchResults = self.performPtbBinarySearch(clusterConfig=clusterConfig, logDirRoot=self.loggingConfig.pluginThreadOptLogsDirPath,
-                                                            delReport=True, quiet=False, delPerfLogs=True)
+                                                            delReport=True, quiet=False, delPerfLogs=True, userTrxDataFile=self.ptConfig.userTrxDataFile)
 
             threadToMaxTpsDict[threadCount] = binSearchResults.maxTpsAchieved
             if not self.ptConfig.quiet:
@@ -353,7 +354,7 @@ class PerformanceTest:
         perfRunSuccessful = False
 
         binSearchResults = self.performPtbBinarySearch(clusterConfig=self.clusterConfig, logDirRoot=self.loggingConfig.ptbLogsDirPath,
-                                                            delReport=self.ptConfig.delReport, quiet=self.ptConfig.quiet, delPerfLogs=self.ptConfig.delPerfLogs)
+                                                            delReport=self.ptConfig.delReport, quiet=self.ptConfig.quiet, delPerfLogs=self.ptConfig.delPerfLogs, userTrxDataFile=self.ptConfig.userTrxDataFile)
 
         print(f"Successful rate of: {binSearchResults.maxTpsAchieved}")
 
@@ -514,10 +515,11 @@ def main():
     resourceMonitorPluginArgs = ResourceMonitorPluginArgs(resourceMonitorNotShutdownOnThresholdExceeded=True)
     extraNodeosArgs = ENA(chainPluginArgs=chainPluginArgs, httpPluginArgs=httpPluginArgs, producerPluginArgs=producerPluginArgs, netPluginArgs=netPluginArgs,
                           resourceMonitorPluginArgs=resourceMonitorPluginArgs)
+    SC = PerformanceTestBasic.ClusterConfig.SpecifiedContract
+    specifiedContract=SC(contractDir=args.contract_dir, wasmFile=args.wasm_file, abiFile=args.abi_file, account=Account(args.account_name))
     testClusterConfig = PerformanceTestBasic.ClusterConfig(pnodes=args.p, totalNodes=args.n, topo=args.s, genesisPath=args.genesis,
                                                            prodsEnableTraceApi=args.prods_enable_trace_api, extraNodeosArgs=extraNodeosArgs,
-                                                           specifiedContract=PerformanceTestBasic.ClusterConfig.SpecifiedContract(account=Account(args.account_name),
-                                                                contractDir=args.contract_dir, wasmFile=args.wasm_file, abiFile=args.abi_file),
+                                                           specifiedContract=specifiedContract,
                                                            nodeosVers=Utils.getNodeosVersion().split('.')[0])
 
     ptConfig = PerformanceTest.PtConfig(testDurationSec=args.test_iteration_duration_sec,
@@ -534,7 +536,8 @@ def main():
                                         skipTpsTests=args.skip_tps_test,
                                         calcProducerThreads=args.calc_producer_threads,
                                         calcChainThreads=args.calc_chain_threads,
-                                        calcNetThreads=args.calc_net_threads)
+                                        calcNetThreads=args.calc_net_threads,
+                                        userTrxDataFile=Path(args.user_trx_data_file) if args.user_trx_data_file is not None else None)
 
     myTest = PerformanceTest(testHelperConfig=testHelperConfig, clusterConfig=testClusterConfig, ptConfig=ptConfig)
     perfRunSuccessful = myTest.runTest()

--- a/tests/performance_tests/performance_test.py
+++ b/tests/performance_tests/performance_test.py
@@ -159,7 +159,8 @@ class PerformanceTest:
             ptbResult = PerformanceTest.PerfTestSearchIndivResult.PerfTestBasicResult()
             scenarioResult = PerformanceTest.PerfTestSearchIndivResult(success=False, searchTarget=searchTarget, searchFloor=absFloor, searchCeiling=absCeiling, basicTestResult=ptbResult)
             ptbConfig = PerformanceTestBasic.PtbConfig(targetTps=searchTarget, testTrxGenDurationSec=self.ptConfig.testDurationSec, tpsLimitPerGenerator=self.ptConfig.tpsLimitPerGenerator,
-                                                    numAddlBlocksToPrune=self.ptConfig.numAddlBlocksToPrune, logDirRoot=self.loggingConfig.ptbLogsDirPath, delReport=self.ptConfig.delReport, quiet=self.ptConfig.quiet, delPerfLogs=self.ptConfig.delPerfLogs)
+                                                    numAddlBlocksToPrune=self.ptConfig.numAddlBlocksToPrune, logDirRoot=self.loggingConfig.ptbLogsDirPath, delReport=self.ptConfig.delReport,
+                                                    quiet=self.ptConfig.quiet, delPerfLogs=self.ptConfig.delPerfLogs, userTrxDataFile=self.ptConfig.userTrxDataFile)
 
             myTest = PerformanceTestBasic(testHelperConfig=self.testHelperConfig, clusterConfig=self.clusterConfig, ptbConfig=ptbConfig)
             testSuccessful = myTest.runTest()

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -560,6 +560,7 @@ class PtbArgumentsHandler(object):
         ptbBaseParserGroup.add_argument("--contract-dir", type=str, help="Path to contract dir", default="unittests/contracts/eosio.system")
         ptbBaseParserGroup.add_argument("--wasm-file", type=str, help="WASM file name for contract", default="eosio.system.wasm")
         ptbBaseParserGroup.add_argument("--abi-file", type=str, help="ABI file name for contract", default="eosio.system.abi")
+        ptbBaseParserGroup.add_argument("--user-trx-data-file", type=str, help="Path to transaction data JSON file")
         ptbBaseParserGroup.add_argument("--wasm-runtime", type=str, help="Override default WASM runtime (\"eos-vm-jit\", \"eos-vm\")\
                                          \"eos-vm-jit\" : A WebAssembly runtime that compiles WebAssembly code to native x86 code prior to\
                                          execution. \"eos-vm\" : A WebAssembly interpreter.",
@@ -588,7 +589,6 @@ class PtbArgumentsHandler(object):
 
         ptbParserGroup.add_argument("--target-tps", type=int, help="The target transfers per second to send during test", default=8000)
         ptbParserGroup.add_argument("--test-duration-sec", type=int, help="The duration of transfer trx generation for the test in seconds", default=90)
-        ptbParserGroup.add_argument("--user-trx-data-file", type=str, help="Path to userTrxDataTransfer.json")
 
         return ptbParser
 


### PR DESCRIPTION
The config option `user-trx-data-file` was not properly being exposed to the top level performance test. This PR exposes it and makes a few related fixes.