### PR TITLE
[4.0] Return Lost Changes to Node.py Functions

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -1727,4 +1727,7 @@ class Cluster(object):
                 for line in f:
                     firstTrxs.append(line.rstrip('\n'))
         Utils.Print(f"first transactions: {firstTrxs}")
-        node.waitForTransactionsInBlock(firstTrxs)
+        status = node.waitForTransactionsInBlock(firstTrxs)
+        if status is None:
+            Utils.Print('ERROR: Failed to spin up transaction generators: never received first transactions')
+        return status

--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -118,10 +118,10 @@ class NodeosQueries:
         # could be a transaction response
         if cntxt.hasKey("processed"):
             cntxt.add("processed")
-            cntxt.add("action_traces")
-            cntxt.index(0)
             if not cntxt.isSectionNull("except"):
                 return "no_block"
+            cntxt.add("action_traces")
+            cntxt.index(0)
             return cntxt.add("block_num")
 
         # or what the trace api plugin returns
@@ -242,7 +242,7 @@ class NodeosQueries:
         assert(isinstance(transId, str))
         exitOnErrorForDelayed=not delayedRetry and exitOnError
         timeout=3
-        cmdDesc="get transaction_trace"
+        cmdDesc=self.fetchTransactionCommand()
         cmd="%s %s" % (cmdDesc, transId)
         msg="(transaction id=%s)" % (transId);
         for i in range(0,(int(60/timeout) - 1)):
@@ -295,8 +295,8 @@ class NodeosQueries:
         refBlockNum=None
         key=""
         try:
-            key="[transaction][transaction_header][ref_block_num]"
-            refBlockNum=trans["transaction_header"]["ref_block_num"]
+            key = self.fetchKeyCommand()
+            refBlockNum = self.fetchRefBlock(trans)
             refBlockNum=int(refBlockNum)+1
         except (TypeError, ValueError, KeyError) as _:
             Utils.Print("transaction%s not found. Transaction: %s" % (key, trans))
@@ -347,8 +347,8 @@ class NodeosQueries:
 
     def getTable(self, contract, scope, table, exitOnError=False):
         cmdDesc = "get table --time-limit 999"
-        cmd="%s %s %s %s" % (cmdDesc, contract, scope, table)
-        msg="contract=%s, scope=%s, table=%s" % (contract, scope, table);
+        cmd=f"{cmdDesc} {self.cleosLimit} {contract} {scope} {table}"
+        msg=f"contract={contract}, scope={scope}, table={table}"
         return self.processCleosCmd(cmd, cmdDesc, exitOnError=exitOnError, exitMsg=msg)
 
     def getTableAccountBalance(self, contract, scope):
