### PR TITLE
P2P:  Inform peer if not accepting transactions

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3598,7 +3598,8 @@ namespace eosio {
          hello.token = sha256();
       hello.p2p_address = my_impl->p2p_address;
       if( is_transactions_only_connection() ) hello.p2p_address += ":trx";
-      if( is_blocks_only_connection() ) hello.p2p_address += ":blk";
+      // if we are not accepting transactions tell peer we are blocks only
+      if( is_blocks_only_connection() || !my_impl->p2p_accept_transactions ) hello.p2p_address += ":blk";
       hello.p2p_address += " - " + hello.node_id.str().substr(0,7);
 #if defined( __APPLE__ )
       hello.os = "osx";


### PR DESCRIPTION
Optimize network traffic by informing peers when node is configured for `p2p-accept-transactions=false`. Since the transactions will be immediately dropped, no reason for the peer to send them. 
If configured to not accept transactions, `p2p-accept-transactions=false`, then inform peer the node is a blocks only connection.

Resolves #767 