### PR TITLE
Extended snapshot scheduler to better handle missing and zero params

### DIFF
--- a/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
@@ -20,6 +20,8 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <limits>
+
 namespace eosio::chain {
 
 namespace bmi = boost::multi_index;
@@ -38,7 +40,7 @@ public:
    struct snapshot_request_information {
       uint32_t block_spacing = 0;
       uint32_t start_block_num = 0;
-      uint32_t end_block_num = UINT32_MAX - 1;
+      uint32_t end_block_num = std::numeric_limits<uint32_t>::max();
       std::string snapshot_description = "";
    };
 

--- a/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
@@ -38,8 +38,17 @@ public:
    struct snapshot_request_information {
       uint32_t block_spacing = 0;
       uint32_t start_block_num = 0;
-      uint32_t end_block_num = 0;
+      uint32_t end_block_num = UINT32_MAX - 1;
       std::string snapshot_description = "";
+   };
+
+   // this struct used to hold request params in api call
+   // it is differentiate between 0 and empty values
+   struct snapshot_request_params {
+      std::optional<uint32_t> block_spacing;
+      std::optional<uint32_t> start_block_num;
+      std::optional<uint32_t> end_block_num;
+      std::optional<std::string> snapshot_description;
    };
 
    struct snapshot_request_id_information {
@@ -205,6 +214,7 @@ public:
 
 FC_REFLECT(eosio::chain::snapshot_scheduler::snapshot_information, (head_block_id) (head_block_num) (head_block_time) (version) (snapshot_name))
 FC_REFLECT(eosio::chain::snapshot_scheduler::snapshot_request_information, (block_spacing) (start_block_num) (end_block_num) (snapshot_description))
+FC_REFLECT(eosio::chain::snapshot_scheduler::snapshot_request_params, (block_spacing) (start_block_num) (end_block_num) (snapshot_description))
 FC_REFLECT(eosio::chain::snapshot_scheduler::snapshot_request_id_information, (snapshot_request_id))
 FC_REFLECT(eosio::chain::snapshot_scheduler::get_snapshot_requests_result, (snapshot_requests))
 FC_REFLECT_DERIVED(eosio::chain::snapshot_scheduler::snapshot_schedule_information, (eosio::chain::snapshot_scheduler::snapshot_request_id_information)(eosio::chain::snapshot_scheduler::snapshot_request_information), (pending_snapshots))

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -132,7 +132,7 @@ void producer_api_plugin::plugin_startup() {
        CALL_ASYNC(producer, snapshot, producer, create_snapshot, chain::snapshot_scheduler::snapshot_information,
             INVOKE_R_V_ASYNC(producer, create_snapshot), 201),
        CALL_WITH_400(producer, snapshot, producer, schedule_snapshot,
-            INVOKE_R_R_II(producer, schedule_snapshot, chain::snapshot_scheduler::snapshot_request_information), 201),
+            INVOKE_R_R_II(producer, schedule_snapshot, chain::snapshot_scheduler::snapshot_request_params), 201),
        CALL_WITH_400(producer, snapshot, producer, unschedule_snapshot,
             INVOKE_R_R(producer, unschedule_snapshot, chain::snapshot_scheduler::snapshot_request_id_information), 201),
        CALL_WITH_400(producer, producer_rw, producer, get_integrity_hash,

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -98,7 +98,7 @@ public:
    integrity_hash_information get_integrity_hash() const;
 
    void create_snapshot(next_function<chain::snapshot_scheduler::snapshot_information> next);
-   chain::snapshot_scheduler::snapshot_schedule_result schedule_snapshot(const chain::snapshot_scheduler::snapshot_request_information& schedule);
+   chain::snapshot_scheduler::snapshot_schedule_result schedule_snapshot(const chain::snapshot_scheduler::snapshot_request_params& srp);
    chain::snapshot_scheduler::snapshot_schedule_result unschedule_snapshot(const chain::snapshot_scheduler::snapshot_request_id_information& schedule);
    chain::snapshot_scheduler::get_snapshot_requests_result get_snapshot_requests() const;
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1511,7 +1511,18 @@ void producer_plugin::create_snapshot(producer_plugin::next_function<chain::snap
 }
 
 chain::snapshot_scheduler::snapshot_schedule_result
-producer_plugin::schedule_snapshot(const chain::snapshot_scheduler::snapshot_request_information& sri) {
+producer_plugin::schedule_snapshot(const chain::snapshot_scheduler::snapshot_request_params& srp) {
+   chain::controller& chain = my->chain_plug->chain();
+   const auto head_block_num = chain.head_block_num();
+
+  // missing start/end is set to head block num, missing end to UINT32_MAX
+  chain::snapshot_scheduler::snapshot_request_information sri = {
+      .block_spacing   = srp.block_spacing ? *srp.block_spacing : 0, 
+      .start_block_num = srp.start_block_num ? *srp.start_block_num : head_block_num,
+      .end_block_num   = srp.end_block_num ? *srp.end_block_num : UINT32_MAX - 1,
+      .snapshot_description = srp.snapshot_description ? *srp.snapshot_description : ""
+   };
+
    return my->_snapshot_scheduler.schedule_snapshot(sri);
 }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1518,7 +1518,7 @@ producer_plugin::schedule_snapshot(const chain::snapshot_scheduler::snapshot_req
   // missing start/end is set to head block num, missing end to UINT32_MAX
   chain::snapshot_scheduler::snapshot_request_information sri = {
       .block_spacing   = srp.block_spacing ? *srp.block_spacing : 0, 
-      .start_block_num = srp.start_block_num ? *srp.start_block_num : head_block_num,
+      .start_block_num = srp.start_block_num ? *srp.start_block_num : head_block_num + 1,
       .end_block_num   = srp.end_block_num ? *srp.end_block_num : UINT32_MAX - 1,
       .snapshot_description = srp.snapshot_description ? *srp.snapshot_description : ""
    };

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1515,11 +1515,11 @@ producer_plugin::schedule_snapshot(const chain::snapshot_scheduler::snapshot_req
    chain::controller& chain = my->chain_plug->chain();
    const auto head_block_num = chain.head_block_num();
 
-  // missing start/end is set to head block num, missing end to UINT32_MAX
-  chain::snapshot_scheduler::snapshot_request_information sri = {
+   // missing start/end is set to head block num, missing end to UINT32_MAX
+   chain::snapshot_scheduler::snapshot_request_information sri = {
       .block_spacing   = srp.block_spacing ? *srp.block_spacing : 0, 
       .start_block_num = srp.start_block_num ? *srp.start_block_num : head_block_num + 1,
-      .end_block_num   = srp.end_block_num ? *srp.end_block_num : UINT32_MAX - 1,
+      .end_block_num   = srp.end_block_num ? *srp.end_block_num : std::numeric_limits<uint32_t>::max(),
       .snapshot_description = srp.snapshot_description ? *srp.snapshot_description : ""
    };
 

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -83,42 +83,46 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
             if (!pp->get_snapshot_requests().snapshot_requests.empty()) {
                const auto& snapshot_requests = pp->get_snapshot_requests().snapshot_requests;
 
-               auto validate_snapshot_request = [&](uint32_t sid, uint32_t block_num) {                  
+               auto validate_snapshot_request = [&](uint32_t sid, uint32_t block_num, uint32_t spacing = 0) {                  
                   auto it = find_if(snapshot_requests.begin(), snapshot_requests.end(), [sid](const snapshot_scheduler::snapshot_schedule_information& obj) {return obj.snapshot_request_id == sid;});
                   if (it != snapshot_requests.end()) {
                      auto& pending = it->pending_snapshots;
                      if (pending.size()==1) {
-                        BOOST_CHECK_EQUAL(block_num, pending.begin()->head_block_num);
+                        auto pbn = pending.begin()->head_block_num;
+                        BOOST_CHECK_EQUAL(block_num,  spacing ?  (spacing + (pbn%spacing)) : pbn);
                      }
                      return true;
                   }
                   return false;                  
                };
 
-               BOOST_REQUIRE(validate_snapshot_request(0, 9));  // snapshot #0 should have pending snapshot at block #9 (8 + 1) and it never expires
-               BOOST_REQUIRE(validate_snapshot_request(4, 12)); // snapshot #4 should have pending snapshot at block # at the moment of scheduling (2) plus 10 = 12
+               BOOST_REQUIRE(validate_snapshot_request(0, 9,  8));  // snapshot #0 should have pending snapshot at block #9 (8 + 1) and it never expires
+               BOOST_REQUIRE(validate_snapshot_request(4, 12, 10)); // snapshot #4 should have pending snapshot at block # at the moment of scheduling (2) plus 10 = 12
+               BOOST_REQUIRE(validate_snapshot_request(5, 10, 10)); // snapshot #5 should have pending snapshot at block #10, #20 etc 
             }
          });
 
          snapshot_request_params sri1 = {.block_spacing = 8, .start_block_num = 1, .end_block_num = 300000, .snapshot_description = "Example of recurring snapshot 1"};
-         snapshot_request_params sri2 = {.block_spacing = 5000, .start_block_num = 100000, .end_block_num = 300000, .snapshot_description = "Example of recurring snapshot 2 that will never happen"};
+         snapshot_request_params sri2 = {.block_spacing = 5000, .start_block_num = 100000, .end_block_num = 300000, .snapshot_description = "Example of recurring snapshot 2 that wont happen in test"};
          snapshot_request_params sri3 = {.block_spacing = 2, .start_block_num = 0, .end_block_num = 3, .snapshot_description = "Example of recurring snapshot 3 that will expire"};
          snapshot_request_params sri4 = {.start_block_num = 1, .snapshot_description = "One time snapshot on first block"};
          snapshot_request_params sri5 = {.block_spacing = 10, .snapshot_description = "Recurring every 10 blocks snapshot starting now"};
+         snapshot_request_params sri6 = {.block_spacing = 10, .start_block_num = 0, .snapshot_description = "Recurring every 10 blocks snapshot starting from 0"};
 
          pp->schedule_snapshot(sri1);
          pp->schedule_snapshot(sri2);
          pp->schedule_snapshot(sri3);
          pp->schedule_snapshot(sri4);
          pp->schedule_snapshot(sri5);
+         pp->schedule_snapshot(sri6);
 
-         // all five snapshot requests should be present now
-         BOOST_CHECK_EQUAL(5, pp->get_snapshot_requests().snapshot_requests.size());
+         // all six snapshot requests should be present now
+         BOOST_CHECK_EQUAL(6, pp->get_snapshot_requests().snapshot_requests.size());
 
-         empty_blocks_fut.wait_for(std::chrono::seconds(6));
+         empty_blocks_fut.wait_for(std::chrono::seconds(10));
 
          // two of the snapshots are done here and requests, corresponding to them should be deleted
-         BOOST_CHECK_EQUAL(3, pp->get_snapshot_requests().snapshot_requests.size());
+         BOOST_CHECK_EQUAL(4, pp->get_snapshot_requests().snapshot_requests.size());
 
          // check whether no pending snapshots present for a snapshot with id 0
          const auto& snapshot_requests = pp->get_snapshot_requests().snapshot_requests;
@@ -137,7 +141,7 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
          std::vector<snapshot_scheduler::snapshot_schedule_information> ssi;
          db.set_path(temp / "snapshots");
          db >> ssi;
-         BOOST_CHECK_EQUAL(3, ssi.size());
+         BOOST_CHECK_EQUAL(4, ssi.size());
          BOOST_CHECK_EQUAL(ssi.begin()->block_spacing, *sri1.block_spacing);
       } catch(...) {
          throw;


### PR DESCRIPTION
This PR add differentiation between missing and zero-valued parameters in api request for start, end and spacing of blocks, in particular, as it was observed in original issue making start_block_num assignable to "0" in request or directly in snapshot-schedule.json file, such as:

```json
{
    "snapshot_requests": [
        {
            "snapshot_request_id": "0",
            "snapshot_description": "Hourly snapshots starting from genesis",
            "block_spacing": "7200",
            "start_block_num": "0",
            "end_block_num": "0"
        }
    ]
}
```

Prior implementation treated zero start as missing value and replaced it with "now" block num

Resolves https://github.com/AntelopeIO/leap/issues/1152


