### PR TITLE
[4.0 -> main] Set an upper limit on read-only-threads of 8

### DIFF
--- a/plugins/producer_plugin/test/test_read_only_trx.cpp
+++ b/plugins/producer_plugin/test/test_read_only_trx.cpp
@@ -172,10 +172,10 @@ BOOST_AUTO_TEST_CASE(with_1_read_only_threads) {
    test_trxs_common(specific_args);
 }
 
-// test read-only trxs on 16 separate threads (with --read-only-threads)
-BOOST_AUTO_TEST_CASE(with_16_read_only_threads) {
+// test read-only trxs on 8 separate threads (with --read-only-threads)
+BOOST_AUTO_TEST_CASE(with_8_read_only_threads) {
    std::vector<const char*> specific_args = { "-p", "eosio", "-e",
-                                              "--read-only-threads=16",
+                                              "--read-only-threads=8",
                                               "--max-transaction-time=10",
                                               "--abi-serializer-max-time-ms=999",
                                               "--read-only-write-window-time-us=100000",


### PR DESCRIPTION
Protect typical EOS Mainnet capable `nodeos` from running out of RAM by limiting read-only-threads to 8. 8 was chosen as it is the same upper limit for when `eos-vm-oc` is enabled. On a 64GB machine 8 should be conservative limit for now. This limit can be raised once #800 is addressed.

Merges #982 into `main`.

Resolves #978
