### PR TITLE
[4.0 -> main] SHiP flush logs on write

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -550,6 +550,9 @@ class state_history_log {
          fc::raw::pack(log, num_blocks_in_log);
       }
 
+      log.flush();
+      index.flush();
+
       auto partition_config = std::get_if<state_history::partition_config>(&config);
       if (partition_config && block_num % partition_config->stride == 0) {
          split_log();


### PR DESCRIPTION
Flush the `state_history_plugin` logs to disk at the end of each write to make it more likely that a `kill -9` or crash leaves valid logs.

Merges #928 & #935 into `main`.

Resolves #596 