### PR TITLE
[4.0 -> main] Test Fix: Pass a large time limit to get table call

### DIFF
--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -346,7 +346,7 @@ class NodeosQueries:
         return self.processCleosCmd(cmd, cmdDesc, silentErrors=False, exitOnError=exitOnError, exitMsg=msg, returnType=returnType)
 
     def getTable(self, contract, scope, table, exitOnError=False):
-        cmdDesc = "get table"
+        cmdDesc = "get table --time-limit 999"
         cmd="%s %s %s %s" % (cmdDesc, contract, scope, table)
         msg="contract=%s, scope=%s, table=%s" % (contract, scope, table);
         return self.processCleosCmd(cmd, cmdDesc, exitOnError=exitOnError, exitMsg=msg)


### PR DESCRIPTION
Modify integration tests to pass a large time-limit to get table calls so it does not have to handle the timeout `more=true` if the default 10ms is not enough time.

Merges #852 into `main`.
Resolves #850 