### PR TITLE
Update boost version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ set(Boost_USE_MULTITHREADED      ON)
 set( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
 # Most boost deps get implictly picked up via fc, as just about everything links to fc. In addition we pick up
 # the pthread dependency through fc.
-find_package(Boost 1.67 REQUIRED COMPONENTS program_options unit_test_framework system)
+find_package(Boost 1.70 REQUIRED COMPONENTS program_options unit_test_framework system)
 
 if( APPLE AND UNIX )
 # Apple Specific Options Here

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You will need to build on a [supported operating system](#supported-operating-sy
 
 Requirements to build:
 - C++17 compiler and standard library
-- boost 1.67+
+- boost 1.70+
 - CMake 3.16+
 - LLVM 7 - 11 - for Linux only
   - newer versions do not work

--- a/libraries/libfc/include/fc/log/appender.hpp
+++ b/libraries/libfc/include/fc/log/appender.hpp
@@ -3,11 +3,7 @@
 #include <fc/string.hpp>
 #include <memory>
 
-#if BOOST_VERSION >= 106600
 namespace boost { namespace asio { class io_context; typedef io_context io_service; } }
-#else
-namespace boost { namespace asio { class io_service; } }
-#endif
 
 namespace fc {
    class appender;

--- a/libraries/libfc/test/network/test_message_buffer.cpp
+++ b/libraries/libfc/test/network/test_message_buffer.cpp
@@ -7,19 +7,11 @@
 
 namespace {
 size_t mb_size(boost::asio::mutable_buffer& mb) {
-#if BOOST_VERSION >= 106600
    return mb.size();
-#else
-   return boost::asio::detail::buffer_size_helper(mb);
-#endif
 }
 
 void* mb_data(boost::asio::mutable_buffer& mb) {
-#if BOOST_VERSION >= 106600
    return mb.data();
-#else
-   return boost::asio::detail::buffer_cast_helper(mb);
-#endif
 }
 }
 

--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -11,20 +11,10 @@ namespace eosio {
 
 using std::chrono::steady_clock;
 
-// Boost 1.70 introduced a breaking change that causes problems with construction of strand objects from tcp_socket
-// this is suggested fix OK'd Beast author (V. Falco) to handle both versions gracefully
-// see https://stackoverflow.com/questions/58453017/boost-asio-tcp-socket-1-70-not-backward-compatible
-#if BOOST_VERSION < 107000
-typedef tcp::socket tcp_socket_t;
-#else
 typedef asio::basic_stream_socket<asio::ip::tcp, asio::io_context::executor_type> tcp_socket_t;
-#endif
 
 using boost::asio::local::stream_protocol;
 
-#if BOOST_VERSION < 107000
-using local_stream = boost::asio::basic_stream_socket<stream_protocol>;
-#else
 #if BOOST_VERSION < 107300
 using local_stream = beast::basic_stream<
       stream_protocol,
@@ -35,7 +25,6 @@ using local_stream = beast::basic_stream<
       stream_protocol,
       asio::any_io_executor,
       beast::unlimited_rate_policy>;
-#endif
 #endif
 
 //------------------------------------------------------------------------------
@@ -54,11 +43,7 @@ bool allow_host(const http::request<http::string_body>& req, T& session,
    auto is_conn_secure = session.is_secure();
 
    auto& socket = session.socket();
-#if BOOST_VERSION < 107000
-   auto& lowest_layer = beast::get_lowest_layer<tcp_socket_t&>(socket);
-#else
    auto& lowest_layer = beast::get_lowest_layer(socket);
-#endif
    auto local_endpoint = lowest_layer.local_endpoint();
    auto local_socket_host_port = local_endpoint.address().to_string() + ":" + std::to_string(local_endpoint.port());
    const std::string host_str(req["host"]);

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -23,21 +23,6 @@
 namespace ws = boost::beast::websocket;
 
 
-/* Prior to boost 1.70, if socket type is not boost::asio::ip::tcp::socket nor boost::asio::ssl::stream beast requires
-   an overload of async_teardown. This has been improved in 1.70+ to support any basic_stream_socket<> out of the box
-   which includes unix sockets. */
-#if BOOST_VERSION < 107000
-namespace boost::beast::websocket {
-template <typename TeardownHandler>
-void async_teardown(role_type, unixs::socket& sock, TeardownHandler&& handler) {
-   boost::system::error_code ec;
-   sock.close(ec);
-   boost::asio::post(boost::asio::get_associated_executor(handler, sock.get_executor()),
-                     [h = std::move(handler), ec]() mutable { h(ec); });
-}
-} // namespace boost::beast::websocket
-#endif
-
 namespace eosio {
 using namespace chain;
 using namespace state_history;

--- a/tests/ship_client.cpp
+++ b/tests/ship_client.cpp
@@ -21,16 +21,6 @@ namespace ws = boost::beast::websocket;
 
 namespace bpo = boost::program_options;
 
-/* Prior to boost 1.70, if socket type is not boost::asio::ip::tcp::socket nor boost::asio::ssl::stream beast requires
-   an overload of async_/teardown. This has been improved in 1.70+ to support any basic_stream_socket<> out of the box
-   which includes unix sockets. */
-#if BOOST_VERSION < 107000
-namespace boost::beast::websocket {
-void teardown(role_type, unixs::socket& sock, error_code& ec) {
-   sock.close(ec);
-}
-}
-#endif
 
 int main(int argc, char* argv[]) {
    boost::asio::io_context ctx;


### PR DESCRIPTION
Updating min Boost version to be in line with `pinned_build.sh` min requirement.

With dropping support for Ubuntu 18.04 and Ubuntu 20.04's min boost version of 1.71, it should be okay to bump `leap`'s min to the pinned build's min required boost version 1.70.