### PR TITLE
prevent the LLVM libraries bundled with clang binary from being discovered in pinned builds

### DIFF
--- a/scripts/pinned_build.sh
+++ b/scripts/pinned_build.sh
@@ -75,6 +75,8 @@ install_clang() {
       try tar -xvf ${CLANG_FN} -C ${CLANG_DIR}
       pushdir ${CLANG_DIR}
       mv clang+*/* .
+      #prevent LLVM bundled with clang from being discovered by cmake
+      try rm -r lib/cmake
       popdir ${DEP_DIR}
       rm ${CLANG_FN}
    fi
@@ -132,7 +134,7 @@ pushdir ${LEAP_DIR}
 
 # build Leap
 echo "Building Leap ${SCRIPT_DIR}"
-try cmake -DCMAKE_TOOLCHAIN_FILE=${SCRIPT_DIR}/pinned_toolchain.cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${LLVM_DIR}/lib/cmake -DCMAKE_PREFIX_PATH=${BOOST_DIR}/bin ${SCRIPT_DIR}/..
+try cmake -DCMAKE_TOOLCHAIN_FILE=${SCRIPT_DIR}/pinned_toolchain.cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${LLVM_DIR}/lib/cmake;${BOOST_DIR}/bin" ${SCRIPT_DIR}/..
 
 try make -j${JOBS}
 try cpack


### PR DESCRIPTION
This fixes a failure of the pinned builds on ubuntu 22.04 that was bubbled up due to changes in #799

cmake has a well defined order in which it searches for packages when doing a `find_package()`. Critically, `CMAKE_PREFIX_PATH` locations are searched before searching something like `PATH`. This meant, previously, when searching for LLVM without a specific version we'd find the LLVM we built in the specified `CMAKE_PREFIX_PATH` early on during the search (except.. for see below). However the new version searching logic has the side effect of searching only for, say, LLVM 11.0 before it falls back to searching for LLVM 7.0. This means it ends up finding the incompatible LLVM 11.0 shipped in the clang binary via `PATH` and uses that instead.

Just remove the LLVM cmake files shipped with the compiler binary so cmake doesn't end up finding them. This compiler is intended for pinned leap builds only, so "damaging" it seems okay.

But wait! There's more!

The script was originally doing `-DCMAKE_PREFIX_PATH=${LLVM_DIR}/lib/cmake -DCMAKE_PREFIX_PATH=${BOOST_DIR}/bin` but these do not compound in to a list: the second parameter overwrites the first. This meant `${LLVM_DIR}/lib/cmake` _was actually not_ in the `CMAKE_PREFIX_PATH` search path! So how did this work before? :woman_shrugging: :shrug: :man_shrugging: I didn't dig more on that.