### PR TITLE
Improve packed_transaction parsing performance

### DIFF
--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -1095,18 +1095,14 @@ public:
             return *it->second;
          return {};
       }
-      try {
-         auto serializer = resolver_(account);
-         auto& dest = abi_serializers[account]; // add entry regardless
-         if (serializer) {
-            // we got a serializer, so move it into the cache
-            dest = abi_serializer_cache_t::mapped_type{std::move(*serializer)};
-            return *dest; // and return a reference to it
-         }
-         return {}; 
-      } catch( ... ) {
-         throw; // throw if embedded resolver throws
+      auto serializer = resolver_(account);
+      auto& dest = abi_serializers[account]; // add entry regardless
+      if (serializer) {
+         // we got a serializer, so move it into the cache
+         dest = abi_serializer_cache_t::mapped_type{std::move(*serializer)};
+         return *dest; // and return a reference to it
       }
+      return {}; 
    };
 
 private:

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -825,13 +825,14 @@ namespace impl {
                from_variant(data, act.data);
                valid_empty_data = act.data.empty();
             } else if ( data.is_object() ) {
-               auto abi = resolver(act.account);
-               if (abi) {
-                  auto type = abi->get_action_type(act.name);
+               auto abi_optional = resolver(act.account);
+               if (abi_optional) {
+                  const abi_serializer& abi = *abi_optional;
+                  auto type = abi.get_action_type(act.name);
                   if (!type.empty()) {
-                     variant_to_binary_context _ctx(*abi, ctx, type);
+                     variant_to_binary_context _ctx(abi, ctx, type);
                      _ctx.short_path = true; // Just to be safe while avoiding the complexity of threading an override boolean all over the place
-                     act.data = std::move( abi->_variant_to_binary( type, data, _ctx ));
+                     act.data = abi._variant_to_binary( type, data, _ctx );
                      valid_empty_data = act.data.empty();
                   }
                }
@@ -1002,6 +1003,7 @@ void abi_serializer::from_variant( const fc::variant& v, T& o, const Resolver& r
 } FC_RETHROW_EXCEPTIONS(error, "Failed to deserialize variant", ("variant",v))
 
 using abi_serializer_cache_t = std::unordered_map<account_name, std::optional<abi_serializer>>;
+using resolver_fn_t = std::function<std::optional<abi_serializer>(const account_name& name)>;
    
 class abi_resolver {
 public:
@@ -1022,7 +1024,7 @@ private:
 
 class abi_serializer_cache_builder {
 public:
-   explicit abi_serializer_cache_builder(std::function<std::optional<abi_serializer>(const account_name& name)> resolver) :
+   explicit abi_serializer_cache_builder(resolver_fn_t resolver) :
       resolver_(std::move(resolver))
    {
    }
@@ -1066,8 +1068,39 @@ private:
       }
    }
 
-   std::function<std::optional<abi_serializer>(const account_name& name)> resolver_;
+   resolver_fn_t resolver_;
    abi_serializer_cache_t abi_serializers;
 };
+
+/*
+ * This is equivalent to a resolver, except that everytime the abi_serializer for an account 
+ * is retrieved, it is stored in an unordered_map, so we won't waste time retrieving it again.
+ * This is handy when parsing packed_transactions received in a fc::variant.
+ */
+class caching_resolver {
+public:
+   explicit caching_resolver(resolver_fn_t resolver) :
+      resolver_(std::move(resolver))
+   {
+   }
+
+   std::optional<std::reference_wrapper<const abi_serializer>> operator()(const account_name& account) const {
+      auto it = abi_serializers.find(account);
+      if (it != abi_serializers.end() && it->second)
+         return *it->second;
+      try {
+         auto& dest = abi_serializers[account];
+         dest = resolver_(account);
+         return *dest;
+      } catch( ... ) {
+         throw; // throw if embedded resolver throws
+      }
+   };
+
+private:
+   const resolver_fn_t resolver_;
+   mutable abi_serializer_cache_t abi_serializers;
+};
+      
 
 } // eosio::chain

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2034,9 +2034,9 @@ void read_write::push_block(read_write::push_block_params&& params, next_functio
 void read_write::push_transaction(const read_write::push_transaction_params& params, next_function<read_write::push_transaction_results> next) {
    try {
       auto pretty_input = std::make_shared<packed_transaction>();
-      auto resolver = make_resolver(db, abi_serializer_max_time, throw_on_yield::yes);
+      auto resolver = caching_resolver(make_resolver(db, abi_serializer_max_time, throw_on_yield::yes));
       try {
-         abi_serializer::from_variant(params, *pretty_input, std::move( resolver ), abi_serializer::create_yield_function( abi_serializer_max_time ));
+         abi_serializer::from_variant(params, *pretty_input, resolver, abi_serializer_max_time);
       } EOS_RETHROW_EXCEPTIONS(chain::packed_transaction_type_exception, "Invalid packed transaction")
 
       app().get_method<incoming::methods::transaction_async>()(pretty_input, true, transaction_metadata::trx_type::input, false,
@@ -2158,7 +2158,7 @@ void api_base::send_transaction_gen(API &api, send_transaction_params_t params, 
       auto ptrx = std::make_shared<packed_transaction>();
       auto resolver = make_resolver(api.db, api.abi_serializer_max_time, throw_on_yield::yes);
       try {
-         abi_serializer::from_variant(params.transaction, *ptrx, resolver, abi_serializer::create_yield_function( api.abi_serializer_max_time ));
+         abi_serializer::from_variant(params.transaction, *ptrx, resolver, api.abi_serializer_max_time);
       } EOS_RETHROW_EXCEPTIONS(packed_transaction_type_exception, "Invalid packed transaction")
 
       bool retry = false;
@@ -2503,7 +2503,7 @@ read_only::get_required_keys_result read_only::get_required_keys( const get_requ
    transaction pretty_input;
    auto resolver = make_resolver(db, abi_serializer_max_time, throw_on_yield::yes);
    try {
-      abi_serializer::from_variant(params.transaction, pretty_input, resolver, abi_serializer::create_yield_function( abi_serializer_max_time ));
+      abi_serializer::from_variant(params.transaction, pretty_input, resolver, abi_serializer_max_time);
    } EOS_RETHROW_EXCEPTIONS(chain::transaction_type_exception, "Invalid transaction")
 
    auto required_keys_set = db.get_authorization_manager().get_required_keys( pretty_input, params.available_keys, fc::seconds( pretty_input.delay_sec ));

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2156,7 +2156,7 @@ template<class API, class Result>
 void api_base::send_transaction_gen(API &api, send_transaction_params_t params, next_function<Result> next) {
    try {
       auto ptrx = std::make_shared<packed_transaction>();
-      auto resolver = make_resolver(api.db, api.abi_serializer_max_time, throw_on_yield::yes);
+      auto resolver = caching_resolver(make_resolver(api.db, api.abi_serializer_max_time, throw_on_yield::yes));
       try {
          abi_serializer::from_variant(params.transaction, *ptrx, resolver, api.abi_serializer_max_time);
       } EOS_RETHROW_EXCEPTIONS(packed_transaction_type_exception, "Invalid packed transaction")
@@ -2501,7 +2501,7 @@ read_only::get_account_return_t read_only::get_account( const get_account_params
 
 read_only::get_required_keys_result read_only::get_required_keys( const get_required_keys_params& params, const fc::time_point& )const {
    transaction pretty_input;
-   auto resolver = make_resolver(db, abi_serializer_max_time, throw_on_yield::yes);
+   auto resolver = caching_resolver(make_resolver(db, abi_serializer_max_time, throw_on_yield::yes));
    try {
       abi_serializer::from_variant(params.transaction, pretty_input, resolver, abi_serializer_max_time);
    } EOS_RETHROW_EXCEPTIONS(chain::transaction_type_exception, "Invalid transaction")
@@ -2597,7 +2597,7 @@ fc::variant chain_plugin::get_log_trx_trace(const transaction_trace_ptr& trx_tra
     fc::variant pretty_output;
     try {
         abi_serializer::to_log_variant(trx_trace, pretty_output,
-                                       make_resolver(chain(), get_abi_serializer_max_time(), throw_on_yield::no),
+                                       caching_resolver(make_resolver(chain(), get_abi_serializer_max_time(), throw_on_yield::no)),
                                        get_abi_serializer_max_time());
     } catch (...) {
         pretty_output = trx_trace;
@@ -2609,7 +2609,7 @@ fc::variant chain_plugin::get_log_trx(const transaction& trx) const {
     fc::variant pretty_output;
     try {
         abi_serializer::to_log_variant(trx, pretty_output,
-                                       make_resolver(chain(), get_abi_serializer_max_time(), throw_on_yield::no),
+                                       caching_resolver(make_resolver(chain(), get_abi_serializer_max_time(), throw_on_yield::no)),
                                        get_abi_serializer_max_time());
     } catch (...) {
         pretty_output = trx;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -70,7 +70,7 @@ namespace eosio {
    }
 
    template<class T>
-   inline abi_resolver get_serializers_cache( const controller& db, const T& obj, const fc::microseconds& max_time ) {
+   inline abi_resolver get_serializers_cache(const controller& db, const T& obj, const fc::microseconds& max_time) {
       return abi_resolver(abi_serializer_cache_builder(make_resolver(db, max_time, throw_on_yield::no)).add_serializers(obj).get());
    }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -45,6 +45,7 @@ namespace eosio {
    using chain::action_name;
    using chain::abi_def;
    using chain::abi_serializer;
+   using chain::abi_serializer_cache_builder;
    using chain::abi_resolver;
    using chain::packed_transaction;
 
@@ -66,6 +67,11 @@ namespace eosio {
          }
          return {};
       };
+   }
+
+   template<class T>
+   inline abi_resolver get_serializers_cache( const controller& db, const T& obj, const fc::microseconds& max_time ) {
+      return abi_resolver(abi_serializer_cache_builder(make_resolver(db, max_time, throw_on_yield::no)).add_serializers(obj).get());
    }
 
 namespace chain_apis {

--- a/plugins/chain_plugin/trx_retry_db.cpp
+++ b/plugins/chain_plugin/trx_retry_db.cpp
@@ -146,8 +146,7 @@ struct trx_retry_db_impl {
                // Convert to variant with abi here and now because abi could change in very next transaction.
                // Alternatively, we could store off all the abis needed and do the conversion later, but as this is designed
                // to run on an API node, probably the best trade off to perform the abi serialization during block processing.
-               auto abi_cache = abi_serializer_cache_builder(make_resolver(control, abi_max_time, throw_on_yield::no)).add_serializers(trace).get();
-               auto resolver = abi_resolver(std::move(abi_cache));
+               auto resolver = get_serializers_cache(control, trace, abi_max_time);
                tt.trx_trace_v.clear();
                abi_serializer::to_variant(*trace, tt.trx_trace_v, resolver, abi_max_time);
             } catch( chain::abi_exception& ) {


### PR DESCRIPTION
Resolves #1025.

Introduce a `caching_resolver `class, which provides the same API as a resolver, but which caches `abi_serializers`  as they are retrieved, so we pay the cost of retrieval only once.