### PR TITLE
get_raw_block api endpoint

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -474,7 +474,7 @@ namespace eosio { namespace chain {
          virtual void     reset(const chain_id_type& chain_id, uint32_t first_block_num)      = 0;
          virtual void     flush()                                                             = 0;
 
-         virtual signed_block_ptr            read_block_by_num(uint32_t block_num)        = 0;
+         virtual signed_block_ptr                   read_block_by_num(uint32_t block_num)        = 0;
          virtual std::optional<signed_block_header> read_block_header_by_num(uint32_t block_num) = 0;
 
          virtual uint32_t version() const = 0;
@@ -1231,6 +1231,7 @@ namespace eosio { namespace chain {
    }
 
    block_id_type block_log::read_block_id_by_num(uint32_t block_num) const {
+      // read_block_header_by_num acquires mutex
       auto bh = read_block_header_by_num(block_num);
       if (bh) { return bh->calculate_id(); }
       return {};

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3093,7 +3093,7 @@ const global_property_object& controller::get_global_properties()const {
   return my->db.get<global_property_object>();
 }
 
-signed_block_ptr controller::fetch_block_by_id( block_id_type id )const {
+signed_block_ptr controller::fetch_block_by_id( const block_id_type& id )const {
    auto state = my->fork_db.get_block(id);
    if( state && state->block ) return state->block;
    auto bptr = my->blog.read_block_by_num( block_header::num_from_id(id) );
@@ -3101,10 +3101,12 @@ signed_block_ptr controller::fetch_block_by_id( block_id_type id )const {
    return signed_block_ptr();
 }
 
-std::optional<signed_block_header> controller::fetch_block_header_by_id( block_id_type id )const {
+std::optional<signed_block_header> controller::fetch_block_header_by_id( const block_id_type& id )const {
    auto state = my->fork_db.get_block(id);
    if( state && state->block ) return state->header;
-   return my->blog.read_block_header_by_num( block_header::num_from_id(id) );
+   auto result = my->blog.read_block_header_by_num( block_header::num_from_id(id) );
+   if( result && result->calculate_id() == id ) return result;
+   return {};
 }
 
 signed_block_ptr controller::fetch_block_by_number( uint32_t block_num )const  { try {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3101,6 +3101,12 @@ signed_block_ptr controller::fetch_block_by_id( block_id_type id )const {
    return signed_block_ptr();
 }
 
+std::optional<signed_block_header> controller::fetch_block_header_by_id( block_id_type id )const {
+   auto state = my->fork_db.get_block(id);
+   if( state && state->block ) return state->header;
+   return my->blog.read_block_header_by_num( block_header::num_from_id(id) );
+}
+
 signed_block_ptr controller::fetch_block_by_number( uint32_t block_num )const  { try {
    auto blk_state = fetch_block_state_by_number( block_num );
    if( blk_state ) {
@@ -3108,6 +3114,15 @@ signed_block_ptr controller::fetch_block_by_number( uint32_t block_num )const  {
    }
 
    return my->blog.read_block_by_num(block_num);
+} FC_CAPTURE_AND_RETHROW( (block_num) ) }
+
+std::optional<signed_block_header> controller::fetch_block_header_by_number( uint32_t block_num )const  { try {
+   auto blk_state = fetch_block_state_by_number( block_num );
+   if( blk_state ) {
+      return blk_state->header;
+   }
+
+   return my->blog.read_block_header_by_num(block_num);
 } FC_CAPTURE_AND_RETHROW( (block_num) ) }
 
 block_state_ptr controller::fetch_block_state_by_id( block_id_type id )const {

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -54,6 +54,7 @@ namespace eosio { namespace chain {
          void reset( const chain_id_type& chain_id, uint32_t first_block_num );
 
          signed_block_ptr read_block_by_num(uint32_t block_num)const;
+         std::optional<signed_block_header> read_block_header_by_num(uint32_t block_num)const;
          block_id_type    read_block_id_by_num(uint32_t block_num)const;
 
          signed_block_ptr read_block_by_id(const block_id_type& id)const {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -239,11 +239,11 @@ namespace eosio { namespace chain {
          // thread-safe
          signed_block_ptr fetch_block_by_number( uint32_t block_num )const;
          // thread-safe
-         signed_block_ptr fetch_block_by_id( block_id_type id )const;
+         signed_block_ptr fetch_block_by_id( const block_id_type& id )const;
          // thread-safe
          std::optional<signed_block_header> fetch_block_header_by_number( uint32_t block_num )const;
          // thread-safe
-         std::optional<signed_block_header> fetch_block_header_by_id( block_id_type id )const;
+         std::optional<signed_block_header> fetch_block_header_by_id( const block_id_type& id )const;
          // return block_state from forkdb, thread-safe
          block_state_ptr fetch_block_state_by_number( uint32_t block_num )const;
          // return block_state from forkdb, thread-safe

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -240,6 +240,10 @@ namespace eosio { namespace chain {
          signed_block_ptr fetch_block_by_number( uint32_t block_num )const;
          // thread-safe
          signed_block_ptr fetch_block_by_id( block_id_type id )const;
+         // thread-safe
+         std::optional<signed_block_header> fetch_block_header_by_number( uint32_t block_num )const;
+         // thread-safe
+         std::optional<signed_block_header> fetch_block_header_by_id( block_id_type id )const;
          // return block_state from forkdb, thread-safe
          block_state_ptr fetch_block_state_by_number( uint32_t block_num )const;
          // return block_state from forkdb, thread-safe

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -111,6 +111,11 @@ void chain_api_plugin::plugin_startup() {
       });
    }
 
+   _http_plugin.add_async_api({
+      CHAIN_RO_CALL_WITH_400(get_raw_block, 200, http_params_types::params_required),
+      CHAIN_RO_CALL_WITH_400(get_block_header, 200, http_params_types::params_required)
+   });
+
    if (chain.transaction_finality_status_enabled()) {
       _http_plugin.add_api({
          CHAIN_RO_CALL_WITH_400(get_transaction_status, 200, http_params_types::params_required),
@@ -124,9 +129,9 @@ void chain_api_plugin::plugin_startup() {
            auto deadline = ro_api.start();
            try {
               auto start = fc::time_point::now();
-              auto params = parse_params<chain_apis::read_only::get_block_params, http_params_types::params_required>(body);
+              auto params = parse_params<chain_apis::read_only::get_raw_block_params, http_params_types::params_required>(body);
               FC_CHECK_DEADLINE( deadline );
-              chain::signed_block_ptr block = ro_api.get_block( params, deadline );
+              chain::signed_block_ptr block = ro_api.get_raw_block( params, deadline );
 
               auto abi_cache = ro_api.get_block_serializers( block, max_time );
               FC_CHECK_DEADLINE( deadline );

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1909,7 +1909,7 @@ chain::signed_block_ptr read_only::get_raw_block(const read_only::get_raw_block_
 
    EOS_ASSERT( !params.block_num_or_id.empty() && params.block_num_or_id.size() <= 64,
                chain::block_id_type_exception,
-               "Invalid Block number or ID, must be greater than 0 and less than 64 characters"
+               "Invalid Block number or ID, must be greater than 0 and less than 65 characters"
    );
 
    try {
@@ -1935,7 +1935,7 @@ read_only::get_block_header_result read_only::get_block_header(const read_only::
 
    EOS_ASSERT( !params.block_num_or_id.empty() && params.block_num_or_id.size() <= 64,
                chain::block_id_type_exception,
-               "Invalid Block number or ID, must be greater than 0 and less than 64 characters"
+               "Invalid Block number or ID, must be greater than 0 and less than 65 characters"
    );
 
    try {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -325,11 +325,11 @@ public:
 
    get_transaction_id_result get_transaction_id( const get_transaction_id_params& params, const fc::time_point& deadline)const;
 
-   struct get_block_params {
+   struct get_raw_block_params {
       string block_num_or_id;
    };
 
-   chain::signed_block_ptr get_block(const get_block_params& params, const fc::time_point& deadline) const;
+   chain::signed_block_ptr get_raw_block(const get_raw_block_params& params, const fc::time_point& deadline) const;
    // call from app() thread
    std::unordered_map<account_name, std::optional<abi_serializer>>
      get_block_serializers( const chain::signed_block_ptr& block, const fc::microseconds& max_time ) const;
@@ -337,6 +337,19 @@ public:
    fc::variant convert_block( const chain::signed_block_ptr& block,
                               std::unordered_map<account_name, std::optional<abi_serializer>> abi_cache,
                               const fc::microseconds& max_time ) const;
+
+   struct get_block_header_params {
+      string block_num_or_id;
+      bool include_extensions = false; // include block extensions (requires reading entire block off disk)
+   };
+
+   struct get_block_header_result {
+      chain::block_id_type  id;
+      fc::variant           signed_block_header;
+      std::optional<chain::extensions_type> block_extensions;
+   };
+
+   get_block_header_result get_block_header(const get_block_header_params& params, const fc::time_point& deadline) const;
 
    struct get_block_info_params {
       uint32_t block_num = 0;
@@ -782,7 +795,7 @@ public:
             // which is the format used by secondary index
             uint8_t buffer[32];
             memcpy(buffer, v.data(), 32);
-            fixed_bytes<32> fb(buffer); 
+            fixed_bytes<32> fb(buffer);
             return chain::key256_t(fb.get_array());
         };
      }
@@ -800,7 +813,7 @@ public:
             // which is the format used by secondary index
             uint8_t buffer[20];
             memcpy(buffer, v.data(), 20);
-            fixed_bytes<20> fb(buffer); 
+            fixed_bytes<20> fb(buffer);
             return chain::key256_t(fb.get_array());
         };
      }
@@ -895,9 +908,11 @@ FC_REFLECT(eosio::chain_apis::read_only::get_transaction_status_results, (state)
            (head_timestamp)(irreversible_number)(irreversible_id)(irreversible_timestamp)(earliest_tracked_block_id)(earliest_tracked_block_number) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse)(time_limit_ms) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
-FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))
+FC_REFLECT(eosio::chain_apis::read_only::get_raw_block_params, (block_num_or_id))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_info_params, (block_num))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_header_state_params, (block_num_or_id))
+FC_REFLECT(eosio::chain_apis::read_only::get_block_header_params, (block_num_or_id)(include_extensions))
+FC_REFLECT(eosio::chain_apis::read_only::get_block_header_result, (id)(signed_block_header)(block_extensions))
 
 FC_REFLECT( eosio::chain_apis::read_write::push_transaction_results, (transaction_id)(processed) )
 FC_REFLECT( eosio::chain_apis::read_write::send_transaction2_params, (return_failure_trace)(retry_trx)(retry_trx_num_blocks)(transaction) )

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -30,6 +30,8 @@ namespace eosio { namespace client { namespace http {
    const string compute_txn_func = chain_func_base + "/compute_transaction";
    const string push_txns_func = chain_func_base + "/push_transactions";
    const string get_block_func = chain_func_base + "/get_block";
+   const string get_raw_block_func = chain_func_base + "/get_raw_block";
+   const string get_block_header_func = chain_func_base + "/get_block_header";
    const string get_block_info_func = chain_func_base + "/get_block_info";
    const string get_block_header_state_func = chain_func_base + "/get_block_header_state";
    const string get_account_func = chain_func_base + "/get_account";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2771,6 +2771,15 @@ struct set_url_no_trailing_slash {
    }
 };
 
+struct get_block_params {
+   string blockArg;
+   bool get_bhs = false;
+   bool get_binfo = false;
+   bool get_braw  = false;
+   bool get_bheader = false;
+   bool get_bheader_extensions = false;
+};
+
 int main( int argc, char** argv ) {
 
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
@@ -3005,29 +3014,39 @@ int main( int argc, char** argv ) {
    });
 
    // get block
-   string blockArg;
-   bool get_bhs = false;
-   bool get_binfo = false;
+   get_block_params params;
    auto getBlock = get->add_subcommand("block", localized("Retrieve a full block from the blockchain"));
-   getBlock->add_option("block", blockArg, localized("The number or ID of the block to retrieve"))->required();
-   getBlock->add_flag("--header-state", get_bhs, localized("Get block header state from fork database instead") );
-   getBlock->add_flag("--info", get_binfo, localized("Get block info from the blockchain by block num only") );
-   getBlock->callback([&blockArg, &get_bhs, &get_binfo] {
-      EOSC_ASSERT( !(get_bhs && get_binfo), "ERROR: Either --header-state or --info can be set" );
-      if (get_binfo) {
+   getBlock->add_option("block", params.blockArg, localized("The number or ID of the block to retrieve"))->required();
+   getBlock->add_flag("--header-state", params.get_bhs, localized("Get block header state from fork database instead") );
+   getBlock->add_flag("--info", params.get_binfo, localized("Get block info from the blockchain by block num only") );
+   getBlock->add_flag("--raw", params.get_braw, localized("Get raw block from the blockchain") );
+   getBlock->add_flag("--header", params.get_bheader, localized("Get block header from the blockchain") );
+   getBlock->add_flag("--header-with-extensions", params.get_bheader_extensions, localized("Get block header with block exntesions from the blockchain") );
+
+   getBlock->callback([&params] {
+      int num_flags = params.get_bhs + params.get_binfo + params.get_braw + params.get_bheader + params.get_bheader_extensions;
+      EOSC_ASSERT( num_flags <= 1, "ERROR: Only one of the following flags can be set: --header-state, --info, --raw, --header, --header-with-extensions." );
+      if (params.get_binfo) {
          std::optional<int64_t> block_num;
          try {
-            block_num = fc::to_int64(blockArg);
+            block_num = fc::to_int64(params.blockArg);
          } catch (...) {
             // error is handled in assertion below
          }
-         EOSC_ASSERT( block_num.has_value() && (*block_num > 0), "Invalid block num: ${block_num}", ("block_num", blockArg) );
+         EOSC_ASSERT( block_num.has_value() && (*block_num > 0), "Invalid block num: ${block_num}", ("block_num", params.blockArg) );
          const auto arg = fc::variant_object("block_num", static_cast<uint32_t>(*block_num));
          std::cout << fc::json::to_pretty_string(call(get_block_info_func, arg)) << std::endl;
       } else {
-         const auto arg = fc::variant_object("block_num_or_id", blockArg);
-         if (get_bhs) {
+         const auto arg = fc::variant_object("block_num_or_id", params.blockArg);
+         if (params.get_bhs) {
             std::cout << fc::json::to_pretty_string(call(get_block_header_state_func, arg)) << std::endl;
+         } else if (params.get_braw) {
+            std::cout << fc::json::to_pretty_string(call(get_raw_block_func, arg)) << std::endl;
+         } else if (params.get_bheader || params.get_bheader_extensions) {
+            std::cout << fc::json::to_pretty_string(
+               call(get_block_header_func,
+                    fc::mutable_variant_object("block_num_or_id", params.blockArg)
+                                              ("include_extensions", params.get_bheader_extensions))) << std::endl;
          } else {
             std::cout << fc::json::to_pretty_string(call(get_block_func, arg)) << std::endl;
          }

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -88,11 +88,11 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
 
    char headnumstr[20];
    sprintf(headnumstr, "%d", headnum);
-   chain_apis::read_only::get_block_params param{headnumstr};
+   chain_apis::read_only::get_raw_block_params param{headnumstr};
    chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
 
    // block should be decoded successfully
-   auto block = plugin.get_block(param, fc::time_point::maximum());
+   auto block = plugin.get_raw_block(param, fc::time_point::maximum());
    auto abi_cache = plugin.get_block_serializers(block, fc::microseconds::maximum());
    std::string block_str = json::to_pretty_string(plugin.convert_block(block, abi_cache, fc::microseconds::maximum()));
    BOOST_TEST(block_str.find("procassert") != std::string::npos);
@@ -112,7 +112,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    BOOST_CHECK_THROW(resolver("asserter"_n), invalid_type_inside_abi);
 
    // get the same block as string, results in decode failed(invalid abi) but not exception
-   auto block2 = plugin.get_block(param, fc::time_point::maximum());
+   auto block2 = plugin.get_raw_block(param, fc::time_point::maximum());
    auto abi_cache2 = plugin.get_block_serializers(block2, fc::microseconds::maximum());
    std::string block_str2 = json::to_pretty_string(plugin.convert_block(block2, abi_cache2, fc::microseconds::maximum()));
    BOOST_TEST(block_str2.find("procassert") != std::string::npos);
@@ -185,7 +185,7 @@ BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
       BOOST_REQUIRE_EQUAL(2, result.permissions.size());
       if (result.permissions.size() > 1) {
          auto perm = result.permissions[0];
-         BOOST_REQUIRE_EQUAL(name("active"_n), perm.perm_name); 
+         BOOST_REQUIRE_EQUAL(name("active"_n), perm.perm_name);
          BOOST_REQUIRE_EQUAL(name("owner"_n), perm.parent);
          auto auth = perm.required_auth;
          BOOST_REQUIRE_EQUAL(1, auth.threshold);
@@ -194,8 +194,8 @@ BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
          BOOST_REQUIRE_EQUAL(0, auth.waits.size());
 
          perm = result.permissions[1];
-         BOOST_REQUIRE_EQUAL(name("owner"_n), perm.perm_name); 
-         BOOST_REQUIRE_EQUAL(name(""_n), perm.parent); 
+         BOOST_REQUIRE_EQUAL(name("owner"_n), perm.perm_name);
+         BOOST_REQUIRE_EQUAL(name(""_n), perm.parent);
          auth = perm.required_auth;
          BOOST_REQUIRE_EQUAL(1, auth.threshold);
          BOOST_REQUIRE_EQUAL(1, auth.keys.size());

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -120,6 +120,14 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    BOOST_TEST(block_str2.find("Should Not Assert!") == std::string::npos); // decode failed
    BOOST_TEST(block_str2.find("011253686f756c64204e6f742041737365727421") != std::string::npos); //action data
 
+
+   chain_apis::read_only::get_block_header_params bh_param{headnumstr, false};
+   auto get_bh_result = plugin.get_block_header(bh_param, fc::time_point::maximum());
+
+   BOOST_TEST(get_bh_result.id == block->calculate_id());
+   BOOST_TEST(json::to_string(get_bh_result.signed_block_header, fc::time_point::maximum()) ==
+              json::to_string(fc::variant{static_cast<signed_block_header&>(*block)}, fc::time_point::maximum()));
+
 } FC_LOG_AND_RETHROW() /// get_block_with_invalid_abi
 
 BOOST_FIXTURE_TEST_CASE( get_consensus_parameters, TESTER ) try {

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -250,6 +250,43 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload)
         self.assertEqual(ret_json["payload"]["block_num"], 1)
 
+        # get_raw_block with empty parameter
+        command = "get_raw_block"
+        ret_json = self.nodeos.processUrllibRequest(resource, command)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block with empty content parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block with invalid parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block with valid parameter
+        payload = {"block_num_or_id":1}
+        ret_json = self.nodeos.processUrllibRequest(resource, command, payload)
+        self.assertTrue("action_mroot" in ret_json["payload"])
+
+        # get_block_header with empty parameter
+        command = "get_block_header"
+        ret_json = self.nodeos.processUrllibRequest(resource, command)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block with empty content parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block with invalid parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block with valid parameters
+        payload = {"block_num_or_id":1, "include_extensions": True}
+        ret_json = self.nodeos.processUrllibRequest(resource, command, payload)
+        self.assertTrue("id" in ret_json["payload"])
+        self.assertTrue("signed_block_header" in ret_json["payload"])
+        self.assertTrue("block_extensions" in ret_json["payload"])
+        payload = {"block_num_or_id":1, "include_extensions": False}
+        ret_json = self.nodeos.processUrllibRequest(resource, command, payload)
+        self.assertTrue("id" in ret_json["payload"])
+        self.assertTrue("signed_block_header" in ret_json["payload"])
+        self.assertFalse("block_extensions" in ret_json["payload"])
+
         # get_block_info with empty parameter
         command =  "get_block_info"
         ret_json = self.nodeos.processUrllibRequest(resource, command)


### PR DESCRIPTION
This PR 
- adds the following API endpoints 
   * `/v1/chain/get_raw_block`: returns the raw block content without ABI decoding
   * `/v1/chain/get_block_header`: returns the block header with optional block extensions
      - Input/output: 
   ```
   struct get_raw_block_header_params {
      string block_num_or_id;
      bool include_extensions = false; // include block extensions (requires reading entire block off disk)
   }; 
  
   struct get_raw_block_header_results {
      chain::block_id_type  id;
      fc::variant           signed_block_header;
      std::optional<chain::extensions_type> block_extensions;
   };
   ```
- add `cleos get block` options for the added API endpoints above
  * `--raw`: corresponding to `get_raw_block`
  * `--header`: corresponding to `get_block_header` with `include_extensions` set to false
  * `--header_with_extensions`: corresponding to `get_block_header` with `include_extensions` set to true

Resolves #642 