### PR TITLE
[3.2] SHiP flush logs on write

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -263,6 +263,9 @@ class state_history_log {
          const uint32_t num_blocks_in_log = _end_block - _begin_block;
          fc::raw::pack(log, num_blocks_in_log);
       }
+
+      log.flush();
+      index.flush();
    }
 
    // returns cfile positioned at payload


### PR DESCRIPTION
Flush the `state_history_plugin` logs to disk at the end of each write to make it more likely that a `kill -9` or crash leaves valid logs.

Resolves #596 