### PR TITLE
fix comparison of different signedness warning in log_index

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -1533,7 +1533,7 @@ namespace eosio { namespace chain {
       ilog("blocks.log and blocks.index agree on number of blocks");
 
       if (interval == 0) {
-         interval = std::max((log_bundle.log_index.num_blocks() + 7) >> 3, 1);
+         interval = std::max((log_bundle.log_index.num_blocks() + 7u) >> 3, 1u);
       }
       uint32_t expected_block_num = log_bundle.log_data.first_block_num();
 

--- a/libraries/chain/include/eosio/chain/log_index.hpp
+++ b/libraries/chain/include/eosio/chain/log_index.hpp
@@ -32,7 +32,7 @@ class log_index {
    bool is_open() const { return file_.is_open(); }
 
    uint64_t back() { return nth_block_position(num_blocks()-1); }
-   int      num_blocks() const { return num_blocks_; }
+   unsigned num_blocks() const { return num_blocks_; }
    uint64_t nth_block_position(uint32_t n) {
       file_.seek(n*sizeof(uint64_t));
       uint64_t r;


### PR DESCRIPTION
fixes
```
/leap/libraries/chain/block_log.cpp: In static member function 'static void eosio::chain::block_log::smoke_test(const fc::path&, uint32_t)':
/leap/libraries/chain/block_log.cpp:1540:34: warning: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int' [-Wsign-compare]
 1540 |       for (uint32_t pos = 0; pos < log_bundle.log_index.num_blocks(); pos += interval, expected_block_num += interval) {
```

I elected to return `unsigned` instead of `size_t` because it makes the `std::max()` easier w/o c++23 size_t literals.