### PR TITLE
add needed `string` include for some newer libc++ versions

### DIFF
--- a/libraries/wasm-jit/Include/WAST/WAST.h
+++ b/libraries/wasm-jit/Include/WAST/WAST.h
@@ -4,6 +4,8 @@
 	#define WAST_API DLL_IMPORT
 #endif
 
+#include <string>
+
 #include "Inline/BasicTypes.h"
 #include "WASM/WASM.h"
 


### PR DESCRIPTION
At least for some newer libc++ versions, like those in latest XCode, we need to include `string` in this file.