### PR TITLE
[4.0] Clean tmp and TestLogs after test runs

### DIFF
--- a/tests/TestHarness/WalletMgr.py
+++ b/tests/TestHarness/WalletMgr.py
@@ -84,7 +84,7 @@ class WalletMgr(object):
             Utils.EosWalletPath, WalletMgr.__walletDataDir, WalletMgr.__walletDataDir, self.host, self.port)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         if not os.path.isdir(WalletMgr.__walletDataDir):
-            if Utils.Debug: Utils.Print("Creating dir %s in dir: %s" % (WalletMgr.__walletDataDir, os.getcwd()))
+            if Utils.Debug: Utils.Print(f"Creating dir {WalletMgr.__walletDataDir} in dir: {os.getcwd()}")
             os.mkdir(WalletMgr.__walletDataDir)
         with open(WalletMgr.__walletLogOutFile, 'w') as sout, open(WalletMgr.__walletLogErrFile, 'w') as serr:
             popen=subprocess.Popen(cmd.split(), stdout=sout, stderr=serr)

--- a/tests/TestHarness/WalletMgr.py
+++ b/tests/TestHarness/WalletMgr.py
@@ -84,8 +84,8 @@ class WalletMgr(object):
             Utils.EosWalletPath, WalletMgr.__walletDataDir, WalletMgr.__walletDataDir, self.host, self.port)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         if not os.path.isdir(WalletMgr.__walletDataDir):
-                if Utils.Debug: Utils.Print("Creating dir %s in dir: %s" % (WalletMgr.__walletDataDir, os.getcwd()))
-                os.mkdir(WalletMgr.__walletDataDir)
+            if Utils.Debug: Utils.Print("Creating dir %s in dir: %s" % (WalletMgr.__walletDataDir, os.getcwd()))
+            os.mkdir(WalletMgr.__walletDataDir)
         with open(WalletMgr.__walletLogOutFile, 'w') as sout, open(WalletMgr.__walletLogErrFile, 'w') as serr:
             popen=subprocess.Popen(cmd.split(), stdout=sout, stderr=serr)
             self.__walletPid=popen.pid

--- a/tests/TestHarness/WalletMgr.py
+++ b/tests/TestHarness/WalletMgr.py
@@ -302,3 +302,5 @@ class WalletMgr(object):
         dataDir=WalletMgr.__walletDataDir
         if os.path.isdir(dataDir) and os.path.exists(dataDir):
             shutil.rmtree(WalletMgr.__walletDataDir)
+            os.remove(WalletMgr.__walletLogOutFile)
+            os.remove(WalletMgr.__walletLogErrFile)

--- a/tests/TestHarness/WalletMgr.py
+++ b/tests/TestHarness/WalletMgr.py
@@ -12,9 +12,9 @@ from .testUtils import Utils
 Wallet=namedtuple("Wallet", "name password host port")
 # pylint: disable=too-many-instance-attributes
 class WalletMgr(object):
-    __walletLogOutFile=f"{Utils.TestLogRoot}/test_keosd_out.log"
-    __walletLogErrFile=f"{Utils.TestLogRoot}/test_keosd_err.log"
     __walletDataDir=f"{Utils.TestLogRoot}/test_wallet_0"
+    __walletLogOutFile=f"{__walletDataDir}/test_keosd_out.log"
+    __walletLogErrFile=f"{__walletDataDir}/test_keosd_err.log"
     __MaxPort=9999
 
     # pylint: disable=too-many-arguments
@@ -83,6 +83,9 @@ class WalletMgr(object):
         cmd="%s --data-dir %s --config-dir %s --unlock-timeout=999999 --http-server-address=%s:%d --http-max-response-time-ms 99999 --verbose-http-errors" % (
             Utils.EosWalletPath, WalletMgr.__walletDataDir, WalletMgr.__walletDataDir, self.host, self.port)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
+        if not os.path.isdir(WalletMgr.__walletDataDir):
+                if Utils.Debug: Utils.Print("Creating dir %s in dir: %s" % (WalletMgr.__walletDataDir, os.getcwd()))
+                os.mkdir(WalletMgr.__walletDataDir)
         with open(WalletMgr.__walletLogOutFile, 'w') as sout, open(WalletMgr.__walletLogErrFile, 'w') as serr:
             popen=subprocess.Popen(cmd.split(), stdout=sout, stderr=serr)
             self.__walletPid=popen.pid
@@ -299,8 +302,5 @@ class WalletMgr(object):
 
     @staticmethod
     def cleanup():
