### PR TITLE
[4.0 -> main] Fix for nodeos large memory consumption during a blocks log replay

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -85,6 +85,8 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
 
    named_thread_pool<struct ship> thread_pool;
 
+   bool  plugin_started = false;
+
    static fc::logger& logger() { return _log; }
 
    std::optional<state_history_log>& get_trace_log() { return trace_log; }
@@ -272,9 +274,15 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
              "the process");
       }
 
-      boost::asio::post(get_ship_executor(), [self = this->shared_from_this(), block_state]() {
-         self->session_mgr.send_update(block_state);
-      });
+      // avoid accumulating all these posts during replay before ship threads started
+      // that can lead to a large memory consumption and failures
+      // this is safe as there are no clients connected until after replay is complete
+      // this method is called from the main thread and "plugin_started" is set on the main thread as well when plugin is started 
+      if (plugin_started) {
+         boost::asio::post(get_ship_executor(), [self = this->shared_from_this(), block_state]() {
+            self->session_mgr.send_update(block_state);
+         });
+      }
 
    }
 
@@ -475,7 +483,8 @@ void state_history_plugin::plugin_startup() {
       my->thread_pool.start( 1, [](const fc::exception& e) {
          fc_elog( _log, "Exception in SHiP thread pool, exiting: ${e}", ("e", e.to_detail_string()) );
          app().quit();
-      } );
+      });
+      my->plugin_started = true; 
    } catch (std::exception& ex) {
       appbase::app().quit();
    }


### PR DESCRIPTION
It was reported that during bloks log replay with a large blocks log nodeos process grows in memory to the point of it's exhaustion.

Resolves https://github.com/AntelopeIO/leap/issues/1130