### PR TITLE
[4.0 -> main] Ignore http error on remote_endpoint() causing shutdown

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_listener.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_listener.hpp
@@ -62,7 +62,9 @@ public:
                fail(ec, "accept", self->plugin_state_->logger, "closing connection");
             } else {
                // Create the session object and run it
-               std::string remote_endpoint = boost::lexical_cast<std::string>(self->socket_.remote_endpoint());
+               boost::system::error_code re_ec;
+               auto re = self->socket_.remote_endpoint(re_ec);
+               std::string remote_endpoint = re_ec ? "unknown" : boost::lexical_cast<std::string>(re);
                std::make_shared<beast_http_session<socket_type>>(
                   std::move(self->socket_),
                   self->plugin_state_,


### PR DESCRIPTION
`remote_endpoint()` call was generating error `Transport endpoint is not connected`. This call is only used for logging of the remote endpoint. Ignore the error and log `unknown` for the remote endpoint. This prevents the http thread pool from exiting due to an uncaught exception.

Merges #1175 into `main`.

Resolves #1149 