### PR TITLE
remove WAVM specific c++11 flag

### DIFF
--- a/libraries/wasm-jit/CMakeLists.txt
+++ b/libraries/wasm-jit/CMakeLists.txt
@@ -1,8 +1,6 @@
 set(WAVM_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/Include)
 include_directories(${WAVM_INCLUDE_DIR})
 
-set(CMAKE_CXX_STANDARD 11)
-
 option(WAVM_METRICS_OUTPUT "controls printing the timings of some operations to stdout" OFF)
 if(WAVM_METRICS_OUTPUT)
 	add_definitions("-DWAVM_METRICS_OUTPUT=1")


### PR DESCRIPTION
This line was hiding in the forest of cmake comments and sprung a surprise via #888. Removing it and allowing the library to compile with c++17 appears to cause no errors nor warnings, soooo, let's do that.