### PR TITLE
[4.0] Correct time summary calculation for transient trxs due to change of read-only trxs windows

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3687,10 +3687,6 @@ void controller::init_thread_local_data() {
    my->init_thread_local_data();
 }
 
-bool controller::is_on_main_thread() const {
-  return my->is_on_main_thread();
-}
-
 /// Protocol feature activation handlers:
 
 template<>

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -373,7 +373,6 @@ namespace eosio { namespace chain {
       void set_db_read_only_mode();
       void unset_db_read_only_mode();
       void init_thread_local_data();
-      bool is_on_main_thread() const;
 
       private:
          friend class apply_context;


### PR DESCRIPTION
Resolved https://github.com/AntelopeIO/leap/issues/950

https://github.com/AntelopeIO/leap/pull/776 assumed read-only transactions to only run on read-only threads. https://github.com/AntelopeIO/leap/pull/901 changed that and read-only transactions can run on main thread too.

- Existing calculation of transient trxs time was done on the main thread. This is not correct any more as read-only trxs on the main thread in the read window will be double counted. The solution is to count transient time only in the write window (dry-run trxs only run in write window). This change makes the intention more clearer and safer, as in write window all processing is single threaded and no read-only threads are running.
- Refactored `push_read_only_transaction` for read-only tasks missed idle time accounting. Add it now.

A sample report looks like
`debug 2023-04-02T20:36:41.903 nodeos   producer_plugin.cpp:284  report  ] Block   #259 trx idle: 555758us out of 565688us, success: 0, 0us, fail: 0, 0us, transient: 14, 2281us,   other: 7649us`