### PR TITLE
Avoid trying to kill a node twice to prevent orphaned processes.

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -272,7 +272,7 @@ class Node(Transactions):
             if self.popenProc is not None:
                 self.popenProc.send_signal(killSignal)
                 self.popenProc.wait()
-            else:
+            elif self.pid is not None:
                 os.kill(self.pid, killSignal)
 
                 # wait for kill validation
@@ -286,6 +286,8 @@ class Node(Transactions):
                 if not Utils.waitForBool(myFunc):
                     Utils.Print("ERROR: Failed to validate node shutdown.")
                     return False
+            else:
+                if Utils.Debug: Utils.Print(f"Called kill on node {self.nodeId} but it has already exited.")
         except OSError as ex:
             Utils.Print("ERROR: Failed to kill node (%s)." % (self.cmd), ex)
             return False
@@ -377,6 +379,7 @@ class Node(Transactions):
         if chainArg:
             cmdArr.extend(shlex.split(chainArg))
         self.popenProc=self.launchCmd(cmdArr, self.data_dir, launch_time=datetime.now().strftime('%Y_%m_%d_%H_%M_%S'))
+        self.pid=self.popenProc.pid
 
         def isNodeAlive():
             """wait for node to be responsive."""


### PR DESCRIPTION
Some tests terminate some nodes but not all.  The `atexit` routine intended to be the final catchall for cleaning up a cluster would fail to terminate all nodes if it tried to terminate a node which had been shut down via `interruptAndVerifyExitStatus` first.  Tolerate terminated nodes and if the global `Debug` flag is set, log double kills. (The log message should be converted to a custom `TRACE` level when the code is converted to the Python `logging` module.)