### PR TITLE
Added missing namespace to logger in case of FC_USE_PTHREAD_NAME_NP not defined

### DIFF
--- a/libraries/libfc/src/log/logger_config.cpp
+++ b/libraries/libfc/src/log/logger_config.cpp
@@ -151,7 +151,7 @@ namespace fc {
          }
 #else
          static int thread_count = 0;
-         thread_name = string( "thread-" ) + fc::to_string( thread_count++ );
+         thread_name = std::string( "thread-" ) + fc::to_string( thread_count++ );
 #endif
       }
       return thread_name;


### PR DESCRIPTION
When compiled not on Linux (BSD here)  FC_USE_PTHREAD_NAME_NP not defined and code for this scenario was missing std:: for string
