### PR TITLE
P2P use round trip of time_message to calculate latency

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3683,10 +3683,13 @@ namespace eosio {
    // called from application thread
    void net_plugin_impl::on_accepted_block_header(const block_state_ptr& bs) {
       update_chain_info();
-      dispatcher->strand.post( [bs]() {
-         fc_dlog( logger, "signaled accepted_block_header, blk num = ${num}, id = ${id}", ("num", bs->block_num)("id", bs->id) );
-         my_impl->dispatcher->bcast_block( bs->block, bs->id );
-      });
+
+      if (!my_impl->sync_master->syncing_from_peer()) {
+         dispatcher->strand.post([bs]() {
+            fc_dlog(logger, "signaled accepted_block_header, blk num = ${num}, id = ${id}", ("num", bs->block_num)("id", bs->id));
+            my_impl->dispatcher->bcast_block(bs->block, bs->id);
+         });
+      }
    }
 
    void net_plugin_impl::on_accepted_block(const block_state_ptr& ) {


### PR DESCRIPTION
Address peer review comment: https://github.com/AntelopeIO/leap/pull/1215#discussion_r1210652126

Use round trip time for `time_message` which was already implemented. Since this already did a round trip for previous versions of P2P, no new P2P protocol version is needed. All that was needed was to add the calculation and normalize epoch time. Previous versions of `leap` did not specify duration resolution of `time_since_epoch`. Some clients returned microsecond values and others returned nanosecond values. Included in this PR is a fix so that all `nodeos` going forward will return nanosecond values even if the resolution is only microseconds.

Resolves #1072 