### PR TITLE
[4.0 -> main] Increase robustness of snapshot diff python test

### DIFF
--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -346,7 +346,7 @@ class NodeosQueries:
         return self.processCleosCmd(cmd, cmdDesc, silentErrors=False, exitOnError=exitOnError, exitMsg=msg, returnType=returnType)
 
     def getTable(self, contract, scope, table, exitOnError=False):
-        cmdDesc = "get table"
+        cmdDesc = "get table --time-limit 999"
         cmd="%s %s %s %s" % (cmdDesc, contract, scope, table)
         msg="contract=%s, scope=%s, table=%s" % (contract, scope, table);
         return self.processCleosCmd(cmd, cmdDesc, exitOnError=exitOnError, exitMsg=msg)


### PR DESCRIPTION
Bringing in https://github.com/AntelopeIO/leap/pull/856 to main

This PR mitigates rare and annoying issue of the test failing when there is a new block happening in between of scheduling and "now" create_snapshot calls. The fix is to execute create_snapshot first and schedule programmable snapshot at exact same block num. Same as with irreversible one.