### PR TITLE
fix ambiguous to_variant()s in json tests

### DIFF
--- a/libraries/libfc/test/io/test_json.cpp
+++ b/libraries/libfc/test/io/test_json.cpp
@@ -72,23 +72,23 @@ BOOST_AUTO_TEST_CASE(to_string_test)
          BOOST_CHECK_EQUAL(length_exception_in_mid_str, "\"" + json_test_util::repeat_chars + "\"");
       }
       {
-         variant v(4294967296); // 0xFFFFFFFF + 1
+         variant v(4294967296LL); // 0xFFFFFFFF + 1
          std::string large_int = json::to_string( v, fc::time_point::maximum(), json::output_formatting::stringify_large_ints_and_doubles, json::max_length_limit);
          BOOST_CHECK_EQUAL(large_int, "\"4294967296\"");
 
-         variant v1(4294967295); // 0xFFFFFFFF
+         variant v1(4294967295LL); // 0xFFFFFFFF
          std::string normal_int = json::to_string( v1, fc::time_point::maximum(), json::output_formatting::stringify_large_ints_and_doubles, json::max_length_limit);
          BOOST_CHECK_EQUAL(normal_int, "4294967295");
 
-         variant v2(-4294967296); 
+         variant v2(-4294967296LL);
          std::string large_int_neg = json::to_string( v2, fc::time_point::maximum(), json::output_formatting::stringify_large_ints_and_doubles, json::max_length_limit);
          BOOST_CHECK_EQUAL(large_int_neg, "\"-4294967296\"");
 
-         variant v3(-4294967295);
+         variant v3(-4294967295LL);
          std::string normal_int_neg = json::to_string( v3, fc::time_point::maximum(), json::output_formatting::stringify_large_ints_and_doubles, json::max_length_limit);
          BOOST_CHECK_EQUAL(normal_int_neg, "-4294967295");
 
-         variant v4(-90909090909090909);
+         variant v4(-90909090909090909LL);
          std::string super_neg = json::to_string( v4, fc::time_point::maximum(), json::output_formatting::stringify_large_ints_and_doubles, json::max_length_limit);
          BOOST_CHECK_EQUAL(super_neg, "\"-90909090909090909\"");
       }


### PR DESCRIPTION
On AppleClang 14.0.3 there is an error in test_json,
```
/Users/spoon/leap/libraries/libfc/include/fc/variant.hpp:619:7: error: call to 'to_variant' is ambiguous
      to_variant( val, *this );
      ^~~~~~~~~~
/Users/spoon/leap/libraries/libfc/test/io/test_json.cpp:75:18: note: in instantiation of function template specialization 'fc::variant::variant<long>' requested here
         variant v(4294967296); // 0xFFFFFFFF + 1
                 ^
/Users/spoon/leap/libraries/libfc/include/fc/variant.hpp:83:9: note: candidate function
   void to_variant( const uint8_t& var,  fc::variant& vo );
        ^
/Users/spoon/leap/libraries/libfc/include/fc/variant.hpp:85:9: note: candidate function
   void to_variant( const int8_t& var,  fc::variant& vo );
        ^
/Users/spoon/leap/libraries/libfc/include/fc/variant.hpp:88:9: note: candidate function
   void to_variant( const uint16_t& var,  fc::variant& vo );
        ^
/Users/spoon/leap/libraries/libfc/include/fc/variant.hpp:90:9: note: candidate function
   void to_variant( const int16_t& var,  fc::variant& vo );
        ^
/Users/spoon/leap/libraries/libfc/include/fc/variant.hpp:93:9: note: candidate function
   void to_variant( const uint32_t& var,  fc::variant& vo );
        ^
/Users/spoon/leap/libraries/libfc/include/fc/variant.hpp:95:9: note: candidate function
   void to_variant( const int32_t& var,  fc::variant& vo );
        ^
/Users/spoon/leap/libraries/libfc/include/fc/variant.hpp:98:9: note: candidate function
   void to_variant( const unsigned __int128& var,  fc::variant& vo );
        ^
/Users/spoon/leap/libraries/libfc/include/fc/variant.hpp:100:9: note: candidate function
   void to_variant( const __int128& var,  fc::variant& vo );
        ^
/Users/spoon/leap/libraries/libfc/include/fc/variant.hpp:160:9: note: candidate function
   void to_variant( size_t s, fc::variant& v );
```
Change these ints to be more explicit on the intended type to resolve the ambiguity.