### PR TITLE
Optimization: New escape_str function for sanitizing strings

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -19,15 +19,26 @@ namespace eosio { namespace chain {
 
 static inline void print_debug(account_name receiver, const action_trace& ar) {
    if (!ar.console.empty()) {
-      auto prefix = fc::format_string(
-                                      "\n[(${a},${n})->${r}]",
-                                      fc::mutable_variant_object()
-                                      ("a", ar.act.account)
-                                      ("n", ar.act.name)
-                                      ("r", receiver));
-      dlog(prefix + ": CONSOLE OUTPUT BEGIN =====================\n"
-           + ar.console
-           + prefix + ": CONSOLE OUTPUT END   =====================" );
+      if (fc::logger::get(DEFAULT_LOGGER).is_enabled( fc::log_level::debug )) {
+         std::string prefix;
+         prefix.reserve(3 + 13 + 1 + 13 + 3 + 13 + 1);
+         prefix += "\n[(";
+         prefix += ar.act.account.to_string();
+         prefix += ",";
+         prefix += ar.act.name.to_string();
+         prefix += ")->";
+         prefix += receiver.to_string();
+         prefix += "]";
+
+         std::string output;
+         output.reserve(512);
+         output += prefix;
+         output += ": CONSOLE OUTPUT BEGIN =====================\n";
+         output += ar.console;
+         output += prefix;
+         output += ": CONSOLE OUTPUT END   =====================";
+         dlog( std::move(output) );
+      }
    }
 }
 

--- a/libraries/libfc/include/fc/string.hpp
+++ b/libraries/libfc/include/fc/string.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <limits>
 #include <string>
 
 namespace fc
@@ -20,4 +21,22 @@ namespace fc
   class variant_object;
   std::string format_string( const std::string&, const variant_object&, bool minimize = false );
   std::string trim( const std::string& );
+
+  /**
+   * Convert '\t', '\r', '\n', '\\' and '"'  to "\t\r\n\\\"" if escape_control_chars == true
+   * Convert all other < 32 & 127 ascii to escaped unicode "\u00xx"
+   * Removes invalid utf8 characters
+   * Escapes Control sequence Introducer 0x9b to \u009b
+   * All other characters unmolested.
+   *
+   * @param str input/output string to escape/truncate
+   * @param escape_control_chars if true escapes control chars in str
+   * @param max_len truncate string to max_len
+   * @param add_truncate_str if truncated by max_len, add add_truncate_str to end of any truncated string,
+   *                         new length with be max_len + strlen(add_truncate_str), nullptr allowed if no append wanted
+   * @return pair<reference to possibly modified passed in str, true if modified>
+   */
+  std::pair<std::string&, bool> escape_str( std::string& str, bool escape_control_chars = true,
+                                            std::size_t max_len = std::numeric_limits<std::size_t>::max(),
+                                            const char* add_truncate_str = "..." );
 }

--- a/libraries/libfc/include/fc/string.hpp
+++ b/libraries/libfc/include/fc/string.hpp
@@ -30,13 +30,14 @@ namespace fc
    * All other characters unmolested.
    *
    * @param str input/output string to escape/truncate
-   * @param escape_control_chars if true escapes control chars in str
+   * @param escape_ctrl if on escapes control chars in str
    * @param max_len truncate string to max_len
    * @param add_truncate_str if truncated by max_len, add add_truncate_str to end of any truncated string,
    *                         new length with be max_len + strlen(add_truncate_str), nullptr allowed if no append wanted
    * @return pair<reference to possibly modified passed in str, true if modified>
    */
-  std::pair<std::string&, bool> escape_str( std::string& str, bool escape_control_chars = true,
+  enum class escape_control_chars { off, on };
+  std::pair<std::string&, bool> escape_str( std::string& str, escape_control_chars escape_ctrl = escape_control_chars::on,
                                             std::size_t max_len = std::numeric_limits<std::size_t>::max(),
                                             const char* add_truncate_str = "..." );
 }

--- a/libraries/libfc/include/fc/string.hpp
+++ b/libraries/libfc/include/fc/string.hpp
@@ -23,7 +23,7 @@ namespace fc
   std::string trim( const std::string& );
 
   /**
-   * Convert '\t', '\r', '\n', '\\' and '"'  to "\t\r\n\\\"" if escape_control_chars == true
+   * Convert '\t', '\r', '\n', '\\' and '"'  to "\t\r\n\\\"" if escape_ctrl == on
    * Convert all other < 32 & 127 ascii to escaped unicode "\u00xx"
    * Removes invalid utf8 characters
    * Escapes Control sequence Introducer 0x9b to \u009b
@@ -33,11 +33,11 @@ namespace fc
    * @param escape_ctrl if on escapes control chars in str
    * @param max_len truncate string to max_len
    * @param add_truncate_str if truncated by max_len, add add_truncate_str to end of any truncated string,
-   *                         new length with be max_len + strlen(add_truncate_str), nullptr allowed if no append wanted
+   *                         new length with be max_len + add_truncate_str.size()
    * @return pair<reference to possibly modified passed in str, true if modified>
    */
   enum class escape_control_chars { off, on };
   std::pair<std::string&, bool> escape_str( std::string& str, escape_control_chars escape_ctrl = escape_control_chars::on,
                                             std::size_t max_len = std::numeric_limits<std::size_t>::max(),
-                                            const char* add_truncate_str = "..." );
+                                            std::string_view add_truncate_str = "..." );
 }

