### PR TITLE
Improve robustness of snapshot unit test

### DIFF
--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -89,7 +89,10 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
                      auto& pending = it->pending_snapshots;
                      if (pending.size()==1) {
                         auto pbn = pending.begin()->head_block_num;
-                        BOOST_CHECK_EQUAL(block_num,  spacing ?  (spacing + (pbn%spacing)) : pbn);
+                        pbn = spacing ?  (spacing + (pbn%spacing)) : pbn;
+                        // if snapshot scheduled with empty start_block_num depending on the timing
+                        // it can be scheduled either for block_num or block_num+1
+                        BOOST_CHECK(block_num==pbn || ((block_num+1)==pbn));                       
                      }
                      return true;
                   }


### PR DESCRIPTION
A recent change introduced in https://github.com/AntelopeIO/leap/pull/1220 changed snapshot scheduling logic in a way that when start block is not specified, snapshot is getting scheduled ASAP. Depending on exact moment of scheduling in tester it can be either current or next block. And the test was failing when next block was selected.

Python tests use api call instead of direct interface function and that API call safely schedules to + 1 block, so there is no issue in any of the python tests. 