### PR TITLE
P2P: Misc improvements

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1061,7 +1061,6 @@ namespace eosio {
       self->flush_queues();
       self->connecting = false;
       self->syncing = false;
-      self->closing = false;
       self->block_status_monitor_.reset();
       ++self->consecutive_immediate_connection_close;
       bool has_last_req = false;
@@ -1082,6 +1081,7 @@ namespace eosio {
       if( !shutdown) my_impl->sync_master->sync_reset_lib_num( self->shared_from_this(), true );
       peer_ilog( self, "closing" );
       self->cancel_wait();
+      self->closing = false;
 
       if( reconnect && !shutdown ) {
          my_impl->start_conn_timer( std::chrono::milliseconds( 100 ), connection_wptr() );


### PR DESCRIPTION
In preparation of work for #452 some initial cleanup.

Testing with performance harness when sending more transactions than nodeos can process it fills up the write queue. This is designed to then close the connection. nodeos was generating thousands of write queue full messages (example below) because the posted `close()` call would have to wait until all the currently queued up tasks on the strand finished. This delayed the close for seconds. Added a `closing` flag to stop existing tasks quickly, resulting in only one message instead of thousands and an immediate close.
```
error 2023-04-15T16:46:16.320 net-0     net_plugin.cpp:2494           start_read_message   ] ["localhost:9877 - d7c63c8" - 1 127.0.0.1:37658] write queue full 71936405 bytes, giving up on connection, closing
```

Added better encapsulation of the `sync_mtx`.
Added `alignas(hardware_destructive_interference_size)` to avoid cache synchronization.

