### PR TITLE
Huangminghuang/fix_prometheus_test

### DIFF
--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -1354,7 +1354,6 @@ class PluginHttpTest(unittest.TestCase):
         self.assertTrue(int(metrics["head_block_num"]) > 1)
         self.assertTrue(int(metrics["blocks_produced"]) > 1)
         self.assertTrue(int(metrics["last_irreversible"]) > 1)
-        self.assertTrue(int(metrics["num_calls"]) > 1)
 
 
     def test_multipleRequests(self):


### PR DESCRIPTION
The PR removes the 'num_calls' assertion from the integration simply because the counter is increamented in a different thread from the one sending the response which causes the assertion to fail occasionally.