### PR TITLE
[3.2] fix: not fail on signature checks for dry-run txns

### DIFF
--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -557,8 +557,8 @@ namespace eosio { namespace chain {
 
       }
 
-      if( !allow_unused_keys  || check_but_dont_fail) {
-         EOS_ASSERT( checker.all_keys_used(), tx_irrelevant_sig,
+      if( !allow_unused_keys ) {
+         EOS_ASSERT( checker.all_keys_used() || check_but_dont_fail, tx_irrelevant_sig,
                      "transaction bears irrelevant signatures from these keys: ${keys}",
                      ("keys", checker.unused_keys()) );
       }


### PR DESCRIPTION
In this method, `check_but_dont_fail` is equivalent to whether the transaction is `dry-run`. However, when `dry-run` is `true`, authorization should not be checked. 

Backport of https://github.com/AntelopeIO/leap/pull/1081
Thanks to @PinelliaC for the fix.