### PR TITLE
[3.2 -> 4.0] SHiP flush logs on write

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -497,9 +497,10 @@ struct controller_impl {
 
    void replay(std::function<bool()> check_shutdown) {
       auto blog_head = blog.head();
-      if( !blog_head && !fork_db.root() ) {
+      if( !fork_db.root() ) {
          fork_db.reset( *head );
-         return;
+         if (!blog_head)
+            return;
       }
 
       replaying = true;

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -552,7 +552,6 @@ class state_history_log {
 
       log.flush();
       index.flush();
-   }
 
       auto partition_config = std::get_if<state_history::partition_config>(&config);
       if (partition_config && block_num % partition_config->stride == 0) {


### PR DESCRIPTION
Flush the `state_history_plugin` logs to disk at the end of each write to make it more likely that a `kill -9` or crash leaves valid logs.

Merges #928 into `release/4.0`.

Includes a fix for replay where `forkdb.root()` is null during the write in SHiP for `on_accepted_block`. 4.0 SHiP calls `chain.last_irreversible_block_id()` in `on_accepted_block` which expects `forkdb.root()` to be valid.

Resolves #596 