### PR TITLE
remove unused libssl from libtester cmakes

### DIFF
--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -89,7 +89,6 @@ macro(add_eosio_test_executable test_name)
        ${libir}
        ${libsoftfloat}
        ${liboscrypto}
-       ${libosssl}
        ${liblogging}
        ${libchainbase}
        ${libbuiltins}

--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -65,8 +65,6 @@ find_library(liblogging Logging @CMAKE_INSTALL_FULL_LIBDIR@ NO_DEFAULT_PATH)
 find_library(libsoftfloat softfloat @CMAKE_INSTALL_FULL_LIBDIR@ NO_DEFAULT_PATH)
 get_filename_component(cryptodir @OPENSSL_CRYPTO_LIBRARY@ DIRECTORY)
 find_library(liboscrypto crypto "${cryptodir}" NO_DEFAULT_PATH)
-get_filename_component(ssldir @OPENSSL_SSL_LIBRARY@ DIRECTORY)
-find_library(libosssl ssl "${ssldir}" NO_DEFAULT_PATH)
 find_library(libchainbase chainbase @CMAKE_INSTALL_FULL_LIBDIR@ NO_DEFAULT_PATH)
 find_library(libbuiltins builtins @CMAKE_INSTALL_FULL_LIBDIR@ NO_DEFAULT_PATH)
 

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -86,7 +86,6 @@ macro(add_eosio_test_executable test_name)
        ${libir}
        ${libsoftfloat}
        ${liboscrypto}
-       ${libosssl}
        ${liblogging}
        ${libchainbase}
        ${libbuiltins}

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -62,8 +62,6 @@ find_library(liblogging Logging @CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/Log
 find_library(libsoftfloat softfloat @CMAKE_BINARY_DIR@/libraries/softfloat NO_DEFAULT_PATH)
 get_filename_component(cryptodir @OPENSSL_CRYPTO_LIBRARY@ DIRECTORY)
 find_library(liboscrypto crypto "${cryptodir}" NO_DEFAULT_PATH)
-get_filename_component(ssldir @OPENSSL_SSL_LIBRARY@ DIRECTORY)
-find_library(libosssl ssl "${ssldir}" NO_DEFAULT_PATH)
 find_library(libchainbase chainbase @CMAKE_BINARY_DIR@/libraries/chainbase NO_DEFAULT_PATH)
 find_library(libbuiltins builtins @CMAKE_BINARY_DIR@/libraries/builtins NO_DEFAULT_PATH)
 


### PR DESCRIPTION
libssl has been unused since #745 so remove it from libtester cmakes

A contract build with this change is available at
https://github.com/eosnetworkfoundation/eos-system-contracts/actions/runs/4765703258