### PR TITLE
bump appbase version and fix logging.json not working problem

### DIFF
--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -98,8 +98,7 @@ int main(int argc, char** argv)
          .server_header = keosd::config::key_store_executable_name + "/" + app->version_string()
       });
       application::register_plugin<wallet_api_plugin>();
-      initialize_logging();
-      if(!app->initialize<wallet_plugin, wallet_api_plugin, http_plugin>(argc, argv)) {
+      if(!app->initialize<wallet_plugin, wallet_api_plugin, http_plugin>(argc, argv, initialize_logging)) {
          const auto &opts = app->get_options();
          if (opts.count("help") || opts.count("version") || opts.count("full-version") ||
              opts.count("print-default-config")) {

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -124,8 +124,7 @@ int main(int argc, char** argv)
          .default_http_port = 8888,
          .server_header = nodeos::config::node_executable_name + "/" + app->version_string()
       });
-      initialize_logging();
-      if(!app->initialize<chain_plugin, net_plugin, producer_plugin, resource_monitor_plugin>(argc, argv)) {
+      if(!app->initialize<chain_plugin, net_plugin, producer_plugin, resource_monitor_plugin>(argc, argv, initialize_logging)) {
          const auto& opts = app->get_options();
          if( opts.count("help") || opts.count("version") || opts.count("full-version") || opts.count("print-default-config") ) {
             return SUCCESS;


### PR DESCRIPTION
This bumps appbase to https://github.com/AntelopeIO/appbase/pull/11 and fixes the logging.json not working problem. Please see https://github.com/AntelopeIO/appbase/pull/11  for details of the fix.

Resolved https://github.com/AntelopeIO/leap/issues/775