### PR TITLE
Fix control reaches end of non-void function warning

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -524,6 +524,9 @@ fc::variant push_transaction( signed_transaction& trx, const std::vector<public_
         return fc::variant(packed_transaction(trx, compression));
       }
    }
+
+   EOSC_ASSERT( fasle, "control reaches end of push_transaction" );
+   return {};
 }
 
 fc::variant push_actions(std::vector<chain::action>&& actions, const std::vector<public_key_type>& signing_keys = std::vector<public_key_type>() ) {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -525,7 +525,7 @@ fc::variant push_transaction( signed_transaction& trx, const std::vector<public_
       }
    }
 
-   EOSC_ASSERT( fasle, "control reaches end of push_transaction" );
+   EOSC_ASSERT( false, "control reaches end of push_transaction" );
    return {};
 }
 


### PR DESCRIPTION
Fix one of the last two warnings in Leap on Ubuntu 20.02:

```
/home/lh/work/leap-main/programs/cleos/main.cpp:527:1: warning: control reaches end of non-void function [-Wreturn-type]
  527 | }
```