### PR TITLE
[4.0] change max-retained-history-files default

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2693,8 +2693,9 @@ fc::variant chain_plugin::get_log_trx(const transaction& trx) const {
     return pretty_output;
 }
 
-const controller::config* chain_plugin::chain_config() const {
-   return my->chain_config.has_value() ? std::addressof(*my->chain_config) : nullptr;
+const controller::config& chain_plugin::chain_config() const {
+   EOS_ASSERT(my->chain_config.has_value(), plugin_exception, "chain_config not initialized");
+   return *my->chain_config;
 }
 } // namespace eosio
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2692,6 +2692,10 @@ fc::variant chain_plugin::get_log_trx(const transaction& trx) const {
     }
     return pretty_output;
 }
+
+const controller::config* chain_plugin::chain_config() const {
+   return my->chain_config.has_value() ? std::addressof(*my->chain_config) : nullptr;
+}
 } // namespace eosio
 
 FC_REFLECT( eosio::chain_apis::detail::ram_market_exchange_state_t, (ignore1)(ignore2)(ignore3)(core_symbol)(ignore4) )

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -886,6 +886,8 @@ public:
    // return variant of trx for logging, trace is modified to minimize log output
    fc::variant get_log_trx(const transaction& trx) const;
 
+   const controller::config* chain_config() const;
+
 private:
    static void log_guard_exception(const chain::guard_exception& e);
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -886,7 +886,7 @@ public:
    // return variant of trx for logging, trace is modified to minimize log output
    fc::variant get_log_trx(const transaction& trx) const;
 
-   const controller::config* chain_config() const;
+   const controller::config& chain_config() const;
 
 private:
    static void log_guard_exception(const chain::guard_exception& e);

