### PR TITLE
Remove deprecated `/v1/chain/abi_bin_to_json` and `/v1/chain/abi_json_to_bin`

### DIFF
--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -548,39 +548,6 @@ paths:
                     type: array
                     items: {}
 
-  /abi_json_to_bin:
-    post:
-      description: Returns an object containing the serialized action data.
-      operationId: abi_json_to_bin
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              title: AbiJsonToBinRequest
-                - code
-                - action
-                - args
-              properties:
-                code:
-                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
-                action:
-                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
-                args:
-                  type: object
-                  description: json object of the action parameters that will be serialized.
-
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  binargs:
-                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/Hex.yaml"
-
   /get_code:
     post:
       description: Returns an object containing the smart contract WASM code.

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -581,35 +581,6 @@ paths:
                   binargs:
                     $ref: "https://docs.eosnetwork.com/openapi/v2.0/Hex.yaml"
 
-  /abi_bin_to_json:
-    post:
-      description: Returns an object containing the deserialized action data.
-      operationId: abi_bin_to_json
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              title: AbiBinToJsonRequest
-              required:
-                - code
-                - action
-                - binargs
-              properties:
-                code:
-                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
-                action:
-                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Name.yaml"
-                binargs:
-                  $ref: "https://docs.eosnetwork.com/openapi/v2.0/Hex.yaml"
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: string
-
   /get_code:
     post:
       description: Returns an object containing the smart contract WASM code.

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -126,7 +126,6 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(get_producer_schedule, 200, http_params_types::no_params),
       CHAIN_RO_CALL(get_scheduled_transactions, 200, http_params_types::params_required),
       CHAIN_RO_CALL(abi_json_to_bin, 200, http_params_types::params_required),
-      CHAIN_RO_CALL(abi_bin_to_json, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_required_keys, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_transaction_id, 200, http_params_types::params_required),
       CHAIN_RO_CALL_ASYNC(compute_transaction, chain_apis::read_only::compute_transaction_results, 200, http_params_types::params_required),

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -125,7 +125,6 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(get_producers, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_producer_schedule, 200, http_params_types::no_params),
       CHAIN_RO_CALL(get_scheduled_transactions, 200, http_params_types::params_required),
-      CHAIN_RO_CALL(abi_json_to_bin, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_required_keys, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_transaction_id, 200, http_params_types::params_required),
       CHAIN_RO_CALL_ASYNC(compute_transaction, chain_apis::read_only::compute_transaction_results, 200, http_params_types::params_required),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2533,18 +2533,6 @@ read_only::abi_json_to_bin_result read_only::abi_json_to_bin( const read_only::a
 } FC_RETHROW_EXCEPTIONS( warn, "code: ${code}, action: ${action}, args: ${args}",
                          ("code", params.code)( "action", params.action )( "args", params.args ))
 
