### PR TITLE
Restore libcurl4-openssl-dev

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -4,4 +4,23 @@ apt-get update --fix-missing
 DEBIAN_FRONTEND='noninteractive'
 TZ='Etc/UTC'
 apt-get install -y tzdata
-apt-get install -y zip unzip libncurses5 wget git build-essential cmake curl libgmp-dev libssl-dev libzstd-dev time zlib1g-dev libtinfo-dev bzip2 libbz2-dev python3 python3-numpy file
+apt-get install -y \
+    build-essential \
+    bzip2 \
+    cmake \
+    curl \
+    file \
+    git \
+    libbz2-dev \
+    libgmp-dev \
+    libncurses5 \
+    libssl-dev \
+    libtinfo-dev \
+    libzstd-dev \
+    python3 \
+    python3-numpy \
+    time \
+    unzip \
+    wget \
+    zip \
+    zlib1g-dev

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -12,6 +12,7 @@ apt-get install -y \
     file \
     git \
     libbz2-dev \
+    libcurl4-openssl-dev \
     libgmp-dev \
     libncurses5 \
     libssl-dev \

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -2,7 +2,7 @@
 apt-get update
 apt-get update --fix-missing
 export DEBIAN_FRONTEND='noninteractive'
-TZ='Etc/UTC'
+export TZ='Etc/UTC'
 apt-get install -y \
     build-essential \
     bzip2 \

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -3,7 +3,6 @@ apt-get update
 apt-get update --fix-missing
 DEBIAN_FRONTEND='noninteractive'
 TZ='Etc/UTC'
-apt-get install -y tzdata
 apt-get install -y \
     build-essential \
     bzip2 \
@@ -21,6 +20,7 @@ apt-get install -y \
     python3 \
     python3-numpy \
     time \
+    tzdata \
     unzip \
     wget \
     zip \

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-
 apt-get update
 apt-get update --fix-missing
-DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
+DEBIAN_FRONTEND=noninteractive
+TZ=Etc/UTC
+apt-get -y install tzdata
 apt-get -y install zip unzip libncurses5 wget git build-essential cmake curl libgmp-dev libssl-dev libzstd-dev time zlib1g-dev libtinfo-dev bzip2 libbz2-dev python3 python3-numpy file

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 apt-get update
 apt-get update --fix-missing
-DEBIAN_FRONTEND=noninteractive
-TZ=Etc/UTC
+DEBIAN_FRONTEND='noninteractive'
+TZ='Etc/UTC'
 apt-get install -y tzdata
 apt-get install -y zip unzip libncurses5 wget git build-essential cmake curl libgmp-dev libssl-dev libzstd-dev time zlib1g-dev libtinfo-dev bzip2 libbz2-dev python3 python3-numpy file

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -3,5 +3,5 @@ apt-get update
 apt-get update --fix-missing
 DEBIAN_FRONTEND=noninteractive
 TZ=Etc/UTC
-apt-get -y install tzdata
-apt-get -y install zip unzip libncurses5 wget git build-essential cmake curl libgmp-dev libssl-dev libzstd-dev time zlib1g-dev libtinfo-dev bzip2 libbz2-dev python3 python3-numpy file
+apt-get install -y tzdata
+apt-get install -y zip unzip libncurses5 wget git build-essential cmake curl libgmp-dev libssl-dev libzstd-dev time zlib1g-dev libtinfo-dev bzip2 libbz2-dev python3 python3-numpy file

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 apt-get update
 apt-get update --fix-missing
-DEBIAN_FRONTEND='noninteractive'
+export DEBIAN_FRONTEND='noninteractive'
 TZ='Etc/UTC'
 apt-get install -y \
     build-essential \


### PR DESCRIPTION
From [issue 735](https://github.com/AntelopeIO/leap/issues/735), this pull request fixes the pinned build by returning the `libcurl4-openssl-dev` dependency.

## See Also
- [Pull Request 811](https://github.com/AntelopeIO/leap/pull/811) - Pinned Build Script Changes + Restore `libcurl4-openssl-dev`
- [Pull Request 812](https://github.com/AntelopeIO/leap/pull/812) - Pinned Build Script Linter Changes
- [Pull Request 832](https://github.com/AntelopeIO/leap/pull/832) - Roll `install_deps.sh` into `pinned_build.sh`
- [Pull Request 833](https://github.com/AntelopeIO/leap/pull/833) - Fix Pinned Build on Ubuntu 22.04
  - Reverts [pull request 799](https://github.com/AntelopeIO/leap/pull/799)
- [Pull Request 835](https://github.com/AntelopeIO/leap/pull/835) - Change ASCII Art Banner in Build Script