### PR TITLE
[4.0 -> main] forkdb reset in replay since blocks are signaled

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -497,9 +497,10 @@ struct controller_impl {
 
    void replay(std::function<bool()> check_shutdown) {
       auto blog_head = blog.head();
-      if( !blog_head && !fork_db.root() ) {
+      if( !fork_db.root() ) {
          fork_db.reset( *head );
-         return;
+         if (!blog_head)
+            return;
       }
 
       replaying = true;


### PR DESCRIPTION
Fix for replay where `forkdb.root()` is null during the write in SHiP for `on_accepted_block`. 4.0 SHiP calls `chain.last_irreversible_block_id()` in `on_accepted_block` which expects `forkdb.root()` to be valid. 

Merges #936 & #938 into `main`

Resolves #596 