--- a/plugins/chain_plugin/test/CMakeLists.txt
+++ b/plugins/chain_plugin/test/CMakeLists.txt
@@ -6,6 +6,6 @@ add_executable( test_trx_retry_db test_trx_retry_db.cpp )
 target_link_libraries( test_trx_retry_db chain_plugin eosio_testing)
 add_test(NAME test_trx_retry_db COMMAND plugins/chain_plugin/test/test_trx_retry_db WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
-add_executable( test_trx_finality_status_processing test_trx_finality_status_processing.cpp )
+add_executable( test_trx_finality_status_processing test_trx_finality_status_processing.cpp plugin_config_test.cpp)
 target_link_libraries( test_trx_finality_status_processing chain_plugin eosio_testing)
 add_test(NAME test_trx_finality_status_processing COMMAND plugins/chain_plugin/test/test_trx_finality_status_processing WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/plugins/chain_plugin/test/plugin_config_test.cpp
+++ b/plugins/chain_plugin/test/plugin_config_test.cpp
@@ -16,8 +16,7 @@ BOOST_AUTO_TEST_CASE(chain_plugin_default_tests) {
    BOOST_CHECK(app->initialize<eosio::chain_plugin>(args.size(), const_cast<char**>(args.data())));
    auto& plugin = app->get_plugin<eosio::chain_plugin>();
 
-   BOOST_REQUIRE(plugin.chain_config());
-   auto* config = std::get_if<eosio::chain::partitioned_blocklog_config>(&plugin.chain_config()->blog);
+   auto* config = std::get_if<eosio::chain::partitioned_blocklog_config>(&plugin.chain_config().blog);
    BOOST_REQUIRE(config);
    BOOST_CHECK_EQUAL(config->max_retained_files, UINT32_MAX);
 }

--- a/plugins/chain_plugin/test/plugin_config_test.cpp
+++ b/plugins/chain_plugin/test/plugin_config_test.cpp
@@ -1,0 +1,23 @@
+#include <array>
+#include <boost/test/unit_test.hpp>
+#include <eosio/chain/application.hpp>
+#include <eosio/chain_plugin/chain_plugin.hpp>
+#include <stdint.h>
+
+BOOST_AUTO_TEST_CASE(chain_plugin_default_tests) {
+   appbase::scoped_app app;
+   fc::temp_directory  tmp;
+
+   auto tmp_path = tmp.path().string();
+   std::array          args = {
+       "test_chain_plugin", "--blocks-log-stride", "10", "--data-dir", tmp_path.c_str(),
+   };
+
+   BOOST_CHECK(app->initialize<eosio::chain_plugin>(args.size(), const_cast<char**>(args.data())));
+   auto& plugin = app->get_plugin<eosio::chain_plugin>();
+
+   BOOST_REQUIRE(plugin.chain_config());
+   auto* config = std::get_if<eosio::chain::partitioned_blocklog_config>(&plugin.chain_config()->blog);
+   BOOST_REQUIRE(config);
+   BOOST_CHECK_EQUAL(config->max_retained_files, UINT32_MAX);
+}

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
@@ -30,6 +30,7 @@ class state_history_plugin : public plugin<state_history_plugin> {
    void handle_sighup() override;
 
    const state_history_log* trace_log() const;
+   const state_history_log* chain_state_log() const;
 
  private:
    state_history_ptr my;

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
@@ -3,6 +3,7 @@
 
 #include <eosio/chain_plugin/chain_plugin.hpp>
 #include <eosio/state_history/types.hpp>
+#include <eosio/state_history/log.hpp>
 
 namespace fc {
 class variant;
@@ -11,7 +12,6 @@ class variant;
 namespace eosio {
 using chain::bytes;
 using std::shared_ptr;
-
 typedef shared_ptr<struct state_history_plugin_impl> state_history_ptr;
 
 class state_history_plugin : public plugin<state_history_plugin> {
@@ -28,6 +28,8 @@ class state_history_plugin : public plugin<state_history_plugin> {
    void plugin_shutdown();
 
    void handle_sighup() override;
+
+   const state_history_log_config* trace_log_config() const;
 
  private:
    state_history_ptr my;

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
@@ -29,7 +29,7 @@ class state_history_plugin : public plugin<state_history_plugin> {
 
    void handle_sighup() override;
 
-   const state_history_log_config* trace_log_config() const;
+   const state_history_log* trace_log() const;
 
  private:
    state_history_ptr my;

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -512,8 +512,8 @@ void state_history_plugin::handle_sighup() {
    fc::logger::update(logger_name, _log);
 }
 
-const state_history_log_config* state_history_plugin::trace_log_config() const {
-   return my->trace_log ? &my->trace_log->config() : nullptr;
+const state_history_log* state_history_plugin::trace_log() const {
+   return my->trace_log ? std::addressof(*my->trace_log) : nullptr;
 }
 
 } // namespace eosio

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -516,4 +516,8 @@ const state_history_log* state_history_plugin::trace_log() const {
    return my->trace_log ? std::addressof(*my->trace_log) : nullptr;
 }
 
+const state_history_log* state_history_plugin::chain_state_log() const {
+   return my->chain_state_log ? std::addressof(*my->chain_state_log) : nullptr;
+}
+
 } // namespace eosio

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -512,4 +512,8 @@ void state_history_plugin::handle_sighup() {
    fc::logger::update(logger_name, _log);
 }
 
+const state_history_log_config* state_history_plugin::trace_log_config() const {
+   return my->trace_log ? &my->trace_log->config() : nullptr;
+}
+
 } // namespace eosio

--- a/plugins/state_history_plugin/tests/CMakeLists.txt
+++ b/plugins/state_history_plugin/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_executable( test_state_history_session session_test.cpp )
-target_link_libraries(test_state_history_session state_history Boost::unit_test_framework)
-target_include_directories( test_state_history_session PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include" )
+add_executable( test_state_history session_test.cpp plugin_config_test.cpp)
+target_link_libraries(test_state_history state_history_plugin Boost::unit_test_framework)
+target_include_directories( test_state_history PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include" )
 
-add_test(test_state_history_session test_state_history_session)
+add_test(test_state_history test_state_history)

--- a/plugins/state_history_plugin/tests/plugin_config_test.cpp
+++ b/plugins/state_history_plugin/tests/plugin_config_test.cpp
@@ -1,0 +1,23 @@
+#include <array>
+#include <boost/test/unit_test.hpp>
+#include <eosio/state_history/log.hpp>
+#include <eosio/state_history_plugin/state_history_plugin.hpp>
+#include <fc/filesystem.hpp>
+#include <stdint.h>
+
+BOOST_AUTO_TEST_CASE(state_history_plugin_default_tests) {
+   fc::temp_directory  tmp;
+   appbase::scoped_app app;
+
+   auto tmp_path = tmp.path().string();
+   std::array args = {"test_state_history",    "--trace-history", "--state-history-stride", "10",
+                      "--disable-replay-opts", "--data-dir",      tmp_path.c_str()};
+
+   BOOST_CHECK(app->initialize<eosio::state_history_plugin>(args.size(), const_cast<char**>(args.data())));
+   auto& plugin = app->get_plugin<eosio::state_history_plugin>();
+
+   BOOST_REQUIRE(plugin.trace_log_config());
+   auto* config = std::get_if<eosio::state_history::partition_config>(plugin.trace_log_config());
+   BOOST_REQUIRE(config);
+   BOOST_CHECK_EQUAL(config->max_retained_files, UINT32_MAX);
+}

--- a/plugins/state_history_plugin/tests/plugin_config_test.cpp
+++ b/plugins/state_history_plugin/tests/plugin_config_test.cpp
@@ -16,8 +16,8 @@ BOOST_AUTO_TEST_CASE(state_history_plugin_default_tests) {
    BOOST_CHECK(app->initialize<eosio::state_history_plugin>(args.size(), const_cast<char**>(args.data())));
    auto& plugin = app->get_plugin<eosio::state_history_plugin>();
 
-   BOOST_REQUIRE(plugin.trace_log_config());
-   auto* config = std::get_if<eosio::state_history::partition_config>(plugin.trace_log_config());
+   BOOST_REQUIRE(plugin.trace_log());
+   auto* config = std::get_if<eosio::state_history::partition_config>(&plugin.trace_log()->config());
    BOOST_REQUIRE(config);
    BOOST_CHECK_EQUAL(config->max_retained_files, UINT32_MAX);
 }


### PR DESCRIPTION
This PR 
- changes the defaults of `max-retained-history-files` to UINT32_MAX when `state-history-retained-dir` is specified,
- adds some unit tests to validate `max-retained-history-files` and `max-retained-block-files`.

Resolves https://github.com/AntelopeIO/leap/issues/1135