### PR TITLE
Make pending_snapshots non-optional (simplification)

### DIFF
--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -377,6 +377,12 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                    - snapshot_request_id
+                    - block_spacing
+                    - start_block_num
+                    - end_block_num
+                    - snapshot_description
                 properties:
                   snapshot_request_id:
                     type: integer
@@ -420,6 +426,13 @@ paths:
                     description: An array of scheduled snapshots
                     items:
                       type: object
+                      required:
+                          - snapshot_request_id
+                          - block_spacing
+                          - start_block_num
+                          - end_block_num
+                          - snapshot_description
+                          - pending_snapshots
                       properties:
                         snapshot_request_id:
                           type: integer
@@ -444,6 +457,12 @@ paths:
                           description: List of pending snapshots
                           items:
                             type: object
+                            required:
+                                - head_block_id
+                                - head_block_num
+                                - head_block_time
+                                - version
+                                - snapshot_name
                             properties:
                               head_block_id:
                                 $ref: "https://docs.eosnetwork.com/openapi/v2.0/Sha256.yaml"
@@ -491,6 +510,12 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - snapshot_request_id
+                  - block_spacing
+                  - start_block_num
+                  - end_block_num
+                  - snapshot_description
                 properties:
                   snapshot_request_id:
                     type: integer

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -95,7 +95,7 @@ public:
    };
 
    struct snapshot_schedule_information : public snapshot_request_id_information, public snapshot_request_information {
-      std::optional<std::vector<snapshot_information>> pending_snapshots;
+      std::vector<snapshot_information> pending_snapshots;
    };
 
    struct get_snapshot_requests_result {

--- a/plugins/producer_plugin/test/test_snapshot_scheduler.cpp
+++ b/plugins/producer_plugin/test/test_snapshot_scheduler.cpp
@@ -98,8 +98,8 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
                // we should have a pending snapshot for request id = 0
                BOOST_REQUIRE(it != snapshot_requests.end());
                auto& pending = it->pending_snapshots;
-               if (pending && pending->size()==1) {
-                  BOOST_CHECK_EQUAL(9, pending->begin()->head_block_num);   
+               if (pending.size()==1) {
+                  BOOST_CHECK_EQUAL(9, pending.begin()->head_block_num);   
                }
             }
          });
@@ -126,8 +126,7 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
 
          // snapshot request with id = 0 should be found and should not have any pending snapshots
          BOOST_REQUIRE(it != snapshot_requests.end());
-         BOOST_REQUIRE(it->pending_snapshots);
-         BOOST_CHECK(!it->pending_snapshots->size());
+         BOOST_CHECK(!it->pending_snapshots.size());
 
          // quit app
          appbase::app().quit();


### PR DESCRIPTION
get_snapshot_requests api call returns list of snapshot requests that includes any pending snapshots associated with this request -> pending_snapshots. Currently pending_snapshots is an optional that uses lazy initialization on the first pending snapshot per request. That leads to three states -> pending_snapshots not created, pending_snapshots is an empty vector (after pending snapshot was finalized) or pending_snapshot is a non-empty vector.

It was discussed and decided that it would be simpler to always have pending_snapshots available in request reply and to avoid "un-initialized" empty state of it, since it brings no additional value