### PR TITLE
fix noisy `ignoring packed attribute` warning on `IR::ControlStructureImm`

### DIFF
--- a/libraries/wasm-jit/Include/IR/Operators.h
+++ b/libraries/wasm-jit/Include/IR/Operators.h
@@ -12,10 +12,11 @@ namespace IR
 	struct NoImm {};
 	struct MemoryImm {};
 
+	PACKED_STRUCT(
 	struct ControlStructureImm
 	{
 		ResultType resultType{};
-	};
+	});
 
 	struct BranchImm
 	{

--- a/libraries/wasm-jit/Include/IR/Operators.h
+++ b/libraries/wasm-jit/Include/IR/Operators.h
@@ -676,3 +676,18 @@ namespace IR
 
 	IR_API const char* getOpcodeName(Opcode opcode);
 }
+
+//paranoia for future platforms
+static_assert(sizeof(IR::OpcodeAndImm<IR::NoImm>) == 2);
+static_assert(sizeof(IR::OpcodeAndImm<IR::MemoryImm>) == 2);
+static_assert(sizeof(IR::OpcodeAndImm<IR::ControlStructureImm>) == 3);
+static_assert(sizeof(IR::OpcodeAndImm<IR::BranchImm>) == 6);
+static_assert(sizeof(IR::OpcodeAndImm<IR::BranchTableImm>) == 18);
+static_assert(sizeof(IR::OpcodeAndImm<IR::LiteralImm<I32>>) == 6);
+static_assert(sizeof(IR::OpcodeAndImm<IR::LiteralImm<I64>>) == 10);
+static_assert(sizeof(IR::OpcodeAndImm<IR::LiteralImm<F32>>) == 6);
+static_assert(sizeof(IR::OpcodeAndImm<IR::LiteralImm<F64>>) == 10);
+static_assert(sizeof(IR::OpcodeAndImm<IR::GetOrSetVariableImm<false>>) == 6);
+static_assert(sizeof(IR::OpcodeAndImm<IR::CallImm>) == 6);
+static_assert(sizeof(IR::OpcodeAndImm<IR::CallIndirectImm>) == 6);
+static_assert(sizeof(IR::OpcodeAndImm<IR::LoadOrStoreImm<0>>) == 10);


### PR DESCRIPTION
There is a noisy warning on at least gcc12,
```
In file included from /home/spoon/f/leap/src/libraries/wasm-jit/Include/Inline/Serialization.h:3,
                 from /home/spoon/f/leap/src/libraries/wasm-jit/Source/WASM/WASMSerialization.cpp:3:
/home/spoon/f/leap/src/libraries/wasm-jit/Include/IR/Operators.h: In instantiation of ‘struct IR::OpcodeAndImm<IR::ControlStructureImm>’:
/home/spoon/f/leap/src/libraries/wasm-jit/Include/IR/Operators.h:637:4:   required from here
/home/spoon/f/leap/src/libraries/wasm-jit/Include/IR/Operators.h:591:21: warning: ignoring packed attribute because of unpacked non-POD field ‘IR::ControlStructureImm IR::OpcodeAndImm<IR::ControlStructureImm>::imm’
  591 |                 Imm imm;
      |                     ^~~
/home/spoon/f/leap/src/libraries/wasm-jit/Include/Platform/Platform.h:15:35: note: in definition of macro ‘PACKED_STRUCT’
   15 | #define PACKED_STRUCT(definition) definition __attribute__((packed));
      |                                   ^~~~~~~~~~
```
(and in many other locations)

This is actually a fairly alarming warning on first look. WAVM's WebAssembly parser -- consensus code -- parses the binary WebAssembly bytes by casting to various `OpcodeAndImm<>` and then advancing based on `sizeof(OpcodeAndImm<>)`
https://github.com/AntelopeIO/leap/blob/bef672aae24a061b8b10b30ca6de6f4cf7718320/libraries/wasm-jit/Include/IR/Operators.h#L627-L634
That the compiler is warning it's ignoring a packed attribute for a struct used in the above manner could obviously be very problematic! Fortunately, presumably because `ControlStructureImm` is simply made up of a `uint8_t`
https://github.com/AntelopeIO/leap/blob/bef672aae24a061b8b10b30ca6de6f4cf7718320/libraries/wasm-jit/Include/IR/Operators.h#L15-L18
the unpacked layout and `sizeof(IR::OpcodeAndImm<IR::ControlStructureImm>)` ends up being what is required anyways. At least on x86_64 & ARM8. It's not clear to me if such layout and/or `sizeof` is guaranteed across all platforms.

I've added `PACKED_STRUCT()` to `IR::ControlStructureImm` to silence the warning, but also added a bunch of `static_asserts()` to verify these stay what they need to stay as; especially on an unknown future platform like POWER or something. All these `static_asserts()` pass as-is before adding the `PACKED_STRUCT()`. I'm pushing this as two separate commit pushes so it's easy to verify that claim with two automatic CI builds.