### PR TITLE
Fix test failure on fast machine (release builds)

### DIFF
--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1349,7 +1349,7 @@ BOOST_FIXTURE_TEST_CASE(checktime_hashing_fail, TESTER) { try {
 
         //hit deadline exception, but cache the contract
         BOOST_CHECK_EXCEPTION( call_test( *this, test_api_action<TEST_METHOD("test_checktime", "checktime_sha1_failure")>{},
-                                          5000, 10, 10 ),
+                                          5000, 8, 8 ),
                                deadline_exception, is_deadline_exception );
 
         BOOST_TEST( is_code_cached("testapi"_n) );

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1072,10 +1072,10 @@ BOOST_AUTO_TEST_CASE(checktime_pause_max_trx_cpu_extended_test) { try {
    dlog("elapsed ${e}us", ("e", dur) );
    BOOST_CHECK( dur >= 24'999 ); // should never fail
    BOOST_TEST( t.is_code_cached("pause"_n) );
-      // This assumes that loading the WASM takes at least 1.5 ms
+   // This assumes that loading the WASM takes at least 0.750 ms
    // If this check fails but duration is >= 24'999 (previous check did not fail), then the check here is likely
-   // because WASM took less than 1.5 ms to load.
-   BOOST_CHECK_MESSAGE( dur > 26'500, "elapsed " << dur << "us" );
+   // because WASM took less than 0.750 ms to load.
+   BOOST_CHECK_MESSAGE( dur > 25'750, "elapsed " << dur << "us" );
    BOOST_CHECK_MESSAGE( dur < 150'000, "elapsed " << dur << "us" ); // Should not run to block_cpu_usage deadline
 
    // Test hitting max_transaction_time throws tx_cpu_usage_exceeded
@@ -1130,10 +1130,10 @@ BOOST_AUTO_TEST_CASE(checktime_pause_max_trx_extended_test) { try {
    dlog("elapsed ${e}us", ("e", dur) );
    BOOST_CHECK( dur >= 25'000 ); // should never fail
    BOOST_TEST( t.is_code_cached("pause"_n) );
-   // This assumes that loading the WASM takes at least 1.5 ms
+   // This assumes that loading the WASM takes at least 0.750 ms
    // If this check fails but duration is >= 25'000 (previous check did not fail), then the check here is likely
-   // because WASM took less than 1.5 ms to load.
-   BOOST_CHECK_MESSAGE( dur > 26'500, "elapsed " << dur << "us" );
+   // because WASM took less than 0.750 ms to load.
+   BOOST_CHECK_MESSAGE( dur > 25'750, "elapsed " << dur << "us" );
    BOOST_CHECK_MESSAGE( dur < 250'000, "elapsed " << dur << "us" ); // Should not run to max_transaction_cpu_usage deadline
 
    BOOST_REQUIRE_EQUAL( t.validate(), true );


### PR DESCRIPTION
When I build in release mode, I have the following tests failing (both gcc-12 and clang-16, no problem in debug) 
```
/home/greg/github/enf/leap/unittests/api_tests.cpp(1078): error: in "api_tests/checktime_pause_max_trx_cpu_extended_test": elapsed 26100us 
/home/greg/github/enf/leap/unittests/api_tests.cpp(1136): error: in "api_tests/checktime_pause_max_trx_extended_test": elapsed 26056us
```

This is the first failure in the code:
```
   // This assumes that loading the WASM takes at least 1.5 ms
   // If this check fails but duration is >= 24'999 (previous check did not fail), then the check here is likely
   // because WASM took less than 1.5 ms to load.
   BOOST_CHECK_MESSAGE( dur > 26'500, "elapsed " << dur << "us" );
```

I also have the following failure occasionally when building in release with gcc-12.

```
/home/greg/github/enf/leap_main/unittests/api_tests.cpp(1351): error: in "api_tests/checktime_hashing_fail": exception deadline_exception expected but not raised
```
So lowering deadline from 10ms to 8ms.