### PR TITLE
Remove time_point implicit conversions

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -478,7 +478,7 @@ void apply_context::schedule_deferred_transaction( const uint128_t& sender_id, a
       trx.ref_block_num = 0;
       trx.ref_block_prefix = 0;
    } else {
-      trx.expiration = control.pending_block_time() + fc::microseconds(999'999); // Rounds up to nearest second (makes expiration check unnecessary)
+      trx.expiration = time_point_sec{control.pending_block_time() + fc::microseconds(999'999)}; // Rounds up to nearest second (makes expiration check unnecessary)
       trx.set_reference_block(control.head_block_id()); // No TaPoS check necessary
    }
 

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -897,7 +897,7 @@ namespace eosio { namespace chain {
 
          static void write_incomplete_block_data(const std::filesystem::path& blocks_dir, fc::time_point now, uint32_t block_num,
                                                  fc::cfile& strm) {
-            auto      tail_path = blocks_dir / std::string("blocks-bad-tail-").append(std::string(now)).append(".log");
+            auto      tail_path = blocks_dir / std::string("blocks-bad-tail-").append(now.to_string()).append(".log");
             fc::cfile tail;
             tail.set_file_path(tail_path);
             tail.open(fc::cfile::create_or_update_rw_mode);
@@ -1320,7 +1320,7 @@ namespace eosio { namespace chain {
       auto blocks_dir = std::filesystem::canonical(
             data_dir); // canonical always returns an absolute path that has no symbolic link, dot, or dot-dot elements
       auto blocks_dir_name = blocks_dir.filename();
-      auto backup_dir      = blocks_dir.parent_path() / blocks_dir_name.generic_string().append("-").append(now);
+      auto backup_dir      = blocks_dir.parent_path() / blocks_dir_name.generic_string().append("-").append(now.to_string());
 
       EOS_ASSERT(!std::filesystem::exists(backup_dir), block_log_backup_dir_exist,
                  "Cannot move existing blocks directory to already existing directory '${new_blocks_dir}'",

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -897,7 +897,7 @@ namespace eosio { namespace chain {
 
          static void write_incomplete_block_data(const std::filesystem::path& blocks_dir, fc::time_point now, uint32_t block_num,
                                                  fc::cfile& strm) {
-            auto      tail_path = blocks_dir / std::string("blocks-bad-tail-").append(now.to_string()).append(".log");
+            auto      tail_path = blocks_dir / std::string("blocks-bad-tail-").append(now.to_iso_string()).append(".log");
             fc::cfile tail;
             tail.set_file_path(tail_path);
             tail.open(fc::cfile::create_or_update_rw_mode);
@@ -1320,7 +1320,7 @@ namespace eosio { namespace chain {
       auto blocks_dir = std::filesystem::canonical(
             data_dir); // canonical always returns an absolute path that has no symbolic link, dot, or dot-dot elements
       auto blocks_dir_name = blocks_dir.filename();
-      auto backup_dir      = blocks_dir.parent_path() / blocks_dir_name.generic_string().append("-").append(now.to_string());
+      auto backup_dir      = blocks_dir.parent_path() / blocks_dir_name.generic_string().append("-").append(now.to_iso_string());
 
       EOS_ASSERT(!std::filesystem::exists(backup_dir), block_log_backup_dir_exist,
                  "Cannot move existing blocks directory to already existing directory '${new_blocks_dir}'",

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1170,7 +1170,7 @@ struct controller_impl {
          etrx.ref_block_num = 0;
          etrx.ref_block_prefix = 0;
       } else {
-         etrx.expiration = self.pending_block_time() + fc::microseconds(999'999); // Round up to nearest second to avoid appearing expired
+         etrx.expiration = time_point_sec{self.pending_block_time() + fc::microseconds(999'999)}; // Round up to nearest second to avoid appearing expired
          etrx.set_reference_block( self.head_block_id() );
       }
 
@@ -2661,7 +2661,7 @@ struct controller_impl {
          trx.ref_block_num = 0;
          trx.ref_block_prefix = 0;
       } else {
-         trx.expiration = self.pending_block_time() + fc::microseconds(999'999); // Round up to nearest second to avoid appearing expired
+         trx.expiration = time_point_sec{self.pending_block_time() + fc::microseconds(999'999)}; // Round up to nearest second to avoid appearing expired
          trx.set_reference_block( self.head_block_id() );
       }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2486,7 +2486,7 @@ struct controller_impl {
       auto now = self.is_building_block() ? self.pending_block_time() : self.head_block_time();
       const auto total = dedupe_index.size();
       uint32_t num_removed = 0;
-      while( (!dedupe_index.empty()) && ( now > fc::time_point(dedupe_index.begin()->expiration) ) ) {
+      while( (!dedupe_index.empty()) && ( now > dedupe_index.begin()->expiration.to_time_point() ) ) {
          transaction_idx.remove(*dedupe_index.begin());
          ++num_removed;
          if( deadline <= fc::time_point::now() ) {
@@ -3482,12 +3482,12 @@ uint32_t controller::configured_subjective_signature_length_limit()const {
 void controller::validate_expiration( const transaction& trx )const { try {
    const auto& chain_configuration = get_global_properties().configuration;
 
-   EOS_ASSERT( time_point(trx.expiration) >= pending_block_time(),
+   EOS_ASSERT( trx.expiration.to_time_point() >= pending_block_time(),
                expired_tx_exception,
                "transaction has expired, "
                "expiration is ${trx.expiration} and pending block time is ${pending_block_time}",
                ("trx.expiration",trx.expiration)("pending_block_time",pending_block_time()));
-   EOS_ASSERT( time_point(trx.expiration) <= pending_block_time() + fc::seconds(chain_configuration.max_transaction_lifetime),
+   EOS_ASSERT( trx.expiration.to_time_point() <= pending_block_time() + fc::seconds(chain_configuration.max_transaction_lifetime),
                tx_exp_too_far_exception,
                "Transaction expiration is too far in the future relative to the reference time of ${reference_time}, "
                "expiration is ${trx.expiration} and the maximum transaction lifetime is ${max_til_exp} seconds",

--- a/libraries/chain/include/eosio/chain/subjective_billing.hpp
+++ b/libraries/chain/include/eosio/chain/subjective_billing.hpp
@@ -8,6 +8,8 @@
 #include <eosio/chain/resource_limits_private.hpp>
 #include <eosio/chain/config.hpp>
 
+#include <fc/time.hpp>
+
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/hashed_index.hpp>
@@ -107,7 +109,7 @@ public:
    void disable_account( chain::account_name a ) { _disabled_accounts.emplace( a ); }
    bool is_account_disabled(const chain::account_name& a ) const { return _disabled || _disabled_accounts.count( a ); }
 
-   void subjective_bill( const chain::transaction_id_type& id, const fc::time_point& expire,
+   void subjective_bill( const chain::transaction_id_type& id, const fc::time_point_sec& expire,
                          const chain::account_name& first_auth, const fc::microseconds& elapsed )
    {
       if( !_disabled && !_disabled_accounts.count( first_auth ) ) {
@@ -116,7 +118,7 @@ public:
                trx_cache_entry{id,
                                first_auth,
                                bill,
-                               expire} );
+                               expire.to_time_point()} );
          if( p.second ) {
             _account_subjective_bill_cache[first_auth].pending_cpu_us += bill;
          }

--- a/libraries/chain/include/eosio/chain/subjective_billing.hpp
+++ b/libraries/chain/include/eosio/chain/subjective_billing.hpp
@@ -109,7 +109,7 @@ public:
    void disable_account( chain::account_name a ) { _disabled_accounts.emplace( a ); }
    bool is_account_disabled(const chain::account_name& a ) const { return _disabled || _disabled_accounts.count( a ); }
 
-   void subjective_bill( const chain::transaction_id_type& id, const fc::time_point_sec& expire,
+   void subjective_bill( const chain::transaction_id_type& id, fc::time_point_sec expire,
                          const chain::account_name& first_auth, const fc::microseconds& elapsed )
    {
       if( !_disabled && !_disabled_accounts.count( first_auth ) ) {

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -94,7 +94,7 @@ public:
       auto& persisted_by_expiry = queue.get<by_expiry>();
       while( !persisted_by_expiry.empty() ) {
          const auto& itr = persisted_by_expiry.begin();
-         if( itr->expiration() > pending_block_time ) {
+         if( itr->expiration().to_time_point() > pending_block_time ) {
             break;
          }
          if( yield() ) {

--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -109,7 +109,7 @@ namespace fc {
     { try {
        uint32_t sec;
        s.read( (char*)&sec, sizeof(sec) );
-       tp = fc::time_point() + fc::seconds(sec);
+       tp = fc::time_point_sec{sec};
     } FC_RETHROW_EXCEPTIONS( warn, "" ) }
 
     template<typename Stream>

--- a/libraries/libfc/include/fc/time.hpp
+++ b/libraries/libfc/include/fc/time.hpp
@@ -46,7 +46,7 @@ namespace fc {
         static constexpr time_point maximum() { return time_point( microseconds::maximum() ); }
         static constexpr time_point min() { return time_point();                      }
 
-        std::string to_string()const;
+        std::string to_iso_string()const;
         static time_point from_iso_string( const std::string& s );
 
         constexpr const microseconds& time_since_epoch()const { return elapsed; }

--- a/libraries/libfc/include/fc/time.hpp
+++ b/libraries/libfc/include/fc/time.hpp
@@ -87,27 +87,12 @@ namespace fc {
         constexpr time_point to_time_point()const { return time_point( fc::seconds( utc_seconds) ); }
         constexpr uint32_t sec_since_epoch()const { return utc_seconds; }
 
-        constexpr time_point_sec& operator = ( const fc::time_point& t ) {
-          utc_seconds = t.time_since_epoch().count() / 1000000ll;
-          return *this;
-        }
         constexpr friend bool      operator < ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds < b.utc_seconds; }
         constexpr friend bool      operator > ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds > b.utc_seconds; }
         constexpr friend bool      operator <= ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds <= b.utc_seconds; }
         constexpr friend bool      operator >= ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds >= b.utc_seconds; }
         constexpr friend bool      operator == ( const time_point_sec& a, const time_point_sec& b ) { return a.utc_seconds == b.utc_seconds; }
         constexpr friend bool      operator != ( const time_point_sec& a, const time_point_sec& b ) { return a.utc_seconds != b.utc_seconds; }
-        constexpr time_point_sec&  operator += ( uint32_t m ) { utc_seconds+=m; return *this; }
-        constexpr time_point_sec&  operator += ( microseconds m ) { utc_seconds+=m.to_seconds(); return *this; }
-        constexpr time_point_sec&  operator -= ( uint32_t m ) { utc_seconds-=m; return *this; }
-        constexpr time_point_sec&  operator -= ( microseconds m ) { utc_seconds-=m.to_seconds(); return *this; }
-        constexpr time_point_sec   operator +( uint32_t offset )const { return time_point_sec(utc_seconds + offset); }
-        constexpr time_point_sec   operator -( uint32_t offset )const { return time_point_sec(utc_seconds - offset); }
-
-        friend constexpr time_point   operator + ( const time_point_sec& t, const microseconds& m )   { return time_point{fc::seconds(t.utc_seconds) + m}; }
-        friend constexpr time_point   operator - ( const time_point_sec& t, const microseconds& m )   { return time_point{fc::seconds(t.utc_seconds) - m}; }
-        friend constexpr microseconds operator - ( const time_point_sec& t, const time_point_sec& m ) { return fc::seconds(t.utc_seconds) - fc::seconds(m.utc_seconds); }
-        friend constexpr microseconds operator - ( const time_point& t, const time_point_sec& m ) { return t.time_since_epoch() - fc::seconds(m.sec_since_epoch()); }
 
         std::string to_non_delimited_iso_string()const;
         std::string to_iso_string()const;

--- a/libraries/libfc/include/fc/time.hpp
+++ b/libraries/libfc/include/fc/time.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <stdint.h>
-#include <fc/string.hpp>
+#include <cstdint>
+#include <string>
 
 #ifdef _MSC_VER
   #pragma warning (push)
@@ -46,7 +46,7 @@ namespace fc {
         static constexpr time_point maximum() { return time_point( microseconds::maximum() ); }
         static constexpr time_point min() { return time_point();                      }
 
-        operator std::string()const;
+        std::string to_string()const;
         static time_point from_iso_string( const std::string& s );
 
         constexpr const microseconds& time_since_epoch()const { return elapsed; }
@@ -78,17 +78,16 @@ namespace fc {
         constexpr explicit time_point_sec(uint32_t seconds )
         :utc_seconds(seconds){}
 
-        constexpr time_point_sec( const time_point& t )
+        constexpr explicit time_point_sec( const time_point& t )
         :utc_seconds( t.time_since_epoch().count() / 1000000ll ){}
 
         static constexpr time_point_sec maximum() { return time_point_sec(0xffffffff); }
         static constexpr time_point_sec min() { return time_point_sec(0); }
 
-        constexpr operator time_point()const { return time_point( fc::seconds( utc_seconds) ); }
+        constexpr time_point to_time_point()const { return time_point( fc::seconds( utc_seconds) ); }
         constexpr uint32_t sec_since_epoch()const { return utc_seconds; }
 
-        constexpr time_point_sec operator = ( const fc::time_point& t )
-        {
+        constexpr time_point_sec& operator = ( const fc::time_point& t ) {
           utc_seconds = t.time_since_epoch().count() / 1000000ll;
           return *this;
         }
@@ -105,15 +104,14 @@ namespace fc {
         constexpr time_point_sec   operator +( uint32_t offset )const { return time_point_sec(utc_seconds + offset); }
         constexpr time_point_sec   operator -( uint32_t offset )const { return time_point_sec(utc_seconds - offset); }
 
-        friend constexpr time_point   operator + ( const time_point_sec& t, const microseconds& m )   { return time_point(t) + m;             }
-        friend constexpr time_point   operator - ( const time_point_sec& t, const microseconds& m )   { return time_point(t) - m;             }
-        friend constexpr microseconds operator - ( const time_point_sec& t, const time_point_sec& m ) { return time_point(t) - time_point(m); }
-        friend constexpr microseconds operator - ( const time_point& t, const time_point_sec& m ) { return time_point(t) - time_point(m); }
+        friend constexpr time_point   operator + ( const time_point_sec& t, const microseconds& m )   { return time_point{fc::seconds(t.utc_seconds) + m}; }
+        friend constexpr time_point   operator - ( const time_point_sec& t, const microseconds& m )   { return time_point{fc::seconds(t.utc_seconds) - m}; }
+        friend constexpr microseconds operator - ( const time_point_sec& t, const time_point_sec& m ) { return fc::seconds(t.utc_seconds) - fc::seconds(m.utc_seconds); }
+        friend constexpr microseconds operator - ( const time_point& t, const time_point_sec& m ) { return t.time_since_epoch() - fc::seconds(m.sec_since_epoch()); }
 
         std::string to_non_delimited_iso_string()const;
         std::string to_iso_string()const;
 
-        operator std::string()const;
         static time_point_sec from_iso_string( const std::string& s );
 
     private:
@@ -124,7 +122,7 @@ namespace fc {
    * e.g., "4 hours ago", "2 months ago", etc.
    */
   std::string get_approximate_relative_time_string(const time_point_sec& event_time,
-                                                   const time_point_sec& relative_to_time = fc::time_point::now(),
+                                                   const time_point_sec& relative_to_time = fc::time_point_sec{fc::time_point::now()},
                                                    const std::string& ago = " ago");
   std::string get_approximate_relative_time_string(const time_point& event_time,
                                                    const time_point& relative_to_time = fc::time_point::now(),

--- a/libraries/libfc/src/log/console_appender.cpp
+++ b/libraries/libfc/src/log/console_appender.cpp
@@ -123,7 +123,7 @@ namespace fc {
       }
       line += fixed_size(  5, context.get_log_level().to_string() ); line += ' ';
       // use now() instead of context.get_timestamp() because log_message construction can include user provided long running calls
-      line += time_point::now().to_string(); line += ' ';
+      line += time_point::now().to_iso_string(); line += ' ';
       line += fixed_size(  9, context.get_thread_name() ); line += ' ';
       line += fixed_size( 29, file_line ); line += ' ';
 

--- a/libraries/libfc/src/log/console_appender.cpp
+++ b/libraries/libfc/src/log/console_appender.cpp
@@ -123,7 +123,7 @@ namespace fc {
       }
       line += fixed_size(  5, context.get_log_level().to_string() ); line += ' ';
       // use now() instead of context.get_timestamp() because log_message construction can include user provided long running calls
-      line += std::string( time_point::now() ); line += ' ';
+      line += time_point::now().to_string(); line += ' ';
       line += fixed_size(  9, context.get_thread_name() ); line += ' ';
       line += fixed_size( 29, file_line ); line += ' ';
 

--- a/libraries/libfc/src/time.cpp
+++ b/libraries/libfc/src/time.cpp
@@ -42,7 +42,7 @@ namespace fc {
       return fc::time_point_sec( (pt - epoch).total_seconds() );
   } FC_RETHROW_EXCEPTIONS( warn, "unable to convert ISO-formatted string to fc::time_point_sec" ) }
 
-   std::string time_point::to_string()const
+   std::string time_point::to_iso_string()const
    {
       auto count = elapsed.count();
       if (count >= 0) {
@@ -73,7 +73,7 @@ namespace fc {
   } FC_RETHROW_EXCEPTIONS( warn, "unable to convert ISO-formatted string to fc::time_point" ) }
 
   void to_variant( const fc::time_point& t, variant& v ) {
-    v = t.to_string();
+    v = t.to_iso_string();
   }
   void from_variant( const fc::variant& v, fc::time_point& t ) {
     t = fc::time_point::from_iso_string( v.as_string() );

--- a/libraries/libfc/src/time.cpp
+++ b/libraries/libfc/src/time.cpp
@@ -31,11 +31,6 @@ namespace fc {
     return boost::posix_time::to_iso_extended_string( ptime );
   }
 
-  time_point_sec::operator std::string()const
-  {
-      return this->to_iso_string();
-  }
-
   time_point_sec time_point_sec::from_iso_string( const std::string& s )
   { try {
       static boost::posix_time::ptime epoch = boost::posix_time::from_time_t( 0 );
@@ -47,18 +42,18 @@ namespace fc {
       return fc::time_point_sec( (pt - epoch).total_seconds() );
   } FC_RETHROW_EXCEPTIONS( warn, "unable to convert ISO-formatted string to fc::time_point_sec" ) }
 
-   time_point::operator std::string()const
+   std::string time_point::to_string()const
    {
       auto count = elapsed.count();
       if (count >= 0) {
          uint64_t secs = (uint64_t)count / 1000000ULL;
          uint64_t msec = ((uint64_t)count % 1000000ULL) / 1000ULL;
-         std::string padded_ms = to_string((uint64_t)(msec + 1000ULL)).substr(1);
+         std::string padded_ms = fc::to_string((uint64_t)(msec + 1000ULL)).substr(1);
          const auto ptime = boost::posix_time::from_time_t(time_t(secs));
          return boost::posix_time::to_iso_extended_string(ptime) + "." + padded_ms;
       } else {
          // negative time_points serialized as "durations" in the ISO form with boost
-         // this is not very human readable but fits the precedent set by the above
+         // this is not very human-readable but fits the precedent set by the above
          auto as_duration = boost::posix_time::microseconds(count);
          return boost::posix_time::to_iso_string(as_duration);
       }
@@ -68,23 +63,23 @@ namespace fc {
   { try {
       auto dot = s.find( '.' );
       if( dot == std::string::npos )
-         return time_point( time_point_sec::from_iso_string( s ) );
+         return time_point_sec::from_iso_string( s ).to_time_point();
       else {
          auto ms = s.substr( dot );
          ms[0] = '1';
          while( ms.size() < 4 ) ms.push_back('0');
-         return time_point( time_point_sec::from_iso_string( s ) ) + milliseconds( to_int64(ms) - 1000 );
+         return time_point_sec::from_iso_string( s ).to_time_point() + milliseconds( to_int64(ms) - 1000 );
       }
   } FC_RETHROW_EXCEPTIONS( warn, "unable to convert ISO-formatted string to fc::time_point" ) }
 
   void to_variant( const fc::time_point& t, variant& v ) {
-    v = std::string( t );
+    v = t.to_string();
   }
   void from_variant( const fc::variant& v, fc::time_point& t ) {
     t = fc::time_point::from_iso_string( v.as_string() );
   }
   void to_variant( const fc::time_point_sec& t, variant& v ) {
-    v = std::string( t );
+    v = t.to_iso_string();
   }
   void from_variant( const fc::variant& v, fc::time_point_sec& t ) {
     t = fc::time_point_sec::from_iso_string( v.as_string() );

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -534,7 +534,7 @@ namespace eosio { namespace testing {
 
 
   void base_tester::set_transaction_headers( transaction& trx, uint32_t expiration, uint32_t delay_sec ) const {
-     trx.expiration = control->head_block_time() + fc::seconds(expiration);
+     trx.expiration = fc::time_point_sec{control->head_block_time() + fc::seconds(expiration)};
      trx.set_reference_block( control->head_block_id() );
 
      trx.max_net_usage_words = 0; // No limit

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1116,7 +1116,7 @@ void chain_plugin::plugin_startup()
 
    if (my->genesis) {
       ilog("Blockchain started; head block is #${num}, genesis timestamp is ${ts}",
-           ("num", my->chain->head_block_num())("ts", (std::string)my->genesis->initial_timestamp));
+           ("num", my->chain->head_block_num())("ts", my->genesis->initial_timestamp));
    }
    else {
       ilog("Blockchain started; head block is #${num}", ("num", my->chain->head_block_num()));
@@ -1305,7 +1305,7 @@ read_only::get_transaction_status(const read_only::get_transaction_status_params
       trx_block_valid ? std::optional<uint32_t>(chain::block_header::num_from_id(trx_st->block_id)) : std::optional<uint32_t>{},
       trx_block_valid ? std::optional<chain::block_id_type>(trx_st->block_id) : std::optional<chain::block_id_type>{},
       trx_block_valid ? std::optional<fc::time_point>(trx_st->block_timestamp) : std::optional<fc::time_point>{},
-      trx_st ? std::optional<fc::time_point_sec>(trx_st->expiration) : std::optional<fc::time_point_sec>{},
+      trx_st ? std::optional<fc::time_point>(trx_st->expiration) : std::optional<fc::time_point>{},
       chain::block_header::num_from_id(ch_state.head_id),
       ch_state.head_id,
       ch_state.head_block_timestamp,

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -203,28 +203,28 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    // Simulate situation where the last 2 trxs do not make it into the block.
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
@@ -279,35 +279,35 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
    BOOST_CHECK(fc::time_point_sec(ts->expiration) == (std::get<1>(trx_pairs_20[1])->expiration()));
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
 
@@ -334,49 +334,49 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
 
@@ -404,56 +404,56 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_22_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
 
@@ -482,63 +482,63 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_22_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22_alt[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_alt_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_22_alt_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
 
@@ -567,49 +567,49 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
@@ -617,21 +617,21 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_22_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22_alt[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_alt_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_22_alt_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_19[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_19_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_19_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
 
@@ -675,49 +675,49 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
@@ -725,21 +725,21 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_22_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22_alt[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_alt_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_22_alt_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_19[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_19_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_19_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
 
@@ -763,49 +763,49 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
@@ -813,21 +813,21 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_22_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22_alt[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_alt_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_22_alt_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_19[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(ts->received.to_string(), block_19_time);
+   BOOST_CHECK_EQUAL(ts->received.to_iso_string(), block_19_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
 } FC_LOG_AND_RETHROW() }

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -63,7 +63,7 @@ auto make_unique_trx( const fc::microseconds& expiration ) {
    account_name creator = config::system_account_name;
    signed_transaction trx;
    const auto now_exp = fc::time_point::now() + expiration;
-   trx.expiration = now_exp;
+   trx.expiration = fc::time_point_sec{now_exp};
    trx.actions.emplace_back( vector<permission_level>{{creator, config::active_name}},
                              testit{ unique_id } );
    trx.sign( get_private_key("test"_n), chain_id );

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -203,28 +203,28 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    // Simulate situation where the last 2 trxs do not make it into the block.
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
@@ -279,35 +279,35 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
    BOOST_CHECK(fc::time_point_sec(ts->expiration) == (std::get<1>(trx_pairs_20[1])->expiration()));
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
 
@@ -334,49 +334,49 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
 
@@ -404,56 +404,56 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_22_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
 
@@ -482,63 +482,63 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_22_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22_alt[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_22_alt_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_alt_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
 
@@ -567,49 +567,49 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_20->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
@@ -617,21 +617,21 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_22_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_time);
    BOOST_CHECK_EQUAL(ts->status, "FAILED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22_alt[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_22_alt_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_alt_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_19[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_19_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_19_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
 
@@ -675,49 +675,49 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
@@ -725,21 +725,21 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_22_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22_alt[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_22_alt_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_alt_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_19[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_19_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_19_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
 
@@ -763,49 +763,49 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[2])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[3])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
    ts = status.get_trx_state(std::get<1>(hold_pairs[1])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == eosio::chain::block_id_type{});
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "LOCALLY_APPLIED");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_21[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_21->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_21->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_21_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_21_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
@@ -813,21 +813,21 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_22_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_22_alt[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_22_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_22_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_22_alt_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_22_alt_time);
    BOOST_CHECK_EQUAL(ts->status, "FORKED_OUT");
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_19[0])->id());
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_19_alt->id);
    BOOST_CHECK(block_timestamp_type(ts->block_timestamp) == bs_19_alt->block->timestamp);
-   BOOST_CHECK_EQUAL(std::string(ts->received), block_19_time);
+   BOOST_CHECK_EQUAL(ts->received.to_string(), block_19_time);
    BOOST_CHECK_EQUAL(ts->status, "IRREVERSIBLE");
 
 } FC_LOG_AND_RETHROW() }

--- a/plugins/chain_plugin/test/test_trx_retry_db.cpp
+++ b/plugins/chain_plugin/test/test_trx_retry_db.cpp
@@ -98,7 +98,7 @@ auto make_unique_trx( const chain_id_type& chain_id, const fc::microseconds& exp
 
    account_name creator = config::system_account_name;
    signed_transaction trx;
-   trx.expiration = fc::time_point::now() + expiration;
+   trx.expiration = fc::time_point_sec{fc::time_point::now() + expiration};
    trx.actions.emplace_back( vector<permission_level>{{creator, config::active_name}},
                              testit{ id } );
    trx.sign( get_private_key("test"_n), chain_id );

--- a/plugins/chain_plugin/test/test_trx_retry_db.cpp
+++ b/plugins/chain_plugin/test/test_trx_retry_db.cpp
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
 
 
       // test get_max_expiration_time
-      BOOST_CHECK( fc::time_point::now() + fc::hours(1) == fc::time_point( trx_retry.get_max_expiration_time() ) );
+      BOOST_CHECK( fc::time_point::now() + fc::hours(1) == trx_retry.get_max_expiration_time().to_time_point() );
 
       //
       // test expired, not in a block

--- a/plugins/chain_plugin/trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/trx_finality_status_processing.cpp
@@ -128,7 +128,7 @@ namespace eosio::chain_apis {
       else {
          _storage.insert(
             finality_status_object{.trx_id = trx_id,
-                                   .trx_expiry = ptrx->expiration(),
+                                   .trx_expiry = ptrx->expiration().to_time_point(),
                                    .received = now,
                                    .block_id = block_id,
                                    .block_timestamp = block_timestamp});

--- a/plugins/chain_plugin/trx_retry_db.cpp
+++ b/plugins/chain_plugin/trx_retry_db.cpp
@@ -262,7 +262,7 @@ private:
       auto& idx = _tracked_trxs.index().get<by_expiry>();
       while( !idx.empty() ) {
          auto itr = idx.begin();
-         if( itr->expiry() > block_time ) {
+         if( itr->expiry().to_time_point() > block_time ) {
             break;
          }
          itr->next( std::static_pointer_cast<fc::exception>(
@@ -299,7 +299,7 @@ void trx_retry_db::track_transaction( chain::packed_transaction_ptr ptrx, std::o
 
 fc::time_point_sec trx_retry_db::get_max_expiration_time()const {
    // conversion from time_point to time_point_sec rounds down, round up to nearest second to avoid appearing expired
-   return fc::time_point::now() + _impl->get_max_expiration() + fc::microseconds(999'999);
+   return fc::time_point_sec{fc::time_point::now() + _impl->get_max_expiration() + fc::microseconds(999'999)};
 }
 
 size_t trx_retry_db::size()const {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2211,7 +2211,7 @@ namespace eosio {
       bool added = (tptr == local_txns.end());
       if( added ) {
          // expire at either transaction expiration or configured max expire time whichever is less
-         time_point_sec expires{now + my_impl->p2p_dedup_cache_expire_time_us};
+         time_point_sec expires{now.to_time_point() + my_impl->p2p_dedup_cache_expire_time_us};
          expires = std::min( trx_expires, expires );
          local_txns.insert( node_transaction_state{
             .id = id,

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -705,7 +705,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             const auto& id = trx->id();
 
             fc::time_point bt = chain.is_building_block() ? chain.pending_block_time() : chain.head_block_time();
-            const fc::time_point expire = trx->packed_trx()->expiration();
+            const fc::time_point expire = trx->packed_trx()->expiration().to_time_point();
             if( expire < bt ) {
                auto except_ptr = std::static_pointer_cast<fc::exception>(
                      std::make_shared<expired_tx_exception>(

--- a/plugins/producer_plugin/test/test_block_timing_util.cpp
+++ b/plugins/producer_plugin/test/test_block_timing_util.cpp
@@ -3,7 +3,7 @@
 #include <fc/mock_time.hpp>
 
 namespace fc {
-std::ostream& boost_test_print_type(std::ostream& os, const time_point& t) { return os << (std::string)t; }
+std::ostream& boost_test_print_type(std::ostream& os, const time_point& t) { return os << t.to_string(); }
 } // namespace fc
 
 static_assert(eosio::chain::config::block_interval_ms == 500);

--- a/plugins/producer_plugin/test/test_block_timing_util.cpp
+++ b/plugins/producer_plugin/test/test_block_timing_util.cpp
@@ -3,7 +3,7 @@
 #include <fc/mock_time.hpp>
 
 namespace fc {
-std::ostream& boost_test_print_type(std::ostream& os, const time_point& t) { return os << t.to_string(); }
+std::ostream& boost_test_print_type(std::ostream& os, const time_point& t) { return os << t.to_iso_string(); }
 } // namespace fc
 
 static_assert(eosio::chain::config::block_interval_ms == 500);

--- a/plugins/producer_plugin/test/test_read_only_trx.cpp
+++ b/plugins/producer_plugin/test/test_read_only_trx.cpp
@@ -35,7 +35,7 @@ auto make_unique_trx( const chain_id_type& chain_id ) {
    ++nextid;
    account_name creator = config::system_account_name;
    signed_transaction trx;
-   trx.expiration = fc::time_point::now() + fc::seconds( nextid % 50 == 0 ? 0 : 60 ); // fail some transactions via expired
+   trx.expiration = fc::time_point_sec{fc::time_point::now() + fc::seconds( nextid % 50 == 0 ? 0 : 60 )}; // fail some transactions via expired
    if( nextid % 10 == 0 ) {
       // fail some for authorization (read-only transaction should not have authorization)
       trx.actions.emplace_back( vector<permission_level>{{creator, config::active_name}}, testit{nextid} );

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -46,7 +46,7 @@ auto make_unique_trx( const chain_id_type& chain_id ) {
 
    signed_transaction trx;
    // if a transaction expires after it was aborted then it will not be included in a block
-   trx.expiration = fc::time_point::now() + fc::seconds( nextid % 20 == 0 ? 0 : 60 ); // fail some transactions via expired
+   trx.expiration = fc::time_point_sec{fc::time_point::now() + fc::seconds( nextid % 20 == 0 ? 0 : 60 )}; // fail some transactions via expired
    if( nextid % 15 == 0 ) { // fail some for invalid unlinkauth
       trx.actions.emplace_back( vector<permission_level>{{creator, config::active_name}},
                                 unlinkauth{} );

--- a/plugins/trace_api_plugin/request_handler.cpp
+++ b/plugins/trace_api_plugin/request_handler.cpp
@@ -8,7 +8,7 @@ namespace {
    using namespace eosio::trace_api;
 
    std::string to_iso8601_datetime( const fc::time_point& t) {
-      return (std::string)t + "Z";
+      return t.to_string() + "Z";
    }
 
    fc::variants process_authorizations(const std::vector<authorization_trace_v0>& authorizations, const yield_function& yield ) {

--- a/plugins/trace_api_plugin/request_handler.cpp
+++ b/plugins/trace_api_plugin/request_handler.cpp
@@ -8,7 +8,7 @@ namespace {
    using namespace eosio::trace_api;
 
    std::string to_iso8601_datetime( const fc::time_point& t) {
-      return t.to_string() + "Z";
+      return t.to_iso_string() + "Z";
    }
 
    fc::variants process_authorizations(const std::vector<authorization_trace_v0>& authorizations, const yield_function& yield ) {

--- a/plugins/trace_api_plugin/test/test_responses.cpp
+++ b/plugins/trace_api_plugin/test/test_responses.cpp
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          10,
          5,
          std::vector<chain::signature_type>{ chain::signature_type() },
-         { chain::time_point(), 1, 0, 100, 50, 0 }
+         { chain::time_point_sec(), 1, 0, 100, 50, 0 }
       };
 
       auto block_trace = block_trace_v1 {
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
                10,
                5,
                std::vector<chain::signature_type>{ chain::signature_type() },
-               { chain::time_point(), 1, 0, 100, 50, 0 }
+               { chain::time_point_sec(), 1, 0, 100, 50, 0 }
             }
          }
       };
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
                10,
                5,
                { chain::signature_type() },
-               { chain::time_point(), 1, 0, 100, 50, 0 }
+               { chain::time_point_sec(), 1, 0, 100, 50, 0 }
             }
          }
       };
@@ -520,7 +520,7 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
                10,
                5,
                std::vector<chain::signature_type>{chain::signature_type()},
-               {chain::time_point(), 1, 0, 100, 50, 0}
+               {chain::time_point_sec(), 1, 0, 100, 50, 0}
             }
          }
       };
@@ -675,7 +675,7 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          10,  // cpu_usage_us
          5,    // net_usage_words
          std::vector<chain::signature_type>{ chain::signature_type() },  // signatures
-         { chain::time_point(), 1, 0, 100, 50, 0 }  //   trx_header
+         { chain::time_point_sec(), 1, 0, 100, 50, 0 }  //   trx_header
       };// trn end
 
       auto block_trace = block_trace_v2 {
@@ -768,7 +768,7 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          10,
          5,
          std::vector<chain::signature_type>{ chain::signature_type() },
-         { chain::time_point(), 1, 0, 100, 50, 0 }
+         { chain::time_point_sec(), 1, 0, 100, 50, 0 }
       };
 
       auto block_trace = block_trace_v2 {
@@ -880,7 +880,7 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          10,
          5,
          { chain::signature_type() },
-         { chain::time_point(), 1, 0, 100, 50, 0 }
+         { chain::time_point_sec(), 1, 0, 100, 50, 0 }
       };
 
       auto block_trace = block_trace_v2 {
@@ -1038,7 +1038,7 @@ BOOST_AUTO_TEST_SUITE(trace_responses)
          10,
          5,
          std::vector<chain::signature_type>{chain::signature_type()},
-         {chain::time_point(), 1, 0, 100, 50, 0}
+         {chain::time_point_sec(), 1, 0, 100, 50, 0}
       };
 
       auto block_trace = block_trace_v2 {

--- a/plugins/trace_api_plugin/test/test_trace_file.cpp
+++ b/plugins/trace_api_plugin/test/test_trace_file.cpp
@@ -48,7 +48,7 @@ namespace {
          10,
          5,
          { chain::signature_type() },
-         { chain::time_point(), 1, 0, 100, 50, 0 }
+         { chain::time_point_sec(), 1, 0, 100, 50, 0 }
       };
 
       block_trace_v2 block_trace1_v2 {
@@ -120,7 +120,7 @@ namespace {
                10,
                5,
                std::vector<chain::signature_type>{chain::signature_type()},
-               chain::transaction_header{chain::time_point(), 1, 0, 100, 50, 0}
+               chain::transaction_header{chain::time_point_sec(), 1, 0, 100, 50, 0}
             }
          }
       };
@@ -146,7 +146,7 @@ namespace {
                10,
                5,
                std::vector<chain::signature_type>{chain::signature_type()},
-               chain::transaction_header{chain::time_point(), 1, 0, 100, 50, 0}
+               chain::transaction_header{chain::time_point_sec(), 1, 0, 100, 50, 0}
             }
          }
       };

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1718,7 +1718,7 @@ struct bidname_info_subcommand {
          const auto& row = result.rows[0];
          string time = row["last_bid_time"].as_string();
          try {
-             time = (string)fc::time_point(fc::microseconds(to_uint64(time)));
+             time = fc::time_point(fc::microseconds(to_uint64(time))).to_string();
          } catch (fc::parse_error_exception&) {
          }
          int64_t bid = row["high_bid"].as_int64();
@@ -2423,7 +2423,7 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          staked = asset( 0, res.core_liquid_balance->get_symbol() );    // Correct core symbol for staked asset.
       }
 
-      std::cout << "created: " << string(res.created) << std::endl;
+      std::cout << "created: " << res.created.to_string() << std::endl;
 
       if(res.privileged) std::cout << "privileged: true" << std::endl;
 
@@ -2666,7 +2666,7 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          if( unstaking > asset( 0, unstaking.get_symbol() ) ) {
             std::cout << std::fixed << setprecision(3);
             std::cout << "unstaking tokens:" << std::endl;
-            std::cout << indent << std::left << std::setw(25) << "time of unstake request:" << std::right << std::setw(20) << string(request_time);
+            std::cout << indent << std::left << std::setw(25) << "time of unstake request:" << std::right << std::setw(20) << request_time.to_iso_string();
             if( now >= refund_time ) {
                std::cout << " (available to claim now with 'eosio::refund' action)\n";
             } else {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -413,7 +413,7 @@ fc::variant push_transaction( signed_transaction& trx, const std::vector<public_
    auto info = get_info();
 
    if (trx.signatures.size() == 0) { // #5445 can't change txn content if already signed
-      trx.expiration = info.head_block_time + tx_expiration;
+      trx.expiration = fc::time_point_sec{info.head_block_time + tx_expiration};
 
       // Set tapos, default to last irreversible block if it's not specified by the user
       block_id_type ref_block_id = info.last_irreversible_block_id;
@@ -2657,7 +2657,7 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
       if( res.refund_request.is_object() ) {
          auto obj = res.refund_request.get_object();
          auto request_time = fc::time_point_sec::from_iso_string( obj["request_time"].as_string() );
-         fc::time_point refund_time = request_time + fc::days(3);
+         fc::time_point refund_time = request_time.to_time_point() + fc::days(3);
          auto now = res.head_block_time;
          asset net = asset::from_string( obj["net_amount"].as_string() );
          asset cpu = asset::from_string( obj["cpu_amount"].as_string() );

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1718,7 +1718,7 @@ struct bidname_info_subcommand {
          const auto& row = result.rows[0];
          string time = row["last_bid_time"].as_string();
          try {
-             time = fc::time_point(fc::microseconds(to_uint64(time))).to_string();
+             time = fc::time_point(fc::microseconds(to_uint64(time))).to_iso_string();
          } catch (fc::parse_error_exception&) {
          }
          int64_t bid = row["high_bid"].as_int64();
@@ -2423,7 +2423,7 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          staked = asset( 0, res.core_liquid_balance->get_symbol() );    // Correct core symbol for staked asset.
       }
 
-      std::cout << "created: " << res.created.to_string() << std::endl;
+      std::cout << "created: " << res.created.to_iso_string() << std::endl;
 
       if(res.privileged) std::cout << "privileged: true" << std::endl;
 

--- a/tests/trx_generator/trx_generator.cpp
+++ b/tests/trx_generator/trx_generator.cpp
@@ -14,7 +14,7 @@ namespace eosio::testing {
    namespace chain = eosio::chain;
 
    void trx_generator_base::set_transaction_headers(chain::transaction& trx, const chain::block_id_type& last_irr_block_id, const fc::microseconds& expiration, uint32_t delay_sec) {
-      trx.expiration = fc::time_point::now() + expiration;
+      trx.expiration = fc::time_point_sec{fc::time_point::now() + expiration};
       trx.set_reference_block(last_irr_block_id);
 
       trx.max_net_usage_words = 0;// No limit

--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -77,7 +77,7 @@ namespace eosio::testing {
       std::ofstream out(fileName.str());
 
       for (logged_trx_data data : _sent_trx_data) {
-         out << std::string(data._trx_id) << ","<< data._sent_timestamp.to_string() << "\n";
+         out << std::string(data._trx_id) << ","<< data._sent_timestamp.to_iso_string() << "\n";
       }
       out.close();
    }

--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -77,7 +77,7 @@ namespace eosio::testing {
       std::ofstream out(fileName.str());
 
       for (logged_trx_data data : _sent_trx_data) {
-         out << std::string(data._trx_id) << ","<< std::string(data._sent_timestamp) << "\n";
+         out << std::string(data._trx_id) << ","<< data._sent_timestamp.to_string() << "\n";
       }
       out.close();
    }

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -2379,7 +2379,7 @@ BOOST_FIXTURE_TEST_CASE( delay_expired, validating_tester) { try {
                              });
    set_transaction_headers(trx);
    trx.delay_sec = 3;
-   trx.expiration = control->head_block_time() + fc::microseconds(1000000);
+   trx.expiration = fc::time_point_sec{control->head_block_time() + fc::microseconds(1000000)};
    trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
 
    auto trace = push_transaction( trx );

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -637,7 +637,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
-      trx.expiration = c.control->head_block_time() + fc::seconds( 60 );
+      trx.expiration = fc::time_point_sec{c.control->head_block_time() + fc::seconds( 60 )};
       trx.set_reference_block( cb->calculate_id() );
       trx.sign( get_private_key( config::system_account_name, "active" ), c.control->get_chain_id()  );
       trace1 = c.push_transaction( trx );
@@ -654,7 +654,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
-      trx.expiration = c.control->head_block_time() + fc::seconds( 60 );
+      trx.expiration = fc::time_point_sec{c.control->head_block_time() + fc::seconds( 60 )};
       trx.set_reference_block( cb->calculate_id() );
       trx.sign( get_private_key( config::system_account_name, "active" ), c.control->get_chain_id()  );
       trace2 = c.push_transaction( trx );
@@ -670,7 +670,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
-      trx.expiration = c.control->head_block_time() + fc::seconds( 60 );
+      trx.expiration = fc::time_point_sec{c.control->head_block_time() + fc::seconds( 60 )};
       trx.set_reference_block( cb->calculate_id() );
       trx.sign( get_private_key( config::system_account_name, "active" ), c.control->get_chain_id()  );
       trace3 = c.push_transaction( trx );
@@ -686,7 +686,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
-      trx.expiration = c.control->head_block_time() + fc::seconds( 60 );
+      trx.expiration = fc::time_point_sec{c.control->head_block_time() + fc::seconds( 60 )};
       trx.set_reference_block( b->calculate_id() ); // tapos to dan's block should be rejected on fork switch
       trx.sign( get_private_key( config::system_account_name, "active" ), c.control->get_chain_id()  );
       trace4 = c.push_transaction( trx );

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -723,7 +723,7 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
 
    test.set_transaction_headers(trx);
 
-   trx.expiration = fc::time_point::now();
+   trx.expiration = fc::time_point_sec{fc::time_point::now()};
    trx.validate();
    BOOST_CHECK_EQUAL(0u, trx.signatures.size());
    ((const signed_transaction &)trx).sign( test.get_private_key( config::system_account_name, "active" ), test.control->get_chain_id());
@@ -886,7 +886,7 @@ BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
       abi_serializer::from_variant(pretty_trx, trx, test.get_resolver(), abi_serializer::create_yield_function( test.abi_serializer_max_time ));
 
       test.set_transaction_headers(trx);
-      trx.expiration = fc::time_point::now();
+      trx.expiration = fc::time_point_sec{fc::time_point::now()};
 
       auto private_key = test.get_private_key( config::system_account_name, "active" );
       auto public_key = private_key.get_public_key();

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE( subjective_restrictions_test ) try {
    BOOST_CHECK_EXCEPTION(  c.produce_block(),
                            protocol_feature_exception,
                            fc_exception_message_starts_with(
-                              c.control->head_block_time().to_string() +
+                              c.control->head_block_time().to_iso_string() +
                               " is too early for the earliest allowed activation time of the protocol feature"
                            )
    );
@@ -339,7 +339,7 @@ BOOST_AUTO_TEST_CASE( subjective_restrictions_test ) try {
    BOOST_CHECK_EXCEPTION(  c.preactivate_protocol_features({only_link_to_existing_permission_digest}),
                            subjective_block_production_exception,
                            fc_exception_message_starts_with(
-                              (c.control->head_block_time() + fc::milliseconds(config::block_interval_ms)).to_string() +
+                              (c.control->head_block_time() + fc::milliseconds(config::block_interval_ms)).to_iso_string() +
                               " is too early for the earliest allowed activation time of the protocol feature"
                            )
    );

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE( subjective_restrictions_test ) try {
    BOOST_CHECK_EXCEPTION(  c.produce_block(),
                            protocol_feature_exception,
                            fc_exception_message_starts_with(
-                              std::string(c.control->head_block_time()) +
+                              c.control->head_block_time().to_string() +
                               " is too early for the earliest allowed activation time of the protocol feature"
                            )
    );
@@ -339,7 +339,7 @@ BOOST_AUTO_TEST_CASE( subjective_restrictions_test ) try {
    BOOST_CHECK_EXCEPTION(  c.preactivate_protocol_features({only_link_to_existing_permission_digest}),
                            subjective_block_production_exception,
                            fc_exception_message_starts_with(
-                              std::string(c.control->head_block_time() + fc::milliseconds(config::block_interval_ms)) +
+                              (c.control->head_block_time() + fc::milliseconds(config::block_interval_ms)).to_string() +
                               " is too early for the earliest allowed activation time of the protocol feature"
                            )
    );

--- a/unittests/subjective_billing_tests.cpp
+++ b/unittests/subjective_billing_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "eosio/chain/subjective_billing.hpp"
 #include <eosio/testing/tester.hpp>
+#include <fc/time.hpp>
 
 namespace {
 
@@ -22,6 +23,7 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
    account_name c = "c"_n;
 
    const auto now = time_point::now();
+   const fc::time_point_sec now_sec{now};
 
    subjective_billing timing_sub_bill;
    const auto halftime = now + fc::milliseconds(timing_sub_bill.get_expired_accumulator_average_window() * subjective_billing::subjective_time_interval_ms / 2);
@@ -31,9 +33,9 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
    {  // Failed transactions remain until expired in subjective billing.
       subjective_billing sub_bill;
 
-      sub_bill.subjective_bill( id1, now, a, fc::microseconds( 13 ) );
-      sub_bill.subjective_bill( id2, now, a, fc::microseconds( 11 ) );
-      sub_bill.subjective_bill( id3, now, b, fc::microseconds( 9 ) );
+      sub_bill.subjective_bill( id1, now_sec, a, fc::microseconds( 13 ) );
+      sub_bill.subjective_bill( id2, now_sec, a, fc::microseconds( 11 ) );
+      sub_bill.subjective_bill( id3, now_sec, b, fc::microseconds( 9 ) );
 
       BOOST_CHECK_EQUAL( 13+11, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 9, sub_bill.get_subjective_bill(b, now) );
@@ -58,9 +60,9 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
    {  // db_read_mode HEAD mode, so transactions are immediately reverted
       subjective_billing sub_bill;
 
-      sub_bill.subjective_bill( id1, now, a, fc::microseconds( 23 ) );
-      sub_bill.subjective_bill( id2, now, a, fc::microseconds( 19 ) );
-      sub_bill.subjective_bill( id3, now, b, fc::microseconds( 7 ) );
+      sub_bill.subjective_bill( id1, now_sec, a, fc::microseconds( 23 ) );
+      sub_bill.subjective_bill( id2, now_sec, a, fc::microseconds( 19 ) );
+      sub_bill.subjective_bill( id3, now_sec, b, fc::microseconds( 7 ) );
 
       BOOST_CHECK_EQUAL( 23+19, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 7, sub_bill.get_subjective_bill(b, now) );
@@ -96,9 +98,9 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
    { // expired handling logic, full billing until expiration then failed/decay logic
       subjective_billing sub_bill;
 
-      sub_bill.subjective_bill( id1, now, a, fc::microseconds( 1024 ) );
-      sub_bill.subjective_bill( id2, now + fc::microseconds(1), a, fc::microseconds( 1024 ) );
-      sub_bill.subjective_bill( id3, now, b, fc::microseconds( 1024 ) );
+      sub_bill.subjective_bill( id1, now_sec, a, fc::microseconds( 1024 ) );
+      sub_bill.subjective_bill( id2, fc::time_point_sec{now + fc::seconds(1)}, a, fc::microseconds( 1024 ) );
+      sub_bill.subjective_bill( id3, now_sec, b, fc::microseconds( 1024 ) );
       BOOST_CHECK_EQUAL( 1024 + 1024, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 1024, sub_bill.get_subjective_bill(b, now) );
 
@@ -112,7 +114,7 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
       BOOST_CHECK_EQUAL( 1024, sub_bill.get_subjective_bill(a, endtime) );
       BOOST_CHECK_EQUAL( 0, sub_bill.get_subjective_bill(b, endtime) );
 
-      sub_bill.remove_expired( log, now + fc::microseconds(1), now, [](){ return false; } );
+      sub_bill.remove_expired( log, now + fc::seconds(1), now, [](){ return false; } );
       BOOST_CHECK_EQUAL( 1024 + 1024, sub_bill.get_subjective_bill(a, now) );
       BOOST_CHECK_EQUAL( 1024, sub_bill.get_subjective_bill(b, now) );
 

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -15,7 +15,7 @@ auto unique_trx_meta_data( fc::time_point expire = fc::time_point::now() + fc::s
 
    signed_transaction trx;
    account_name creator = config::system_account_name;
-   trx.expiration = expire;
+   trx.expiration = fc::time_point_sec{expire};
    trx.actions.emplace_back( vector<permission_level>{{creator,config::active_name}},
                              onerror{ nextid, "test", 4 });
    return transaction_metadata::create_no_recover_keys( std::make_shared<packed_transaction>( std::move(trx) ),

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -611,7 +611,7 @@ BOOST_FIXTURE_TEST_CASE( simple_no_memory_check, validating_tester ) try {
    act.name = ""_n;
    act.authorization = vector<permission_level>{{"nomem"_n,config::active_name}};
    trx.actions.push_back(act);
-   trx.expiration = control->head_block_time();
+   trx.expiration = fc::time_point_sec{control->head_block_time()};
    set_transaction_headers(trx);
    trx.sign(get_private_key( "nomem"_n, "active" ), control->get_chain_id());
    BOOST_CHECK_THROW(push_transaction( trx ), wasm_execution_error);


### PR DESCRIPTION
Some cleanup while working #1062.
Remove implicit conversions of `time_point` and `time_point_sec`. They are error prone and were used in some "interesting" ways.
Removed arithmetic operators of `time_point_sec` as the results could be unexpected.