-        dataDir=WalletMgr.__walletDataDir
-        if os.path.isdir(dataDir) and os.path.exists(dataDir):
+        if os.path.isdir(WalletMgr.__walletDataDir) and os.path.exists(WalletMgr.__walletDataDir):
             shutil.rmtree(WalletMgr.__walletDataDir)
-            os.remove(WalletMgr.__walletLogOutFile)
-            os.remove(WalletMgr.__walletLogErrFile)

--- a/tests/auto_bp_peering_test.py
+++ b/tests/auto_bp_peering_test.py
@@ -33,7 +33,7 @@ args = TestHelper.parse_args({
 })
 
 Utils.Debug = args.v
-killAll = True
+killAll = args.clean_run
 dumpErrorDetails = args.dump_error_details
 dontKill = args.leave_running
 killEosInstances = not dontKill

--- a/tests/auto_bp_peering_test.py
+++ b/tests/auto_bp_peering_test.py
@@ -33,10 +33,9 @@ args = TestHelper.parse_args({
 })
 
 Utils.Debug = args.v
-killAll = args.clean_run
+killAll = True
 dumpErrorDetails = args.dump_error_details
-# dontKill = args.leave_running
-dontKill = True
+dontKill = args.leave_running
 killEosInstances = not dontKill
 killWallet = not dontKill
 keepLogs = args.keep_logs
@@ -131,9 +130,6 @@ try:
     testSuccessful = (connection_check_failures == 0)
 
 finally:
-    killAll=True
-    killWallet=True
-    killEosInstances=True
     TestHelper.shutdown(
         cluster,
         walletMgr,

--- a/tests/auto_bp_peering_test.py
+++ b/tests/auto_bp_peering_test.py
@@ -131,6 +131,9 @@ try:
     testSuccessful = (connection_check_failures == 0)
 
 finally:
+    killAll=True
+    killWallet=True
+    killEosInstances=True
     TestHelper.shutdown(
         cluster,
         walletMgr,

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -11,7 +11,7 @@ import time
 import shutil
 import signal
 
-from TestHarness import Account, Cluster, Node, ReturnType, Utils, WalletMgr
+from TestHarness import Account, Node, ReturnType, Utils, WalletMgr
 
 testSuccessful=False
 
@@ -403,7 +403,7 @@ def abi_file_with_nodeos_test():
                     os.kill(node.pid, signal.SIGKILL)
         if testSuccessful:
             Utils.Print("Cleanup nodeos data.")
-            shutil.rmtree(data_dir)
+            shutil.rmtree(Utils.DataPath)
 
         if malicious_token_abi_path:
             if os.path.exists(malicious_token_abi_path):

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -115,7 +115,7 @@ try:
         errorExit("Failed to kill the seed node")
 
 finally:
-    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=True, killWallet=True, keepLogs=True, cleanRun=True, dumpErrorDetails=True)
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=True, killWallet=True, keepLogs=False, cleanRun=True, dumpErrorDetails=True)
 
 errorCode = 0 if testSuccessful else 1
 exit(errorCode)

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -498,14 +498,14 @@ class PerformanceTestBasic:
 
         finally:
             TestHelper.shutdown(
-                self.cluster,
-                self.walletMgr,
-                testSuccessful,
-                self.testHelperConfig._killEosInstances,
-                self.testHelperConfig._killWallet,
-                self.testHelperConfig.keepLogs,
-                self.testHelperConfig.killAll,
-                self.testHelperConfig.dumpErrorDetails
+                cluster=self.cluster,
+                walletMgr=self.walletMgr,
+                testSuccessful=testSuccessful,
+                killEosInstances=self.testHelperConfig._killEosInstances,
+                killWallet=self.testHelperConfig._killWallet,
+                keepLogs=not testSuccessful,
+                cleanRun=self.testHelperConfig.killAll,
+                dumpErrorDetails=self.testHelperConfig.dumpErrorDetails
                 )
 
             if self.ptbConfig.delPerfLogs:

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -497,13 +497,15 @@ class PerformanceTestBasic:
             traceback.print_exc()
 
         finally:
+            # Despite keepLogs being hardcoded to False, logs will still appear on test failure in TestLogs
+            # due to testSuccessful being False
             TestHelper.shutdown(
                 cluster=self.cluster,
                 walletMgr=self.walletMgr,
                 testSuccessful=testSuccessful,
                 killEosInstances=self.testHelperConfig._killEosInstances,
                 killWallet=self.testHelperConfig._killWallet,
-                keepLogs=not testSuccessful,
+                keepLogs=False,
                 cleanRun=self.testHelperConfig.killAll,
                 dumpErrorDetails=self.testHelperConfig.dumpErrorDetails
                 )

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -40,8 +40,8 @@ class PluginHttpTest(unittest.TestCase):
         self.keosd.killall(True)
         WalletMgr.cleanup()
         Node.killAllNodeos()