--- a/libraries/libfc/src/string.cpp
+++ b/libraries/libfc/src/string.cpp
@@ -113,7 +113,7 @@ namespace fc  {
         }
      }
 
-     if (truncated && !add_truncate_str.empty()) {
+     if (truncated) {
         str += add_truncate_str;
      }
 

--- a/libraries/libfc/src/string.cpp
+++ b/libraries/libfc/src/string.cpp
@@ -87,7 +87,7 @@ namespace fc  {
       return boost::algorithm::trim_copy(s);
   }
 
-  std::pair<std::string&, bool> escape_str( std::string& str, bool escape_control_chars,
+  std::pair<std::string&, bool> escape_str( std::string& str, escape_control_chars escape_ctrl,
                                             std::size_t max_len, const char* add_truncate_str )
   {
      bool modified = false, truncated = false;
@@ -96,7 +96,7 @@ namespace fc  {
         str.resize(max_len);
         modified = truncated = true;
      }
-     auto itr = escape_control_chars
+     auto itr = escape_ctrl == escape_control_chars::on
            ? std::find_if(str.begin(), str.end(),
                           [](const auto& c) {
               return c == '\x7f' || c == '\\' || c == '\"' ||  (c >= '\x00' && c <= '\x1f'); } )
@@ -105,7 +105,7 @@ namespace fc  {
               return c == '\x7f' || (c >= '\x00' && c <= '\x08') || c == '\x0b' || c == '\x0c' || (c >= '\x0e' && c <= '\x1f'); } );
 
      if (itr != str.end() || !fc::is_valid_utf8( str )) {
-        str = escape_string(str, nullptr, escape_control_chars);
+        str = escape_string(str, nullptr, escape_ctrl == escape_control_chars::on);
         modified = true;
         if (str.size() > max_len) {
            str.resize(max_len);

--- a/libraries/libfc/src/string.cpp
+++ b/libraries/libfc/src/string.cpp
@@ -1,4 +1,6 @@
 #include <fc/string.hpp>
+#include <fc/utf8.hpp>
+#include <fc/io/json.hpp>
 #include <fc/exception/exception.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
@@ -83,12 +85,41 @@ namespace fc  {
   std::string trim( const std::string& s )
   {
       return boost::algorithm::trim_copy(s);
-      /*
-      std::string cpy(s);
-      boost::algorithm::trim(cpy);
-      return cpy;
-      */
   }
+
+  std::pair<std::string&, bool> escape_str( std::string& str, bool escape_control_chars,
+                                            std::size_t max_len, const char* add_truncate_str )
+  {
+     bool modified = false, truncated = false;
+     // truncate early to speed up escape
+     if (str.size() > max_len) {
+        str.resize(max_len);
+        modified = truncated = true;
+     }
+     auto itr = escape_control_chars
+           ? std::find_if(str.begin(), str.end(),
+                          [](const auto& c) {
+              return c == '\x7f' || c == '\\' || c == '\"' ||  (c >= '\x00' && c <= '\x1f'); } )
+           : std::find_if(str.begin(), str.end(),
+                          [](const auto& c) {               // x09 = \t, x0a = \n,                   x0d = \r
+              return c == '\x7f' || (c >= '\x00' && c <= '\x08') || c == '\x0b' || c == '\x0c' || (c >= '\x0e' && c <= '\x1f'); } );
+
+     if (itr != str.end() || !fc::is_valid_utf8( str )) {
+        str = escape_string(str, nullptr, escape_control_chars);
+        modified = true;
+        if (str.size() > max_len) {
+           str.resize(max_len);
+           truncated = true;
+        }
+     }
+
+     if (truncated && add_truncate_str != nullptr ) {
+        str += add_truncate_str;
+     }
+
+     return std::make_pair(std::ref(str), modified);
+  }
+
 
 } // namespace fc
 

--- a/libraries/libfc/src/string.cpp
+++ b/libraries/libfc/src/string.cpp
@@ -88,7 +88,7 @@ namespace fc  {
   }
 
   std::pair<std::string&, bool> escape_str( std::string& str, escape_control_chars escape_ctrl,
-                                            std::size_t max_len, const char* add_truncate_str )
+                                            std::size_t max_len, std::string_view add_truncate_str )
   {
      bool modified = false, truncated = false;
      // truncate early to speed up escape
@@ -113,7 +113,7 @@ namespace fc  {
         }
      }
 
-     if (truncated && add_truncate_str != nullptr ) {
+     if (truncated && !add_truncate_str.empty()) {
         str += add_truncate_str;
      }
 

--- a/libraries/libfc/test/CMakeLists.txt
+++ b/libraries/libfc/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable( test_fc
         variant/test_variant.cpp
         variant_estimated_size/test_variant_estimated_size.cpp
         test_base64.cpp
+        test_escape_str.cpp
         main.cpp
         )
 target_link_libraries( test_fc fc )

--- a/libraries/libfc/test/test_escape_str.cpp
+++ b/libraries/libfc/test/test_escape_str.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(empty) try {
    BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::on, 256, "").first, "");
 
    input = "";
-   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::off, 512, nullptr).first, "");
+   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::off, 512, {}).first, "");
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(truncate) try {
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(truncate) try {
    BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::on, 256, "").first, repeat_256_chars);
 
    input = repeat_512_chars;
