### PR TITLE
[4.0->main] change max-retained-history-files default

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -88,7 +88,7 @@ namespace state_history {
       std::filesystem::path retained_dir       = "retained";
       std::filesystem::path archive_dir        = "archive";
       uint32_t              stride             = 1000000;
-      uint32_t              max_retained_files = 10;
+      uint32_t              max_retained_files = UINT32_MAX;
    };
 } // namespace state_history
 
@@ -128,7 +128,7 @@ struct locked_decompress_stream {
 
 namespace detail {
 
-std::vector<char> zlib_decompress(fc::cfile& file, uint64_t compressed_size) {
+inline std::vector<char> zlib_decompress(fc::cfile& file, uint64_t compressed_size) {
    if (compressed_size) {
       std::vector<char> compressed(compressed_size);
       file.read(compressed.data(), compressed_size);
@@ -137,7 +137,7 @@ std::vector<char> zlib_decompress(fc::cfile& file, uint64_t compressed_size) {
    return {};
 }
 
-std::vector<char> zlib_decompress(fc::datastream<const char*>& strm, uint64_t compressed_size) {
+inline std::vector<char> zlib_decompress(fc::datastream<const char*>& strm, uint64_t compressed_size) {
    if (compressed_size) {
       return state_history::zlib_decompress({strm.pos(), compressed_size});
    }
@@ -282,7 +282,7 @@ private:
 class state_history_log {
  private:
    const char* const       name = "";
-   state_history_log_config config;
+   state_history_log_config _config;
 
    // provide exclusive access to all data of this object since accessed from the main thread and the ship thread
    mutable std::mutex      _mx;
@@ -304,7 +304,7 @@ class state_history_log {
    state_history_log(const char* name, const std::filesystem::path& log_dir,
                      state_history_log_config conf = {})
        : name(name)
-       , config(std::move(conf)) {
+       , _config(std::move(conf)) {
 
       log.set_file_path(log_dir/(std::string(name) + ".log"));
       index.set_file_path(log_dir/(std::string(name) + ".index"));
@@ -326,7 +326,7 @@ class state_history_log {
                _begin_block = _end_block = catalog.last_block_num() +1;
             }
          }
-      }, config);
+      }, _config);
 
       //check for conversions to/from pruned log, as long as log contains something
       if(_begin_block != _end_block) {
@@ -334,7 +334,7 @@ class state_history_log {
          log.seek(0);
          read_header(first_header);
 
-         auto prune_config = std::get_if<state_history::prune_config>(&config);
+         auto prune_config = std::get_if<state_history::prune_config>(&_config);
 
          if((is_ship_log_pruned(first_header.magic) == false) && prune_config) {
             //need to convert non-pruned to pruned; first prune any ranges we can (might be none)
@@ -361,7 +361,7 @@ class state_history_log {
       if(_begin_block == _end_block)
          return;
 
-      auto prune_config = std::get_if<state_history::prune_config>(&config);
+      auto prune_config = std::get_if<state_history::prune_config>(&_config);
       if(!prune_config || !prune_config->vacuum_on_close)
          return;
 
@@ -369,6 +369,10 @@ class state_history_log {
       const size_t last_data_pos = std::filesystem::file_size(log.get_file_path());
       if(last_data_pos - first_data_pos < *prune_config->vacuum_on_close)
          vacuum();
+   }
+
+   const state_history_log_config& config() const {
+      return _config;
    }
 
    //        begin     end
@@ -499,7 +503,7 @@ class state_history_log {
          }
       }
 
-      auto prune_config = std::get_if<state_history::prune_config>(&config);
+      auto prune_config = std::get_if<state_history::prune_config>(&_config);
       if (block_num < _end_block) {
          // This is typically because of a fork, and we need to truncate the log back to the beginning of the fork.
          static uint32_t start_block_num = block_num;
@@ -552,7 +556,7 @@ class state_history_log {
       log.flush();
       index.flush();
 
-      auto partition_config = std::get_if<state_history::partition_config>(&config);
+      auto partition_config = std::get_if<state_history::partition_config>(&_config);
       if (partition_config && block_num % partition_config->stride == 0) {
          split_log();
       }
@@ -608,7 +612,7 @@ class state_history_log {
    }
 
    void prune(const fc::log_level& loglevel) {
-      auto prune_config = std::get_if<state_history::prune_config>(&config);
+      auto prune_config = std::get_if<state_history::prune_config>(&_config);
 
       if(!prune_config)
          return;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2645,6 +2645,11 @@ fc::variant chain_plugin::get_log_trx(const transaction& trx) const {
     }
     return pretty_output;
 }
+
+const controller::config& chain_plugin::chain_config() const {
+   EOS_ASSERT(my->chain_config.has_value(), plugin_exception, "chain_config not initialized");
+   return *my->chain_config;
+}
 } // namespace eosio
 
 FC_REFLECT( eosio::chain_apis::detail::ram_market_exchange_state_t, (ignore1)(ignore2)(ignore3)(core_symbol)(ignore4) )

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -979,6 +979,8 @@ public:
    // return variant of trx for logging, trace is modified to minimize log output
    fc::variant get_log_trx(const transaction& trx) const;
 
+   const controller::config& chain_config() const;
+
 private:
    static void log_guard_exception(const chain::guard_exception& e);
 

--- a/plugins/chain_plugin/test/CMakeLists.txt
+++ b/plugins/chain_plugin/test/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable( test_chain_plugin
         test_account_query_db.cpp
         test_trx_retry_db.cpp
         test_trx_finality_status_processing.cpp
+        plugin_config_test.cpp
         main.cpp
         )
 target_link_libraries( test_chain_plugin chain_plugin eosio_testing)

--- a/plugins/chain_plugin/test/plugin_config_test.cpp
+++ b/plugins/chain_plugin/test/plugin_config_test.cpp
@@ -1,0 +1,22 @@
+#include <array>
+#include <boost/test/unit_test.hpp>
+#include <eosio/chain/application.hpp>
+#include <eosio/chain_plugin/chain_plugin.hpp>
+#include <stdint.h>
+
+BOOST_AUTO_TEST_CASE(chain_plugin_default_tests) {
+   appbase::scoped_app app;
+   fc::temp_directory  tmp;
+
+   auto tmp_path = tmp.path().string();
+   std::array          args = {
+       "test_chain_plugin", "--blocks-log-stride", "10", "--data-dir", tmp_path.c_str(),
+   };
+
+   BOOST_CHECK(app->initialize<eosio::chain_plugin>(args.size(), const_cast<char**>(args.data())));
+   auto& plugin = app->get_plugin<eosio::chain_plugin>();
+
+   auto* config = std::get_if<eosio::chain::partitioned_blocklog_config>(&plugin.chain_config().blog);
+   BOOST_REQUIRE(config);
+   BOOST_CHECK_EQUAL(config->max_retained_files, UINT32_MAX);
+}

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_plugin.hpp
@@ -3,6 +3,7 @@
 
 #include <eosio/chain_plugin/chain_plugin.hpp>
 #include <eosio/state_history/types.hpp>
+#include <eosio/state_history/log.hpp>
 
 namespace fc {
 class variant;
@@ -11,7 +12,6 @@ class variant;
 namespace eosio {
 using chain::bytes;
 using std::shared_ptr;
-
 typedef shared_ptr<struct state_history_plugin_impl> state_history_ptr;
 
 class state_history_plugin : public plugin<state_history_plugin> {
@@ -28,6 +28,9 @@ class state_history_plugin : public plugin<state_history_plugin> {
    void plugin_shutdown();
 
    void handle_sighup() override;
+
+   const state_history_log* trace_log() const;
+   const state_history_log* chain_state_log() const;
 
  private:
    state_history_ptr my;

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -492,4 +492,12 @@ void state_history_plugin::handle_sighup() {
    fc::logger::update(logger_name, _log);
 }
 
+const state_history_log* state_history_plugin::trace_log() const {
+   return my->trace_log ? std::addressof(*my->trace_log) : nullptr;
+}
+
+const state_history_log* state_history_plugin::chain_state_log() const {
+   return my->chain_state_log ? std::addressof(*my->chain_state_log) : nullptr;
+}
+
 } // namespace eosio

--- a/plugins/state_history_plugin/tests/CMakeLists.txt
+++ b/plugins/state_history_plugin/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_executable( test_state_history_session session_test.cpp )
-target_link_libraries(test_state_history_session state_history Boost::unit_test_framework)
-target_include_directories( test_state_history_session PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include" )
+add_executable( test_state_history session_test.cpp plugin_config_test.cpp)
+target_link_libraries(test_state_history state_history_plugin Boost::unit_test_framework)
+target_include_directories( test_state_history PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include" )
 
-add_test(test_state_history_session test_state_history_session)
+add_test(test_state_history test_state_history)

--- a/plugins/state_history_plugin/tests/plugin_config_test.cpp
+++ b/plugins/state_history_plugin/tests/plugin_config_test.cpp
@@ -1,0 +1,23 @@
+#include <array>
+#include <boost/test/unit_test.hpp>
+#include <eosio/state_history/log.hpp>
+#include <eosio/state_history_plugin/state_history_plugin.hpp>
+#include <fc/filesystem.hpp>
+#include <stdint.h>
+
+BOOST_AUTO_TEST_CASE(state_history_plugin_default_tests) {
+   fc::temp_directory  tmp;
+   appbase::scoped_app app;
+
+   auto tmp_path = tmp.path().string();
+   std::array args = {"test_state_history",    "--trace-history", "--state-history-stride", "10",
+                      "--disable-replay-opts", "--data-dir",      tmp_path.c_str()};
+
+   BOOST_CHECK(app->initialize<eosio::state_history_plugin>(args.size(), const_cast<char**>(args.data())));
+   auto& plugin = app->get_plugin<eosio::state_history_plugin>();
+
+   BOOST_REQUIRE(plugin.trace_log());
+   auto* config = std::get_if<eosio::state_history::partition_config>(&plugin.trace_log()->config());
+   BOOST_REQUIRE(config);
+   BOOST_CHECK_EQUAL(config->max_retained_files, UINT32_MAX);
+}


### PR DESCRIPTION
This PR merges PR #1141 into main.

- changes the defaults of `max-retained-history-files` to UINT32_MAX when `state-history-retained-dir` is specified,
- adds some unit tests to validate `max-retained-history-files` and `max-retained-block-files`.

Resolves https://github.com/AntelopeIO/leap/issues/1135