### PR TITLE
Added cpm-cmake to manage download / build and finding local boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,6 @@ set(CPM_USE_LOCAL_PACKAGES TRUE)
 
 # Most boost deps get implictly picked up via fc, as just about everything links to fc. In addition we pick up
 # the pthread dependency through fc.
-#find_package(Boost 1.71 REQUIRED COMPONENTS program_options unit_test_framework system)
 CPMAddPackage(
   NAME Boost
   VERSION ${Boost_MINIMUM_VERSION}
@@ -122,9 +121,9 @@ CPMAddPackage(
 )
 
 # in case of using local package
-if(NOT CPM_PACKAGE_ALREADY_ADDED)
-   find_package(Boost ${Boost_MINIMUM_VERSION} REQUIRED COMPONENTS program_options unit_test_framework system)
-endif()
+#if(NOT CPM_PACKAGE_ALREADY_ADDED)
+#   find_package(Boost ${Boost_MINIMUM_VERSION} REQUIRED COMPONENTS program_options unit_test_framework system)
+#endif()
 
 if( APPLE AND UNIX )
 # Apple Specific Options Here

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(CPM_USE_LOCAL_PACKAGES TRUE)
 
 # Most boost deps get implictly picked up via fc, as just about everything links to fc. In addition we pick up
 # the pthread dependency through fc.
+#find_package(Boost 1.71 REQUIRED COMPONENTS program_options unit_test_framework system)
 CPMAddPackage(
   NAME Boost
   VERSION ${Boost_MINIMUM_VERSION}
@@ -121,9 +122,9 @@ CPMAddPackage(
 )
 
 # in case of using local package
-#if(NOT CPM_PACKAGE_ALREADY_ADDED)
-#   find_package(Boost ${Boost_MINIMUM_VERSION} REQUIRED COMPONENTS program_options unit_test_framework system)
-#endif()
+if(NOT CPM_PACKAGE_ALREADY_ADDED)
+   find_package(Boost ${Boost_MINIMUM_VERSION} REQUIRED COMPONENTS program_options unit_test_framework system)
+endif()
 
 if( APPLE AND UNIX )
 # Apple Specific Options Here

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
 include( GNUInstallDirs )
 include( MASSigning )
+include( CPM )
 
 set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_EXTENSIONS ON )
@@ -102,10 +103,28 @@ else()
 endif()
 
 set(Boost_USE_MULTITHREADED      ON)
-set( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
+set(Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
+
+# this is the minimum required version of Boost
+# if system already has boost of such or greater version installed, it will be used
+# if system has no boost or older boost installed, it will be downloaded and built from github automatically by CPM 
+set(Boost_MINIMUM_VERSION "1.82.0")
+set(CPM_USE_LOCAL_PACKAGES TRUE)
+
 # Most boost deps get implictly picked up via fc, as just about everything links to fc. In addition we pick up
 # the pthread dependency through fc.
-find_package(Boost 1.71 REQUIRED COMPONENTS program_options unit_test_framework system)
+#find_package(Boost 1.71 REQUIRED COMPONENTS program_options unit_test_framework system)
+CPMAddPackage(
+  NAME Boost
+  VERSION ${Boost_MINIMUM_VERSION}
+  GITHUB_REPOSITORY "boostorg/boost"
+  GIT_TAG "boost-${Boost_MINIMUM_VERSION}"
+)
+
+# in case of using local package
+if(NOT CPM_PACKAGE_ALREADY_ADDED)
+   find_package(Boost ${Boost_MINIMUM_VERSION} REQUIRED COMPONENTS program_options unit_test_framework system)
+endif()
 
 if( APPLE AND UNIX )
 # Apple Specific Options Here

--- a/CMakeModules/CPM.cmake
+++ b/CMakeModules/CPM.cmake
@@ -1,0 +1,33 @@
+set(CPM_DOWNLOAD_VERSION 0.38.1)
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+function(download_cpm)
+  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+  file(DOWNLOAD
+       https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION}
+  )
+endfunction()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  download_cpm()
+else()
+  # resume download if it previously failed
+  file(READ ${CPM_DOWNLOAD_LOCATION} check)
+  if("${check}" STREQUAL "")
+    download_cpm()
+  endif()
+  unset(check)
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -91,6 +91,12 @@ if(APPLE)
   add_library(zstd INTERFACE)
 endif()
 
+find_package(Boost 1.66 REQUIRED COMPONENTS
+    date_time
+    chrono
+    unit_test_framework
+    iostreams)
+
 find_path(GMP_INCLUDE_DIR NAMES gmp.h)
 find_library(GMP_LIBRARY gmp)
 if(NOT GMP_LIBRARY MATCHES ${CMAKE_SHARED_LIBRARY_SUFFIX})

--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -91,12 +91,6 @@ if(APPLE)
   add_library(zstd INTERFACE)
 endif()
 
-find_package(Boost 1.66 REQUIRED COMPONENTS
-    date_time
-    chrono
-    unit_test_framework
-    iostreams)
-
 find_path(GMP_INCLUDE_DIR NAMES gmp.h)
 find_library(GMP_LIBRARY gmp)
 if(NOT GMP_LIBRARY MATCHES ${CMAKE_SHARED_LIBRARY_SUFFIX})


### PR DESCRIPTION
This is now experimental / work in progress. As @huangminghuang mentioned in original issue in discussion with @greg7mdp, in order to simplify dependency management I tried out cpm-cmake (https://github.com/cpm-cmake) to manage Boost dependency as it pretty much covers all required cases, in particular:
- if system already has boost of such or greater version installed, it will be used
- if system has no boost or older boost installed, it will be downloaded and built from github automatically by CPM

There was one (for now) makefile adjustment has to be done in chainbase submodule to make errorless configuration and build.  