### PR TITLE
Replace needless std::map with std::vector, and std::move in capture

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -37,7 +37,8 @@ namespace eosio {
     * a handler. The URL is the path on the web server that triggers the
     * call, and the handler is the function which implements the API call
     */
-   using api_description = std::map<string, url_handler>;
+   using api_entry = std::pair<string, url_handler>;
+   using api_description = std::vector<api_entry>;
 
    enum class http_content_type {
       json = 1,

--- a/plugins/http_plugin/include/eosio/http_plugin/macros.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/macros.hpp
@@ -15,7 +15,7 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
          auto params = parse_params<api_namespace::call_name ## _params, params_type>(body);\
          FC_CHECK_DEADLINE(deadline);\
          api_handle.call_name( std::move(params), \
-            [cb, body](const std::variant<fc::exception_ptr, call_result>& result){\
+               [cb=std::move(cb), body=std::move(body)](const std::variant<fc::exception_ptr, call_result>& result){ \
                if (std::holds_alternative<fc::exception_ptr>(result)) {\
                   try {\
                      std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();\

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -43,7 +43,7 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
 {std::string("/v1/" #api_name "/" #call_name), \
    [&api_handle](string&&, string&& body, url_response_callback&& cb) mutable { \
       if (body.empty()) body = "{}"; \
-      auto next = [cb, body](const std::variant<fc::exception_ptr, call_result>& result){\
+      auto next = [cb=std::move(cb), body=std::move(body)](const std::variant<fc::exception_ptr, call_result>& result){ \
          if (std::holds_alternative<fc::exception_ptr>(result)) {\
             try {\
                std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();\


### PR DESCRIPTION
small optimizations.