### PR TITLE
Refactor: Move subjective_billing to chain library

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -21,6 +21,7 @@
 #include <eosio/chain/protocol_feature_manager.hpp>
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/subjective_billing.hpp>
 #include <eosio/chain/chain_snapshot.hpp>
 #include <eosio/chain/thread_utils.hpp>
 #include <eosio/chain/platform_timer.hpp>
@@ -232,6 +233,7 @@ struct controller_impl {
    block_state_ptr                 head;
    fork_database                   fork_db;
    resource_limits_manager         resource_limits;
+   subjective_billing              subjective_bill;
    authorization_manager           authorization;
    protocol_feature_manager        protocol_features;
    controller::config              conf;
@@ -2766,6 +2768,15 @@ const protocol_feature_manager& controller::get_protocol_feature_manager()const
 {
    return my->protocol_features;
 }
+
+const subjective_billing& controller::get_subjective_billing()const {
+   return my->subjective_bill;
+}
+
+subjective_billing& controller::get_mutable_subjective_billing() {
+   return my->subjective_bill;
+}
+
 
 uint32_t controller::get_max_nonprivileged_inline_action_size()const
 {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -39,6 +39,7 @@ namespace eosio { namespace chain {
    class permission_object;
    class account_object;
    class deep_mind_handler;
+   class subjective_billing;
    using resource_limits::resource_limits_manager;
    using apply_handler = std::function<void(apply_context&)>;
    using forked_branch_callback = std::function<void(const branch_type&)>;
@@ -197,6 +198,8 @@ namespace eosio { namespace chain {
          const authorization_manager&          get_authorization_manager()const;
          authorization_manager&                get_mutable_authorization_manager();
          const protocol_feature_manager&       get_protocol_feature_manager()const;
+         const subjective_billing&             get_subjective_billing()const;
+         subjective_billing&                   get_mutable_subjective_billing();
          uint32_t                              get_max_nonprivileged_inline_action_size()const;
 
          const flat_set<account_name>&   get_actor_whitelist() const;

--- a/libraries/chain/include/eosio/chain/subjective_billing.hpp
+++ b/libraries/chain/include/eosio/chain/subjective_billing.hpp
@@ -13,7 +13,7 @@
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 
-namespace eosio {
+namespace eosio::chain {
 
 class subjective_billing {
 private:
@@ -92,7 +92,7 @@ private:
 
 public: // public for tests
    static constexpr uint32_t subjective_time_interval_ms = 5'000;
-   size_t get_account_cache_size() {return _account_subjective_bill_cache.size();}
+   size_t get_account_cache_size() const {return _account_subjective_bill_cache.size();}
    void remove_subjective_billing( const chain::transaction_id_type& trx_id, uint32_t time_ordinal ) {
       auto& idx = _trx_cache_index.get<by_id>();
       auto itr = idx.find( trx_id );
@@ -149,9 +149,6 @@ public:
       }
    }
 
-   void abort_block() {
-   }
-
    void on_block( fc::logger& log, const chain::block_state_ptr& bsp, const fc::time_point& now ) {
       if( bsp == nullptr || _disabled ) return;
       const auto time_ordinal = time_ordinal_for(now);
@@ -200,4 +197,4 @@ public:
    }
 };
 
-} //eosio
+} //eosio::chain

--- a/plugins/chain_plugin/CMakeLists.txt
+++ b/plugins/chain_plugin/CMakeLists.txt
@@ -11,7 +11,7 @@ if(EOSIO_ENABLE_DEVELOPER_OPTIONS)
     target_compile_definitions(chain_plugin PUBLIC EOSIO_DEVELOPER)
 endif()
 
-target_link_libraries( chain_plugin producer_plugin eosio_chain appbase resource_monitor_plugin )
-target_include_directories( chain_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/../chain_interface/include" "${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/appbase/include" "${CMAKE_CURRENT_SOURCE_DIR}/../producer_plugin/include" "${CMAKE_CURRENT_SOURCE_DIR}/../resource_monitor_plugin/include")
+target_link_libraries( chain_plugin eosio_chain custom_appbase appbase resource_monitor_plugin )
+target_include_directories( chain_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/../chain_interface/include" "${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/appbase/include" "${CMAKE_CURRENT_SOURCE_DIR}/../resource_monitor_plugin/include")
 
 add_subdirectory( test )

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -47,8 +47,6 @@ namespace eosio {
    using chain::abi_resolver;
    using chain::packed_transaction;
 
-class producer_plugin;
-
 namespace chain_apis {
 struct empty{};
 
@@ -128,7 +126,6 @@ class read_only : public api_base {
    const fc::microseconds abi_serializer_max_time;
    const fc::microseconds http_max_response_time;
    bool  shorten_abi_errors = true;
-   const producer_plugin* producer_plug;
    const trx_finality_status_processing* trx_finality_status_proc;
    friend class api_base;
    
@@ -137,13 +134,11 @@ public:
 
    read_only(const controller& db, const std::optional<account_query_db>& aqdb,
              const fc::microseconds& abi_serializer_max_time, const fc::microseconds& http_max_response_time,
-             const producer_plugin* producer_plug,
              const trx_finality_status_processing* trx_finality_status_proc)
       : db(db)
       , aqdb(aqdb)
       , abi_serializer_max_time(abi_serializer_max_time)
       , http_max_response_time(http_max_response_time)
-      , producer_plug(producer_plug)
       , trx_finality_status_proc(trx_finality_status_proc) {
    }
 

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -138,7 +138,6 @@ public:
 
    bool                   is_producer_key(const chain::public_key_type& key) const;
    chain::signature_type  sign_compact(const chain::public_key_type& key, const fc::sha256& digest) const;
-   int64_t get_subjective_bill( const account_name& first_auth, const fc::time_point& now ) const;
 
    virtual void plugin_initialize(const boost::program_options::variables_map& options);
    virtual void plugin_startup();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1,12 +1,12 @@
 #include <eosio/producer_plugin/producer_plugin.hpp>
 #include <eosio/producer_plugin/pending_snapshot.hpp>
-#include <eosio/producer_plugin/subjective_billing.hpp>
 #include <eosio/producer_plugin/snapshot_scheduler.hpp>
 #include <eosio/producer_plugin/block_timing_util.hpp>
 #include <eosio/chain/plugin_interface.hpp>
 #include <eosio/chain/global_property_object.hpp>
 #include <eosio/chain/generated_transaction_object.hpp>
 #include <eosio/chain/snapshot.hpp>
+#include <eosio/chain/subjective_billing.hpp>
 #include <eosio/chain/transaction_object.hpp>
 #include <eosio/chain/thread_utils.hpp>
 #include <eosio/chain/unapplied_transaction_queue.hpp>
@@ -141,12 +141,7 @@ namespace {
 // track multiple failures on unapplied transactions
 class account_failures {
 public:
-
-   //lifetime of sb must outlive account_failures
-   explicit account_failures( const eosio::subjective_billing& sb )
-   : subjective_billing(sb)
-   {
-   }
+   account_failures() = default;
 
    void set_max_failures_per_account( uint32_t max_failures, uint32_t size ) {
       max_failures_per_account = max_failures;
@@ -162,17 +157,16 @@ public:
    // return true if exceeds max_failures_per_account and should be dropped
    bool failure_limit( const account_name& n ) {
       auto fitr = failed_accounts.find( n );
-      bool is_whitelisted = subjective_billing.is_account_disabled( n );
-      if( !is_whitelisted && fitr != failed_accounts.end() && fitr->second.num_failures >= max_failures_per_account ) {
+      if( fitr != failed_accounts.end() && fitr->second.num_failures >= max_failures_per_account ) {
          ++fitr->second.num_failures;
          return true;
       }
       return false;
    }
 
-   void report_and_clear(uint32_t block_num) {
+   void report_and_clear(uint32_t block_num, const chain::subjective_billing& sub_bill) {
       if (last_reset_block_num != block_num && (block_num % reset_window_size_in_num_blocks == 0) ) {
-         report(block_num);
+         report(block_num, sub_bill);
          failed_accounts.clear();
          last_reset_block_num = block_num;
       }
@@ -184,7 +178,7 @@ public:
    }
 
 private:
-   void report(uint32_t block_num) const {
+   void report(uint32_t block_num, const chain::subjective_billing& sub_bill) const {
       if( _log.is_enabled(fc::log_level::debug)) {
          auto now = fc::time_point::now();
          for ( const auto& e : failed_accounts ) {
@@ -203,7 +197,7 @@ private:
                reason += "other";
             }
             fc_dlog( _log, "Failed ${n} trxs, account: ${a}, sub bill: ${b}us, reason: ${r}",
-                     ("n", e.second.num_failures)("b", subjective_billing.get_subjective_bill(e.first, now))
+                     ("n", e.second.num_failures)("b", sub_bill.get_subjective_bill(e.first, now))
                      ("a", e.first)("r", reason) );
          }
       }
@@ -245,7 +239,6 @@ private:
    uint32_t max_failures_per_account = 3;
    uint32_t last_reset_block_num = 0;
    uint32_t reset_window_size_in_num_blocks = 1;
-   const eosio::subjective_billing& subjective_billing;
 };
 
 struct block_time_tracker {
@@ -339,7 +332,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       push_result handle_push_result( const transaction_metadata_ptr& trx,
                                       const next_function<transaction_trace_ptr>& next,
                                       const fc::time_point& start,
-                                      const chain::controller& chain,
+                                      chain::controller& chain,
                                       const transaction_trace_ptr& trace,
                                       bool return_failure_trace,
                                       bool disable_subjective_enforcement,
@@ -391,8 +384,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
       transaction_id_with_expiry_index                         _blacklisted_transactions;
       pending_snapshot_index                                   _pending_snapshot_index;
-      subjective_billing                                       _subjective_billing;
-      account_failures                                         _account_fails{_subjective_billing};
+      account_failures                                         _account_fails;
       block_time_tracker                                       _time_tracker;
 
       std::optional<scoped_connection>                          _accepted_block_connection;
@@ -500,9 +492,10 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       }
 
       void on_block( const block_state_ptr& bsp ) {
+         auto& chain = chain_plug->chain();
          auto before = _unapplied_transactions.size();
          _unapplied_transactions.clear_applied( bsp );
-         _subjective_billing.on_block( _log, bsp, fc::time_point::now() );
+         chain.get_mutable_subjective_billing().on_block( _log, bsp, fc::time_point::now() );
          if (before > 0) {
             fc_dlog( _log, "Removed applied transactions before: ${before}, after: ${after}",
                      ("before", before)("after", _unapplied_transactions.size()) );
@@ -536,12 +529,12 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
       void update_block_metrics() {
          if (_metrics.should_post()) {
+            auto& chain = chain_plug->chain();
             _metrics.unapplied_transactions.value = _unapplied_transactions.size();
-            _metrics.subjective_bill_account_size.value = _subjective_billing.get_account_cache_size();
+            _metrics.subjective_bill_account_size.value = chain.get_subjective_billing().get_account_cache_size();
             _metrics.blacklisted_transactions.value = _blacklisted_transactions.size();
             _metrics.unapplied_transactions.value = _unapplied_transactions.size();
 
-            auto &chain = chain_plug->chain();
             _metrics.last_irreversible.value = chain.last_irreversible_block_num();
             _metrics.head_block_num.value = chain.head_block_num();
 
@@ -559,7 +552,6 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             _time_tracker.report( _idle_trx_time, chain.pending_block_num() );
          }
          _unapplied_transactions.add_aborted( chain.abort_block() );
-         _subjective_billing.abort_block();
          _idle_trx_time = fc::time_point::now();
       }
 
@@ -939,11 +931,6 @@ bool producer_plugin::is_producer_key(const chain::public_key_type& key) const
   return false;
 }
 
-int64_t producer_plugin::get_subjective_bill( const account_name& first_auth, const fc::time_point& now ) const
-{
-   return my->_subjective_billing.get_subjective_bill( first_auth, now );
-}
-
 chain::signature_type producer_plugin::sign_compact(const chain::public_key_type& key, const fc::sha256& digest) const
 {
   if(key != chain::public_key_type()) {
@@ -1026,7 +1013,7 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
    fc::microseconds subjective_account_decay_time = fc::minutes(options.at( "subjective-account-decay-time-minutes" ).as<uint32_t>());
    EOS_ASSERT( subjective_account_decay_time.count() > 0, plugin_config_exception,
                "subjective-account-decay-time-minutes ${dt} must be greater than 0", ("dt", subjective_account_decay_time.to_seconds() / 60));
-   my->_subjective_billing.set_expired_accumulator_average_window( subjective_account_decay_time );
+   chain.get_mutable_subjective_billing().set_expired_accumulator_average_window( subjective_account_decay_time );
 
    my->_max_transaction_time_ms = options.at("max-transaction-time").as<int32_t>();
 
@@ -1052,7 +1039,7 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
        disable_subjective_billing = false;
    }
    if( disable_subjective_billing ) {
-       my->_subjective_billing.disable();
+      chain.get_mutable_subjective_billing().disable();
        ilog( "Subjective CPU billing disabled" );
    } else if( !my->_disable_subjective_p2p_billing && !my->_disable_subjective_api_billing ) {
        ilog( "Subjective CPU billing enabled" );
@@ -1179,7 +1166,7 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
    if( options.count("disable-subjective-account-billing") ) {
       std::vector<std::string> accounts = options["disable-subjective-account-billing"].as<std::vector<std::string>>();
       for( const auto& a : accounts ) {
-         my->_subjective_billing.disable_account( account_name(a) );
+         chain.get_mutable_subjective_billing().disable_account( account_name(a) );
       }
    }
 
@@ -1979,15 +1966,16 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
       }
 
       try {
-         _account_fails.report_and_clear(hbs->block_num);
+         chain::subjective_billing& subjective_bill = chain.get_mutable_subjective_billing();
+         _account_fails.report_and_clear(hbs->block_num, subjective_bill);
          _time_tracker.clear();
 
          if( !remove_expired_trxs( preprocess_deadline ) )
             return start_block_result::exhausted;
          if( !remove_expired_blacklisted_trxs( preprocess_deadline ) )
             return start_block_result::exhausted;
-         if( !_subjective_billing.remove_expired( _log, chain.pending_block_time(), fc::time_point::now(),
-                                                  [&](){ return should_interrupt_start_block( preprocess_deadline, pending_block_num ); } ) ) {
+         if( !subjective_bill.remove_expired( _log, chain.pending_block_time(), fc::time_point::now(),
+                                              [&](){ return should_interrupt_start_block( preprocess_deadline, pending_block_num ); } ) ) {
             return start_block_result::exhausted;
          }
 
@@ -2220,12 +2208,16 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
    auto start = fc::time_point::now();
    EOS_ASSERT(!trx->is_read_only(), producer_exception, "Unexpected read-only trx");
 
+   chain::controller& chain = chain_plug->chain();
+   chain::subjective_billing& subjective_bill = chain.get_mutable_subjective_billing();
+
+   auto first_auth = trx->packed_trx()->get_transaction().first_authorizer();
+
    bool disable_subjective_enforcement = (api_trx && _disable_subjective_api_billing)
                                          || (!api_trx && _disable_subjective_p2p_billing)
+                                         || subjective_bill.is_account_disabled( first_auth )
                                          || trx->is_transient();
 
-   chain::controller& chain = chain_plug->chain();
-   auto first_auth = trx->packed_trx()->get_transaction().first_authorizer();
    if( !disable_subjective_enforcement && _account_fails.failure_limit( first_auth ) ) {
       if( next ) {
          auto except_ptr = std::static_pointer_cast<fc::exception>( std::make_shared<tx_cpu_usage_exceeded>(
@@ -2244,12 +2236,12 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
 
    int64_t sub_bill = 0;
    if( !disable_subjective_enforcement )
-      sub_bill = _subjective_billing.get_subjective_bill( first_auth, fc::time_point::now() );
+      sub_bill = subjective_bill.get_subjective_bill( first_auth, fc::time_point::now() );
 
    auto prev_billed_cpu_time_us = trx->billed_cpu_time_us;
    if( _pending_block_mode == pending_block_mode::producing && prev_billed_cpu_time_us > 0 ) {
       const auto& rl = chain.get_resource_limits_manager();
-      if ( !_subjective_billing.is_account_disabled( first_auth ) && !rl.is_unlimited_cpu( first_auth ) ) {
+      if ( !subjective_bill.is_account_disabled( first_auth ) && !rl.is_unlimited_cpu( first_auth ) ) {
          int64_t prev_billed_plus100_us = prev_billed_cpu_time_us + EOS_PERCENT( prev_billed_cpu_time_us, 100 * config::percent_1 );
          if( prev_billed_plus100_us < max_trx_time.count() ) max_trx_time = fc::microseconds( prev_billed_plus100_us );
       }
@@ -2264,7 +2256,7 @@ producer_plugin_impl::push_result
 producer_plugin_impl::handle_push_result( const transaction_metadata_ptr& trx,
                                           const next_function<transaction_trace_ptr>& next,
                                           const fc::time_point& start,
-                                          const chain::controller& chain,
+                                          chain::controller& chain,
                                           const transaction_trace_ptr& trace,
                                           bool return_failure_trace,
                                           bool disable_subjective_enforcement,
@@ -2272,6 +2264,8 @@ producer_plugin_impl::handle_push_result( const transaction_metadata_ptr& trx,
                                           int64_t sub_bill,
                                           uint32_t prev_billed_cpu_time_us) {
    auto end = fc::time_point::now();
+   chain::subjective_billing& subjective_bill = chain.get_mutable_subjective_billing();
+
    push_result pr;
    if( trace->except ) {
       // Transient trxs are dry-run or read-only.
@@ -2299,7 +2293,7 @@ producer_plugin_impl::handle_push_result( const transaction_metadata_ptr& trx,
             fc_tlog( _log, "Subjective bill for failed ${a}: ${b} elapsed ${t}us, time ${r}us",
                      ("a",first_auth)("b",sub_bill)("t",trace->elapsed)("r", end - start));
             if (!disable_subjective_enforcement) // subjectively bill failure when producing since not in objective cpu account billing
-               _subjective_billing.subjective_bill_failure( first_auth, trace->elapsed, fc::time_point::now() );
+               subjective_bill.subjective_bill_failure( first_auth, trace->elapsed, fc::time_point::now() );
 
             log_trx_results( trx, trace, start );
             // this failed our configured maximum transaction time, we don't want to replay it
@@ -2332,7 +2326,7 @@ producer_plugin_impl::handle_push_result( const transaction_metadata_ptr& trx,
       log_trx_results( trx, trace, start );
       // if producing then trx is in objective cpu account billing
       if (!disable_subjective_enforcement && _pending_block_mode != pending_block_mode::producing) {
-         _subjective_billing.subjective_bill( trx->id(), trx->packed_trx()->expiration(), first_auth, trace->elapsed );
+         subjective_bill.subjective_bill( trx->id(), trx->packed_trx()->expiration(), first_auth, trace->elapsed );
       }
       if( next ) next( trace );
    }

--- a/plugins/producer_plugin/test/CMakeLists.txt
+++ b/plugins/producer_plugin/test/CMakeLists.txt
@@ -1,8 +1,3 @@
-add_executable( test_subjective_billing test_subjective_billing.cpp )
-target_link_libraries( test_subjective_billing producer_plugin eosio_testing )
-
-add_test(NAME test_subjective_billing COMMAND plugins/producer_plugin/test/test_subjective_billing WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
 add_executable( test_trx_full test_trx_full.cpp )
 target_link_libraries( test_trx_full producer_plugin eosio_testing )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ list(REMOVE_ITEM UNIT_TESTS ship_client.cpp)
 list(REMOVE_ITEM UNIT_TESTS ship_streamer.cpp)
 
 add_executable( plugin_test ${UNIT_TESTS} )
-target_link_libraries( plugin_test eosio_testing eosio_chain chainbase chain_plugin wallet_plugin fc state_history ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( plugin_test eosio_testing eosio_chain chainbase chain_plugin producer_plugin wallet_plugin fc state_history ${PLATFORM_SPECIFIC_LIBS} )
 
 target_include_directories( plugin_test PUBLIC
                             ${CMAKE_SOURCE_DIR}/plugins/net_plugin/include

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -95,7 +95,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    char headnumstr[20];
    sprintf(headnumstr, "%d", headnum);
    chain_apis::read_only::get_raw_block_params param{headnumstr};
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
 
    // block should be decoded successfully
    auto block = plugin.get_raw_block(param, fc::time_point::maximum());
@@ -139,7 +139,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( get_consensus_parameters, TESTER ) try {
    produce_blocks(1);
 
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr, nullptr);
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
 
    auto parms = plugin.get_consensus_parameters({}, fc::time_point::maximum());
 
@@ -186,7 +186,7 @@ BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
 
    produce_block();
 
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr, nullptr);
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
 
    chain_apis::read_only::get_account_params p{"alice"_n};
 

--- a/tests/get_producers_tests.cpp
+++ b/tests/get_producers_tests.cpp
@@ -16,7 +16,7 @@ using namespace eosio::testing;
 BOOST_AUTO_TEST_CASE( get_producers) { try {
       tester chain;
 
-      eosio::chain_apis::read_only plugin(*(chain.control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
+      eosio::chain_apis::read_only plugin(*(chain.control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
       eosio::chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
 
       auto results = plugin.get_producers(params, fc::time_point::maximum());
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE( get_producers_from_table) { try {
       // ensure that enough voting is occurring so that producer1111 is elected as the producer
       chain.cross_15_percent_threshold();
 
-      eosio::chain_apis::read_only plugin(*(chain.control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
+      eosio::chain_apis::read_only plugin(*(chain.control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
       eosio::chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
 
       auto results = plugin.get_producers(params, fc::time_point::maximum());

--- a/tests/get_table_seckey_tests.cpp
+++ b/tests/get_table_seckey_tests.cpp
@@ -49,7 +49,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, TESTER ) try {
    set_abi( "test"_n, test_contracts::get_table_seckey_test_abi().data() );
    produce_block();
 
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    chain_apis::read_only::get_table_rows_params params = []{
       chain_apis::read_only::get_table_rows_params params{};
       params.json=true;

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -96,7 +96,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    produce_blocks(1);
 
    // iterate over scope
-   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_by_scope_params param{"eosio.token"_n, "accounts"_n, "inita", "", 10};
    eosio::chain_apis::read_only::get_table_by_scope_result result = plugin.read_only::get_table_by_scope(param, fc::time_point::maximum());
 
@@ -201,7 +201,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    produce_blocks(1);
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = "eosio.token"_n;
    p.scope = "inita";
@@ -371,7 +371,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
    produce_blocks(1);
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = "eosio"_n;
    p.scope = "eosio";
@@ -523,7 +523,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, TESTER ) try {
    // }
 
 
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    chain_apis::read_only::get_table_rows_params params = []{
       chain_apis::read_only::get_table_rows_params params{};
       params.json=true;

--- a/tests/test_chain_plugin.cpp
+++ b/tests/test_chain_plugin.cpp
@@ -232,7 +232,7 @@ public:
     read_only::get_account_results get_account_info(const account_name acct){
        auto account_object = control->get_account(acct);
        read_only::get_account_params params = { account_object.name };
-       chain_apis::read_only plugin(*(control.get()), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {}, {});
+       chain_apis::read_only plugin(*(control.get()), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
        auto res =   plugin.get_account(params, fc::time_point::maximum())();
        BOOST_REQUIRE(!std::holds_alternative<fc::exception_ptr>(res));
        return std::get<chain_apis::read_only::get_account_results>(std::move(res));

--- a/unittests/subjective_billing_tests.cpp
+++ b/unittests/subjective_billing_tests.cpp
@@ -8,7 +8,7 @@ namespace {
 using namespace eosio;
 using namespace eosio::chain;
 
-BOOST_AUTO_TEST_SUITE( subjective_billing_test )
+BOOST_AUTO_TEST_SUITE(subjective_billing_test)
 
 BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
 

--- a/unittests/test_subjective_billing.cpp
+++ b/unittests/test_subjective_billing.cpp
@@ -1,8 +1,6 @@
-#define BOOST_TEST_MODULE subjective_billing
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
-#include <eosio/producer_plugin/subjective_billing.hpp>
-
+#include "eosio/chain/subjective_billing.hpp"
 #include <eosio/testing/tester.hpp>
 
 namespace {
@@ -41,7 +39,6 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
       BOOST_CHECK_EQUAL( 9, sub_bill.get_subjective_bill(b, now) );
 
       sub_bill.on_block(log, {}, now);
-      sub_bill.abort_block(); // they all failed so nothing in aborted block
 
       BOOST_CHECK_EQUAL( 13+11, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 9, sub_bill.get_subjective_bill(b, now) );
@@ -69,14 +66,12 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
       BOOST_CHECK_EQUAL( 7, sub_bill.get_subjective_bill(b, now) );
 
       sub_bill.on_block(log, {}, now); // have not seen any of the transactions come back yet
-      sub_bill.abort_block();
 
       BOOST_CHECK_EQUAL( 23+19, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 7, sub_bill.get_subjective_bill(b, now) );
 
       sub_bill.on_block(log, {}, now);
       sub_bill.remove_subjective_billing( id1, 0 ); // simulate seeing id1 come back in block (this is what on_block would do)
-      sub_bill.abort_block();
 
       BOOST_CHECK_EQUAL( 19, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 7, sub_bill.get_subjective_bill(b, now) );


### PR DESCRIPTION
Break circular dependency between `producer_plugin` and `chain_plugin` by moving `subjective_billing` into the `chain` library and moving ownership of `subjective_billing` object from the `producer_plugin` to `controller`.

Resolves #668 