### PR TITLE
[4.0->main] unshare import fix & SHiP: Send until queue is empty

### DIFF
--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -103,7 +103,7 @@ public:
    void pop_entry(bool call_send = true) {
       send_queue.erase(send_queue.begin());
       sending = false;
-      if (call_send)
+      if (call_send || !send_queue.empty())
          send();
    }
 

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -22,8 +22,11 @@ from .Node import BlockType
 from .Node import Node
 from .WalletMgr import WalletMgr
 from .launch_transaction_generators import TransactionGeneratorsLauncher, TpsTrxGensConfig
-from .libc import unshare, CLONE_NEWNET
-from .interfaces import getInterfaceFlags, setInterfaceUp, IFF_LOOPBACK
+try:
+    from .libc import unshare, CLONE_NEWNET
+    from .interfaces import getInterfaceFlags, setInterfaceUp, IFF_LOOPBACK
+except:
+    pass
 
 # Protocol Feature Setup Policy
 class PFSetupPolicy:


### PR DESCRIPTION
* Fixes the import failure for platform which doesn't support unshare.
* Make sure that SHiP continues to send until the send queue is drained.

Resolves https://github.com/AntelopeIO/leap/issues/861

Merges PR #869 & #876 into main