### PR TITLE
Remove deprecated `--private-key` option from nodeos

### DIFF
--- a/docs/01_nodeos/02_usage/03_development-environment/01_local-multi-node-testnet.md
+++ b/docs/01_nodeos/02_usage/03_development-environment/01_local-multi-node-testnet.md
@@ -143,7 +143,7 @@ We now have an account that is available to have a contract assigned to it, enab
 In the fourth terminal window, start a second `nodeos` instance. Notice that this command line is substantially longer than the one we used above to create the first producer. This is necessary to avoid collisions with the first `nodeos` instance. Fortunately, you can just cut and paste this command line and adjust the keys:
 
 ```sh
-nodeos --producer-name inita --plugin eosio::chain_api_plugin --plugin eosio::net_api_plugin --http-server-address 127.0.0.1:8889 --p2p-listen-endpoint 127.0.0.1:9877 --p2p-peer-address 127.0.0.1:9876 --config-dir node2 --data-dir node2 --private-key [\"EOS6hMjoWRF2L8x9YpeqtUEcsDKAyxSuM1APicxgRU1E3oyV5sDEg\",\"5JgbL2ZnoEAhTudReWH1RnMuQS6DBeLZt4ucV6t8aymVEuYg7sr\"]
+nodeos --producer-name inita --plugin eosio::chain_api_plugin --plugin eosio::net_api_plugin --http-server-address 127.0.0.1:8889 --p2p-listen-endpoint 127.0.0.1:9877 --p2p-peer-address 127.0.0.1:9876 --config-dir node2 --data-dir node2 --signature-provider EOS6hMjoWRF2L8x9YpeqtUEcsDKAyxSuM1APicxgRU1E3oyV5sDEg=KEY:5JgbL2ZnoEAhTudReWH1RnMuQS6DBeLZt4ucV6t8aymVEuYg7sr
 ```
 
 The output from this new node will show a little activity but will stop reporting until the last step in this tutorial, when the `inita` account is registered as a producer account and activated. Here is some example output from a newly started node. Your output might look a little different, depending on how much time you took entering each of these commands. Furthermore, this example is only the last few lines of output:

--- a/docs/01_nodeos/03_plugins/producer_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/producer_plugin/index.md
@@ -39,10 +39,6 @@ Config Options for eosio::producer_plugin:
   -p [ --producer-name ] arg            ID of producer controlled by this node
                                         (e.g. inita; may specify multiple
                                         times)
-  --private-key arg                     (DEPRECATED - Use signature-provider
-                                        instead) Tuple of [public key, WIF
-                                        private key] (may specify multiple
-                                        times)
   --signature-provider arg (=EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV=KEY:5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3)
                                         Key=Value pairs in the form
                                         <public-key>=<provider-spec>

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -728,8 +728,6 @@ void producer_plugin::set_program_options(
           "Limits the maximum age (in seconds) of the DPOS Irreversible Block for a chain this node will produce blocks on (use negative value to indicate unlimited)")
          ("producer-name,p", boost::program_options::value<vector<string>>()->composing()->multitoken(),
           "ID of producer controlled by this node (e.g. inita; may specify multiple times)")
