### PR TITLE
P2P: Save and retry unlinkable blocks

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2159,10 +2159,12 @@ namespace eosio {
       unlinkable_blk_state.insert( {id, std::move(b)} ); // does not insert if already there
       if (unlinkable_blk_state.size() > max_unlinkable_cache_size) {
          auto& index = unlinkable_blk_state.get<by_timestamp>();
-         index.erase( index.begin() );
+         auto begin = index.begin();
+         block_id_type rm_block_id = begin->id;
+         index.erase( begin );
          g.unlock();
          // rm_block since we are no longer tracking this not applied block, allowing it to flow back in if needed
-         rm_block(id);
+         rm_block(rm_block_id);
       }
    }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -131,7 +131,6 @@ namespace eosio {
       const block_timestamp_type& timestamp() const { return block->timestamp; }
    };
 
-   class dispatch_manager;
    class unlinkable_block_state_cache {
    private:
       struct by_timestamp;


### PR DESCRIPTION
Keep a small cache of unlinkable blocks to retry. This is mainly to address the issue of blocks coming in on multiple connections and getting processed out of order. On an unlinkable block exception, store the block and retry it if its `previous` block is applied.

Resolves #452