### PR TITLE
[4.0] make `eosio_exit` impl more direct

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -63,9 +63,6 @@ namespace eosio { namespace chain {
          //Calls apply or error on a given code
          void apply(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context);
 
-         //Immediately exits currently running wasm. UB is called when no wasm running
-         void exit();
-
          //Returns true if the code is cached
          bool is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) const;
 

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc.hpp
@@ -33,7 +33,6 @@ class eosvmoc_runtime : public eosio::chain::wasm_runtime_interface {
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
                                                                              const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
 
-      void immediately_exit_currently_running_module() override;
       void init_thread_local_data() override;
 
       friend eosvmoc_instantiated_module;

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp
@@ -46,12 +46,8 @@ class eos_vm_runtime : public eosio::chain::wasm_runtime_interface {
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
                                                                              const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
 
-      void immediately_exit_currently_running_module() override;
-
    private:
       // todo: managing this will get more complicated with sync calls;
-      //       immediately_exit_currently_running_module() should probably
-      //       move from wasm_runtime_interface to wasm_instantiated_module_interface.
       eos_vm_backend_t<Backend>* _bkend = nullptr;  // non owning pointer to allow for immediate exit
 
    template<typename Impl>
@@ -63,8 +59,6 @@ class eos_vm_profile_runtime : public eosio::chain::wasm_runtime_interface {
       eos_vm_profile_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
                                                                              const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
-
-      void immediately_exit_currently_running_module() override;
 };
 
 }}}}// eosio::chain::webassembly::eos_vm_runtime

--- a/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
@@ -23,9 +23,6 @@ class wasm_runtime_interface {
       virtual std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
                                                                                      const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) = 0;
 
-      //immediately exit the currently running wasm_instantiated_module_interface. Yep, this assumes only one can possibly run at a time.
-      virtual void immediately_exit_currently_running_module() = 0;
-
       virtual ~wasm_runtime_interface();
 
       // eosvmoc_runtime needs this

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -112,10 +112,6 @@ namespace eosio { namespace chain {
       my->get_instantiated_module(code_hash, vm_type, vm_version, context.trx_context)->apply(context);
    }
 
-   void wasm_interface::exit() {
-      my->runtime_interface->immediately_exit_currently_running_module();
-   }
-
    bool wasm_interface::is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) const {
       return my->is_code_cached(code_hash, vm_type, vm_version);
    }

--- a/libraries/chain/webassembly/cf_system.cpp
+++ b/libraries/chain/webassembly/cf_system.cpp
@@ -45,7 +45,8 @@ namespace eosio { namespace chain { namespace webassembly {
       }
    }
 
+   //be aware that EOS VM OC handles eosio_exit internally and this function will not be called by OC
    void interface::eosio_exit( int32_t code ) const {
-      context.control.get_wasm_interface().exit();
+      throw wasm_exit{};
    }
 }}} // ns eosio::chain::webassembly

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
@@ -55,9 +55,6 @@ std::unique_ptr<wasm_instantiated_module_interface> eosvmoc_runtime::instantiate
    return std::make_unique<eosvmoc_instantiated_module>(code_hash, vm_type, *this);
 }
 
-//never called. EOS VM OC overrides eosio_exit to its own implementation
-void eosvmoc_runtime::immediately_exit_currently_running_module() {}
-
 void eosvmoc_runtime::init_thread_local_data() {
    exec_thread_local = std::make_unique<eosvmoc::executor>(cc);
 }

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -234,11 +234,6 @@ template<typename Impl>
 eos_vm_runtime<Impl>::eos_vm_runtime() {}
 
 template<typename Impl>
-void eos_vm_runtime<Impl>::immediately_exit_currently_running_module() {
-   throw wasm_exit{};
-}
-
-template<typename Impl>
 std::unique_ptr<wasm_instantiated_module_interface> eos_vm_runtime<Impl>::instantiate_module(const char* code_bytes, size_t code_size,
                                                                                              const digest_type&, const uint8_t&, const uint8_t&) {
 
@@ -260,10 +255,6 @@ template class eos_vm_runtime<eosio::vm::interpreter>;
 template class eos_vm_runtime<eosio::vm::jit>;
 
 eos_vm_profile_runtime::eos_vm_profile_runtime() {}
-
-void eos_vm_profile_runtime::immediately_exit_currently_running_module() {
-   throw wasm_exit{};
-}
 
 std::unique_ptr<wasm_instantiated_module_interface> eos_vm_profile_runtime::instantiate_module(const char* code_bytes, size_t code_size,
                                                                                                const digest_type&, const uint8_t&, const uint8_t&) {


### PR DESCRIPTION
This is simply a clean up change to try and make it more explicit how `eosio_exit` works by eliminating some needless abstraction that contains a deceptive comment.

When the host function `eosio_exit` is called the contract execution is considered successfully complete immediately.

I don't remember the exact historical reasons the code was written the way it was, so I'll go with a plausible theory.

A reasonable way to accomplish the required behavior is to throw an exception in the `eosio_exit` impl that is caught as a do-nothing in the appropriate location (ideally immediately after the line that 'entered' wasm execution). This catch continues to live on
https://github.com/AntelopeIO/leap/blob/dfe829e7dc0d7420e73905cba7d520a3f8dc8769/libraries/chain/apply_context.cpp#L96-L98

However, at some point the performance of this exception was quite poor. Early in EOS' chain history `eosio_exit` is used _a lot_. And old EOSIO/Leap implementations had extremely poor exception handling performance when WAVM was being used (the process could spend >50% of its time just handling the `eosio_exit` host function exceptions!). At some point I did a refactor skipping the exception in WAVM's case to improve performance. Since there isn't an object that represents the "currently running wasm instance", instead `wasm_interface` gained a new function which purpose was to exit the currently running wasm instance, and then each runtime (like WAVM, etc) could implement this as appropriate.

That's a bad abstraction in the new world of multiple wasm instances executing at the same time.

So this PR restores what was likely similar to the original implementation: just simply throw the exception in `eosio_exit` host function impl. However, OC continues to use an exception-free optimization for `eosio_exit` by handling that host function internal to its implementation. So note that on the host function's implementation.

Resolves #956 