### PR TITLE
[4.0 -> main] Cleanup and prevent thread starvation while in the read window.

### DIFF
--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -204,9 +204,12 @@ public:
    // thread-safe, called when a new block is received
    void received_block();
 
-const std::set<account_name>& producer_accounts() const;
+   const std::set<account_name>& producer_accounts() const;
 
+   static void set_test_mode(bool m) { test_mode_ = m; }
  private:
+   inline static bool test_mode_{false}; // to be moved into appbase (application_base)
+   
    std::shared_ptr<class producer_plugin_impl> my;
 };
 

--- a/plugins/producer_plugin/test/test_read_only_trx.cpp
+++ b/plugins/producer_plugin/test/test_read_only_trx.cpp
@@ -94,6 +94,7 @@ void test_trxs_common(std::vector<const char*>& specific_args) {
 
    auto[prod_plug, chain_plug] = plugin_fut.get();
    auto chain_id = chain_plug->get_chain_id();
+   prod_plug->set_test_mode(true);
 
    std::atomic<size_t> next_calls = 0;
    std::atomic<size_t> num_posts = 0;
@@ -149,5 +150,28 @@ BOOST_AUTO_TEST_CASE(no_read_only_threads) {
    std::vector<const char*> specific_args = { "-p", "eosio", "-e" };
    test_trxs_common(specific_args);
 }
+
+// test read-only trxs on 1 threads (with --read-only-threads)
+BOOST_AUTO_TEST_CASE(with_1_read_only_threads) {
+   std::vector<const char*> specific_args = { "-p", "eosio", "-e",
+                                              "--read-only-threads=1",
+                                              "--max-transaction-time=10",
+                                              "--read-only-write-window-time-us=100000",
+                                              "--read-only-read-window-time-us=40000",
+                                              "--disable-subjective-billing=true" };
+   test_trxs_common(specific_args);
+}
+
+// test read-only trxs on 16 separate threads (with --read-only-threads)
+BOOST_AUTO_TEST_CASE(with_16_read_only_threads) {
+   std::vector<const char*> specific_args = { "-p", "eosio", "-e",
+                                              "--read-only-threads=16",
+                                              "--max-transaction-time=10",
+                                              "--read-only-write-window-time-us=100000",
+                                              "--read-only-read-window-time-us=40000",
+                                              "--disable-subjective-billing=true" };
+   test_trxs_common(specific_args);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Resolves https://github.com/AntelopeIO/leap/issues/822.

This PR encapsulate wait and lock operations in the ro transaction queue, and makes the tasks wait on a condition variable while the read window is active, and there are transactions either in the queue or being processed.

It addresses the issue of thread starvation described in issue https://github.com/AntelopeIO/leap/issues/822.