### PR TITLE
Remove disable-subjective-billing option

### DIFF
--- a/docs/01_nodeos/03_plugins/producer_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/producer_plugin/index.md
@@ -122,8 +122,6 @@ Config Options for eosio::producer_plugin:
                                         transaction queue. Exceeding this value
                                         will subjectively drop transaction with
                                         resource exhaustion.
-  --disable-subjective-billing arg (=1) Disable subjective CPU billing for
-                                        API/P2P transactions
   --disable-subjective-account-billing arg
                                         Account which is excluded from
                                         subjective CPU billing

--- a/plugins/producer_plugin/test/test_options.cpp
+++ b/plugins/producer_plugin/test/test_options.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(state_dir) {
           "--data-dir",   temp_dir_str.c_str(),
           "--state-dir",  custom_state_dir_str.c_str(),
           "--config-dir", temp_dir_str.c_str(),
-          "-p", "eosio", "-e", "--max-transaction-time", "475", "--disable-subjective-billing=true" };
+          "-p", "eosio", "-e" };
       app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
       app->startup();
       plugin_promise.set_value( {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );

--- a/plugins/producer_plugin/test/test_read_only_trx.cpp
+++ b/plugins/producer_plugin/test/test_read_only_trx.cpp
@@ -183,8 +183,7 @@ BOOST_AUTO_TEST_CASE(with_1_read_only_threads) {
                                               "--max-transaction-time=10",
                                               "--abi-serializer-max-time-ms=999",
                                               "--read-only-write-window-time-us=100000",
-                                              "--read-only-read-window-time-us=40000",
-                                              "--disable-subjective-billing=true" };
+                                              "--read-only-read-window-time-us=40000" };
    test_trxs_common(specific_args);
 }
 
@@ -195,8 +194,7 @@ BOOST_AUTO_TEST_CASE(with_8_read_only_threads) {
                                               "--max-transaction-time=10",
                                               "--abi-serializer-max-time-ms=999",
                                               "--read-only-write-window-time-us=100000",
-                                              "--read-only-read-window-time-us=40000",
-                                              "--disable-subjective-billing=true" };
+                                              "--read-only-read-window-time-us=40000" };
    test_trxs_common(specific_args);
 }
 

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(producer) {
          fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
          std::vector<const char*> argv =
                {"test", "--data-dir", temp_dir_str.c_str(), "--config-dir", temp_dir_str.c_str(),
-                "-p", "eosio", "-e", "--disable-subjective-billing=true" };
+                "-p", "eosio", "-e", "--disable-subjective-p2p-billing=true" };
          app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
          app->startup();
          plugin_promise.set_value(

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -547,7 +547,8 @@ class PerformanceTestBasic:
                                         blockLogRetainBlocks=args.block_log_retain_blocks,
                                         chainStateDbSizeMb=args.chain_state_db_size_mb, abiSerializerMaxTimeMs=990000)
 
-        producerPluginArgs = ProducerPluginArgs(disableSubjectiveBilling=args.disable_subjective_billing,
+        producerPluginArgs = ProducerPluginArgs(disableSubjectiveApiBilling=args.disable_subjective_billing,
+                                                disableSubjectiveP2pBilling=args.disable_subjective_billing,
                                                 cpuEffortPercent=args.cpu_effort_percent,
                                                 producerThreads=args.producer_threads, maxTransactionTime=-1)
         httpPluginArgs = HttpPluginArgs(httpMaxBytesInFlightMb=args.http_max_bytes_in_flight_mb, httpMaxInFlightRequests=args.http_max_in_flight_requests,

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
             fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
             std::vector<const char*> argv =
                   {"test", "--data-dir", temp.c_str(), "--config-dir", temp.c_str(),
-                   "-p", "eosio", "-e", "--disable-subjective-billing=true"};
+                   "-p", "eosio", "-e"};
             app->initialize<chain_plugin, producer_plugin>(argv.size(), (char**) &argv[0]);
             app->startup();
             plugin_promise.set_value(


### PR DESCRIPTION
The options `disable-subjective-p2p-billing` and `disable-subjective-api-billing` cover the same functionality as `disable-subjective-billing`. `disable-subjective-billing` simply set the other two options to `true`. Simplify options by removing this redundant option.

Resolves #1173 