-   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::on, 256, nullptr).first, repeat_256_chars);
+   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::on, 256, {}).first, repeat_256_chars);
 
    input = repeat_512_chars;
    BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::on, 256).first, repeat_256_chars + "...");
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(modify) try {
    BOOST_CHECK(escape_str(input, fc::escape_control_chars::on, 256, "").second);
 
    input = repeat_512_chars;
-   BOOST_CHECK(escape_str(input, fc::escape_control_chars::on, 256, nullptr).second);
+   BOOST_CHECK(escape_str(input, fc::escape_control_chars::on, 256, {}).second);
 
    input = repeat_512_chars;
    BOOST_CHECK(escape_str(input, fc::escape_control_chars::on, 256).second);

--- a/libraries/libfc/test/test_escape_str.cpp
+++ b/libraries/libfc/test/test_escape_str.cpp
@@ -1,0 +1,98 @@
+#include <boost/test/unit_test.hpp>
+
+#include <fc/string.hpp>
+#include <fc/exception/exception.hpp>
+
+using namespace fc;
+using namespace std::literals;
+
+BOOST_AUTO_TEST_SUITE(escape_str_test)
+
+BOOST_AUTO_TEST_CASE(escape_control_chars) try {
+   const std::string escape_input_str = "\b\f\n\r\t\\\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
+                                        "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f";
+   std::string escaped_str = "\\u0008\\u000c\\n\\r\\t\\\\\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\u0008\\t\\n\\u000b\\u000c\\r\\u000e\\u000f"
+                             "\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001a\\u001b\\u001c\\u001d\\u001e\\u001f";
+
+   std::string input = escape_input_str;
+   BOOST_CHECK_EQUAL(escape_str(input).first, escaped_str);
+
+   input = escape_input_str;
+   escaped_str = "\\u0008\\u000c\n"
+                 "\r\t\\\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\u0008\t\n"
+                 "\\u000b\\u000c\r\\u000e\\u000f\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001a\\u001b\\u001c\\u001d\\u001e\\u001f";
+   BOOST_CHECK_EQUAL(escape_str(input, false).first, escaped_str);
+
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(empty) try {
+   std::string input;
+   BOOST_CHECK_EQUAL(escape_str(input, true, 256, "").first, "");
+
+   input = "";
+   BOOST_CHECK_EQUAL(escape_str(input, false, 512, nullptr).first, "");
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(truncate) try {
+   const std::string repeat_512_chars(512, 'a');
+   const std::string repeat_256_chars(256, 'a');
+
+   std::string input = repeat_512_chars;
+   BOOST_CHECK_EQUAL(escape_str(input, true, 256, "").first, repeat_256_chars);
+
+   input = repeat_512_chars;
+   BOOST_CHECK_EQUAL(escape_str(input, true, 256, nullptr).first, repeat_256_chars);
+
+   input = repeat_512_chars;
+   BOOST_CHECK_EQUAL(escape_str(input, true, 256).first, repeat_256_chars + "...");
+
+   input = repeat_512_chars;
+   BOOST_CHECK_EQUAL(escape_str(input, true, 256, "<-the end->").first, repeat_256_chars + "<-the end->");
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(modify) try {
+   const std::string repeat_512_chars(512, 'a');
+   const std::string repeat_256_chars(256, 'a');
+
+   std::string input = repeat_512_chars;
+   BOOST_CHECK(escape_str(input, true, 256, "").second);
+
+   input = repeat_512_chars;
+   BOOST_CHECK(escape_str(input, true, 256, nullptr).second);
+
+   input = repeat_512_chars;
+   BOOST_CHECK(escape_str(input, true, 256).second);
+
+   input = repeat_512_chars;
+   BOOST_CHECK(!escape_str(input, true, 512).second);
+
+   input = repeat_512_chars;
+   BOOST_CHECK(!escape_str(input, true).second);
+
+   input = repeat_512_chars;
+   BOOST_CHECK(!escape_str(input, true, 1024).second);
+
+   input = "";
+   BOOST_CHECK(!escape_str(input, true, 1024).second);
+
+   input = "hello";
+   BOOST_CHECK(!escape_str(input, true, 1024).second);
+
+   input = "\n";
+   BOOST_CHECK(escape_str(input, true, 1024).second);
+
+   input ="\xb4";
+   BOOST_CHECK(escape_str(input, true, 1024).second);
+   BOOST_CHECK_EQUAL(input, "");
+
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(remove_invalid_utf8) try {
+   auto input = "abc123$&()'?\xb4\xf5\x01\xfa~a"s; // remove invalid utf8 values, \x01 => \u0001
+   auto expected_output = "abc123$&()'?\\u0001~a"s;
+
+   BOOST_CHECK_EQUAL(escape_str(input).first, expected_output);
+} FC_LOG_AND_RETHROW();
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libraries/libfc/test/test_escape_str.cpp
+++ b/libraries/libfc/test/test_escape_str.cpp
@@ -21,16 +21,16 @@ BOOST_AUTO_TEST_CASE(escape_control_chars) try {
    escaped_str = "\\u0008\\u000c\n"
                  "\r\t\\\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\u0008\t\n"
                  "\\u000b\\u000c\r\\u000e\\u000f\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001a\\u001b\\u001c\\u001d\\u001e\\u001f";
-   BOOST_CHECK_EQUAL(escape_str(input, false).first, escaped_str);
+   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::off).first, escaped_str);
 
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(empty) try {
    std::string input;
-   BOOST_CHECK_EQUAL(escape_str(input, true, 256, "").first, "");
+   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::on, 256, "").first, "");
 
    input = "";
-   BOOST_CHECK_EQUAL(escape_str(input, false, 512, nullptr).first, "");
+   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::off, 512, nullptr).first, "");
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(truncate) try {
@@ -38,16 +38,16 @@ BOOST_AUTO_TEST_CASE(truncate) try {
    const std::string repeat_256_chars(256, 'a');
 
    std::string input = repeat_512_chars;
-   BOOST_CHECK_EQUAL(escape_str(input, true, 256, "").first, repeat_256_chars);
+   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::on, 256, "").first, repeat_256_chars);
 
    input = repeat_512_chars;
-   BOOST_CHECK_EQUAL(escape_str(input, true, 256, nullptr).first, repeat_256_chars);
+   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::on, 256, nullptr).first, repeat_256_chars);
 
    input = repeat_512_chars;