-         ("private-key", boost::program_options::value<vector<string>>()->composing()->multitoken(),
-          "(DEPRECATED - Use signature-provider instead) Tuple of [public key, WIF private key] (may specify multiple times)")
          ("signature-provider", boost::program_options::value<vector<string>>()->composing()->multitoken()->default_value(
                {default_priv_key.get_public_key().to_string() + "=KEY:" + default_priv_key.to_string()},
                 default_priv_key.get_public_key().to_string() + "=KEY:" + default_priv_key.to_string()),
@@ -829,22 +827,6 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
    LOAD_VALUE_SET(options, "producer-name", my->_producers)
 
    chain::controller& chain = my->chain_plug->chain();
-
-   if( options.count("private-key") )
-   {
-      const std::vector<std::string> key_id_to_wif_pair_strings = options["private-key"].as<std::vector<std::string>>();
-      for (const std::string& key_id_to_wif_pair_string : key_id_to_wif_pair_strings)
-      {
-         try {
-            auto key_id_to_wif_pair = dejsonify<std::pair<public_key_type, private_key_type>>(key_id_to_wif_pair_string);
-            my->_signature_providers[key_id_to_wif_pair.first] = app().get_plugin<signature_provider_plugin>().signature_provider_for_private_key(key_id_to_wif_pair.second);
-            auto blanked_privkey = std::string(key_id_to_wif_pair.second.to_string().size(), '*' );
-            wlog("\"private-key\" is DEPRECATED, use \"signature-provider=${pub}=KEY:${priv}\"", ("pub",key_id_to_wif_pair.first)("priv", blanked_privkey));
-         } catch ( const std::exception& e ) {
-            elog("Malformed private key pair");
-         }
-      }
-   }
 
    if( options.count("signature-provider") ) {
       const std::vector<std::string> key_spec_pairs = options["signature-provider"].as<std::vector<std::string>>();

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -969,7 +969,7 @@ class Cluster(object):
         with open(configFile, 'r') as f:
             configStr=f.read()
 
-        pattern=r"^\s*private-key\s*=\W+(\w+)\W+(\w+)\W+$"
+        pattern=r"^\s*signature-provider\s*=(\w+)=KEY:(\w+)$"
         m=re.search(pattern, configStr, re.MULTILINE)
         regMsg="None" if m is None else "NOT None"
         if m is None:

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -969,7 +969,7 @@ class Cluster(object):
         with open(configFile, 'r') as f:
             configStr=f.read()
 
-        pattern=r"^\s*signature-provider\s*=(\w+)=KEY:(\w+)$"
+        pattern=r"^\s*signature-provider\s*=\s*(\w+)=KEY:(\w+)$"
         m=re.search(pattern, configStr, re.MULTILINE)
         regMsg="None" if m is None else "NOT None"
         if m is None:

--- a/tests/launcher.py
+++ b/tests/launcher.py
@@ -349,7 +349,7 @@ class launcher(object):
             is_bios = node.name == 'bios'
             peers = '\n'.join([f'p2p-peer-address = {self.network.nodes[p].p2p_endpoint}' for p in node.peers])
             if len(node.producers) > 0:
-                producer_keys = f'private-key = ["{node.keys[0].pubkey}","{node.keys[0].privkey}"]\n'
+                producer_keys = f'signature-provider = {node.keys[0].pubkey}=KEY:{node.keys[0].privkey}\n'
                 producer_names = '\n'.join([f'producer-name = {p}' for p in node.producers])
                 producer_plugin = 'plugin = eosio::producer_plugin\n'
             else:

--- a/tests/p2p_tests/dawn_515/test.sh
+++ b/tests/p2p_tests/dawn_515/test.sh
@@ -50,7 +50,7 @@ http-server-address = 127.0.0.1:8888
 blocks-dir = blocks
 p2p-listen-endpoint = 0.0.0.0:9876
 allowed-connection = any
-private-key = ['EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV','5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3']
+signature-provider = EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV=KEY:5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3
 send-whole-blocks = true
 readonly = 0
 p2p-max-nodes-per-host = 10

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -118,7 +118,7 @@ def startNode(nodeIndex, account):
         '    --p2p-max-nodes-per-host ' + str(maxClients) +
         '    --enable-stale-production'
         '    --producer-name ' + account['name'] +
-        '    --private-key \'["' + account['pub'] + '","' + account['pvt'] + '"]\''
+        '    --signature-provider ' + account['pub'] + '=KEY:' + account['pvt'] +
         '    --plugin eosio::http_plugin'
         '    --plugin eosio::chain_api_plugin'
         '    --plugin eosio::chain_plugin'


### PR DESCRIPTION
Remove the the long deprecated `--private-key` option.
Use `--signature-provider` instead.

See https://github.com/AntelopeIO/leap/wiki/Deprecations-and-Proposed-Deprecations-In-Leap-Software

For example:
```
--private-key [\"EOS6hMjoWRF2L8x9YpeqtUEcsDKAyxSuM1APicxgRU1E3oyV5sDEg\",\"5JgbL2ZnoEAhTudReWH1RnMuQS6DBeLZt4ucV6t8aymVEuYg7sr\"]
```
Becomes:
```
--signature-provider EOS6hMjoWRF2L8x9YpeqtUEcsDKAyxSuM1APicxgRU1E3oyV5sDEg=KEY:5JgbL2ZnoEAhTudReWH1RnMuQS6DBeLZt4ucV6t8aymVEuYg7sr
```

Resolves #789 