### PR TITLE
P2P sync ahead while applying received blocks

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2311,12 +2311,6 @@ namespace eosio {
                }
 
                sync_next_expected_num = blk_num + 1;
-            } else {
-               if (sync_last_requested_num != 0 && blk_num >= sync_last_requested_num) {
-                  sync_next_expected_num = blk_num + 1;
-                  request_next_chunk(std::move(g_sync));
-                  return;
-               }
             }
 
             uint32_t head = my_impl->get_chain_head_num();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -212,10 +212,10 @@ namespace eosio {
 
       alignas(hardware_destructive_interference_size)
       std::mutex     sync_mtx;
-      uint32_t       sync_known_lib_num{0};
-      uint32_t       sync_last_requested_num{0};
-      uint32_t       sync_next_expected_num{0};
-      connection_ptr sync_source;
+      uint32_t       sync_known_lib_num{0};       // highest known lib num from currently connected peers
+      uint32_t       sync_last_requested_num{0};  // end block number of the last requested range, inclusive
+      uint32_t       sync_next_expected_num{0};   // the next block number we need from peer
+      connection_ptr sync_source;                 // connection we are currently syncing from
 
       const uint32_t       sync_req_span{0};
       const uint32_t       sync_peer_limit{0};

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2322,10 +2322,8 @@ namespace eosio {
             uint32_t head = my_impl->get_chain_head_num();
             if (head + sync_req_span > sync_last_requested_num) { // don't allow to get too far head (one sync_req_span)
                if (sync_next_expected_num > sync_last_requested_num && sync_last_requested_num < sync_known_lib_num) {
-                  if (head < sync_next_expected_num - sync_req_span) {
-                     fc_elog(logger, "requesting chunk ahead of time, head: ${h} blk_num: ${bn} sync_next_expected_num ${nen} sync_last_requested_num: ${lrn}",
-                             ("h", head)("bn", blk_num)("nen", sync_next_expected_num)("lrn", sync_last_requested_num));
-                  }
+                  fc_dlog(logger, "Requesting range ahead, head: ${h} blk_num: ${bn} sync_next_expected_num ${nen} sync_last_requested_num: ${lrn}",
+                          ("h", head)("bn", blk_num)("nen", sync_next_expected_num)("lrn", sync_last_requested_num));
                   request_next_chunk(std::move(g_sync));
                }
             }


### PR DESCRIPTION
Continue syncing the next `sync-fetch-span` while apply current range of synced blocks. It is prevented from running too far ahead of `head` by `sync-fetch-span`. It does queue up to double the amount of blocks during syncing than before this PR.

Before this PR:
```
[ sync blks A ]             [ sync blks B ]             [ sync blks C ]
    [ apply blocks A.. ... ]    [ apply blocks B.. ... ]    [ apply blocks C.. ... ]
```
After this PR:
```
[ sync blks A ][ sync blks B ][ sync blks C ]       [ sync blks D ]         [ sync blks E ]
    [ apply blocks A.. ... ][ apply blocks B.. ... ][ apply blocks C.. ... ][ apply blocks D.. ... ]
```
On my machine syncing into EOS mainnet, I was able to maintain 100% CPU while syncing.

Includes a fix for excessive handshake messages during syncing.

Resolves #1072 