### PR TITLE
[3.2] forkdb reset in replay since blocks are signaled

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -477,12 +477,13 @@ struct controller_impl {
    }
 
    void replay(std::function<bool()> check_shutdown) {
-      if( !blog.head() && !fork_db.root() ) {
+      auto blog_head = blog.head();
+      if( !fork_db.root() ) {
          fork_db.reset( *head );
-         return;
+         if (!blog_head)
+            return;
       }
 
-      auto blog_head = blog.head();
       replaying = true;
       auto start_block_num = head->block_num + 1;
       auto start = fc::time_point::now();


### PR DESCRIPTION
Fix for replay where `forkdb.root()` is null during the write in SHiP for `on_accepted_block`. 4.0 SHiP calls `chain.last_irreversible_block_id()` in `on_accepted_block` which expects `forkdb.root()` to be valid. Not clear this is strictly needed for 3.2 since 3.2 SHiP does not call `chain.last_irreversible_block_id()`, but other plugins do; e.g. `net_plugin`.

Resolves #596 