@@ -529,7 +529,7 @@ class NodeosQueries:
             return m.group(1)
         except subprocess.CalledProcessError as ex:
             end=time.perf_counter()
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             Utils.Print("ERROR: Exception during code hash retrieval.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
             return None
 
@@ -580,8 +580,9 @@ class NodeosQueries:
         except subprocess.CalledProcessError as ex:
             if not silentErrors:
                 end=time.perf_counter()
-                msg=ex.output.decode("utf-8")
-                errorMsg="Exception during \"%s\". Exception message: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, end-start, exitMsg)
+                out=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
+                errorMsg="Exception during \"%s\". Exception message: %s.  stdout: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, out, end-start, exitMsg)
                 if exitOnError:
                     Utils.cmdError(errorMsg)
                     Utils.errorExit(errorMsg)

--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -107,7 +107,7 @@ class Transactions(NodeosQueries):
                 self.trackCmdTransaction(trans, reportStatus=reportStatus)
         except subprocess.CalledProcessError as ex:
             end=time.perf_counter()
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             Utils.Print("ERROR: Exception during funds transfer.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
             if exitOnError:
                 Utils.cmdError("could not transfer \"%s\" from %s to %s" % (amountStr, source, destination))
@@ -131,7 +131,7 @@ class Transactions(NodeosQueries):
                 Utils.Print("cmd Duration: %.3f sec" % (end-start))
         except subprocess.CalledProcessError as ex:
             end=time.perf_counter()
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             Utils.Print("ERROR: Exception during spawn of funds transfer.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
             if exitOnError:
                 Utils.cmdError("could not transfer \"%s\" from %s to %s" % (amountStr, source, destination))
@@ -158,15 +158,15 @@ class Transactions(NodeosQueries):
         except subprocess.CalledProcessError as ex:
             if not shouldFail:
                 end=time.perf_counter()
-                msg=ex.output.decode("utf-8")
-                Utils.Print("ERROR: Exception during set contract.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
+                out=ex.output.decode("utf-8")
+                msg=ex.stderr.decode("utf-8")
+                Utils.Print("ERROR: Exception during set contract. stderr: %s.  stdout: %s.  cmd Duration: %.3f sec." % (msg, out, end-start))
                 return None
             else:
                 retMap={}
                 retMap["returncode"]=ex.returncode
                 retMap["cmd"]=ex.cmd
                 retMap["output"]=ex.output
-                retMap["stdout"]=ex.stdout
                 retMap["stderr"]=ex.stderr
                 return retMap
 
@@ -213,7 +213,7 @@ class Transactions(NodeosQueries):
                 Utils.Print("cmd Duration: %.3f sec" % (end-start))
             return (NodeosQueries.getTransStatus(retTrans) == 'executed', retTrans)
         except subprocess.CalledProcessError as ex:
-            msg=ex.output.decode("utf-8")
+            msg=ex.stderr.decode("utf-8")
             if not silentErrors:
                 end=time.perf_counter()
                 Utils.Print("ERROR: Exception during push transaction.  cmd Duration=%.3f sec.  %s" % (end - start, msg))
@@ -245,7 +245,6 @@ class Transactions(NodeosQueries):
         except subprocess.CalledProcessError as ex:
             msg=ex.stderr.decode("utf-8")
             output=ex.output.decode("utf-8")
-            msg=ex.output.decode("utf-8")
             if not silentErrors:
                 end=time.perf_counter()
                 Utils.Print("ERROR: Exception during push message. stderr: %s. stdout: %s.  cmd Duration=%.3f sec." % (msg, output, end - start))

--- a/tests/nodeos_snapshot_diff_test.py
+++ b/tests/nodeos_snapshot_diff_test.py
@@ -133,7 +133,8 @@ try:
                                 acctPrivKeysList=[account1PrivKey,account2PrivKey], nodeId=snapshotNodeId, tpsPerGenerator=targetTpsPerGenerator,
                                 numGenerators=trxGeneratorCnt, durationSec=testTrxGenDurationSec, waitToComplete=False)
 
-    cluster.waitForTrxGeneratorsSpinup(nodeId=snapshotNodeId, numGenerators=trxGeneratorCnt)
+    status = cluster.waitForTrxGeneratorsSpinup(nodeId=snapshotNodeId, numGenerators=trxGeneratorCnt)
+    assert status is not None, "ERROR: Failed to spinup Transaction Generators"
 
     blockNum=node0.getBlockNum(BlockType.head)
     timePerBlock=500

--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -118,7 +118,8 @@ try:
                                 tpsPerGenerator=targetTpsPerGenerator, numGenerators=trxGeneratorCnt, durationSec=testTrxGenDurationSec,
                                 waitToComplete=False)
 
-    cluster.waitForTrxGeneratorsSpinup(nodeId=node0.nodeId, numGenerators=trxGeneratorCnt)
+    status = cluster.waitForTrxGeneratorsSpinup(nodeId=node0.nodeId, numGenerators=trxGeneratorCnt)
+    assert status is not None, "ERROR: Failed to spinup Transaction Generators"
 
     blockNum=head(node0)
     timePerBlock=500


### PR DESCRIPTION
A number of changes to functions in Node.py were lost as a result of the splitting of Node.py into itself plus 2 additional files.  This PR returns all those lost changes. 

Process for finding missing changes:

Last commit prior to merge was df5ad0c,
First commit prior to branch was bf4267e

Therefore, every change that happened in the diff of the two must be reflected in the current main code.
Diff: https://www.diffchecker.com/dYC5EHTW/

```
getTransBlockNum -> Moved to queries.py
Moved a piece of code

stdinAndCheckOutput still in Node.py, merge caught change

getTransaction -> Moved to queries.py
"get transaction_trace" replaced with lambda call

getBlockNumByTransId -> moved to queries.py
key and refBlockNum both now use a lambda

createInitializeAccount -> Moved to transactions.py
 self.waitForTransInBlock(transId) was replaced by self.waitForTransactionInBlock(transId)
This was caught by an earlier merge

createAccount -> moved to transactions.py
 self.waitForTransInBlock(transId) was replaced by self.waitForTransactionInBlock(transId)
This was caught by an earlier merge

getTable -> moved to queries.py
self.cleosLimit was added to cmd, along with an additional %s to hold it

waitForTransInBlock renamed to waitForTransactionInBlock, still in Node.py

checkBlockForTransactions
new, and added to Node.py, unchanged on merge

waitForTransactionsInBlockRange
new, and added to Node.py, unchanged on merge

waitForTransactionsInBlock
new, and added to Node.py, was intentionally changed in Python Port PR
waitForTrxGeneratorsSpinup called this and needed to be changed due to now returning a status. Updated nodeos_snapshot_diff_tests.py and nodeos_startup_catchup.py as a result.

transferFunds -> moved to transactions.py
  msg=ex.output.decode("utf-8") changed to msg=ex.stderr.decode("utf-8")

transferFundsAsync-> moved to transactions.py
  msg=ex.output.decode("utf-8") changed to msg=ex.stderr.decode("utf-8")

getAccountCodeHash -> moved to queries.py
  msg=ex.output.decode("utf-8") changed to msg=ex.stderr.decode("utf-8")

publishContract -> moved to transactions.py
Print statement adds out, changes msg to stderr, changes print order
retMap ["stdout"=ex.stdout removed

pushTransaction -> moved to transactions.py
  msg=ex.output.decode("utf-8") changed to msg=ex.stderr.decode("utf-8")

pushMessage -> moved to transactions.py
adds force=False to function. Caught and added by Peter already.
msg=ex.stderr.decode("utf-8") got doubled up.
print statement appears to have added output but it is the same on main already

processCleosCmd -> moved to queries.py
 out=ex.output.decode("utf-8") added, msg changed to be stderr
print statement adds out

killNodeOnProducer still in node.py
Merge caught changes already

processUrllibRequest -> moved to queries.py
New to the code, replaced processCurlCmd, merged properly

waitForTransBlockIfNeeded still in Node.py
waitForTransInBlock changed to waitForTransactionInBlock, merged previously

relaunch still in Node.py
waitForTerm default changed from True to False, already caught in prior merge.

didNodeExitGracefully is still in Node.py
if "successfully exiting" in f.read(): replaced old check
if waitForTerm: added
else behavior changed
All these merged properly


scheduleProtocolFeatureActivations still in Node.py
processCurlCmd replaced by processUrllibRequest, caught by merge

getSupportedProtocolFeatures -> moved to queries.py
processCurlCmd replaced by processUrllibRequest, caught by merge

getSupportedProtocolFeatureDict -> moved to queries.py
for protocolFeature in supportedProtocolFeatures: changed to
for protocolFeature in supportedProtocolFeatures["payload"]:
caught by merge

getAllBuiltinFeatureDigestsToPreactivate -> moved to transactions.py
for protocolFeature in supportedProtocolFeatures: changed to
for protocolFeature in supportedProtocolFeatures["payload"]:
caught by merge

createSnapshot still in Node.py
processCurlCmd replaced by processUrllibRequest, caught by merge

```