### PR TITLE
Reorganize tests for plugins

### DIFF
--- a/plugins/chain_plugin/test/CMakeLists.txt
+++ b/plugins/chain_plugin/test/CMakeLists.txt
@@ -1,11 +1,8 @@
-add_executable( test_account_query_db test_account_query_db.cpp )
-target_link_libraries( test_account_query_db chain_plugin eosio_testing)
-add_test(NAME test_account_query_db COMMAND plugins/chain_plugin/test/test_account_query_db WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_trx_retry_db test_trx_retry_db.cpp )
-target_link_libraries( test_trx_retry_db chain_plugin eosio_testing)
-add_test(NAME test_trx_retry_db COMMAND plugins/chain_plugin/test/test_trx_retry_db WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_trx_finality_status_processing test_trx_finality_status_processing.cpp )
-target_link_libraries( test_trx_finality_status_processing chain_plugin eosio_testing)
-add_test(NAME test_trx_finality_status_processing COMMAND plugins/chain_plugin/test/test_trx_finality_status_processing WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_executable( test_chain_plugin
+        test_account_query_db.cpp
+        test_trx_retry_db.cpp
+        test_trx_finality_status_processing.cpp
+        main.cpp
+        )
+target_link_libraries( test_chain_plugin chain_plugin eosio_testing)
+add_test(NAME test_chain_plugin COMMAND plugins/chain_plugin/test/test_chain_plugin WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/plugins/chain_plugin/test/main.cpp
+++ b/plugins/chain_plugin/test/main.cpp
@@ -1,0 +1,2 @@
+#define BOOST_TEST_MODULE chain_plugin
+#include <boost/test/included/unit_test.hpp>

--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -1,6 +1,5 @@
-#define BOOST_TEST_MODULE account_query_db
+#include <boost/test/unit_test.hpp>
 #include <eosio/chain/permission_object.hpp>
-#include <boost/test/included/unit_test.hpp>
 #include <eosio/testing/tester.hpp>
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/block_state.hpp>

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE transaction_finality_status
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <eosio/chain_plugin/trx_finality_status_processing.hpp>
 

--- a/plugins/chain_plugin/test/test_trx_retry_db.cpp
+++ b/plugins/chain_plugin/test/test_trx_retry_db.cpp
@@ -1,6 +1,5 @@
 #include "eosio/chain_plugin/chain_plugin.hpp"
-#define BOOST_TEST_MODULE transaction_retry
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <eosio/chain_plugin/trx_retry_db.hpp>
 

--- a/plugins/producer_plugin/include/eosio/producer_plugin/block_timing_util.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/block_timing_util.hpp
@@ -16,7 +16,7 @@ namespace block_timing_util {
    // example, given block_interval=500 ms and cpu effort=400 ms, assuming the our round start at time point 0; in the
    // past, the block start time points would be at time point -500, 0, 500, 1000, 1500, 2000 ....  With this new
    // approach, the block time points would become -500, -100, 300, 700, 1200 ...
-   fc::time_point production_round_block_start_time(uint32_t cpu_effort_us, chain::block_timestamp_type block_time) {
+   inline fc::time_point production_round_block_start_time(uint32_t cpu_effort_us, chain::block_timestamp_type block_time) {
       uint32_t block_slot = block_time.slot;
       uint32_t production_round_start_block_slot =
             (block_slot / chain::config::producer_repetitions) * chain::config::producer_repetitions;
@@ -25,7 +25,7 @@ namespace block_timing_util {
              fc::microseconds(cpu_effort_us * production_round_index);
    }
 
-   fc::time_point calculate_block_deadline(uint32_t cpu_effort_us, pending_block_mode mode, chain::block_timestamp_type block_time) {
+   inline fc::time_point calculate_block_deadline(uint32_t cpu_effort_us, pending_block_mode mode, chain::block_timestamp_type block_time) {
       const auto hard_deadline =
                   block_time.to_time_point() - fc::microseconds(chain::config::block_interval_us - cpu_effort_us);
       if (mode == pending_block_mode::producing) {

--- a/plugins/producer_plugin/test/CMakeLists.txt
+++ b/plugins/producer_plugin/test/CMakeLists.txt
@@ -1,23 +1,9 @@
-add_executable( test_trx_full test_trx_full.cpp )
-target_link_libraries( test_trx_full producer_plugin eosio_testing )
-
-add_test(NAME test_trx_full COMMAND plugins/producer_plugin/test/test_trx_full WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_options test_options.cpp )
-target_link_libraries( test_options producer_plugin eosio_testing )
-
-add_test(NAME test_options COMMAND plugins/producer_plugin/test/test_options WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_snapshot_scheduler test_snapshot_scheduler.cpp )
-target_link_libraries( test_snapshot_scheduler producer_plugin eosio_testing )
-
-add_test(NAME test_snapshot_scheduler COMMAND plugins/producer_plugin/test/test_snapshot_scheduler WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_read_only_trx test_read_only_trx.cpp )
-target_link_libraries( test_read_only_trx producer_plugin eosio_testing )
-
-add_test(NAME test_read_only_trx COMMAND plugins/producer_plugin/test/test_read_only_trx WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_block_timing_util test_block_timing_util.cpp )
-target_link_libraries( test_block_timing_util producer_plugin eosio_testing )
-add_test(NAME test_block_timing_util COMMAND plugins/producer_plugin/test/test_block_timing_util WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_executable( test_producer_plugin
+        test_trx_full.cpp
+        test_options.cpp
+        test_read_only_trx.cpp
+        test_block_timing_util.cpp
+        main.cpp
+        )
+target_link_libraries( test_producer_plugin producer_plugin eosio_testing )
+add_test(NAME test_producer_plugin COMMAND plugins/producer_plugin/test/test_producer_plugin WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/plugins/producer_plugin/test/main.cpp
+++ b/plugins/producer_plugin/test/main.cpp
@@ -1,0 +1,2 @@
+#define BOOST_TEST_MODULE producer_plugin
+#include <boost/test/included/unit_test.hpp>

--- a/plugins/producer_plugin/test/test_block_timing_util.cpp
+++ b/plugins/producer_plugin/test/test_block_timing_util.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE block_timing_util
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <eosio/producer_plugin/block_timing_util.hpp>
 #include <fc/mock_time.hpp>
 

--- a/plugins/producer_plugin/test/test_options.cpp
+++ b/plugins/producer_plugin/test/test_options.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE test --state-dir option
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <eosio/producer_plugin/producer_plugin.hpp>
 

--- a/plugins/producer_plugin/test/test_read_only_trx.cpp
+++ b/plugins/producer_plugin/test/test_read_only_trx.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE producer_read_only_trxs
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <eosio/producer_plugin/producer_plugin.hpp>
 #include <eosio/testing/tester.hpp>

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE full_producer_trxs
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <eosio/producer_plugin/producer_plugin.hpp>
 

--- a/plugins/trace_api_plugin/test/CMakeLists.txt
+++ b/plugins/trace_api_plugin/test/CMakeLists.txt
@@ -1,35 +1,13 @@
-add_executable( test_extraction test_extraction.cpp )
-target_link_libraries( test_extraction trace_api_plugin )
-target_include_directories( test_extraction PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+add_executable( test_trace_api_plugin
+        test_extraction.cpp
+        test_responses.cpp
+        test_trace_file.cpp
+        test_data_handlers.cpp
+        test_configuration_utils.cpp
+        test_compressed_file.cpp
+        main.cpp
+        )
+target_link_libraries( test_trace_api_plugin trace_api_plugin )
+target_include_directories( test_trace_api_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 
-add_test(NAME test_extraction COMMAND plugins/trace_api_plugin/test/test_extraction WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_responses test_responses.cpp )
-target_link_libraries( test_responses trace_api_plugin )
-target_include_directories( test_responses PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test(NAME test_responses COMMAND plugins/trace_api_plugin/test/test_responses WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_trace_file test_trace_file.cpp )
-target_link_libraries( test_trace_file trace_api_plugin )
-target_include_directories( test_trace_file PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test(NAME test_trace_file COMMAND plugins/trace_api_plugin/test/test_trace_file WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_data_handlers test_data_handlers.cpp )
-target_link_libraries( test_data_handlers trace_api_plugin )
-target_include_directories( test_data_handlers PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test(NAME test_data_handlers COMMAND plugins/trace_api_plugin/test/test_data_handlers WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_configuration_utils test_configuration_utils.cpp )
-target_link_libraries( test_configuration_utils trace_api_plugin )
-target_include_directories( test_configuration_utils PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test(NAME test_configuration_utils COMMAND plugins/trace_api_plugin/test/test_configuration_utils WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable( test_compressed_file test_compressed_file.cpp )
-target_link_libraries( test_compressed_file trace_api_plugin )
-target_include_directories( test_compressed_file PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test(NAME test_compressed_file COMMAND plugins/trace_api_plugin/test/test_compressed_file WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME test_trace_api_plugin COMMAND plugins/trace_api_plugin/test/test_trace_api_plugin WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/plugins/trace_api_plugin/test/include/eosio/trace_api/test_common.hpp
+++ b/plugins/trace_api_plugin/test/include/eosio/trace_api/test_common.hpp
@@ -20,28 +20,28 @@ namespace eosio::trace_api {
     */
 
    namespace test_common {
-      fc::sha256 operator"" _h(const char* input, std::size_t) {
+      inline fc::sha256 operator"" _h(const char* input, std::size_t) {
          return fc::sha256(input);
       }
 
-      chain::name operator"" _n(const char* input, std::size_t) {
+      inline chain::name operator"" _n(const char* input, std::size_t) {
          return chain::name(input);
       }
 
-      chain::asset operator"" _t(const char* input, std::size_t) {
+      inline chain::asset operator"" _t(const char* input, std::size_t) {
          return chain::asset::from_string(input);
       }
 
-      auto get_private_key( chain::name keyname, std::string role = "owner" ) {
+      inline auto get_private_key( chain::name keyname, std::string role = "owner" ) {
          auto secret = fc::sha256::hash( keyname.to_string() + role );
          return chain::private_key_type::regenerate<fc::ecc::private_key_shim>( secret );
       }
 
-      auto get_public_key( chain::name keyname, std::string role = "owner" ) {
+      inline auto get_public_key( chain::name keyname, std::string role = "owner" ) {
          return get_private_key( keyname, role ).get_public_key();
       }
 
-      chain::bytes make_transfer_data( chain::name from, chain::name to, chain::asset quantity, std::string&& memo) {
+      inline chain::bytes make_transfer_data( chain::name from, chain::name to, chain::asset quantity, std::string&& memo) {
          fc::datastream<size_t> ps;
          fc::raw::pack(ps, from, to, quantity, memo);
          chain::bytes result( ps.tellp());
@@ -53,7 +53,7 @@ namespace eosio::trace_api {
          return result;
       }
 
-      auto make_block_state( chain::block_id_type previous, uint32_t height, uint32_t slot, chain::name producer,
+      inline auto make_block_state( chain::block_id_type previous, uint32_t height, uint32_t slot, chain::name producer,
                              std::vector<chain::packed_transaction> trxs ) {
          chain::signed_block_ptr block = std::make_shared<chain::signed_block>();
          for( auto& trx : trxs ) {
@@ -107,7 +107,7 @@ namespace eosio::trace_api {
          return bsp;
       }
 
-      void to_kv_helper(const fc::variant& v, std::function<void(const std::string&, const std::string&)>&& append){
+      inline void to_kv_helper(const fc::variant& v, std::function<void(const std::string&, const std::string&)>&& append){
          if (v.is_object() ) {
             const auto& obj = v.get_object();
             static const std::string sep = ".";
@@ -130,7 +130,7 @@ namespace eosio::trace_api {
          }
       }
 
-      auto to_kv(const fc::variant& v) {
+      inline auto to_kv(const fc::variant& v) {
          std::map<std::string, std::string> result;
          to_kv_helper(v, [&result](const std::string& k, const std::string& v){
             result.emplace(k, v);
@@ -143,13 +143,13 @@ namespace eosio::trace_api {
    // I prefer not to have these operators but they are convenient for BOOST TEST integration
    //
 
-   bool operator==(const authorization_trace_v0& lhs, const authorization_trace_v0& rhs) {
+   inline bool operator==(const authorization_trace_v0& lhs, const authorization_trace_v0& rhs) {
       return
          lhs.account == rhs.account &&
          lhs.permission == rhs.permission;
    }
 
-   bool operator==(const action_trace_v0& lhs, const action_trace_v0& rhs) {
+   inline bool operator==(const action_trace_v0& lhs, const action_trace_v0& rhs) {
       return
          lhs.global_sequence == rhs.global_sequence &&
          lhs.receiver == rhs.receiver &&
@@ -159,13 +159,13 @@ namespace eosio::trace_api {
          lhs.data == rhs.data;
    }
 
-   bool operator==(const transaction_trace_v0& lhs,  const transaction_trace_v0& rhs) {
+   inline bool operator==(const transaction_trace_v0& lhs,  const transaction_trace_v0& rhs) {
       return
          lhs.id == rhs.id &&
          lhs.actions == rhs.actions;
    }
 
-   bool operator==(const transaction_trace_v2& lhs,  const transaction_trace_v2& rhs) {
+   inline bool operator==(const transaction_trace_v2& lhs,  const transaction_trace_v2& rhs) {
       return
          lhs.id == rhs.id &&
          lhs.actions == rhs.actions &&
@@ -181,7 +181,7 @@ namespace eosio::trace_api {
          lhs.trx_header.delay_sec == rhs.trx_header.delay_sec ;
    }
 
-   bool operator==(const block_trace_v0 &lhs, const block_trace_v0 &rhs) {
+   inline bool operator==(const block_trace_v0 &lhs, const block_trace_v0 &rhs) {
       return
          lhs.id == rhs.id &&
          lhs.number == rhs.number &&
@@ -191,7 +191,7 @@ namespace eosio::trace_api {
          lhs.transactions == rhs.transactions;
    }
 
-   bool operator==(const block_trace_v2 &lhs, const block_trace_v2 &rhs) {
+   inline bool operator==(const block_trace_v2 &lhs, const block_trace_v2 &rhs) {
       return
          lhs.id == rhs.id &&
          lhs.number == rhs.number &&
@@ -204,42 +204,42 @@ namespace eosio::trace_api {
          lhs.transactions == rhs.transactions;
    }
 
-   std::ostream& operator<<(std::ostream &os, const block_trace_v0 &bt) {
+   inline std::ostream& operator<<(std::ostream &os, const block_trace_v0 &bt) {
       os << fc::json::to_string( bt, fc::time_point::maximum() );
       return os;
    }
 
-   std::ostream& operator<<(std::ostream &os, const block_trace_v2 &bt) {
+   inline std::ostream& operator<<(std::ostream &os, const block_trace_v2 &bt) {
       os << fc::json::to_string( bt, fc::time_point::maximum() );
       return os;
    }
 
-   bool operator==(const block_entry_v0& lhs, const block_entry_v0& rhs) {
+   inline bool operator==(const block_entry_v0& lhs, const block_entry_v0& rhs) {
       return
          lhs.id == rhs.id &&
          lhs.number == rhs.number &&
          lhs.offset == rhs.offset;
    }
 
-   bool operator!=(const block_entry_v0& lhs, const block_entry_v0& rhs) {
+   inline bool operator!=(const block_entry_v0& lhs, const block_entry_v0& rhs) {
       return !(lhs == rhs);
    }
 
-   bool operator==(const lib_entry_v0& lhs, const lib_entry_v0& rhs) {
+   inline bool operator==(const lib_entry_v0& lhs, const lib_entry_v0& rhs) {
       return
          lhs.lib == rhs.lib;
    }
 
-   bool operator!=(const lib_entry_v0& lhs, const lib_entry_v0& rhs) {
+   inline bool operator!=(const lib_entry_v0& lhs, const lib_entry_v0& rhs) {
       return !(lhs == rhs);
    }
 
-   std::ostream& operator<<(std::ostream& os, const block_entry_v0& be) {
+   inline std::ostream& operator<<(std::ostream& os, const block_entry_v0& be) {
       os << fc::json::to_string(be, fc::time_point::maximum());
       return os;
    }
 
-   std::ostream& operator<<(std::ostream& os, const lib_entry_v0& le) {
+   inline std::ostream& operator<<(std::ostream& os, const lib_entry_v0& le) {
       os << fc::json::to_string(le, fc::time_point::maximum());
       return os;
    }
@@ -252,7 +252,7 @@ namespace fc {
       return os;
    }
 
-   std::ostream& operator<<(std::ostream &os, const fc::microseconds& t ) {
+   inline std::ostream& operator<<(std::ostream &os, const fc::microseconds& t ) {
       os << t.count();
       return os;
    }
@@ -260,15 +260,15 @@ namespace fc {
 }
 
 namespace eosio::chain {
-   bool operator==(const abi_def& lhs, const abi_def& rhs) {
+   inline bool operator==(const abi_def& lhs, const abi_def& rhs) {
       return fc::raw::pack(lhs) == fc::raw::pack(rhs);
    }
 
-   bool operator!=(const abi_def& lhs, const abi_def& rhs) {
+   inline bool operator!=(const abi_def& lhs, const abi_def& rhs) {
       return !(lhs == rhs);
    }
 
-   std::ostream& operator<<(std::ostream& os, const abi_def& abi) {
+   inline std::ostream& operator<<(std::ostream& os, const abi_def& abi) {
       os << fc::json::to_string(abi, fc::time_point::maximum());
       return os;
    }
@@ -278,7 +278,7 @@ namespace std {
    /*
     * operator for printing to_kv entries
     */
-   ostream& operator<<(ostream& os, const pair<string, string>& entry) {
+   inline ostream& operator<<(ostream& os, const pair<string, string>& entry) {
       os << entry.first + "=" + entry.second;
       return os;
    }

--- a/plugins/trace_api_plugin/test/main.cpp
+++ b/plugins/trace_api_plugin/test/main.cpp
@@ -1,0 +1,2 @@
+#define BOOST_TEST_MODULE trace_api_plugin
+#include <boost/test/included/unit_test.hpp>

--- a/plugins/trace_api_plugin/test/test_compressed_file.cpp
+++ b/plugins/trace_api_plugin/test/test_compressed_file.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE trace_compressed_file
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <list>
 
 #include <eosio/trace_api/compressed_file.hpp>

--- a/plugins/trace_api_plugin/test/test_configuration_utils.cpp
+++ b/plugins/trace_api_plugin/test/test_configuration_utils.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE trace_configuration_utils
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <list>
 
 #include <eosio/trace_api/configuration_utils.hpp>

--- a/plugins/trace_api_plugin/test/test_data_handlers.cpp
+++ b/plugins/trace_api_plugin/test/test_data_handlers.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE trace_data_handlers
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <eosio/trace_api/abi_data_handler.hpp>
 

--- a/plugins/trace_api_plugin/test/test_extraction.cpp
+++ b/plugins/trace_api_plugin/test/test_extraction.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE trace_data_extraction
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/contract_types.hpp>

--- a/plugins/trace_api_plugin/test/test_responses.cpp
+++ b/plugins/trace_api_plugin/test/test_responses.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE trace_data_responses
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <fc/variant_object.hpp>
 

--- a/plugins/trace_api_plugin/test/test_trace_file.cpp
+++ b/plugins/trace_api_plugin/test/test_trace_file.cpp
@@ -1,5 +1,4 @@
-#define BOOST_TEST_MODULE trace_trace_file
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <fc/io/cfile.hpp>
 #include <eosio/trace_api/test_common.hpp>
 #include <eosio/trace_api/store_provider.hpp>

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -1,11 +1,8 @@
-#define BOOST_TEST_MODULE snapshot_scheduler
-#include <boost/test/included/unit_test.hpp>
-
+#include <boost/test/unit_test.hpp>
+#include <eosio/chain/authority.hpp>
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/producer_plugin/producer_plugin.hpp>
 #include <eosio/testing/tester.hpp>
-
-namespace {
 
 using namespace eosio;
 using namespace eosio::chain;
@@ -13,10 +10,9 @@ using namespace eosio::chain;
 using snapshot_request_information = snapshot_scheduler::snapshot_request_information;
 using snapshot_request_id_information = snapshot_scheduler::snapshot_request_id_information;
 
-BOOST_AUTO_TEST_SUITE(snapshot_scheduler_test)
+BOOST_AUTO_TEST_SUITE(producer_snapshot_scheduler_tests)
 
 BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
-
    fc::logger log;
    producer_plugin scheduler;
 
@@ -148,5 +144,5 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
       }
    }
 }
-   BOOST_AUTO_TEST_SUITE_END()
-}// namespace
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Currently we have different types of tests stored under a test folder for some plugins, e.g. chain_plugin and producer_plugin.

Some of these are proper unit tests of the plugin code in isolation. Those can remain in the folder but we should group them all together in a single executable rather than using different executable for each.

Some of these are bringing in other libraries and/or plugins and really should be considered integration tests (not to be confused with the Python end-to-end tests). These belong somewhere outside of the directories for the plugins. I suggest putting them in a sub-directory within the tests folder. It would also seem appropriate to bundle these tests together into one executable rather than linking separate executable for each test suite.

This PR reorganizes tests for the following plugins:
producer_plugin
chain_plugin
trace_api_plugin

Resolves https://github.com/AntelopeIO/leap/issues/586
