### PR TITLE
[4.0] Fix for nodeos large memory consumption during a blocks log replay

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -99,7 +99,8 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
    std::set<acceptor_type>          acceptors;
 
    named_thread_pool<struct ship> thread_pool;
-   bool                           thread_pool_started = false;
+
+   bool  plugin_started = false;
 
    static fc::logger& logger() { return _log; }
 
@@ -295,7 +296,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
 
       // avoid accumulating all these posts during replay before ship threads started
       // this is safe as there are no clients connected untill after replay is complete 
-      if (thread_pool_started) {
+      if (plugin_started) {
          boost::asio::post(get_ship_executor(), [self = this->shared_from_this(), block_state]() {
             self->session_mgr.send_update(block_state);
          });
@@ -500,10 +501,8 @@ void state_history_plugin::plugin_startup() {
       my->thread_pool.start( 1, [](const fc::exception& e) {
          fc_elog( _log, "Exception in SHiP thread pool, exiting: ${e}", ("e", e.to_detail_string()) );
          app().quit();
-      },
-      [this]() {
-         my->thread_pool_started = true;
       });
+      my->plugin_started = true; 
    } catch (std::exception& ex) {
       appbase::app().quit();
    }

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -295,7 +295,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
       }
 
       // avoid accumulating all these posts during replay before ship threads started
-      // this is safe as there are no clients connected untill after replay is complete 
+      // this is safe as there are no clients connected until after replay is complete 
       if (plugin_started) {
          boost::asio::post(get_ship_executor(), [self = this->shared_from_this(), block_state]() {
             self->session_mgr.send_update(block_state);

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -295,7 +295,9 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
       }
 
       // avoid accumulating all these posts during replay before ship threads started
-      // this is safe as there are no clients connected until after replay is complete 
+      // that can lead to a large memory consumption and failures
+      // this is safe as there are no clients connected until after replay is complete
+      // this method is called from the main thread and "plugin_started" is set on the main thread as well when plugin is started 
       if (plugin_started) {
          boost::asio::post(get_ship_executor(), [self = this->shared_from_this(), block_state]() {
             self->session_mgr.send_update(block_state);

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -292,7 +292,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
              "the process");
       }
 
-      boost::asio::post(get_ship_executor(), [self = this->shared_from_this(), block_state]() {
+      boost::asio::post(get_ship_executor(), [self = this->shared_from_this(), &block_state]() {
          self->session_mgr.send_update(block_state);
       });
 


### PR DESCRIPTION
It was reported that during bloks log replay with a large blocks log nodeos process grows in memory to the point of it's exhaustion.

Resolves https://github.com/AntelopeIO/leap/issues/1130