### PR TITLE
Added leap-util subcommand to check for a clean shutdown

### DIFF
--- a/programs/leap-util/actions/chain.hpp
+++ b/programs/leap-util/actions/chain.hpp
@@ -5,6 +5,7 @@
 struct chain_options {
    bool build_just_print = false;
    std::string build_output_file = "";
+   std::string sstate_state_dir = "";
 };
 
 class chain_actions : public sub_command<chain_options> {
@@ -14,4 +15,5 @@ public:
 
    // callbacks
    int run_subcommand_build();
+   int run_subcommand_sstate();
 };


### PR DESCRIPTION
This PR adds command line option to leap-util to indicate if the last shutdown was clean or not. This would allow someone to better control logic about perhaps automatically starting from snapshot if the state database was crashed.
