### PR TITLE
[4.0->main] response to disallowed host

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -115,8 +115,12 @@ protected:
       }
 
       try {
-         if(!derived().allow_host(req))
+         if(!derived().allow_host(req)) {
+            error_results results{static_cast<uint16_t>(http::status::bad_request), "Disallowed HTTP HOST header in the request"};
+            send_response( fc::json::to_string( results, fc::time_point::maximum() ),
+                        static_cast<unsigned int>(http::status::bad_request) );
             return;
+         }
 
          if(!plugin_state_->access_control_allow_origin.empty()) {
             res_->set("Access-Control-Allow-Origin", plugin_state_->access_control_allow_origin);

--- a/tests/http_plugin_test.py
+++ b/tests/http_plugin_test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 from TestHarness import Cluster, Node, ReturnType, TestHelper, Utils
+import urllib.request
+import sys
 
 ###############################################################
 # http_plugin_tests.py
@@ -22,7 +24,7 @@ dumpErrorDetails = dumpErrorDetails=args.dump_error_details
 
 
 Utils.Debug=debug
-cluster=Cluster(walletd=True,unshared=args.unshared)
+cluster=Cluster(host="127.0.0.1",walletd=True,unshared=args.unshared)
 
 testSuccessful=False
 
@@ -34,17 +36,34 @@ try:
     TestHelper.printSystemInfo("BEGIN")
 
     Print("Stand up cluster")
-
-    if cluster.launch(dontBootstrap=True, loadSystemContract=False) is False:
+    node0_extra_config = "--http-validate-host true --http-server-address 127.0.0.1:8888"
+    if cluster.launch(dontBootstrap=True, loadSystemContract=False, specificExtraNodeosArgs = {0: node0_extra_config}) is False:
         cmdError("launcher")
         errorExit("Failed to stand up eos cluster.")
-
     Print("Getting cluster info")
     cluster.getInfos()
+
+    node0 = cluster.nodes[0]
+    ## HTTP plugin listens to 127.0.0.1:8888 by default. With the --http-validate-host=true,
+    ## the HTTP request to "http://localhost:8888" should fail because the HOST header doesn't
+    ## match "127.0.0.1".
+
+    def get_info_status(url):
+        try:
+            req = urllib.request.Request( url, method = "GET")
+            return urllib.request.urlopen(req, data=None).code
+        except urllib.error.HTTPError as response:
+            return response.code
+        except:
+            e = sys.exc_info()[0]
+            return e
+    url = node0.endpointHttp.replace("127.0.0.1", "localhost") + "/v1/chain/get_info"
+    code = get_info_status(url)
+    assert code == 400, f"Expected HTTP returned code 400, got {code}"
     testSuccessful = True
+
 finally:
     TestHelper.shutdown(cluster, None, testSuccessful, killEosInstances, True, keepLogs, killAll, dumpErrorDetails)
 
 exitCode = 0 if testSuccessful else 1
 exit(exitCode)
-        


### PR DESCRIPTION
This PR fixes the problem where HTTP plugin doesn't response to requests with disallowed HTTP HOST header.

Merges PR https://github.com/AntelopeIO/leap/pull/1008 into 4.0
Resolves https://github.com/AntelopeIO/leap/issues/859