### PR TITLE
check for existance of BMI2 & ADX instructions on CI workers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,7 +141,7 @@ jobs:
           cd build
           ctest --output-on-failure -j $(nproc) -LE "(nonparallelizable_tests|long_running_tests)" --timeout 420
       - name: Check CPU Features
-        run: awk 'BEGIN {err = 1} /bmi2/ && /adx/ {err = 0} END {exit err}' /proc/cpuinfo
+        run: awk '/bmi2f/ && /adx/ {exit 0} ENDFILE {exit 1}' /proc/cpuinfo
 
   np-tests:
     name: NP Tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,7 +141,7 @@ jobs:
           cd build
           ctest --output-on-failure -j $(nproc) -LE "(nonparallelizable_tests|long_running_tests)" --timeout 420
       - name: Check CPU Features
-        run: awk '/bmi2f/ && /adx/ {exit 0} ENDFILE {exit 1}' /proc/cpuinfo
+        run: awk 'BEGIN {err = 1} /bmi2/ && /adx/ {err = 0} END {exit err}' /proc/cpuinfo
 
   np-tests:
     name: NP Tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -140,6 +140,8 @@ jobs:
           zstdcat build.tar.zst | tar x
           cd build
           ctest --output-on-failure -j $(nproc) -LE "(nonparallelizable_tests|long_running_tests)" --timeout 420
+      - name: Check CPU Features
+        run: awk 'BEGIN {err = 1} /bmi2/ && /adx/ {err = 0} END {exit err}' /proc/cpuinfo
 
   np-tests:
     name: NP Tests


### PR DESCRIPTION
As we start to add some hand rolled assembly that can detect and utilize optional CPU instruction sets at runtime (#1071), maybe it would be worthwhile checking that the CI runners are able to run all potential implementation combinations.