### PR TITLE
Fix Pinned Build on Ubuntu 22.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,29 +77,9 @@ if(ENABLE_OC AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT WIN32)
       list(APPEND EOSIO_WASM_RUNTIMES eos-vm-oc)
       # EOS VM OC requires LLVM, but move the check up here to a central location so that the EosioTester.cmakes
       # can be created with the exact version found
-      # find_package VERSION range is only available in 3.19 and newer.
-      if(${CMAKE_VERSION} VERSION_LESS "3.19")
-         find_package(LLVM REQUIRED CONFIG)
-      else()
-         # Preferring the latest LLVM version, search through major 11..7 and minor 9..0 in reverse order.
-         # Minor versions may break API. This manifests in the LLVM config files such that a range of `11...<12`
-         # will NOT find LLVM `11.1`. We loop over minor as well as major to resolve this.
-         set(max_minor 9)
-         set(major 11)
-         set(minor ${max_minor})
-         while(NOT LLVM_FOUND AND major GREATER_EQUAL 7)
-            math(EXPR end "${major} + 1")
-            find_package(LLVM ${major}.${minor}...<${end} CONFIG QUIET)
-            if(minor GREATER 0)
-               math(EXPR minor "${minor} - 1")
-            else()
-               math(EXPR major "${major} - 1")
-               set(minor ${max_minor})
-            endif()
-         endwhile()
-      endif()
+      find_package(LLVM REQUIRED CONFIG)
       if(LLVM_VERSION_MAJOR VERSION_LESS 7 OR LLVM_VERSION_MAJOR VERSION_GREATER_EQUAL 12)
-         message(FATAL_ERROR "Leap requires an LLVM version 7 through 11")
+	      message(FATAL_ERROR "Leap requires an LLVM version 7 through 11")
       endif()
    endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -146,11 +146,9 @@ To build, make sure you are in the root of the `leap` repo, then run the followi
 ```bash
 mkdir -p build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/llvm-11 ..
 make -j "$(nproc)" package
 ```
-
-If CMake fails to find a valid llvm configure file, it may be necessary to add `-DCMAKE_PREFIX_PATH=/usr/lib/llvm-11` to the cmake command.
 </details>
 
 <details> <summary>Ubuntu 18.04 Bionic</summary>


### PR DESCRIPTION
From [issue 735](https://github.com/AntelopeIO/leap/issues/735), this reverts [pull request 799](https://github.com/AntelopeIO/leap/pull/799) (Search for LLVM versions 7-11, prefering latest version) to fix the pinned build on Ubuntu 22.04. There are no other changes in this PR besides the revert.

[Pull request 799](https://github.com/AntelopeIO/leap/pull/799) introduced code that attempts to automagically find the correct version of LLVM for the Leap build on systems that have multiple versions of LLVM installed and available. This code only runs when `cmake` is version 3.19 or newer. Ubuntu 22.04 ships with CMake version 3.22.1, following the new code path, whereas Ubuntu 20.04 ships with version 3.16.3 that does not follow the new code path. This explains why the pinned build only fails on Ubuntu 22.04.

I have verified the Ubuntu 22.04 pinned build works on this branch.

Credit to @spoonincode for identifying the cause of the bug.

## See Also
- [Pull Request 811](https://github.com/AntelopeIO/leap/pull/811) - Pinned Build Script Changes + Restore `libcurl4-openssl-dev`
- [Pull Request 812](https://github.com/AntelopeIO/leap/pull/812) - Pinned Build Script Linter Changes
- [Pull Request 832](https://github.com/AntelopeIO/leap/pull/832) - Roll `install_deps.sh` into `pinned_build.sh`
- [Pull Request 833](https://github.com/AntelopeIO/leap/pull/833) - Fix Pinned Build on Ubuntu 22.04
  - Reverts [pull request 799](https://github.com/AntelopeIO/leap/pull/799)
- [Pull Request 835](https://github.com/AntelopeIO/leap/pull/835) - Change ASCII Art Banner in Build Script