### PR TITLE
[4.0] fix resource not found bug

### DIFF
--- a/plugins/prometheus_plugin/include/eosio/prometheus_plugin/simple_rest_server.hpp
+++ b/plugins/prometheus_plugin/include/eosio/prometheus_plugin/simple_rest_server.hpp
@@ -67,7 +67,7 @@ namespace eosio { namespace rest {
          try {
             auto res = self()->on_request(std::move(req));
             if (!res)
-               not_found(target);
+               return not_found(target);
             return *res;
          } catch (std::exception& ex) { return server_error(ex.what()); }
       }

--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -643,6 +643,8 @@ class NodeosQueries:
                         rtn = ex.read()
                     else:
                         unhandledEnumType(returnType)
+            elif returnType==ReturnType.raw:
+                return ex.code
             else:
                 return None
 

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -1352,6 +1352,8 @@ class PluginHttpTest(unittest.TestCase):
         self.assertTrue(int(metrics["blocks_produced"]) > 1)
         self.assertTrue(int(metrics["last_irreversible"]) > 1)
 
+        ret = self.nodeos.processUrllibRequest(resource, "m", returnType = ReturnType.raw, method="GET", silentErrors= True, endpoint=endpointPrometheus)
+        self.assertTrue(ret == 404)
 
     def test_multipleRequests(self):
         """Test keep-alive ability of HTTP plugin.  Handle multiple requests in a single session"""


### PR DESCRIPTION
This PR fixes promethues plugin crash problem when the resource path is not exactly "v1/prometheus/metrics".

Resolves [#IS 1002](https://github.com/AntelopeIO/leap/issues/1002)