-   BOOST_CHECK_EQUAL(escape_str(input, true, 256).first, repeat_256_chars + "...");
+   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::on, 256).first, repeat_256_chars + "...");
 
    input = repeat_512_chars;
-   BOOST_CHECK_EQUAL(escape_str(input, true, 256, "<-the end->").first, repeat_256_chars + "<-the end->");
+   BOOST_CHECK_EQUAL(escape_str(input, fc::escape_control_chars::on, 256, "<-the end->").first, repeat_256_chars + "<-the end->");
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(modify) try {
@@ -55,34 +55,34 @@ BOOST_AUTO_TEST_CASE(modify) try {
    const std::string repeat_256_chars(256, 'a');
 
    std::string input = repeat_512_chars;
-   BOOST_CHECK(escape_str(input, true, 256, "").second);
+   BOOST_CHECK(escape_str(input, fc::escape_control_chars::on, 256, "").second);
 
    input = repeat_512_chars;
-   BOOST_CHECK(escape_str(input, true, 256, nullptr).second);
+   BOOST_CHECK(escape_str(input, fc::escape_control_chars::on, 256, nullptr).second);
 
    input = repeat_512_chars;
-   BOOST_CHECK(escape_str(input, true, 256).second);
+   BOOST_CHECK(escape_str(input, fc::escape_control_chars::on, 256).second);
 
    input = repeat_512_chars;
-   BOOST_CHECK(!escape_str(input, true, 512).second);
+   BOOST_CHECK(!escape_str(input, fc::escape_control_chars::on, 512).second);
 
    input = repeat_512_chars;
-   BOOST_CHECK(!escape_str(input, true).second);
+   BOOST_CHECK(!escape_str(input, fc::escape_control_chars::on).second);
 
    input = repeat_512_chars;
-   BOOST_CHECK(!escape_str(input, true, 1024).second);
+   BOOST_CHECK(!escape_str(input, fc::escape_control_chars::on, 1024).second);
 
    input = "";
-   BOOST_CHECK(!escape_str(input, true, 1024).second);
+   BOOST_CHECK(!escape_str(input, fc::escape_control_chars::on, 1024).second);
 
    input = "hello";
-   BOOST_CHECK(!escape_str(input, true, 1024).second);
+   BOOST_CHECK(!escape_str(input, fc::escape_control_chars::on, 1024).second);
 
    input = "\n";
-   BOOST_CHECK(escape_str(input, true, 1024).second);
+   BOOST_CHECK(escape_str(input, fc::escape_control_chars::on, 1024).second);
 
    input ="\xb4";
-   BOOST_CHECK(escape_str(input, true, 1024).second);
+   BOOST_CHECK(escape_str(input, fc::escape_control_chars::on, 1024).second);
    BOOST_CHECK_EQUAL(input, "");
 
 } FC_LOG_AND_RETHROW();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2099,8 +2099,7 @@ inline std::string get_detailed_contract_except_info(const packed_transaction_pt
    std::string details = except_ptr ? except_ptr->top_message()
                                     : ((trace && trace->except) ? trace->except->top_message()
                                                                 : std::string());
-   const bool escape_control_chars = true;
-   fc::escape_str(details, escape_control_chars, 1024);
+   fc::escape_str(details, fc::escape_control_chars::on, 1024);
 
    // this format is parsed by external tools
    return "action: " + contract_name + ":" + act_name + ", " + details;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2097,8 +2097,8 @@ inline std::string get_detailed_contract_except_info(const packed_transaction_pt
    }
 
    std::string details = except_ptr ? except_ptr->top_message()
-                                    : (trace && trace->except) ? trace->except->top_message()
-                                                               : std::string();
+                                    : ((trace && trace->except) ? trace->except->top_message()
+                                                                : std::string());
    const bool escape_control_chars = true;
    fc::escape_str(details, escape_control_chars, 1024);
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2085,23 +2085,22 @@ inline std::string get_detailed_contract_except_info(const packed_transaction_pt
 {
    std::string contract_name;
    std::string act_name;
-   std::string details;
-
    if( trace && !trace->action_traces.empty() ) {
       auto last_action_ordinal = trace->action_traces.size() - 1;
       contract_name = trace->action_traces[last_action_ordinal].receiver.to_string();
       act_name = trace->action_traces[last_action_ordinal].act.name.to_string();
    } else if ( trx ) {
       const auto& actions = trx->get_transaction().actions;
-      if( actions.empty() ) return details; // should not be possible
+      if( actions.empty() ) return {}; // should not be possible
       contract_name = actions[0].account.to_string();
       act_name = actions[0].name.to_string();
    }
 
-   details = except_ptr ? except_ptr->top_message() : (trace && trace->except) ? trace->except->top_message() : std::string();
-   if (!details.empty()) {
-      details = fc::format_string("${d}", fc::mutable_variant_object() ("d", details), true);  // true for limiting the formatted string size
-   }
+   std::string details = except_ptr ? except_ptr->top_message()
+                                    : (trace && trace->except) ? trace->except->top_message()
+                                                               : std::string();
+   const bool escape_control_chars = true;
+   fc::escape_str(details, escape_control_chars, 1024);
 
    // this format is parsed by external tools
    return "action: " + contract_name + ":" + act_name + ", " + details;


### PR DESCRIPTION
Create a new `escape_str` function for use of sanitizing strings without having to use `format_string` with its overhead of `mutable_variant_object`.
Also optimize `print_debug` used for contract console output.

Resolves #641 