### PR TITLE
Fix clang++16 warnings

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -69,7 +69,7 @@ class maybe_session {
       maybe_session() = default;
 
       maybe_session( maybe_session&& other)
-      :_session(move(other._session))
+      :_session(std::move(other._session))
       {
       }
 
@@ -96,7 +96,7 @@ class maybe_session {
 
       maybe_session& operator = ( maybe_session&& mv ) {
          if (mv._session) {
-            _session.emplace(move(*mv._session));
+            _session.emplace(std::move(*mv._session));
             mv._session.reset();
          } else {
             _session.reset();
@@ -150,7 +150,7 @@ struct pending_state {
                   block_timestamp_type when,
                   uint16_t num_prev_blocks_to_confirm,
                   const vector<digest_type>& new_protocol_feature_activations )
-   :_db_session( move(s) )
+   :_db_session( std::move(s) )
    ,_block_stage( building_block( prev, when, num_prev_blocks_to_confirm, new_protocol_feature_activations ) )
    {}
 
@@ -2429,7 +2429,7 @@ struct controller_impl {
       for( const auto& a : trxs )
          trx_digests.emplace_back( a.digest() );
 
-      return merkle( move(trx_digests) );
+      return merkle( std::move(trx_digests) );
    }
 
    void update_producers_authority() {

--- a/libraries/chain/include/eosio/chain/authority.hpp
+++ b/libraries/chain/include/eosio/chain/authority.hpp
@@ -188,7 +188,7 @@ struct authority {
    }
 
    authority( uint32_t t, vector<key_weight> k, vector<permission_level_weight> p = {}, vector<wait_weight> w = {} )
-   :threshold(t),keys(move(k)),accounts(move(p)),waits(move(w)){}
+   :threshold(t),keys(std::move(k)),accounts(std::move(p)),waits(std::move(w)){}
    authority(){}
 
    uint32_t                          threshold = 0;

--- a/libraries/libfc/include/fc/crypto/common.hpp
+++ b/libraries/libfc/include/fc/crypto/common.hpp
@@ -178,7 +178,7 @@ namespace fc { namespace crypto {
       {}
 
       shim(data_type&& data)
-      :_data(forward<data_type>(data))
+      :_data(std::forward<data_type>(data))
       {}
 
       shim(const data_type& data)

--- a/libraries/libfc/include/fc/crypto/private_key.hpp
+++ b/libraries/libfc/include/fc/crypto/private_key.hpp
@@ -53,7 +53,7 @@ namespace fc { namespace crypto {
          storage_type _storage;
 
          private_key( storage_type&& other_storage )
-         :_storage(forward<storage_type>(other_storage))
+         :_storage(std::forward<storage_type>(other_storage))
          {}
 
          friend bool operator == ( const private_key& p1, const private_key& p2);

--- a/libraries/libfc/include/fc/crypto/public_key.hpp
+++ b/libraries/libfc/include/fc/crypto/public_key.hpp
@@ -31,7 +31,7 @@ namespace fc { namespace crypto {
          public_key( const signature& c, const sha256& digest, bool check_canonical = true );
 
          public_key( storage_type&& other_storage )
-         :_storage(forward<storage_type>(other_storage))
+         :_storage(std::forward<storage_type>(other_storage))
          {}
 
          bool valid()const;

--- a/libraries/libfc/include/fc/variant_object.hpp
+++ b/libraries/libfc/include/fc/variant_object.hpp
@@ -77,7 +77,7 @@ namespace fc
       variant_object( string key, T&& val )
       :_key_value( std::make_shared<std::vector<entry> >() )
       {
-         *this = variant_object( std::move(key), variant(forward<T>(val)) );
+         *this = variant_object( std::move(key), variant(std::forward<T>(val)) );
       }
       variant_object( const variant_object& );
       variant_object( variant_object&& );
@@ -223,7 +223,7 @@ namespace fc
       mutable_variant_object( string key, T&& val )
       :_key_value( new std::vector<entry>() )
       {
-         set( std::move(key), variant(forward<T>(val)) );
+         set( std::move(key), variant(std::forward<T>(val)) );
       }
 
       mutable_variant_object( mutable_variant_object&& );

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -280,12 +280,12 @@ namespace eosio { namespace testing {
 
          template<typename ObjectType, typename IndexBy, typename... Args>
          const auto& get( Args&&... args ) {
-            return control->db().get<ObjectType,IndexBy>( forward<Args>(args)... );
+            return control->db().get<ObjectType,IndexBy>( std::forward<Args>(args)... );
          }
 
          template<typename ObjectType, typename IndexBy, typename... Args>
          const auto* find( Args&&... args ) {
-            return control->db().find<ObjectType,IndexBy>( forward<Args>(args)... );
+            return control->db().find<ObjectType,IndexBy>( std::forward<Args>(args)... );
          }
 
          template< typename KeyType = fc::ecc::private_key_shim >

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -864,7 +864,7 @@ namespace eosio { namespace testing {
                                    .account    = account,
                                    .permission = perm,
                                    .parent     = parent,
-                                   .auth       = move(auth),
+                                   .auth       = std::move(auth),
                                 });
 
          set_transaction_headers(trx);

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -715,7 +715,7 @@ void send_actions(std::vector<chain::action>&& actions, const std::vector<public
       out.open(tx_json_save_file);
       EOSC_ASSERT(!out.fail(), "ERROR: Failed to create file \"${p}\"", ("p", tx_json_save_file));
    }
-   auto result = push_actions( move(actions), signing_keys);
+   auto result = push_actions( std::move(actions), signing_keys);
 
    string jsonstr;
    if (tx_json_save_file.length()) {

--- a/tests/trx_generator/trx_generator.hpp
+++ b/tests/trx_generator/trx_generator.hpp
@@ -11,7 +11,7 @@
 namespace eosio::testing {
 
    struct signed_transaction_w_signer {
-      signed_transaction_w_signer(eosio::chain::signed_transaction trx, fc::crypto::private_key key) : _trx(move(trx)), _signer(key) {}
+      signed_transaction_w_signer(eosio::chain::signed_transaction trx, fc::crypto::private_key key) : _trx(std::move(trx)), _signer(key) {}
 
       eosio::chain::signed_transaction _trx;
       fc::crypto::private_key _signer;

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_test)
    const auto& trxs = copy_b->transactions;
    for( const auto& a : trxs )
       trx_digests.emplace_back( a.digest() );
-   copy_b->transaction_mroot = merkle( move(trx_digests) );
+   copy_b->transaction_mroot = merkle( std::move(trx_digests) );
 
    // Re-sign the block
    auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), main.control->head_block_state()->blockroot_merkle.get_root() ) );
@@ -115,7 +115,7 @@ std::pair<signed_block_ptr, signed_block_ptr> corrupt_trx_in_block(validating_te
    const auto& trxs = copy_b->transactions;
    for( const auto& a : trxs )
       trx_digests.emplace_back( a.digest() );
-   copy_b->transaction_mroot = merkle( move(trx_digests) );
+   copy_b->transaction_mroot = merkle( std::move(trx_digests) );
 
    // Re-sign the block
    auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), main.control->head_block_state()->blockroot_merkle.get_root() ) );


### PR DESCRIPTION
Just add `std::` to `move` and `forward`.