### PR TITLE
[3.2] Use block_num for interrupt of start_block

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3166,13 +3166,13 @@ namespace eosio {
          return;
       }
 
-      bool signal_producer = !!bsp; // ready to process immediately, so signal producer to interrupt start_block
+      uint32_t block_num = bsp ? bsp->block_num : 0;
       app().post(priority::medium, [ptr{std::move(ptr)}, bsp{std::move(bsp)}, id, c = shared_from_this()]() mutable {
          c->process_signed_block( id, std::move(ptr), std::move(bsp) );
       });
 
-      if( signal_producer )
-         my_impl->producer_plug->received_block();
+      if( block_num != 0 ) // ready to process immediately, so signal producer to interrupt start_block
+         my_impl->producer_plug->received_block(block_num);
    }
 
    // called from application thread

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -145,7 +145,7 @@ public:
    void log_failed_transaction(const transaction_id_type& trx_id, const chain::packed_transaction_ptr& packed_trx_ptr, const char* reason) const;
 
    // thread-safe, called when a new block is received
-   void received_block();
+   void received_block(uint32_t block_num);
 
  private:
    std::shared_ptr<class producer_plugin_impl> my;


### PR DESCRIPTION
Signal received block with the block number so that `start_block` can be interrupted even if the block is received before the start of `start_block`. This is particularly important for #867, but also useful as mitigation against race condition of receiving block right before start of the block in current implementation. See https://github.com/AntelopeIO/leap/pull/648.

Resolves #891 
