### PR TITLE
curl is no longer a required dependency; remove from docs & CI environment

### DIFF
--- a/.cicd/platforms/ubuntu20.Dockerfile
+++ b/.cicd/platforms/ubuntu20.Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:focal
 RUN apt-get update && apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential      \
                                                       cmake                \
-                                                      curl                 \
                                                       git                  \
                                                       jq                   \
                                                       libboost-all-dev     \

--- a/.cicd/platforms/ubuntu22.Dockerfile
+++ b/.cicd/platforms/ubuntu22.Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:jammy
 RUN apt-get update && apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential      \
                                                       cmake                \
-                                                      curl                 \
                                                       git                  \
                                                       jq                   \
                                                       libboost-all-dev     \

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Requirements to build:
 - LLVM 7 - 11 - for Linux only
   - newer versions do not work
 - openssl 1.1+
-- curl
 - libcurl 7.40.0+
 - git
 - GMP
@@ -132,7 +131,6 @@ sudo apt-get update
 sudo apt-get install -y \
         build-essential \
         cmake \
-        curl \
         git \
         libboost-all-dev \
         libcurl4-openssl-dev \


### PR DESCRIPTION
As of #442 curl is no longer required to run tests. Remove it from docs & CI environment