### PR TITLE
fix mixed up boost test linkage in ship session_test

### DIFF
--- a/plugins/state_history_plugin/tests/session_test.cpp
+++ b/plugins/state_history_plugin/tests/session_test.cpp
@@ -1,6 +1,6 @@
 
 #define BOOST_TEST_MODULE example
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <algorithm>
 #include <boost/asio/dispatch.hpp>


### PR DESCRIPTION
SHIP's session_test is linking to boost unit test library
https://github.com/AntelopeIO/leap/blob/84c48b78e961fcbde24ed54c1097fd8593846f10/plugins/state_history_plugin/tests/CMakeLists.txt#L2
but then was using the header-only variant of boost unit test
https://github.com/AntelopeIO/leap/blob/993bcbae736a0ce8543adf89da30e8492867f644/plugins/state_history_plugin/tests/session_test.cpp#L3

This results in duplicate symbol errors on (at least) gcc12 + boost 1.81. Change to just using the static library. See more information here https://www.boost.org/doc/libs/1_81_0/libs/test/doc/html/boost_test/usage_variants.html