### PR TITLE
Tests: misc cleanup

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -67,6 +67,8 @@ namespace eosio { namespace testing {
       full
    };
 
+   std::ostream& operator<<(std::ostream& os, setup_policy p);
+
    std::vector<uint8_t> read_wasm( const char* fn );
    std::vector<char>    read_abi( const char* fn );
    std::string          read_wast( const char* fn );
@@ -528,7 +530,7 @@ namespace eosio { namespace testing {
       }
       controller::config vcfg;
 
-      validating_tester(const flat_set<account_name>& trusted_producers = flat_set<account_name>(), deep_mind_handler* dmlog = nullptr) {
+      validating_tester(const flat_set<account_name>& trusted_producers = flat_set<account_name>(), deep_mind_handler* dmlog = nullptr, setup_policy p = setup_policy::full) {
          auto def_conf = default_config(tempdir);
 
          vcfg = def_conf.first;
@@ -538,7 +540,7 @@ namespace eosio { namespace testing {
          validating_node = create_validating_node(vcfg, def_conf.second, true, dmlog);
 
          init(def_conf.first, def_conf.second);
-         execute_setup_policy(setup_policy::full);
+         execute_setup_policy(p);
       }
 
       static void config_validator(controller::config& vcfg) {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -20,6 +20,32 @@ eosio::chain::asset core_from_string(const std::string& s) {
 }
 
 namespace eosio { namespace testing {
+
+   std::ostream& operator<<(std::ostream& os, setup_policy p) {
+      switch(p) {
+         case setup_policy::none:
+            os << "none";
+            break;
+         case setup_policy::old_bios_only:
+            os << "old_bios_only";
+            break;
+         case setup_policy::preactivate_feature_only:
+            os << "preactivate_feature_only";
+            break;
+         case setup_policy::preactivate_feature_and_new_bios:
+            os << "preactivate_feature_and_new_bios";
+            break;
+         case setup_policy::old_wasm_parser:
+            os << "old_wasm_parser";
+            break;
+         case setup_policy::full:
+            os << "full";
+            break;
+      }
+      return os;
+   }
+
+
    std::string read_wast( const char* fn ) {
       std::ifstream wast_file(fn);
       FC_ASSERT( wast_file.is_open(), "wast file cannot be found" );

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -21,6 +21,7 @@ eosio::chain::asset core_from_string(const std::string& s) {
 
 namespace eosio { namespace testing {
 
+   // required by boost::unit_test::data
    std::ostream& operator<<(std::ostream& os, setup_policy p) {
       switch(p) {
          case setup_policy::none:
@@ -41,6 +42,8 @@ namespace eosio { namespace testing {
          case setup_policy::full:
             os << "full";
             break;
+         default:
+            FC_ASSERT(false, "Unknown setup_policy");
       }
       return os;
    }

--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -7,12 +7,6 @@
 #include <eosio/chain_plugin/account_query_db.hpp>
 #include <eosio/chain/thread_utils.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
@@ -39,7 +33,7 @@ bool find_account_auth(results rst, account_name name, permission_name perm){
 
 BOOST_AUTO_TEST_SUITE(account_query_db_tests)
 
-BOOST_FIXTURE_TEST_CASE(newaccount_test, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(newaccount_test, validating_tester) { try {
 
    // instantiate an account_query_db
    auto aq_db = account_query_db(*control);
@@ -64,7 +58,7 @@ BOOST_FIXTURE_TEST_CASE(newaccount_test, TESTER) { try {
 
 } FC_LOG_AND_RETHROW() }
 
-BOOST_FIXTURE_TEST_CASE(updateauth_test, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(updateauth_test, validating_tester) { try {
 
     // instantiate an account_query_db
     auto aq_db = account_query_db(*control);
@@ -98,7 +92,7 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test, TESTER) { try {
 
 } FC_LOG_AND_RETHROW() }
 
-BOOST_FIXTURE_TEST_CASE(updateauth_test_multi_threaded, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(updateauth_test_multi_threaded, validating_tester) { try {
 
    // instantiate an account_query_db
    auto aq_db = account_query_db(*control);

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -20,12 +20,6 @@
 #include <array>
 #include <utility>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
@@ -41,7 +35,7 @@ static auto get_account_full = [](chain_apis::read_only& plugin,
 
 BOOST_AUTO_TEST_SUITE(chain_plugin_tests)
 
-BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"asserter"_n} );
@@ -136,7 +130,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
 
 } FC_LOG_AND_RETHROW() /// get_block_with_invalid_abi
 
-BOOST_FIXTURE_TEST_CASE( get_consensus_parameters, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( get_consensus_parameters, validating_tester ) try {
    produce_blocks(1);
 
    chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
@@ -178,7 +172,7 @@ BOOST_FIXTURE_TEST_CASE( get_consensus_parameters, TESTER ) try {
 
 } FC_LOG_AND_RETHROW() //get_consensus_parameters
 
-BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( get_account, validating_tester ) try {
    produce_blocks(2);
 
    std::vector<account_name> accs{{ "alice"_n, "bob"_n, "cindy"_n}};

--- a/tests/get_table_seckey_tests.cpp
+++ b/tests/get_table_seckey_tests.cpp
@@ -19,12 +19,6 @@
 #include <array>
 #include <utility>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
@@ -41,7 +35,7 @@ static auto get_table_rows_full = [](chain_apis::read_only& plugin,
 
 BOOST_AUTO_TEST_SUITE(get_table_seckey_tests)
 
-BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    create_account("test"_n);
 
    // setup contract and abi

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -20,12 +20,6 @@
 #include <array>
 #include <utility>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
@@ -42,7 +36,7 @@ static auto get_table_rows_full = [](chain_apis::read_only& plugin,
 BOOST_AUTO_TEST_SUITE(get_table_tests)
 
 transaction_trace_ptr
-issue_tokens( TESTER& t, account_name issuer, account_name to, const asset& amount,
+issue_tokens( validating_tester& t, account_name issuer, account_name to, const asset& amount,
               std::string memo = "", account_name token_contract = "eosio.token"_n )
 {
    signed_transaction trx;
@@ -69,7 +63,7 @@ issue_tokens( TESTER& t, account_name issuer, account_name to, const asset& amou
    return t.push_transaction( trx );
 }
 
-BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( get_scope_test, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
@@ -141,7 +135,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
 
 } FC_LOG_AND_RETHROW() /// get_scope_test
 
-BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
@@ -321,7 +315,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
@@ -457,7 +451,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 
-BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    create_account("test"_n);
 
    // setup contract and abi

--- a/tests/test_chain_plugin.cpp
+++ b/tests/test_chain_plugin.cpp
@@ -14,12 +14,6 @@
 #include <fc/log/logger.hpp>
 #include <eosio/chain/exceptions.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::chain_apis;
@@ -29,7 +23,7 @@ using namespace fc;
 
 using mvo = fc::mutable_variant_object;
 
-class chain_plugin_tester : public TESTER {
+class chain_plugin_tester : public validating_tester {
 public:
 
     action_result push_action( const account_name& signer, const action_name &name, const variant_object &data, bool auth = true ) {
@@ -324,7 +318,7 @@ public:
         }
         produce_blocks( 250);
 
-        auto trace_auth = TESTER::push_action(config::system_account_name, updateauth::get_name(), config::system_account_name, mvo()
+        auto trace_auth = validating_tester::push_action(config::system_account_name, updateauth::get_name(), config::system_account_name, mvo()
                 ("account", name(config::system_account_name).to_string())
                 ("permission", name(config::active_name).to_string())
                 ("parent", name(config::owner_name).to_string())

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -91,12 +91,6 @@ FC_REFLECT( u128_action, (values) )
 FC_REFLECT( dtt_action, (payer)(deferred_account)(deferred_action)(permission_name)(delay_sec) )
 FC_REFLECT( invalid_access_action, (code)(val)(index)(store) )
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::testing;
 using namespace chain;
@@ -183,7 +177,7 @@ string U128Str(unsigned __int128 i)
 }
 
 template <typename T>
-transaction_trace_ptr CallAction(TESTER& test, T ac, const vector<account_name>& scope = {"testapi"_n}) {
+transaction_trace_ptr CallAction(validating_tester& test, T ac, const vector<account_name>& scope = {"testapi"_n}) {
    signed_transaction trx;
 
 
@@ -302,7 +296,7 @@ struct MySink : public bio::sink
 };
 uint32_t last_fnc_err = 0;
 
-BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(action_receipt_tests, validating_tester) { try {
    produce_blocks(2);
    create_account( "test"_n );
    set_code( "test"_n, test_contracts::payloadless_wasm() );
@@ -408,7 +402,7 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
 /*************************************************************************************
  * action_tests test case
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(action_tests, validating_tester) { try {
 	produce_blocks(2);
 	create_account( "testapi"_n );
 	create_account( "acc1"_n );
@@ -561,7 +555,7 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
 } FC_LOG_AND_RETHROW() }
 
 // test require_recipient loop (doesn't cause infinite loop)
-BOOST_FIXTURE_TEST_CASE(require_notice_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(require_notice_tests, validating_tester) { try {
       produce_blocks(2);
       create_account( "testapi"_n );
       create_account( "acc5"_n );
@@ -617,7 +611,7 @@ BOOST_AUTO_TEST_CASE(ram_billing_in_notify_tests) { try {
 /*************************************************************************************
  * context free action tests
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(cf_action_tests, validating_tester) { try {
       produce_blocks(2);
       create_account( "testapi"_n );
       create_account( "dummy"_n );
@@ -723,7 +717,7 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
 } FC_LOG_AND_RETHROW() }
 
 
-BOOST_FIXTURE_TEST_CASE(cfa_tx_signature, TESTER)  try {
+BOOST_FIXTURE_TEST_CASE(cfa_tx_signature, validating_tester)  try {
 
    action cfa({}, cf_action());
 
@@ -743,7 +737,7 @@ BOOST_FIXTURE_TEST_CASE(cfa_tx_signature, TESTER)  try {
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE(cfa_stateful_api, TESTER)  try {
+BOOST_FIXTURE_TEST_CASE(cfa_stateful_api, validating_tester)  try {
 
    create_account( "testapi"_n );
 	produce_blocks(1);
@@ -773,7 +767,7 @@ BOOST_FIXTURE_TEST_CASE(cfa_stateful_api, TESTER)  try {
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, TESTER)  try {
+BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, validating_tester)  try {
 
    create_account( "testapi"_n );
 	produce_blocks(1);
@@ -809,7 +803,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, TESTER)  try {
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, TESTER)  try {
+BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, validating_tester)  try {
 
    create_account( "testapi"_n );
 	produce_blocks(1);
@@ -932,7 +926,7 @@ BOOST_AUTO_TEST_CASE(light_validation_skip_cfa) try {
 /*************************************************************************************
  * checktime_tests test case
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(checktime_pass_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(checktime_pass_tests, validating_tester) { try {
 	produce_blocks(2);
 	create_account( "testapi"_n );
 	produce_blocks(10);
@@ -985,7 +979,7 @@ void call_test(Tester& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cp
 }
 
 BOOST_AUTO_TEST_CASE(checktime_fail_tests) { try {
-   TESTER t;
+   validating_tester t;
    t.produce_blocks(2);
 
    ilog( "create account" );
@@ -1238,7 +1232,7 @@ BOOST_AUTO_TEST_CASE(checktime_pause_block_deadline_not_extended_while_loading_t
    BOOST_REQUIRE_EQUAL( t.validate(), true );
 } FC_LOG_AND_RETHROW() }
 
-BOOST_FIXTURE_TEST_CASE(checktime_intrinsic, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(checktime_intrinsic, validating_tester) { try {
 	produce_blocks(2);
 	create_account( "testapi"_n );
 	produce_blocks(10);
@@ -1299,7 +1293,7 @@ BOOST_FIXTURE_TEST_CASE(checktime_intrinsic, TESTER) { try {
                                deadline_exception, is_deadline_exception );
 } FC_LOG_AND_RETHROW() }
 
-BOOST_FIXTURE_TEST_CASE(checktime_grow_memory, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(checktime_grow_memory, validating_tester) { try {
 	produce_blocks(2);
 	create_account( "testapi"_n );
 	produce_blocks(10);
@@ -1338,7 +1332,7 @@ BOOST_FIXTURE_TEST_CASE(checktime_grow_memory, TESTER) { try {
                                deadline_exception, is_deadline_exception );
 } FC_LOG_AND_RETHROW() }
 
-BOOST_FIXTURE_TEST_CASE(checktime_hashing_fail, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(checktime_hashing_fail, validating_tester) { try {
 	produce_blocks(2);
 	create_account( "testapi"_n );
 	produce_blocks(10);
@@ -1391,7 +1385,7 @@ BOOST_FIXTURE_TEST_CASE(checktime_hashing_fail, TESTER) { try {
 } FC_LOG_AND_RETHROW() }
 
 
-BOOST_FIXTURE_TEST_CASE(checktime_start, TESTER) try {
+BOOST_FIXTURE_TEST_CASE(checktime_start, validating_tester) try {
    const char checktime_start_wast[] = R"=====(
 (module
  (func $start (loop (br 0)))
@@ -1413,7 +1407,7 @@ BOOST_FIXTURE_TEST_CASE(checktime_start, TESTER) try {
 /*************************************************************************************
  * transaction_tests test case
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(transaction_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(transaction_tests, validating_tester) { try {
    produce_blocks(2);
    create_account( "testapi"_n );
    produce_blocks(100);
@@ -1690,7 +1684,7 @@ BOOST_AUTO_TEST_CASE(deferred_inline_action_subjective_limit) { try {
 
 } FC_LOG_AND_RETHROW() }
 
-BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, validating_tester) { try {
    produce_blocks(2);
    create_accounts( {"testapi"_n, "testapi2"_n, "alice"_n} );
    set_code( "testapi"_n, test_contracts::test_api_wasm() );
@@ -2059,7 +2053,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
 /*************************************************************************************
  * chain_tests test case
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(chain_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(chain_tests, validating_tester) { try {
    produce_blocks(2);
 
    create_account( "testapi"_n );
@@ -2106,7 +2100,7 @@ BOOST_FIXTURE_TEST_CASE(chain_tests, TESTER) { try {
 /*************************************************************************************
  * db_tests test case
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(db_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(db_tests, validating_tester) { try {
    produce_blocks(2);
    create_account( "testapi"_n );
    create_account( "testapi2"_n );
@@ -2213,7 +2207,7 @@ BOOST_FIXTURE_TEST_CASE(db_tests, TESTER) { try {
 } FC_LOG_AND_RETHROW() }
 
 // The multi_index iterator cache is preserved across notifications for the same action.
-BOOST_FIXTURE_TEST_CASE(db_notify_tests, TESTER) {
+BOOST_FIXTURE_TEST_CASE(db_notify_tests, validating_tester) {
    create_accounts( {"notifier"_n,"notified"_n } );
    const char notifier[] = R"=====(
 (module
@@ -2267,7 +2261,7 @@ BOOST_FIXTURE_TEST_CASE(db_notify_tests, TESTER) {
 /*************************************************************************************
  * multi_index_tests test case
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(multi_index_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(multi_index_tests, validating_tester) { try {
    produce_blocks(1);
    create_account( "testapi"_n );
    produce_blocks(1);
@@ -2323,7 +2317,7 @@ BOOST_FIXTURE_TEST_CASE(multi_index_tests, TESTER) { try {
 /*************************************************************************************
  * crypto_tests test cases
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(crypto_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(crypto_tests, validating_tester) { try {
    produce_block();
    create_account("testapi"_n );
    produce_block();
@@ -2536,7 +2530,7 @@ static const char memset_pass_wast[] = R"======(
 )
 )======";
 
-BOOST_FIXTURE_TEST_CASE(memory_tests, TESTER) {
+BOOST_FIXTURE_TEST_CASE(memory_tests, validating_tester) {
    produce_block();
    create_accounts( { "memcpy"_n, "memcpy2"_n, "memcpy3"_n, "memmove"_n, "memcmp"_n, "memset"_n } );
    set_code( "memcpy"_n, memcpy_pass_wast );
@@ -2577,7 +2571,7 @@ static const char cstr_wast[] = R"======(
 )
 )======";
 
-BOOST_FIXTURE_TEST_CASE(cstr_tests, TESTER) {
+BOOST_FIXTURE_TEST_CASE(cstr_tests, validating_tester) {
    produce_block();
    create_accounts( { "cstr"_n } );
    set_code( "cstr"_n, cstr_wast );
@@ -2594,7 +2588,7 @@ BOOST_FIXTURE_TEST_CASE(cstr_tests, TESTER) {
 /*************************************************************************************
  * print_tests test case
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(print_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(print_tests, validating_tester) { try {
 	produce_blocks(2);
 	create_account("testapi"_n );
 	produce_blocks(1000);
@@ -2720,7 +2714,7 @@ BOOST_FIXTURE_TEST_CASE(print_tests, TESTER) { try {
 /*************************************************************************************
  * types_tests test case
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(types_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(types_tests, validating_tester) { try {
 	produce_blocks(1000);
 	create_account( "testapi"_n );
 
@@ -2738,7 +2732,7 @@ BOOST_FIXTURE_TEST_CASE(types_tests, TESTER) { try {
 /*************************************************************************************
  * permission_tests test case
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(permission_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(permission_tests, validating_tester) { try {
    produce_blocks(1);
    create_account( "testapi"_n );
 
@@ -2895,7 +2889,7 @@ static const char get_resource_limits_null_cpu_wast[] = R"=====(
 )
 )=====";
 
-BOOST_FIXTURE_TEST_CASE(resource_limits_tests, TESTER) {
+BOOST_FIXTURE_TEST_CASE(resource_limits_tests, validating_tester) {
    create_accounts( { "rlimits"_n, "testacnt"_n } );
    set_code("rlimits"_n, resource_limits_wast);
    push_action( "eosio"_n, "setpriv"_n, "eosio"_n, mutable_variant_object()("account", "rlimits"_n)("is_priv", 1));
@@ -2988,7 +2982,7 @@ BOOST_FIXTURE_TEST_CASE(privileged_tests, tester) { try {
 /*************************************************************************************
  * real_tests test cases
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(datastream_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(datastream_tests, validating_tester) { try {
    produce_blocks(1000);
    create_account("testapi"_n );
    produce_blocks(1000);
@@ -3003,7 +2997,7 @@ BOOST_FIXTURE_TEST_CASE(datastream_tests, TESTER) { try {
 /*************************************************************************************
  * permission_usage_tests test cases
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(permission_usage_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(permission_usage_tests, validating_tester) { try {
    produce_block();
    create_accounts( {"testapi"_n, "alice"_n, "bob"_n} );
    produce_block();
@@ -3084,7 +3078,7 @@ BOOST_FIXTURE_TEST_CASE(permission_usage_tests, TESTER) { try {
 /*************************************************************************************
  * account_creation_time_tests test cases
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(account_creation_time_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(account_creation_time_tests, validating_tester) { try {
    produce_block();
    create_account( "testapi"_n );
    produce_block();
@@ -3111,7 +3105,7 @@ BOOST_FIXTURE_TEST_CASE(account_creation_time_tests, TESTER) { try {
 /*************************************************************************************
  * extended_symbol_api_tests test cases
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(extended_symbol_api_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(extended_symbol_api_tests, validating_tester) { try {
    name n0{"1"};
    name n1{"5"};
    name n2{"a"};
@@ -3146,7 +3140,7 @@ BOOST_FIXTURE_TEST_CASE(extended_symbol_api_tests, TESTER) { try {
 /*************************************************************************************
  * eosio_assert_code_tests test cases
  *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, validating_tester) { try {
    produce_block();
    create_account( "testapi"_n );
    produce_block();
@@ -3225,7 +3219,7 @@ BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, TESTER) { try {
 /*************************************************************************************
 + * action_ordinal_test test cases
 + *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(action_ordinal_test, validating_tester) { try {
 
    produce_blocks(1);
    create_account("testapi"_n );
@@ -3408,7 +3402,7 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
 /*************************************************************************************
 + * action_ordinal_failtest1 test cases
 + *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, validating_tester) { try {
 
    produce_blocks(1);
    create_account("testapi"_n );
@@ -3476,7 +3470,7 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, TESTER) { try {
 /*************************************************************************************
 + * action_ordinal_failtest2 test cases
 + *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, validating_tester) { try {
 
    produce_blocks(1);
    create_account("testapi"_n );
@@ -3597,7 +3591,7 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
 /*************************************************************************************
 + * action_ordinal_failtest3 test cases
 + *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
+BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, validating_tester) { try {
 
    produce_blocks(1);
    create_account("testapi"_n );
@@ -3752,7 +3746,7 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(action_results_tests) { try {
-   TESTER t;
+   validating_tester t;
    t.produce_blocks(2);
    t.create_account( "test"_n );
    t.set_code( "test"_n, test_contracts::action_results_wasm() );
@@ -3861,7 +3855,7 @@ static const char get_code_hash_wast[] = R"=====(
 )=====";
 
 BOOST_AUTO_TEST_CASE(get_code_hash_tests) { try {
-   TESTER t;
+   validating_tester t;
    t.produce_blocks(2);
    t.create_account("gethash"_n);
    t.create_account("test"_n);

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -9,19 +9,13 @@
 
 #include <eosio/testing/tester_network.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
 
 BOOST_AUTO_TEST_SUITE(auth_tests)
 
-BOOST_FIXTURE_TEST_CASE( missing_sigs, TESTER ) { try {
+BOOST_FIXTURE_TEST_CASE( missing_sigs, validating_tester ) { try {
    create_accounts( {"alice"_n} );
    produce_block();
 
@@ -33,7 +27,7 @@ BOOST_FIXTURE_TEST_CASE( missing_sigs, TESTER ) { try {
 
 } FC_LOG_AND_RETHROW() } /// missing_sigs
 
-BOOST_FIXTURE_TEST_CASE( missing_multi_sigs, TESTER ) { try {
+BOOST_FIXTURE_TEST_CASE( missing_multi_sigs, validating_tester ) { try {
     produce_block();
     create_account("alice"_n, config::system_account_name, true);
     produce_block();
@@ -46,7 +40,7 @@ BOOST_FIXTURE_TEST_CASE( missing_multi_sigs, TESTER ) { try {
 
  } FC_LOG_AND_RETHROW() } /// missing_multi_sigs
 
-BOOST_FIXTURE_TEST_CASE( missing_auths, TESTER ) { try {
+BOOST_FIXTURE_TEST_CASE( missing_auths, validating_tester ) { try {
    create_accounts( {"alice"_n, "bob"_n} );
    produce_block();
 
@@ -59,7 +53,7 @@ BOOST_FIXTURE_TEST_CASE( missing_auths, TESTER ) { try {
  *  This test case will attempt to allow one account to transfer on behalf
  *  of another account by updating the active authority.
  */
-BOOST_FIXTURE_TEST_CASE( delegate_auth, TESTER ) { try {
+BOOST_FIXTURE_TEST_CASE( delegate_auth, validating_tester ) { try {
    create_accounts( {"alice"_n,"bob"_n});
    produce_block();
 
@@ -95,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE( delegate_auth, TESTER ) { try {
 
 BOOST_AUTO_TEST_CASE(update_auths) {
 try {
-   TESTER chain;
+   validating_tester chain;
    chain.create_account(name("alice"));
    chain.create_account(name("bob"));
 
@@ -228,7 +222,7 @@ try {
 
 BOOST_AUTO_TEST_CASE(update_auth_unknown_private_key) {
    try {
-      TESTER chain;
+      validating_tester chain;
       chain.create_account(name("alice"));
 
       // public key with no corresponding private key
@@ -262,7 +256,7 @@ BOOST_AUTO_TEST_CASE(update_auth_unknown_private_key) {
 }
 
 BOOST_AUTO_TEST_CASE(link_auths) { try {
-   TESTER chain;
+   validating_tester chain;
 
    chain.create_accounts({name("alice"),name("bob")});
 
@@ -305,7 +299,7 @@ BOOST_AUTO_TEST_CASE(link_auths) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(link_then_update_auth) { try {
-   TESTER chain;
+   validating_tester chain;
 
    chain.create_account(name("alice"));
 
@@ -332,7 +326,7 @@ BOOST_AUTO_TEST_CASE(link_then_update_auth) { try {
 
 BOOST_AUTO_TEST_CASE(create_account) {
 try {
-   TESTER chain;
+   validating_tester chain;
    chain.create_account(name("joe"));
    chain.produce_block();
 
@@ -370,7 +364,7 @@ try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( any_auth ) { try {
-   TESTER chain;
+   validating_tester chain;
    chain.create_accounts( {name("alice"), name("bob")} );
    chain.produce_block();
 
@@ -466,7 +460,7 @@ try {
 
 BOOST_AUTO_TEST_CASE(stricter_auth) {
 try {
-   TESTER chain;
+   validating_tester chain;
 
    chain.produce_block();
 
@@ -515,7 +509,7 @@ try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( linkauth_special ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
    std::vector<transaction_id_type> ids;

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -8,13 +8,6 @@
 #include <contracts.hpp>
 #include <test_contracts.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
@@ -62,7 +55,7 @@ std::vector<genesis_account> test_genesis( {
   {"masses"_n,   800'000'000'0000ll}
 });
 
-class bootseq_tester : public TESTER {
+class bootseq_tester : public validating_tester {
 public:
    void deploy_contract( bool call_init = true ) {
       set_code( config::system_account_name, test_contracts::eosio_system_wasm() );

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -13,18 +13,12 @@
 #include <contracts.hpp>
 #include <test_contracts.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
 using namespace fc;
 
-class currency_tester : public TESTER {
+class currency_tester : public validating_tester {
    public:
 
       auto push_action(const account_name& signer, const action_name &name, const variant_object &data ) {
@@ -70,7 +64,7 @@ class currency_tester : public TESTER {
       }
 
       currency_tester()
-         :TESTER(),abi_ser(json::from_string(test_contracts::eosio_token_abi().data()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ))
+         :validating_tester(),abi_ser(json::from_string(test_contracts::eosio_token_abi().data()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ))
       {
          create_account( "eosio.token"_n);
          set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
@@ -258,7 +252,7 @@ BOOST_FIXTURE_TEST_CASE( test_fullspend, currency_tester ) try {
 
 
 
-BOOST_FIXTURE_TEST_CASE(test_symbol, TESTER) try {
+BOOST_FIXTURE_TEST_CASE(test_symbol, validating_tester) try {
 
    {
       symbol dollar(2, "DLLR");

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -5,12 +5,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio::chain;
 using namespace eosio::testing;
 
@@ -19,7 +13,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
    // Simple tests of undo infrastructure
    BOOST_AUTO_TEST_CASE(undo_test) {
       try {
-         TESTER test;
+         validating_tester test;
 
          // Bypass read-only restriction on state DB access for this unit test which really needs to mutate the DB to properly conduct its test.
          eosio::chain::database& db = const_cast<eosio::chain::database&>( test.control->db() );
@@ -47,7 +41,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
    // Test the block fetching methods on database, fetch_bock_by_id, and fetch_block_by_number
    BOOST_AUTO_TEST_CASE(get_blocks) {
       try {
-         TESTER test;
+         validating_tester test;
          vector<block_id_type> block_ids;
 
          const uint32_t num_of_blocks_to_prod = 200;

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -8,12 +8,6 @@
 #include <contracts.hpp>
 #include <test_contracts.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
@@ -85,7 +79,7 @@ BOOST_FIXTURE_TEST_CASE( delay_error_create_account, validating_tester) { try {
 } FC_LOG_AND_RETHROW() }
 
 
-asset get_currency_balance(const TESTER& chain, account_name account) {
+asset get_currency_balance(const validating_tester& chain, account_name account) {
    return chain.get_currency_balance("eosio.token"_n, symbol(SY(4,CUR)), account);
 }
 
@@ -93,7 +87,7 @@ const std::string eosio_token = name("eosio.token"_n).to_string();
 
 // test link to permission with delay directly on it
 BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -231,7 +225,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
 
 
 BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -368,7 +362,7 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
 
 // test link to permission with delay on permission which is parent of min permission (special logic in permission_object::satisfies)
 BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -506,7 +500,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
 
 // test link to permission with delay on permission between min permission and authorizing permission it
 BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -650,7 +644,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
 
 // test removing delay on permission
 BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -841,7 +835,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
 
 // test removing delay on permission based on heirarchy delay
 BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -1038,7 +1032,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
 
 // test moving link with delay on permission
 BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -1240,7 +1234,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
 
 // test link with unlink
 BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -1429,7 +1423,7 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
 
 // test moving link with delay on permission's parent
 BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -1620,7 +1614,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
 
 // test delay_sec field imposing unneeded delay
 BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    chain.produce_blocks();
    chain.create_account("eosio.token"_n);
@@ -1750,7 +1744,7 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
 
 // test canceldelay action cancelling a delayed transaction
 BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
-   TESTER chain;
+   validating_tester chain;
    const auto& tester_account = "tester"_n;
    std::vector<transaction_id_type> ids;
 
@@ -1987,7 +1981,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
 
 // test canceldelay action under different permission levels
 BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -2254,7 +2248,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
 BOOST_AUTO_TEST_CASE( max_transaction_delay_create ) { try {
    //assuming max transaction delay is 45 days (default in config.hpp)
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 
@@ -2276,7 +2270,7 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_create ) { try {
 
 BOOST_AUTO_TEST_CASE( max_transaction_delay_execute ) { try {
    //assuming max transaction delay is 45 days (default in config.hpp)
-   TESTER chain;
+   validating_tester chain;
 
    const auto& tester_account = "tester"_n;
 

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -14,21 +14,13 @@ using namespace fc;
 
 using mvo = fc::mutable_variant_object;
 
-#ifndef TESTER
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-#endif
-
 namespace eosio_system {
 
-class eosio_system_tester : public TESTER {
+class eosio_system_tester : public validating_tester {
 public:
 
    eosio_system_tester()
-   : eosio_system_tester([](TESTER& ) {}){}
+   : eosio_system_tester([](validating_tester& ) {}){}
 
    template<typename Lambda>
    eosio_system_tester(Lambda setup) {
@@ -455,7 +447,7 @@ public:
       }
       produce_blocks( 250);
 
-      auto trace_auth = TESTER::push_action(config::system_account_name, updateauth::get_name(), config::system_account_name, mvo()
+      auto trace_auth = validating_tester::push_action(config::system_account_name, updateauth::get_name(), config::system_account_name, mvo()
                                             ("account", name(config::system_account_name).to_string())
                                             ("permission", name(config::active_name).to_string())
                                             ("parent", name(config::owner_name).to_string())

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -14,12 +14,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio::chain;
 using namespace eosio::testing;
 
@@ -380,7 +374,7 @@ struct permission_visitor {
 
 BOOST_AUTO_TEST_CASE(authority_checker)
 { try {
-   testing::TESTER test;
+   testing::validating_tester test;
    auto a = test.get_public_key(name("a"), "active");
    auto b = test.get_public_key(name("b"), "active");
    auto c = test.get_public_key(name("c"), "active");
@@ -698,7 +692,7 @@ BOOST_AUTO_TEST_CASE(alphabetic_sort)
 
 BOOST_AUTO_TEST_CASE(transaction_test) { try {
 
-   testing::TESTER test;
+   testing::validating_tester test;
    signed_transaction trx;
 
    fc::variant pretty_trx = fc::mutable_variant_object()
@@ -863,7 +857,7 @@ BOOST_AUTO_TEST_CASE(signed_int_test) { try {
 
 BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
 
-   testing::TESTER test;
+   testing::validating_tester test;
    signed_transaction trx;
 
    fc::variant pretty_trx = fc::mutable_variant_object()

--- a/unittests/payloadless_tests.cpp
+++ b/unittests/payloadless_tests.cpp
@@ -13,18 +13,12 @@
 
 #include <test_contracts.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
 using namespace fc;
 
-class payloadless_tester : public TESTER {
+class payloadless_tester : public validating_tester {
 
 };
 

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -5,12 +5,6 @@
 
 #include "fork_test_utilities.hpp"
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio::testing;
 using namespace eosio::chain;
 using mvo = fc::mutable_variant_object;
@@ -44,7 +38,7 @@ BOOST_AUTO_TEST_SUITE(producer_schedule_tests)
       return res;
    };
 #if 0
-   BOOST_FIXTURE_TEST_CASE( verify_producer_schedule, TESTER ) try {
+   BOOST_FIXTURE_TEST_CASE( verify_producer_schedule, validating_tester ) try {
 
       // Utility function to ensure that producer schedule work as expected
       const auto& confirm_schedule_correctness = [&](const vector<producer_key>& new_prod_schd, const uint64_t eff_new_prod_schd_block_num)  {
@@ -120,7 +114,7 @@ BOOST_AUTO_TEST_SUITE(producer_schedule_tests)
    } FC_LOG_AND_RETHROW()
 
 
-   BOOST_FIXTURE_TEST_CASE( verify_producers, TESTER ) try {
+   BOOST_FIXTURE_TEST_CASE( verify_producers, validating_tester ) try {
 
       vector<account_name> valid_producers = {
          "inita", "initb", "initc", "initd", "inite", "initf", "initg",
@@ -145,7 +139,7 @@ BOOST_AUTO_TEST_SUITE(producer_schedule_tests)
 
    } FC_LOG_AND_RETHROW()
 
-   BOOST_FIXTURE_TEST_CASE( verify_header_schedule_version, TESTER ) try {
+   BOOST_FIXTURE_TEST_CASE( verify_header_schedule_version, validating_tester ) try {
 
       // Utility function to ensure that producer schedule version in the header is correct
       const auto& confirm_header_schd_ver_correctness = [&](const uint64_t expected_version, const uint64_t eff_new_prod_schd_block_num)  {
@@ -199,7 +193,7 @@ BOOST_AUTO_TEST_SUITE(producer_schedule_tests)
 #endif
 
 
-BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, validating_tester ) try {
    create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
    while (control->head_block_num() < 3) {
       produce_block();
@@ -521,7 +515,7 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( producer_one_of_n_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( producer_one_of_n_test, validating_tester ) try {
    create_accounts( {"alice"_n,"bob"_n} );
    produce_block();
 
@@ -539,7 +533,7 @@ BOOST_FIXTURE_TEST_CASE( producer_one_of_n_test, TESTER ) try {
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( producer_m_of_n_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( producer_m_of_n_test, validating_tester ) try {
    create_accounts( {"alice"_n,"bob"_n} );
    produce_block();
 
@@ -560,7 +554,7 @@ BOOST_FIXTURE_TEST_CASE( producer_m_of_n_test, TESTER ) try {
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( satisfiable_msig_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( satisfiable_msig_test, validating_tester ) try {
    create_accounts( {"alice"_n,"bob"_n} );
    produce_block();
 
@@ -578,7 +572,7 @@ BOOST_FIXTURE_TEST_CASE( satisfiable_msig_test, TESTER ) try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( duplicate_producers_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( duplicate_producers_test, validating_tester ) try {
    create_accounts( {"alice"_n} );
    produce_block();
 
@@ -597,7 +591,7 @@ BOOST_FIXTURE_TEST_CASE( duplicate_producers_test, TESTER ) try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( duplicate_keys_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( duplicate_keys_test, validating_tester ) try {
    create_accounts( {"alice"_n,"bob"_n} );
    produce_block();
 

--- a/unittests/ram_tests.cpp
+++ b/unittests/ram_tests.cpp
@@ -75,7 +75,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
    buyrambytes(config::system_account_name, "testram11111"_n, more_ram);
    buyrambytes(config::system_account_name, "testram22222"_n, more_ram);
 
-   TESTER* tester = this;
+   validating_tester* tester = this;
    // allocate just under the allocated bytes
    tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                         ("payer", "testram11111")

--- a/unittests/read_only_trx_tests.cpp
+++ b/unittests/read_only_trx_tests.cpp
@@ -5,12 +5,6 @@
 #include <fc/variant_object.hpp>
 #include <test_contracts.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
@@ -18,7 +12,7 @@ using namespace fc;
 
 using mvo = fc::mutable_variant_object;
 
-struct read_only_trx_tester : TESTER {
+struct read_only_trx_tester : validating_tester {
    read_only_trx_tester() {
       produce_block();
    };

--- a/unittests/wasm-spec-tests/generated-tests/wasm_spec_tests.hpp.in
+++ b/unittests/wasm-spec-tests/generated-tests/wasm_spec_tests.hpp.in
@@ -5,16 +5,10 @@
 #include <eosio/testing/tester.hpp>
 #include <contracts.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::testing;
 
-inline void push_action(TESTER& tester, action&& act, uint64_t authorizer) {
+inline void push_action(validating_tester& tester, action&& act, uint64_t authorizer) {
    signed_transaction trx;
    if (authorizer) {
       act.authorization = vector<permission_level>{{account_name(authorizer), config::active_name}};

--- a/unittests/wasm-spec-tests/generated-tests/wasm_spec_tests.hpp.in
+++ b/unittests/wasm-spec-tests/generated-tests/wasm_spec_tests.hpp.in
@@ -5,10 +5,12 @@
 #include <eosio/testing/tester.hpp>
 #include <contracts.hpp>
 
+#define TESTER validating_tester
+
 using namespace eosio;
 using namespace eosio::testing;
 
-inline void push_action(validating_tester& tester, action&& act, uint64_t authorizer) {
+inline void push_action(TESTER& tester, action&& act, uint64_t authorizer) {
    signed_transaction trx;
    if (authorizer) {
       act.authorization = vector<permission_level>{{account_name(authorizer), config::active_name}};

--- a/unittests/wasm_config_tests.cpp
+++ b/unittests/wasm_config_tests.cpp
@@ -20,14 +20,8 @@ using namespace eosio::testing;
 using namespace fc;
 namespace data = boost::unit_test::data;
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 namespace {
-struct wasm_config_tester : TESTER {
+struct wasm_config_tester : validating_tester {
    wasm_config_tester() {
       set_abi(config::system_account_name, test_contracts::wasm_config_bios_abi().data());
       set_code(config::system_account_name, test_contracts::wasm_config_bios_wasm());
@@ -1061,7 +1055,7 @@ static const char check_get_wasm_parameters_wast[] = R"======(
 )
 )======";
 
-BOOST_FIXTURE_TEST_CASE(get_wasm_parameters_test, TESTER) {
+BOOST_FIXTURE_TEST_CASE(get_wasm_parameters_test, validating_tester) {
    produce_block();
 
    create_account( "test"_n );

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -28,12 +28,6 @@
 
 #include <test_contracts.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
@@ -73,7 +67,7 @@ BOOST_AUTO_TEST_SUITE(wasm_tests)
 /**
  * Prove that action reading and assertions are working
  */
-BOOST_FIXTURE_TEST_CASE( basic_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( basic_test, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"asserter"_n} );
@@ -132,7 +126,7 @@ BOOST_FIXTURE_TEST_CASE( basic_test, TESTER ) try {
 /**
  * Prove the modifications to global variables are wiped between runs
  */
-BOOST_FIXTURE_TEST_CASE( prove_mem_reset, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( prove_mem_reset, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"asserter"_n} );
@@ -162,7 +156,7 @@ BOOST_FIXTURE_TEST_CASE( prove_mem_reset, TESTER ) try {
 /**
  * Prove the modifications to global variables are wiped between runs
  */
-BOOST_FIXTURE_TEST_CASE( abi_from_variant, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( abi_from_variant, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"asserter"_n} );
@@ -212,7 +206,7 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, TESTER ) try {
 } FC_LOG_AND_RETHROW() /// prove_mem_reset
 
 // test softfloat 32 bit operations
-BOOST_FIXTURE_TEST_CASE( f32_tests, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( f32_tests, validating_tester ) try {
    produce_blocks(2);
    produce_block();
    create_accounts( {"f32.tests"_n} );
@@ -235,7 +229,7 @@ BOOST_FIXTURE_TEST_CASE( f32_tests, TESTER ) try {
       get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
-BOOST_FIXTURE_TEST_CASE( f32_test_bitwise, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( f32_test_bitwise, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"f32.tests"_n} );
    produce_block();
@@ -258,7 +252,7 @@ BOOST_FIXTURE_TEST_CASE( f32_test_bitwise, TESTER ) try {
       get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
-BOOST_FIXTURE_TEST_CASE( f32_test_cmp, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( f32_test_cmp, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"f32.tests"_n} );
    produce_block();
@@ -283,7 +277,7 @@ BOOST_FIXTURE_TEST_CASE( f32_test_cmp, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 // test softfloat 64 bit operations
-BOOST_FIXTURE_TEST_CASE( f64_tests, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( f64_tests, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"f.tests"_n} );
    produce_block();
@@ -306,7 +300,7 @@ BOOST_FIXTURE_TEST_CASE( f64_tests, TESTER ) try {
       get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
-BOOST_FIXTURE_TEST_CASE( f64_test_bitwise, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( f64_test_bitwise, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"f.tests"_n} );
    produce_block();
@@ -329,7 +323,7 @@ BOOST_FIXTURE_TEST_CASE( f64_test_bitwise, TESTER ) try {
       get_transaction_receipt(trx.id());
    }
 } FC_LOG_AND_RETHROW()
-BOOST_FIXTURE_TEST_CASE( f64_test_cmp, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( f64_test_cmp, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"f.tests"_n} );
    produce_block();
@@ -354,7 +348,7 @@ BOOST_FIXTURE_TEST_CASE( f64_test_cmp, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 // test softfloat conversion operations
-BOOST_FIXTURE_TEST_CASE( f32_f64_conversion_tests, tester ) try {
+BOOST_FIXTURE_TEST_CASE( f32_f64_conversion_tests, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"ftests"_n} );
@@ -380,7 +374,7 @@ BOOST_FIXTURE_TEST_CASE( f32_f64_conversion_tests, tester ) try {
 } FC_LOG_AND_RETHROW()
 
 // test softfloat conversion operations
-BOOST_FIXTURE_TEST_CASE( f32_f64_overflow_tests, tester ) try {
+BOOST_FIXTURE_TEST_CASE( f32_f64_overflow_tests, validating_tester ) try {
    int count = 0;
    auto check = [&](const char *wast_template, const char *op, const char *param) -> bool {
       count+=16;
@@ -481,7 +475,7 @@ BOOST_FIXTURE_TEST_CASE( f32_f64_overflow_tests, tester ) try {
    BOOST_REQUIRE_EQUAL(false, check(i64_overflow_wast, "i64_trunc_u_f64", "f64.const 18446744073709551616"));
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE(misaligned_tests, tester ) try {
+BOOST_FIXTURE_TEST_CASE(misaligned_tests, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"aligncheck"_n} );
    produce_block();
@@ -514,7 +508,7 @@ BOOST_FIXTURE_TEST_CASE(misaligned_tests, tester ) try {
 /**
  * Make sure WASM "start" method is used correctly
  */
-BOOST_FIXTURE_TEST_CASE( check_entry_behavior, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( check_entry_behavior, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"entrycheck"_n} );
    produce_block();
@@ -538,7 +532,7 @@ BOOST_FIXTURE_TEST_CASE( check_entry_behavior, TESTER ) try {
    BOOST_CHECK_EQUAL(transaction_receipt::executed, receipt.status);
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( check_entry_behavior_2, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( check_entry_behavior_2, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"entrycheck"_n} );
    produce_block();
@@ -562,7 +556,7 @@ BOOST_FIXTURE_TEST_CASE( check_entry_behavior_2, TESTER ) try {
    BOOST_CHECK_EQUAL(transaction_receipt::executed, receipt.status);
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( entry_import, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( entry_import, validating_tester ) try {
    create_accounts( {"enterimport"_n} );
    produce_block();
 
@@ -580,7 +574,7 @@ BOOST_FIXTURE_TEST_CASE( entry_import, TESTER ) try {
    BOOST_CHECK_THROW(push_transaction(trx), abort_called);
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( entry_db, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( entry_db, validating_tester ) try {
    create_accounts( {"entrydb"_n} );
    produce_block();
 
@@ -601,7 +595,7 @@ BOOST_FIXTURE_TEST_CASE( entry_db, TESTER ) try {
 /**
  * Ensure we can load a wasm w/o memory
  */
-BOOST_FIXTURE_TEST_CASE( simple_no_memory_check, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( simple_no_memory_check, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"nomem"_n} );
@@ -624,7 +618,7 @@ BOOST_FIXTURE_TEST_CASE( simple_no_memory_check, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 //Make sure globals are all reset to their inital values
-BOOST_FIXTURE_TEST_CASE( check_global_reset, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( check_global_reset, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"globalreset"_n} );
@@ -712,7 +706,7 @@ BOOST_DATA_TEST_CASE( table_init_tests, bdata::make({setup_policy::preactivate_f
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( table_init_oob, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( table_init_oob, validating_tester ) try {
    create_accounts( {"tableinitoob"_n} );
    produce_block();
 
@@ -753,7 +747,7 @@ BOOST_FIXTURE_TEST_CASE( table_init_oob, TESTER ) try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( memory_init_border, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( memory_init_border, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"memoryborder"_n} );
@@ -767,7 +761,7 @@ BOOST_FIXTURE_TEST_CASE( memory_init_border, TESTER ) try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( imports, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( imports, validating_tester ) try {
    try {
       produce_blocks(2);
 
@@ -785,7 +779,7 @@ BOOST_FIXTURE_TEST_CASE( imports, TESTER ) try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( nested_limit_test, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"nested"_n} );
@@ -983,7 +977,7 @@ BOOST_AUTO_TEST_CASE( offset_check_old ) try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( offset_check, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( offset_check, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"offsets"_n} );
@@ -1028,7 +1022,7 @@ BOOST_FIXTURE_TEST_CASE( offset_check, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 
-BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
+BOOST_FIXTURE_TEST_CASE(noop, validating_tester) try {
    produce_blocks(2);
    create_accounts( {"noop"_n, "alice"_n} );
    produce_block();
@@ -1096,7 +1090,7 @@ BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
 // abi_serializer::to_variant failed because eosio_system_abi modified via set_abi.
 // This test also verifies that chain_initializer::eos_contract_abi() does not conflict
 // with eosio_system_abi as they are not allowed to contain duplicates.
-BOOST_FIXTURE_TEST_CASE(eosio_abi, TESTER) try {
+BOOST_FIXTURE_TEST_CASE(eosio_abi, validating_tester) try {
    produce_blocks(2);
 
    const auto& accnt  = control->db().get<account_object,by_name>(config::system_account_name);
@@ -1205,7 +1199,7 @@ BOOST_AUTO_TEST_CASE( check_big_deserialization ) try {
 } FC_LOG_AND_RETHROW()
 
 
-BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( check_table_maximum, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"tbl"_n} );
    produce_block();
@@ -1348,7 +1342,7 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    }
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( protected_globals, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( protected_globals, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"gob"_n} );
@@ -1383,7 +1377,7 @@ BOOST_FIXTURE_TEST_CASE( protected_globals, TESTER ) try {
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( apply_export_and_signature, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( apply_export_and_signature, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"bbb"_n} );
    produce_block();
@@ -1401,7 +1395,7 @@ BOOST_FIXTURE_TEST_CASE( apply_export_and_signature, TESTER ) try {
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( trigger_serialization_errors, TESTER) try {
+BOOST_FIXTURE_TEST_CASE( trigger_serialization_errors, validating_tester) try {
    produce_blocks(2);
    const vector<uint8_t> proper_wasm = { 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0d, 0x02, 0x60, 0x03, 0x7f, 0x7f, 0x7f,
                                          0x00, 0x60, 0x03, 0x7e, 0x7e, 0x7e, 0x00, 0x02, 0x0e, 0x01, 0x03, 0x65, 0x6e, 0x76, 0x06, 0x73,
@@ -1425,7 +1419,7 @@ BOOST_FIXTURE_TEST_CASE( trigger_serialization_errors, TESTER) try {
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( protect_injected, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( protect_injected, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"inj"_n} );
@@ -1435,7 +1429,7 @@ BOOST_FIXTURE_TEST_CASE( protect_injected, TESTER ) try {
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( import_signature, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( import_signature, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"imp"_n} );
@@ -1445,7 +1439,7 @@ BOOST_FIXTURE_TEST_CASE( import_signature, TESTER ) try {
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( mem_growth_memset, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( mem_growth_memset, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"grower"_n} );
@@ -1512,7 +1506,7 @@ INCBIN(deep_loops_ext_report, "deep_loops_ext_report.wasm");
 INCBIN(80k_deep_loop_with_ret, "80k_deep_loop_with_ret.wasm");
 INCBIN(80k_deep_loop_with_void, "80k_deep_loop_with_void.wasm");
 
-BOOST_FIXTURE_TEST_CASE( fuzz, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( fuzz, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"fuzzy"_n} );
@@ -1670,7 +1664,7 @@ BOOST_FIXTURE_TEST_CASE( fuzz, TESTER ) try {
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( big_maligned_host_ptr, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( big_maligned_host_ptr, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"bigmaligned"_n} );
    produce_block();
@@ -1822,7 +1816,7 @@ static char reset_memory_fail3_wast[] = R"======(
 )
 )======";
 
-BOOST_FIXTURE_TEST_CASE( reset_memory_fail, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( reset_memory_fail, validating_tester ) try {
    produce_block();
    create_accounts( {"usemem"_n, "resetmem"_n, "accessmem"_n} );
    produce_block();
@@ -2080,7 +2074,7 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
 /**
  * various tests with wasm & 0 pages worth of memory
  */
-BOOST_FIXTURE_TEST_CASE( zero_memory_pages, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( zero_memory_pages, validating_tester ) try {
    produce_blocks(2);
 
    create_accounts( {"zero"_n} );
@@ -2125,7 +2119,7 @@ BOOST_FIXTURE_TEST_CASE( zero_memory_pages, TESTER ) try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( eosio_exit_in_start, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( eosio_exit_in_start, validating_tester ) try {
    produce_blocks(2);
    create_accounts( {"startexit"_n} );
    produce_block();
@@ -2146,7 +2140,7 @@ BOOST_FIXTURE_TEST_CASE( eosio_exit_in_start, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 // memory.grow with a negative argument can shrink the available memory.
-BOOST_FIXTURE_TEST_CASE( negative_memory_grow, TESTER ) try {
+BOOST_FIXTURE_TEST_CASE( negative_memory_grow, validating_tester ) try {
    produce_blocks(2);
 
 

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -70,13 +70,6 @@ FC_REFLECT_EMPTY(provereset);
 
 BOOST_AUTO_TEST_SUITE(wasm_tests)
 
-// https://github.com/AntelopeIO/leap/issues/259 was created to track this.
-// Remove those comments after the issue is resolved.
-//#warning Change this back to using TESTER
-struct old_wasm_tester : tester {
-   old_wasm_tester() : tester{setup_policy::old_wasm_parser} {}
-};
-
 /**
  * Prove that action reading and assertions are working
  */
@@ -666,21 +659,22 @@ BOOST_FIXTURE_TEST_CASE( check_global_reset, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 //Make sure we can create a wasm with maximum pages, but not grow it any
-BOOST_DATA_TEST_CASE_F( old_wasm_tester, big_memory, bdata::make({false, true}), activate_wasm_config ) try {
-   if(activate_wasm_config)
-      preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+BOOST_DATA_TEST_CASE( big_memory, bdata::make({setup_policy::preactivate_feature_and_new_bios, setup_policy::old_wasm_parser, setup_policy::full}), policy ) try {
+   validating_tester t(flat_set<account_name>{}, {}, policy);
+   if(policy != setup_policy::full)
+      t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
 
-   produce_blocks(2);
+   t.produce_blocks(2);
 
 
-   create_accounts( {"bigmem"_n} );
-   produce_block();
+   t.create_accounts( {"bigmem"_n} );
+   t.produce_block();
 
    string biggest_memory_wast_f = fc::format_string(biggest_memory_wast, fc::mutable_variant_object(
                                           "MAX_WASM_PAGES", eosio::chain::wasm_constraints::maximum_linear_memory/(64*1024)));
 
-   set_code("bigmem"_n, biggest_memory_wast_f.c_str());
-   produce_blocks(1);
+   t.set_code("bigmem"_n, biggest_memory_wast_f.c_str());
+   t.produce_blocks(1);
 
    signed_transaction trx;
    action act;
@@ -689,31 +683,32 @@ BOOST_DATA_TEST_CASE_F( old_wasm_tester, big_memory, bdata::make({false, true}),
    act.authorization = vector<permission_level>{{"bigmem"_n,config::active_name}};
    trx.actions.push_back(act);
 
-   set_transaction_headers(trx);
-   trx.sign(get_private_key( "bigmem"_n, "active" ), control->get_chain_id());
+   t.set_transaction_headers(trx);
+   trx.sign(validating_tester::get_private_key( "bigmem"_n, "active" ), t.control->get_chain_id());
    //but should not be able to grow beyond largest page
-   push_transaction(trx);
+   t.push_transaction(trx);
 
-   produce_blocks(1);
+   t.produce_blocks(1);
 
    string too_big_memory_wast_f = fc::format_string(too_big_memory_wast, fc::mutable_variant_object(
                                           "MAX_WASM_PAGES_PLUS_ONE", eosio::chain::wasm_constraints::maximum_linear_memory/(64*1024)+1));
-   BOOST_CHECK_THROW(set_code("bigmem"_n, too_big_memory_wast_f.c_str()), eosio::chain::wasm_exception);
+   BOOST_CHECK_THROW(t.set_code("bigmem"_n, too_big_memory_wast_f.c_str()), eosio::chain::wasm_exception);
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_DATA_TEST_CASE_F( old_wasm_tester, table_init_tests, bdata::make({false, true}), activate_wasm_config ) try {
-   if(activate_wasm_config)
-      preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
-   produce_blocks(2);
+BOOST_DATA_TEST_CASE( table_init_tests, bdata::make({setup_policy::preactivate_feature_and_new_bios, setup_policy::old_wasm_parser, setup_policy::full}), policy ) try {
+   validating_tester t(flat_set<account_name>{}, {}, policy);
+   if(policy != setup_policy::full)
+      t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+   t.produce_blocks(2);
 
-   create_accounts( {"tableinit"_n} );
-   produce_block();
+   t.create_accounts( {"tableinit"_n} );
+   t.produce_block();
 
-   set_code("tableinit"_n, valid_sparse_table);
-   produce_blocks(1);
+   t.set_code("tableinit"_n, valid_sparse_table);
+   t.produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code("tableinit"_n, too_big_table), eosio::chain::wasm_exception);
+   BOOST_CHECK_THROW(t.set_code("tableinit"_n, too_big_table), eosio::chain::wasm_exception);
 
 } FC_LOG_AND_RETHROW()
 
@@ -897,14 +892,15 @@ BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 
-BOOST_DATA_TEST_CASE_F( old_wasm_tester, lotso_globals, bdata::make({false, true}), activate_wasm_config ) try {
-   if(activate_wasm_config)
-      preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+BOOST_DATA_TEST_CASE( lotso_globals, bdata::make({setup_policy::preactivate_feature_and_new_bios, setup_policy::old_wasm_parser, setup_policy::full}), policy ) try {
+   validating_tester t(flat_set<account_name>{}, {}, policy);
+   if(policy != setup_policy::full)
+      t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
 
-   produce_blocks(2);
+   t.produce_blocks(2);
 
-   create_accounts( {"globals"_n} );
-   produce_block();
+   t.create_accounts( {"globals"_n} );
+   t.produce_block();
 
    std::stringstream ss;
    ss << "(module (export \"apply\" (func $apply)) (func $apply (param $0 i64) (param $1 i64) (param $2 i64))";
@@ -915,24 +911,20 @@ BOOST_DATA_TEST_CASE_F( old_wasm_tester, lotso_globals, bdata::make({false, true
    for(unsigned int i = 0; i < 10; ++i)
       ss << "(global $g" << i+200 << " i32 (i32.const 0))";
 
-   set_code("globals"_n,
-      string(ss.str() + ")")
-   .c_str());
+   t.set_code("globals"_n, (ss.str() + ")").c_str());
    //1024 should pass
-   set_code("globals"_n,
-      string(ss.str() + "(global $z (mut i32) (i32.const -12)))")
-   .c_str());
+   t.set_code("globals"_n, (ss.str() + "(global $z (mut i32) (i32.const -12)))").c_str());
    //1028 should fail
-   BOOST_CHECK_THROW(set_code("globals"_n,
-      string(ss.str() + "(global $z (mut i64) (i64.const -12)))")
-   .c_str()), eosio::chain::wasm_exception);
+   BOOST_CHECK_THROW(t.set_code("globals"_n, (ss.str() + "(global $z (mut i64) (i64.const -12)))").c_str()), eosio::chain::wasm_exception);
+
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
-   produce_blocks(2);
+BOOST_AUTO_TEST_CASE( offset_check_old ) try {
+   validating_tester t(flat_set<account_name>{}, {}, setup_policy::old_wasm_parser);
+   t.produce_blocks(2);
 
-   create_accounts( {"offsets"_n} );
-   produce_block();
+   t.create_accounts( {"offsets"_n} );
+   t.produce_block();
 
    vector<string> loadops = {
       "i32.load", "i64.load", "f32.load", "f64.load", "i32.load8_s", "i32.load8_u",
@@ -957,8 +949,8 @@ BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
       ss << "(drop (" << s << " offset=" << eosio::chain::wasm_constraints::maximum_linear_memory-2 << " (i32.const 0)))";
       ss << ") (export \"apply\" (func $apply)) )";
 
-      set_code("offsets"_n, ss.str().c_str());
-      produce_block();
+      t.set_code("offsets"_n, ss.str().c_str());
+      t.produce_block();
    }
    for(const vector<string>& o : storeops) {
       std::stringstream ss;
@@ -966,8 +958,8 @@ BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
       ss << "(" << o[0] << " offset=" << eosio::chain::wasm_constraints::maximum_linear_memory-2 << " (i32.const 0) (" << o[1] << ".const 0))";
       ss << ") (export \"apply\" (func $apply)) )";
 
-      set_code("offsets"_n, ss.str().c_str());
-      produce_block();
+      t.set_code("offsets"_n, ss.str().c_str());
+      t.produce_block();
    }
 
    for(const string& s : loadops) {
@@ -976,8 +968,8 @@ BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
       ss << "(drop (" << s << " offset=" << eosio::chain::wasm_constraints::maximum_linear_memory+4 << " (i32.const 0)))";
       ss << ") (export \"apply\" (func $apply)) )";
 
-      BOOST_CHECK_THROW(set_code("offsets"_n, ss.str().c_str()), eosio::chain::wasm_exception);
-      produce_block();
+      BOOST_CHECK_THROW(t.set_code("offsets"_n, ss.str().c_str()), eosio::chain::wasm_exception);
+      t.produce_block();
    }
    for(const vector<string>& o : storeops) {
       std::stringstream ss;
@@ -985,8 +977,8 @@ BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
       ss << "(" << o[0] << " offset=" << eosio::chain::wasm_constraints::maximum_linear_memory+4 << " (i32.const 0) (" << o[1] << ".const 0))";
       ss << ") (export \"apply\" (func $apply)) )";
 
-      BOOST_CHECK_THROW(set_code("offsets"_n, ss.str().c_str()), eosio::chain::wasm_exception);
-      produce_block();
+      BOOST_CHECK_THROW(t.set_code("offsets"_n, ss.str().c_str()), eosio::chain::wasm_exception);
+      t.produce_block();
    }
 
 } FC_LOG_AND_RETHROW()
@@ -1136,10 +1128,11 @@ BOOST_FIXTURE_TEST_CASE(eosio_abi, TESTER) try {
    produce_block();
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
-   produce_blocks(2);
-   create_accounts( {"cbd"_n} );
-   produce_block();
+BOOST_AUTO_TEST_CASE( check_big_deserialization ) try {
+   validating_tester t(flat_set<account_name>{}, {}, setup_policy::old_wasm_parser);
+   t.produce_blocks(2);
+   t.create_accounts( {"cbd"_n} );
+   t.produce_block();
 
    std::stringstream ss;
    ss << "(module ";
@@ -1149,10 +1142,10 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
       ss << "  (func " << "$AA_" << i << ")";
    ss << ")";
 
-   set_code("cbd"_n, ss.str().c_str());
-   produce_blocks(1);
+   t.set_code("cbd"_n, ss.str().c_str());
+   t.produce_blocks(1);
 
-   produce_blocks(1);
+   t.produce_blocks(1);
 
    ss.str("");
    ss << "(module ";
@@ -1162,8 +1155,8 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
       ss << "  (func " << "$AA_" << i << ")";
    ss << ")";
 
-   BOOST_CHECK_THROW(set_code("cbd"_n, ss.str().c_str()), wasm_serialization_error);
-   produce_blocks(1);
+   BOOST_CHECK_THROW(t.set_code("cbd"_n, ss.str().c_str()), wasm_serialization_error);
+   t.produce_blocks(1);
 
    ss.str("");
    ss << "(module ";
@@ -1174,8 +1167,8 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
       ss << "  (drop (i32.const 3))";
    ss << "))";
 
-   BOOST_CHECK_THROW(set_code("cbd"_n, ss.str().c_str()), fc::assert_exception); // this is caught first by MAX_SIZE_OF_ARRAYS check
-   produce_blocks(1);
+   BOOST_CHECK_THROW(t.set_code("cbd"_n, ss.str().c_str()), fc::assert_exception); // this is caught first by MAX_SIZE_OF_ARRAYS check
+   t.produce_blocks(1);
 
    ss.str("");
    ss << "(module ";
@@ -1190,8 +1183,8 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
       ss << "  (drop (i32.const 3))";
    ss << "))";
 
-   set_code("cbd"_n, ss.str().c_str());
-   produce_blocks(1);
+   t.set_code("cbd"_n, ss.str().c_str());
+   t.produce_blocks(1);
 
    ss.str("");
    ss << "(module ";
@@ -1206,8 +1199,8 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
       ss << "  (drop (i32.const 3))";
    ss << "))";
 
-   BOOST_CHECK_THROW(set_code("cbd"_n, ss.str().c_str()), wasm_serialization_error);
-   produce_blocks(1);
+   BOOST_CHECK_THROW(t.set_code("cbd"_n, ss.str().c_str()), wasm_serialization_error);
+   t.produce_blocks(1);
 
 } FC_LOG_AND_RETHROW()
 
@@ -1701,69 +1694,71 @@ BOOST_FIXTURE_TEST_CASE( big_maligned_host_ptr, TESTER ) try {
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
-BOOST_DATA_TEST_CASE_F( old_wasm_tester, depth_tests, bdata::make({false, true}), activate_wasm_config ) try {
-   if(activate_wasm_config)
-      preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+BOOST_DATA_TEST_CASE( depth_tests, bdata::make({setup_policy::preactivate_feature_and_new_bios, setup_policy::old_wasm_parser, setup_policy::full}), policy ) try {
+   validating_tester t(flat_set<account_name>{}, {}, policy);
+   if(policy != setup_policy::full)
+      t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
 
-   produce_block();
-   create_accounts( {"depth"_n} );
-   produce_block();
+   t.produce_block();
+   t.create_accounts( {"depth"_n} );
+   t.produce_block();
 
    signed_transaction trx;
    trx.actions.emplace_back(vector<permission_level>{{"depth"_n,config::active_name}}, "depth"_n, ""_n, bytes{});
    trx.actions[0].authorization = vector<permission_level>{{"depth"_n,config::active_name}};
 
     auto pushit = [&]() {
-      produce_block();
+      t.produce_block();
       trx.signatures.clear();
-      set_transaction_headers(trx);
-      trx.sign(get_private_key("depth"_n, "active"), control->get_chain_id());
-      push_transaction(trx);
+      t.set_transaction_headers(trx);
+      trx.sign(validating_tester::get_private_key("depth"_n, "active"), t.control->get_chain_id());
+      t.push_transaction(trx);
    };
 
    //strictly wasm recursion to maximum_call_depth & maximum_call_depth+1
    string wasm_depth_okay = fc::format_string(depth_assert_wasm, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth));
-   set_code("depth"_n, wasm_depth_okay.c_str());
+   t.set_code("depth"_n, wasm_depth_okay.c_str());
    pushit();
 
    string wasm_depth_one_over = fc::format_string(depth_assert_wasm, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth+1));
-   set_code("depth"_n, wasm_depth_one_over.c_str());
+   t.set_code("depth"_n, wasm_depth_one_over.c_str());
    BOOST_CHECK_THROW(pushit(), wasm_execution_error);
 
    //wasm recursion but call an intrinsic as the last function instead
    string intrinsic_depth_okay = fc::format_string(depth_assert_intrinsic, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth));
-   set_code("depth"_n, intrinsic_depth_okay.c_str());
+   t.set_code("depth"_n, intrinsic_depth_okay.c_str());
    pushit();
 
    string intrinsic_depth_one_over = fc::format_string(depth_assert_intrinsic, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth+1));
-   set_code("depth"_n, intrinsic_depth_one_over.c_str());
+   t.set_code("depth"_n, intrinsic_depth_one_over.c_str());
    BOOST_CHECK_THROW(pushit(), wasm_execution_error);
 
    //add a float operation in the mix to ensure any injected softfloat call doesn't count against limit
    string wasm_float_depth_okay = fc::format_string(depth_assert_wasm_float, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth));
-   set_code("depth"_n, wasm_float_depth_okay.c_str());
+   t.set_code("depth"_n, wasm_float_depth_okay.c_str());
    pushit();
 
    string wasm_float_depth_one_over = fc::format_string(depth_assert_wasm_float, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth+1));
-   set_code("depth"_n, wasm_float_depth_one_over.c_str());
+   t.set_code("depth"_n, wasm_float_depth_one_over.c_str());
    BOOST_CHECK_THROW(pushit(), wasm_execution_error);
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE( varuint_memory_flags_tests, old_wasm_tester ) try {
-   produce_block();
+BOOST_AUTO_TEST_CASE( varuint_memory_flags_tests ) try {
+   validating_tester t(flat_set<account_name>{}, {}, setup_policy::preactivate_feature_and_new_bios);
+   t.produce_block();
 
-   create_accounts( {"memflags"_n} );
-   produce_block();
+   t.create_accounts( {"memflags"_n} );
+   t.produce_block();
 
-   set_code("memflags"_n, varuint_memory_flags);
-   produce_block();
+   t.set_code("memflags"_n, varuint_memory_flags);
+   t.produce_block();
 
    {
    signed_transaction trx;
@@ -1772,15 +1767,15 @@ BOOST_FIXTURE_TEST_CASE( varuint_memory_flags_tests, old_wasm_tester ) try {
    act.name = ""_n;
    act.authorization = vector<permission_level>{{"memflags"_n,config::active_name}};
    trx.actions.push_back(act);
-   set_transaction_headers(trx);
-   trx.sign(get_private_key( "memflags"_n, "active" ), control->get_chain_id());
-   push_transaction(trx);
-   produce_block();
+   t.set_transaction_headers(trx);
+   trx.sign(validating_tester::get_private_key( "memflags"_n, "active" ), t.control->get_chain_id());
+   t.push_transaction(trx);
+   t.produce_block();
    }
 
    // Activate new parser
-   preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
-   produce_block();
+   t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+   t.produce_block();
 
    // We should still be able to execute the old code
    {
@@ -1790,14 +1785,14 @@ BOOST_FIXTURE_TEST_CASE( varuint_memory_flags_tests, old_wasm_tester ) try {
    act.name = ""_n;
    act.authorization = vector<permission_level>{{"memflags"_n,config::active_name}};
    trx.actions.push_back(act);
-   set_transaction_headers(trx);
-   trx.sign(get_private_key( "memflags"_n, "active" ), control->get_chain_id());
-   push_transaction(trx);
-   produce_block();
+   t.set_transaction_headers(trx);
+   trx.sign(validating_tester::get_private_key( "memflags"_n, "active" ), t.control->get_chain_id());
+   t.push_transaction(trx);
+   t.produce_block();
    }
 
-   set_code("memflags"_n, std::vector<uint8_t>{});
-   BOOST_REQUIRE_THROW(set_code("memflags"_n, varuint_memory_flags), wasm_exception);
+   t.set_code("memflags"_n, std::vector<uint8_t>{});
+   BOOST_REQUIRE_THROW(t.set_code("memflags"_n, varuint_memory_flags), wasm_exception);
 } FC_LOG_AND_RETHROW()
 
 static char reset_memory_fail1_wast[] = R"======(

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -10,19 +10,13 @@
 #include <contracts.hpp>
 #include <test_contracts.hpp>
 
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
 
 using mvo = fc::mutable_variant_object;
 
-template<class Tester = TESTER>
+template<class Tester = validating_tester>
 class whitelist_blacklist_tester {
    public:
       whitelist_blacklist_tester() {}
@@ -385,7 +379,7 @@ BOOST_AUTO_TEST_CASE( deferred_blacklist_failure ) { try {
 
 
 BOOST_AUTO_TEST_CASE( blacklist_onerror ) { try {
-   whitelist_blacklist_tester<TESTER> tester1;
+   whitelist_blacklist_tester<validating_tester> tester1;
    tester1.init();
    tester1.chain->execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
    tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );


### PR DESCRIPTION
- Remove unused `NON_VALIDATING_TEST` macro.
- Add `operator<<` for `setup_policy` so `setup_policy` can be used with boost data in tests.
- Allow the `setup_policy` to be provided to `validating_tester` instead of being hard-coded to `full`.
- Update wasm tests to use `validating_tester` with different `setup_policy`.

Resolves #259 