### PR TITLE
[3.1 -> 3.2] Move subjective bill log to `all` level of `producer_plugin` logger.

### DIFF
--- a/libraries/libfc/include/fc/log/logger.hpp
+++ b/libraries/libfc/include/fc/log/logger.hpp
@@ -74,6 +74,12 @@ namespace fc
 # define FC_MULTILINE_MACRO_END  } while (0)
 #endif
 
+#define fc_tlog( LOGGER, FORMAT, ... ) \
+  FC_MULTILINE_MACRO_BEGIN \
+   if( (LOGGER).is_enabled( fc::log_level::all ) ) \
+      (LOGGER).log( FC_LOG_MESSAGE( all, FORMAT, __VA_ARGS__ ) ); \
+  FC_MULTILINE_MACRO_END
+
 #define fc_dlog( LOGGER, FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
    if( (LOGGER).is_enabled( fc::log_level::debug ) ) \

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -40,13 +40,6 @@ using std::string;
 using std::vector;
 using boost::signals2::scoped_connection;
 
-// in release/3.2+ move to fc logger.hpp
-#define fc_tlog( LOGGER, FORMAT, ... ) \
-  FC_MULTILINE_MACRO_BEGIN \
-   if( (LOGGER).is_enabled( fc::log_level::all ) ) \
-      (LOGGER).log( FC_LOG_MESSAGE( all, FORMAT, __VA_ARGS__ ) ); \
-  FC_MULTILINE_MACRO_END
-
 #undef FC_LOG_AND_DROP
 #define LOG_AND_DROP()  \
    catch ( const guard_exception& e ) { \

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -560,7 +560,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                   auto start = fc::time_point::now();
                   auto idle_time = start - self->_idle_trx_time;
                   self->_account_fails.add_idle_time( idle_time );
-                  fc_dlog( _trx_successful_trace_log, "Time since last trx: ${t}us", ("t", idle_time) );
+                  fc_tlog( _log, "Time since last trx: ${t}us", ("t", idle_time) );
 
                   auto exception_handler = [self, &next, trx{std::move(trx)}, &start](fc::exception_ptr ex) {
                      self->_account_fails.add_idle_time( start - self->_idle_trx_time );
@@ -2043,14 +2043,14 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
          pr.failed = true;
          auto failure_code = trace->except->code();
          if( failure_code != tx_duplicate::code_value ) {
-            fc_dlog( _trx_failed_trace_log, "Subjective bill for failed ${a}: ${b} elapsed ${t}us, time ${r}us",
+            fc_tlog( _log, "Subjective bill for failed ${a}: ${b} elapsed ${t}us, time ${r}us",
                      ("a",first_auth)("b",sub_bill)("t",trace->elapsed)("r", end - start));
             if (!disable_subjective_billing)
                _subjective_billing.subjective_bill_failure( first_auth, trace->elapsed, fc::time_point::now() );
 
             log_trx_results( trx, trace, start );
             // this failed our configured maximum transaction time, we don't want to replay it
-            fc_dlog( _trx_failed_trace_log, "Failed ${c} trx, auth: ${a}, prev billed: ${p}us, ran: ${r}us, id: ${id}",
+            fc_tlog( _log, "Failed ${c} trx, auth: ${a}, prev billed: ${p}us, ran: ${r}us, id: ${id}",
                      ("c", failure_code)("a", first_auth)("p", prev_billed_cpu_time_us)
                      ( "r", end - start )( "id", trx->id() ) );
             if( !disable_subjective_enforcement )
@@ -2066,7 +2066,7 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
          }
       }
    } else {
-      fc_dlog( _trx_successful_trace_log, "Subjective bill for success ${a}: ${b} elapsed ${t}us, time ${r}us",
+      fc_tlog( _log, "Subjective bill for success ${a}: ${b} elapsed ${t}us, time ${r}us",
                ("a",first_auth)("b",sub_bill)("t",trace->elapsed)("r", end - start));
       _account_fails.add_success_time(end - start);
       log_trx_results( trx, trace, start );


### PR DESCRIPTION
Log "Subjective bill" log entries to `producer_plugin` logger at `all` (trace) level.

Merges `release/3.1` into `release/3.2` including #773.
Re-implements functionality since 3.2 is completely different in logging in this area.

Resolves #768 