### PR TITLE
[4.0 -> main] Log all http request/response at debug log level

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -385,25 +385,35 @@ namespace eosio {
          boost::asio::post( my->plugin_state->thread_pool.get_executor(), f );
    }
 
-   void http_plugin::handle_exception( const char *api_name, const char *call_name, const string& body, const url_response_callback& cb) {
+   void http_plugin::handle_exception( const char* api_name, const char* call_name, const string& body, const url_response_callback& cb) {
       try {
          try {
             throw;
          } catch (chain::unknown_block_exception& e) {
             error_results results{400, "Unknown Block", error_results::error_info(e, verbose_http_errors)};
             cb( 400, fc::time_point::maximum(), fc::variant( results ));
+            fc_dlog( logger(), "Unknown block while processing ${api}.${call}: ${e}",
+                     ("api", api_name)("call", call_name)("e", e.to_detail_string()) );
          } catch (chain::invalid_http_request& e) {
             error_results results{400, "Invalid Request", error_results::error_info(e, verbose_http_errors)};
             cb( 400, fc::time_point::maximum(), fc::variant( results ));
+            fc_dlog( logger(), "Invalid http request while processing ${api}.${call}: ${e}",
+                     ("api", api_name)("call", call_name)("e", e.to_detail_string()) );
          } catch (chain::account_query_exception& e) {
             error_results results{400, "Account lookup", error_results::error_info(e, verbose_http_errors)};
             cb( 400, fc::time_point::maximum(), fc::variant( results ));
+            fc_dlog( logger(), "Account query exception while processing ${api}.${call}: ${e}",
+                     ("api", api_name)("call", call_name)("e", e.to_detail_string()) );
          } catch (chain::unsatisfied_authorization& e) {
             error_results results{401, "UnAuthorized", error_results::error_info(e, verbose_http_errors)};
             cb( 401, fc::time_point::maximum(), fc::variant( results ));
+            fc_dlog( logger(), "Auth error while processing ${api}.${call}: ${e}",
+                     ("api", api_name)("call", call_name)("e", e.to_detail_string()) );
          } catch (chain::tx_duplicate& e) {
             error_results results{409, "Conflict", error_results::error_info(e, verbose_http_errors)};
             cb( 409, fc::time_point::maximum(), fc::variant( results ));
+            fc_dlog( logger(), "Duplicate trx while processing ${api}.${call}: ${e}",
+                     ("api", api_name)("call", call_name)("e", e.to_detail_string()) );
          } catch (fc::eof_exception& e) {
             error_results results{422, "Unprocessable Entity", error_results::error_info(e, verbose_http_errors)};
             cb( 422, fc::time_point::maximum(), fc::variant( results ));

--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_listener.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_listener.hpp
@@ -121,9 +121,11 @@ private:
                fail(ec, "accept", self->plugin_state_->logger, "closing connection");
             } else {
                // Create the session object and run it
+               std::string remote_endpoint = boost::lexical_cast<std::string>(self->socket_.remote_endpoint());
                std::make_shared<session_type>(
                   std::move(self->socket_),
-                  self->plugin_state_)
+                  self->plugin_state_,
+                  std::move(remote_endpoint))
                   ->run_session();
             }
             

--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -3,6 +3,9 @@
 #include <eosio/http_plugin/common.hpp>
 #include <fc/io/json.hpp>
 
+#include <boost/iostreams/device/array.hpp>
+#include <boost/iostreams/stream.hpp>
+
 #include <memory>
 #include <string>
 #include <charconv>
@@ -59,6 +62,26 @@ bool allow_host(const http::request<http::string_body>& req, T& session,
 
 // Handle HTTP connection using boost::beast for TCP communication
 // Subclasses of this class (plain_session, ssl_session (now removed), etc.)
+// T can be request or response or anything serializable to boost iostreams
+template<typename T>
+std::string to_log_string(const T& req, size_t max_size = 1024) {
+   assert( max_size > 4 );
+   std::string buffer( max_size, '\0' );
+   {
+      boost::iostreams::array_sink sink( buffer.data(), buffer.size() );
+      boost::iostreams::stream stream( sink );
+      stream << req;
+   }
+   buffer.resize( std::strlen( buffer.data() ) );
+   if( buffer.size() == max_size ) {
+      buffer[max_size - 3] = '.';
+      buffer[max_size - 2] = '.';
+      buffer[max_size - 1] = '.';
+   }
+   std::replace_if( buffer.begin(), buffer.end(), []( unsigned char c ) { return c == '\r' || c == '\n'; }, ' ' );
+   return buffer;
+}
+
 // use the Curiously Recurring Template Pattern so that
 // the same code works with both regular TCP sockets and UNIX sockets
 template<class Derived>
@@ -77,6 +100,7 @@ protected:
    std::optional<http::response<http::string_body>> res_;
 
    std::shared_ptr<http_plugin_state> plugin_state_;
+   std::string remote_endpoint_;
 
    // whether response should be sent back to client when an exception occurs
    bool is_send_exception_response_ = true;
@@ -140,6 +164,9 @@ protected:
             send_response("{}", static_cast<unsigned int>(http::status::ok));
             return;
          }
+
+         fc_dlog( plugin_state_->logger, "Request:  ${ep} ${r}",
+                  ("ep", remote_endpoint_)("r", to_log_string(req)) );
 
          std::string resource = std::string(req.target());
          // look for the URL handler to handle this resource
@@ -234,9 +261,9 @@ public:
    // shared_from_this() requires default constructor
    beast_http_session() = default;
 
-   beast_http_session(
-         std::shared_ptr<http_plugin_state> plugin_state)
-       : plugin_state_(std::move(plugin_state)) {
+   beast_http_session(std::shared_ptr<http_plugin_state> plugin_state, std::string remote_endpoint)
+       : plugin_state_(std::move(plugin_state)),
+         remote_endpoint_(std::move(remote_endpoint)) {
       plugin_state_->requests_in_flight += 1;
       req_parser_.emplace();
       req_parser_->body_limit(plugin_state_->max_body_size);
@@ -457,6 +484,9 @@ public:
       // Determine if we should close the connection after
       bool close = !(plugin_state_->keep_alive) || res_->need_eof();
 
+      fc_dlog( plugin_state_->logger, "Response: ${ep} ${b}",
+               ("ep", remote_endpoint_)("b", to_log_string(*res_)) );
+
       // Write the response
       http::async_write(
          derived().stream(),
@@ -487,8 +517,9 @@ public:
    // Create the session
    plain_session(
          tcp_socket_t socket,
-         std::shared_ptr<http_plugin_state> plugin_state)
-       : beast_http_session<plain_session>(std::move(plugin_state)), socket_(std::move(socket)) {}
+         std::shared_ptr<http_plugin_state> plugin_state,
+         std::string remote_endpoint)
+       : beast_http_session<plain_session>(std::move(plugin_state), std::move(remote_endpoint)), socket_(std::move(socket)) {}
 
    tcp_socket_t& stream() { return socket_; }
    tcp_socket_t& socket() { return socket_; }
@@ -531,8 +562,9 @@ class unix_socket_session
 
 public:
    unix_socket_session(stream_protocol::socket sock,
-                       std::shared_ptr<http_plugin_state> plugin_state)
-       : beast_http_session(std::move(plugin_state)), socket_(std::move(sock)) {}
+                       std::shared_ptr<http_plugin_state> plugin_state,
+                       std::string remote_endpoint)
+       : beast_http_session(std::move(plugin_state), std::move(remote_endpoint)), socket_(std::move(sock)) {}
 
    virtual ~unix_socket_session() = default;
 


### PR DESCRIPTION
Log all http request and response at `debug` log level. Limit output to 1024 characters to avoid excessive logging.

Examples:
```
debug 2023-04-10T22:14:42.274 http-0    beast_http_session.hpp:171    handle_request       ] Request:  127.0.0.1:50544 POST /v1/chain/get_info HTTP/1.1  Host: localhost:8888  content-length: 0  Accept: */*  Connection: close    
debug 2023-04-10T22:14:42.275 http-0    beast_http_session.hpp:399    send_response        ] Response: 127.0.0.1:50544 HTTP/1.1 200 OK  Content-Type: application/json  Connection: close  Server: nodeos/v3.2.2  Content-Length: 903    {"server_version":"061f0102","chain_id":"79148b80a054744b63fb590f38bd9dbaac9386c9c0b779c6bbf9f44f97e85d12","head_block_num":4,"last_irreversible_block_num":3,"last_irreversible_block_id":"00000003c406dfd187750cd21bf096ca8c2fe4a8617b324c6c10028c0e298817","head_block_id":"000000040daa201279f98ce7cd4933b7a6fbca66cb92d1704360438f2c501908","head_block_time":"2023-04-10T22:14:42.000","head_block_producer":"eosio","virtual_block_cpu_limit":160320480,"virtual_block_net_limit":1051726,"block_cpu_limit":159999900,"block_net_limit":1048576,"server_version_string":"v3.2.2","fork_db_head_block_num":4,"fork_db_head_block_id":"000000040daa201279f98ce7cd4933b7a6fbca66cb92d1704360438f2c501908","server_full_version_string":"v3.2.2-061f01025885cde8d181a433469a2872dab2148f-dirty","total_cpu_weight":0,"total_net_weight":0,"earliest_available_block_num":1,"last_irreversible_block_time":"2023-04-10T22:14:41.500"}
```
```
debug 2023-04-10T22:15:02.755 http-1    beast_http_session.hpp:171    handle_request       ] Request:  127.0.0.1:53040 POST /v1/chain/send_transaction2 HTTP/1.1  Host: localhost:8888  content-length: 851  Accept: */*  Connection: close    {"return_failure_trace":true,"retry_trx":false,"transaction":{"signatures":["SIG_K1_JyzLqbvpdybyujtiN1YdY2FWcBBi8dWWiFgZ515qyyqgKJJ6892i4rXTHdw5KGYut6EBuXPR3ExRwPSioSZ2bZ1RjNUXVj"],"compression":"none","packed_context_free_data":"","packed_trx":"848a34641800f994a24e00000000030000000000ea305500409e9a2264b89a0160ae423ad15b974a00000000a8ed32326660ae423ad15b974a1042088a4dd35057010000000100038d26b3d5ce8c7d76ef00d3d586a3d7bbc76c42f0b0719cc6f7b0cce1790622c301000000010000000100028dc3921705c71d30b0b26674536fff934f8e43890c980aa1d2c168f00f406539010000000000000000ea3055000000004873bd3e0160ae423ad15b974a00000000a8ed32322060ae423ad15b974a1042088a4dd35057009435770000000004535953000000000000000000ea305500003f2a1ba6a24a0160ae423ad15b974a00000000a8ed32323160ae423ad15b974a1042088a4dd3505740420f0000000000045359530000000040420f000000000004535953000000000000"}}
debug 2023-04-10T22:15:02.766 http-1    beast_http_session.hpp:399    send_response        ] Response: 127.0.0.1:53040 HTTP/1.1 202 Accepted  Content-Type: application/json  Connection: close  Server: nodeos/v3.2.2  Content-Length: 12400    {"transaction_id":"a0dcbbf9a33eb9714baa3ff32b2ca10578852283a5a5befba96c085c6bbd6b1d","processed":{"id":"a0dcbbf9a33eb9714baa3ff32b2ca10578852283a5a5befba96c085c6bbd6b1d","block_num":46,"block_time":"2023-04-10T22:15:03.000","producer_block_id":null,"receipt":{"status":"executed","cpu_usage_us":1324,"net_usage_words":43},"elapsed":1324,"net_usage":344,"scheduled":false,"action_traces":[{"action_ordinal":1,"creator_action_ordinal":0,"closest_unnotified_ancestor_action_ordinal":0,"receipt":{"receiver":"eosio","act_digest":"4f9d85e9c084dbb6c810a1ea89584ee30778796e11b9023add948520a1ba342d","global_sequence":484,"recv_sequence":283,"auth_sequence":[["defproducera",42]],"code_sequence":2,"abi_sequence":2},"receiver":"eosio","act":{"account":"eosio","name":"newaccount","authorization":[{"actor":"defproducera","permission":"active"}],"data":{"creator":"defproducera","name":"exchange1111","owner"...
```
```
debug 2023-04-10T22:14:59.021 http-0    beast_http_session.hpp:171    handle_request       ] Request:  127.0.0.1:52564 POST /v1/chain/get_required_keys HTTP/1.1  Host: localhost:8888  content-length: 1344  Accept: */*  Connection: close    {"transaction":{"expiration":"2023-04-10T22:15:29","ref_block_num":24,"ref_block_prefix":1319277817,"max_net_usage_words":0,"max_cpu_usage_ms":0,"delay_sec":0,"context_free_actions":[],"actions":[{"account":"eosio","name":"newaccount","authorization":[{"actor":"defproducera","permission":"active"}],"data":"60ae423ad15b974a104208c15c95b1ca01000000010003a96e8a12c60247787fd66062e9af194c0a9b26d46048981a7d97abe3f5ec26e301000000010000000100028dc3921705c71d30b0b26674536fff934f8e43890c980aa1d2c168f00f40653901000000"},{"account":"eosio","name":"buyram","authorization":[{"actor":"defproducera","permission":"active"}],"data":"60ae423ad15b974a104208c15c95b1ca00e1f505000000000453595300000000"},{"account":"eosio","name":"delegatebw","authorization":[{"actor":"defproducera","permission":"active"}],"data":"60ae423ad15b974a104208c15c95b1ca40420f0000000000045359530000000040420f0000000000045359530000000000...
debug 2023-04-10T22:14:59.022 http-0    beast_http_session.hpp:399    send_response        ] Response: 127.0.0.1:52564 HTTP/1.1 200 OK  Content-Type: application/json  Connection: close  Server: nodeos/v3.2.2  Content-Length: 75    {"required_keys":["EOS6m1AQKwtJgXdCMMPoVK4nKYD2id1tQ2jtd3TdDXdYXbJwQC41y"]}
```

Merges #1000 & #1009 into `main`

Resolves #678 