-read_only::abi_bin_to_json_result read_only::abi_bin_to_json( const read_only::abi_bin_to_json_params& params, const fc::time_point& deadline )const {
-   abi_bin_to_json_result result;
-   const auto& code_account = db.db().get<account_object,by_name>( params.code );
-   if( abi_def abi; abi_serializer::to_abi(code_account.abi, abi) ) {
-      abi_serializer abis( std::move(abi), abi_serializer::create_yield_function( abi_serializer_max_time ) );
-      result.args = abis.binary_to_variant( abis.get_action_type( params.action ), params.binargs, abi_serializer::create_yield_function( abi_serializer_max_time ), shorten_abi_errors );
-   } else {
-      EOS_ASSERT(false, abi_not_found_exception, "No ABI found for ${contract}", ("contract", params.code));
-   }
-   return result;
-}
-
 read_only::get_required_keys_result read_only::get_required_keys( const get_required_keys_params& params, const fc::time_point& deadline )const {
    transaction pretty_input;
    auto resolver = make_resolver(db, abi_serializer::create_yield_function( abi_serializer_max_time ));

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -323,18 +323,6 @@ public:
    abi_json_to_bin_result abi_json_to_bin( const abi_json_to_bin_params& params, const fc::time_point& deadline )const;
 
 
-   struct abi_bin_to_json_params {
-      name         code;
-      name         action;
-      vector<char> binargs;
-   };
-   struct abi_bin_to_json_result {
-      fc::variant    args;
-   };
-
-   abi_bin_to_json_result abi_bin_to_json( const abi_bin_to_json_params& params, const fc::time_point& deadline )const;
-
-
    struct get_required_keys_params {
       fc::variant transaction;
       flat_set<public_key_type> available_keys;
@@ -968,8 +956,6 @@ FC_REFLECT( eosio::chain_apis::read_only::get_raw_abi_results, (account_name)(co
 FC_REFLECT( eosio::chain_apis::read_only::producer_info, (producer_name) )
 FC_REFLECT( eosio::chain_apis::read_only::abi_json_to_bin_params, (code)(action)(args) )
 FC_REFLECT( eosio::chain_apis::read_only::abi_json_to_bin_result, (binargs) )
-FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_params, (code)(action)(binargs) )
-FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_result, (args) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction)(available_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_params, (transaction))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -310,19 +310,6 @@ public:
    get_raw_abi_results get_raw_abi( const get_raw_abi_params& params, const fc::time_point& deadline)const;
 
 
-
-   struct abi_json_to_bin_params {
-      name         code;
-      name         action;
-      fc::variant  args;
-   };
-   struct abi_json_to_bin_result {
-      vector<char>   binargs;
-   };
-
-   abi_json_to_bin_result abi_json_to_bin( const abi_json_to_bin_params& params, const fc::time_point& deadline )const;
-
-
    struct get_required_keys_params {
       fc::variant transaction;
       flat_set<public_key_type> available_keys;
@@ -954,8 +941,6 @@ FC_REFLECT( eosio::chain_apis::read_only::get_raw_code_and_abi_results, (account
 FC_REFLECT( eosio::chain_apis::read_only::get_raw_abi_params, (account_name)(abi_hash) )
 FC_REFLECT( eosio::chain_apis::read_only::get_raw_abi_results, (account_name)(code_hash)(abi_hash)(abi) )
 FC_REFLECT( eosio::chain_apis::read_only::producer_info, (producer_name) )
-FC_REFLECT( eosio::chain_apis::read_only::abi_json_to_bin_params, (code)(action)(args) )
-FC_REFLECT( eosio::chain_apis::read_only::abi_json_to_bin_result, (binargs) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction)(available_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_params, (transaction))

--- a/programs/cleos/help_text.cpp.in
+++ b/programs/cleos/help_text.cpp.in
@@ -79,7 +79,6 @@ const std::vector<std::pair<const char*, std::vector<const char *>>> error_help_
    {"Error\n: 3030008[^\\x00]*\\{\"scope\":\"([^\"]*)\"\\}", {transaction_help_text_header, missing_scope_help_text}},
    {"Account not found: ([\\S]*)", {transaction_help_text_header, tx_unknown_account_help_text, unknown_account_help_text}},
    {"Error\n: 303", {transaction_help_text_header}},
-   {"unknown key[^\\x00]*abi_json_to_bin.*code\":\"([^\"]*)\".*action\":\"([^\"]*)\"", {missing_abi_help_text}},
    {"unknown key[^\\x00]*chain/get_code.*name\":\"([^\"]*)\"", {unknown_account_help_text}},
    {"Unable to open file[^\\x00]*wallet/open.*postdata\":\"([^\"]*)\"", {unknown_wallet_help_text}},
    {"AES error[^\\x00]*wallet/unlock.*postdata\":\\[\"([^\"]*)\"", {bad_wallet_password_help_text}},

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -29,7 +29,6 @@ namespace eosio { namespace client { namespace http {
    const string send_read_only_txn_func = chain_func_base + "/send_read_only_transaction";
    const string compute_txn_func = chain_func_base + "/compute_transaction";
    const string push_txns_func = chain_func_base + "/push_transactions";
-   const string json_to_bin_func = chain_func_base + "/abi_json_to_bin";
    const string get_block_func = chain_func_base + "/get_block";
    const string get_block_info_func = chain_func_base + "/get_block_info";
    const string get_block_header_state_func = chain_func_base + "/get_block_header_state";

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -550,26 +550,6 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload)
         self.assertEqual(ret_json["code"], 500)
 
-        # abi_bin_to_json with empty parameter
-        command = "abi_bin_to_json"
-        ret_json = self.nodeos.processUrllibRequest(resource, command)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # abi_bin_to_json with empty content parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # abi_bin_to_json with invalid parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # abi_bin_to_json with valid parameter
-        payload = {"code":"eosio.token",
-                   "action":"issue",
-                   "args":"ee6fff5a5c02c55b6304000000000100a6823403ea3055000000572d3ccdcd0100000000007015d600000000a8ed32322a00000000007015d6000000005c95b1ca102700000000000004454f53000000000968656c6c6f206d616e00"}
-        ret_json = self.nodeos.processUrllibRequest(resource, command, payload)
-        self.assertEqual(ret_json["code"], 500)
-
         # get_required_keys with empty parameter
         command = "get_required_keys"
         ret_json = self.nodeos.processUrllibRequest(resource, command)

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -530,26 +530,6 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload)
         self.assertEqual(type(ret_json["payload"]["transactions"]), list)
 
-        # abi_json_to_bin with empty parameter
-        command = "abi_json_to_bin"
-        ret_json = self.nodeos.processUrllibRequest(resource, command)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # abi_json_to_bin with empty content parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # abi_json_to_bin with invalid parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # abi_json_to_bin with valid parameter
-        payload = {"code":"eosio.token",
-                   "action":"issue",
-                   "args":{"to":"eosio.token", "quantity":"1.0000\%20EOS","memo":"m"}}
-        ret_json = self.nodeos.processUrllibRequest(resource, command, payload)
-        self.assertEqual(ret_json["code"], 500)
-
         # get_required_keys with empty parameter
         command = "get_required_keys"
         ret_json = self.nodeos.processUrllibRequest(resource, command)

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -2088,7 +2088,6 @@ BOOST_AUTO_TEST_CASE(abi_large_array)
 
       abi_serializer abis( fc::json::from_string( abi_str ).as<abi_def>(), abi_serializer::create_yield_function( max_serialization_time ) );
       // indicate a very large array, but don't actually provide a large array
-      // curl http://127.0.0.1:8888/v1/chain/abi_bin_to_json -X POST -d '{"code":"eosio", "action":"hi", "binargs":"ffffffff08"}'
       bytes bin = {static_cast<char>(0xff),
                    static_cast<char>(0xff),
                    static_cast<char>(0xff),


### PR DESCRIPTION
See https://github.com/AntelopeIO/leap/wiki/Deprecations-and-Proposed-Deprecations-In-Leap-Software

Remove the deprecated endpoints: 
- `/v1/chain/abi_bin_to_json`
- `/v1/chain/abi_json_to_bin`

Resolves #788 