### PR TITLE
Main: Documentation fix Error path in producer plugin swagger 

### DIFF
--- a/plugins/producer_api_plugin/producer.swagger.yaml
+++ b/plugins/producer_api_plugin/producer.swagger.yaml
@@ -342,7 +342,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/component/schema/Error"
+                $ref: "#/components/schemas/Error"
   /producer/schedule_snapshot:
     post:
       summary: schedule_snapshot
@@ -407,7 +407,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/component/schema/Error"
+                $ref: "#/components/schemas/Error"
   /producer/get_snapshot_requests:
     post:
       summary: get_snapshot_requests
@@ -487,7 +487,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/component/schema/Error"
+                $ref: "#/components/schemas/Error"
   /producer/unschedule_snapshot:
     post:
       summary: unschedule_snapshot


### PR DESCRIPTION
fixes #1094 

## Screenshot of working swagger
<img width="958" alt="Screenshot 2023-04-27 at 3 32 00 PM" src="https://user-images.githubusercontent.com/6685407/235159441-75cd8dde-050f-4e06-85f6-1eaeaf213d0a.png">

## Steps to validate
Ran documentation build and validated API page came up.

```
git clone -b "ehp/how-to-update-in-place" https://github.com/eosnetworkfoundation/docsgen.git
cd docsgen
# will prompt if ok to delete clean out directory answer "YES"
./scripts/clean_rebuild.sh -d ~/eosnetworkfoundation/build_root
cd ~eosnetworkfoundation/build_root/devdocs 
npm run serve 
```

Navigate to http://localhost:3000/leap-plugins/latest/producer.api/ and review page
