### PR TITLE
Keep `subprocess_results.log` around when test fails

### DIFF
--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -88,13 +88,13 @@ class Utils:
     @staticmethod
     def checkOutputFileWrite(time, cmd, output, error):
         stop=Utils.timestamp()
+        if not os.path.isdir(Utils.TestLogRoot):
+            if Utils.Debug: Utils.Print("TestLogRoot creating dir %s in dir: %s" % (Utils.TestLogRoot, os.getcwd()))
+            os.mkdir(Utils.TestLogRoot)
+        if not os.path.isdir(Utils.DataPath):
+            if Utils.Debug: Utils.Print("DataPath creating dir %s in dir: %s" % (Utils.DataPath, os.getcwd()))
+            os.mkdir(Utils.DataPath)
         if not hasattr(Utils, "checkOutputFile"):
-            if not os.path.isdir(Utils.TestLogRoot):
-                if Utils.Debug: Utils.Print("TestLogRoot creating dir %s in dir: %s" % (Utils.TestLogRoot, os.getcwd()))
-                os.mkdir(Utils.TestLogRoot)
-            if not os.path.isdir(Utils.DataPath):
-                if Utils.Debug: Utils.Print("DataPath creating dir %s in dir: %s" % (Utils.DataPath, os.getcwd()))
-                os.mkdir(Utils.DataPath)
             Utils.checkOutputFilename=f"{Utils.DataPath}/subprocess_results.log"
             if Utils.Debug: Utils.Print("opening %s in dir: %s" % (Utils.checkOutputFilename, os.getcwd()))
             Utils.checkOutputFile=open(Utils.checkOutputFilename,"w")

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -95,9 +95,11 @@ class Utils:
             if not os.path.isdir(Utils.DataPath):
                 if Utils.Debug: Utils.Print("DataPath creating dir %s in dir: %s" % (Utils.DataPath, os.getcwd()))
                 os.mkdir(Utils.DataPath)
-            filename=f"{Utils.DataPath}/subprocess_results.log"
-            if Utils.Debug: Utils.Print("opening %s in dir: %s" % (filename, os.getcwd()))
-            Utils.checkOutputFile=open(filename,"w")
+            Utils.checkOutputFilename=f"{Utils.DataPath}/subprocess_results.log"
+            if Utils.Debug: Utils.Print("opening %s in dir: %s" % (Utils.checkOutputFilename, os.getcwd()))
+            Utils.checkOutputFile=open(Utils.checkOutputFilename,"w")
+        else:
+            Utils.checkOutputFile=open(Utils.checkOutputFilename,"a")
 
         Utils.checkOutputFile.write(Utils.FileDivider + "\n")
         Utils.checkOutputFile.write("start={%s}\n" % (time))


### PR DESCRIPTION
Reopen `checkOutputFilename` (`subprocess_results.log`) in case where file may have been deleted, but attr was already set.

Allows for cases where `Cluster.cleanup` is called initially in tests to remove old test data, which should no longer be a problem, however in doing so it now deletes `subprocess_results.log` while attr for `checkOutputFile` has already been set.  This allows reopening/recreating the file and continuing to log to it to capture all commands after the initial cleanup.