-        if os.path.exists(self.data_dir):
-            shutil.rmtree(self.data_dir)
+        if os.path.exists(Utils.DataPath):
+            shutil.rmtree(Utils.DataPath)
         if os.path.exists(self.config_dir):
             shutil.rmtree(self.config_dir)
         time.sleep(self.sleep_s)

--- a/tests/trace_plugin_test.py
+++ b/tests/trace_plugin_test.py
@@ -8,6 +8,8 @@ import os
 
 from TestHarness import Cluster, Node, TestHelper, Utils, WalletMgr, CORE_SYMBOL
 
+testSuccessful = True
+
 class TraceApiPluginTest(unittest.TestCase):
     sleep_s = 1
     cluster=Cluster(walletd=True, defproduceraPrvtKey=None)
@@ -101,6 +103,8 @@ class TraceApiPluginTest(unittest.TestCase):
                     self.assertIn('memo', prms)
                 break
         self.assertTrue(isTrxInBlockFromTraceApi)
+        global testSuccessful
+        testSuccessful = True
 
     @classmethod
     def setUpClass(self):
@@ -109,7 +113,7 @@ class TraceApiPluginTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(self):
-        self.cleanEnv(self, shouldCleanup=False)   # not cleanup to save log in case for further investigation
+        self.cleanEnv(self, shouldCleanup=testSuccessful)
 
 if __name__ == "__main__":
     unittest.main()

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -237,19 +237,4 @@ BOOST_AUTO_TEST_CASE(test_light_validation_restart_from_block_log) {
    BOOST_CHECK_EQUAL(trace->action_traces.at(1).receipt->digest(), other_trace->action_traces.at(1).receipt->digest());
 }
 
-namespace{
-   struct scoped_temp_path {
-      boost::filesystem::path path;
-      scoped_temp_path() {
-         path = boost::filesystem::unique_path();
-         if (boost::unit_test::framework::master_test_suite().argc >= 2) {
-            path += boost::unit_test::framework::master_test_suite().argv[1];
-         }
-      }
-      ~scoped_temp_path() {
-         boost::filesystem::remove_all(path);
-      }
-   };
-}
-
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -412,8 +412,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_compatible_versions, SNAPSHOT_SUITE, snapshot
       bfs::copy_file(source_i, source_log_dir / "blocks.index", bfs::copy_option::overwrite_if_exists);
       chain.close();
    }
-
-   auto config = tester::default_config(fc::temp_directory(), legacy_default_max_inline_action_size).first;
+   fc::temp_directory temp_dir;
+   auto config = tester::default_config(temp_dir, legacy_default_max_inline_action_size).first;
    auto genesis = eosio::chain::block_log::extract_genesis_state(source_log_dir);
    bfs::create_directories(config.blocks_dir);
    bfs::copy(source_log_dir / "blocks.log", config.blocks_dir / "blocks.log");
@@ -477,7 +477,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_pending_schedule_snapshot, SNAPSHOT_SUITE, sn
    source_log_dir_str += "prod_sched";
    const auto source_log_dir = bfs::path(source_log_dir_str.c_str());
    const uint32_t legacy_default_max_inline_action_size = 4 * 1024;
-   auto config = tester::default_config(fc::temp_directory(), legacy_default_max_inline_action_size).first;
+   fc::temp_directory temp_dir;
+   auto config = tester::default_config(temp_dir, legacy_default_max_inline_action_size).first;
    auto genesis = eosio::chain::block_log::extract_genesis_state(source_log_dir);
    bfs::create_directories(config.blocks_dir);
    bfs::copy(source_log_dir / "blocks.log", config.blocks_dir / "blocks.log");


### PR DESCRIPTION
This PR cleans up a number of tests that have been littering.

`unittests/snapshot_tests.cpp` was leaving tmp files around even on success

These tests were all leaving logs around in TestLogs even on on success:
`tests/auto_bp_peering_test.py`
`tests/cli_test.py`
`tests/nodeos_contrl_c_test.py`
`tests/plugin_http_api_test.py`
`tests/trace_plugin_test.py`
`test/performance_test_basic` (nonbasic also as a result)

`unittests/restart_chain_tests.cpp` had some old code that was unused, which had previously behaved similarly to temp_dir.

Additionally changed `tests/TestHarness/WalletMgr.py` to clean up the test wallets after test success.

Resolves: https://github.com/AntelopeIO/leap/issues/719