### PR TITLE
[4.0] Ignore http error on remote_endpoint() causing shutdown

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_listener.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_listener.hpp
@@ -121,12 +121,18 @@ private:
                fail(ec, "accept", self->plugin_state_->logger, "closing connection");
             } else {
                // Create the session object and run it
-               std::string remote_endpoint = boost::lexical_cast<std::string>(self->socket_.remote_endpoint());
-               std::make_shared<session_type>(
-                  std::move(self->socket_),
-                  self->plugin_state_,
-                  std::move(remote_endpoint))
-                  ->run_session();
+               boost::system::error_code re_ec;
+               auto re = self->socket_.remote_endpoint(re_ec);
+               if (re_ec) {
+                  fail(re_ec, "remote_endpoint", self->plugin_state_->logger, "closing connection");
+               } else {
+                  std::string remote_endpoint = boost::lexical_cast<std::string>(re);
+                  std::make_shared<session_type>(
+                     std::move(self->socket_),
+                     self->plugin_state_,
+                     std::move(remote_endpoint))
+                     ->run_session();
+               }
             }
             
             // Accept another connection

--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_listener.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_listener.hpp
@@ -123,16 +123,12 @@ private:
                // Create the session object and run it
                boost::system::error_code re_ec;
                auto re = self->socket_.remote_endpoint(re_ec);
-               if (re_ec) {
-                  fail(re_ec, "remote_endpoint", self->plugin_state_->logger, "closing connection");
-               } else {
-                  std::string remote_endpoint = boost::lexical_cast<std::string>(re);
-                  std::make_shared<session_type>(
-                     std::move(self->socket_),
-                     self->plugin_state_,
-                     std::move(remote_endpoint))
-                     ->run_session();
-               }
+               std::string remote_endpoint = re_ec ? "unknown" : boost::lexical_cast<std::string>(re);
+               std::make_shared<session_type>(
+                  std::move(self->socket_),
+                  self->plugin_state_,
+                  std::move(remote_endpoint))
+                  ->run_session();
             }
             
             // Accept another connection


### PR DESCRIPTION
`remote_endpoint()` call was generating error `Transport endpoint is not connected`. This call is only used for logging of the remote endpoint. Ignore the error and log `unknown` for the remote endpoint. This prevents the http thread pool from exiting due to an uncaught exception.

Resolves #1149 