### PR TITLE
[4.0 -> main] Correctly handle close while syncing

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1715,8 +1715,8 @@ namespace eosio {
          } );
          sync_known_lib_num = highest_lib_num;
 
-         // if closing the connection we are currently syncing from, then reset our last requested and next expected.
-         if( c == sync_source ) {
+         // if closing the connection we are currently syncing from or not syncing, then reset our last requested and next expected.
+         if( !sync_source || c == sync_source ) {
             sync_last_requested_num = 0;
             // if starting to sync need to always start from lib as we might be on our own fork
             uint32_t lib_num = my_impl->get_chain_lib_num();


### PR DESCRIPTION
When generating snapshots during syncing, nodeos would timeout a sync and close the connection. The close would cause all queued blocks on that connection to be dropped. Also the `sync_next_expected_num` would not be reset because the `sync_source` had been reset.

Merges #1171 into `main`. `main` already has the fix for not dropping queued blocks on a closed connection. See https://github.com/AntelopeIO/leap/pull/1040

Resolves #1170 