### PR TITLE
[4.0 -> main] allow ROtrx threads unlimited time to start

### DIFF
--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -37,9 +37,13 @@ namespace eosio { namespace chain {
 
       /// Spawn threads, can be re-started after stop().
       /// Assumes start()/stop() called from the same thread or externally protected.
+      /// Blocks until all threads are created and completed their init function, or an exception is thrown
+      ///  during thread startup or an init function. Exceptions thrown during these stages are rethrown from start()
+      ///  but some threads might still have been started. Calling stop() after such a failure is safe.
       /// @param num_threads is number of threads spawned
       /// @param on_except is the function to call if io_context throws an exception, is called from thread pool thread.
-      ///                  if an empty function then logs and rethrows exception on thread which will terminate.
+      ///                  if an empty function then logs and rethrows exception on thread which will terminate. Not called
+      ///                  for exceptions during the init function (such exceptions are rethrown from start())
       /// @param init is an optional function to call at startup to initialize any data.
       /// @throw assert_exception if already started and not stopped.
       void start( size_t num_threads, on_except_t on_except, init_t init = {} ) {
@@ -47,9 +51,25 @@ namespace eosio { namespace chain {
          _ioc_work.emplace( boost::asio::make_work_guard( _ioc ) );
          _ioc.restart();
          _thread_pool.reserve( num_threads );
-         for( size_t i = 0; i < num_threads; ++i ) {
-            _thread_pool.emplace_back( std::thread( &named_thread_pool::run_thread, this, i, on_except, init )  );
+
+         std::promise<void> start_complete;
+         std::atomic<uint32_t> threads_remaining = num_threads;
+         std::exception_ptr pending_exception;
+         std::mutex pending_exception_mutex;
+
+         try {
+            for( size_t i = 0; i < num_threads; ++i ) {
+               _thread_pool.emplace_back( std::thread( &named_thread_pool::run_thread, this, i, on_except, init, std::ref(start_complete),
+                                                       std::ref(threads_remaining), std::ref(pending_exception), std::ref(pending_exception_mutex) ) );
+            }
          }
+         catch( ... ) {
+            /// only an exception from std::thread's ctor should end up here. shut down all threads to ensure no
+            ///  potential access to the promise, atomic, etc above performed after throwing out of start
+            stop();
+            throw;
+         }
+         start_complete.get_future().get();
       }
 
       /// destroy work guard, stop io_context, join thread_pool
@@ -63,16 +83,42 @@ namespace eosio { namespace chain {
       }
 
    private:
-      void run_thread( size_t i, const on_except_t& on_except, const init_t& init ) {
-         std::string tn = boost::core::demangle(typeid(this).name());
-         auto offset = tn.rfind("::");
-         if (offset != std::string::npos)
-            tn.erase(0, offset+2);
-         tn = tn.substr(0, tn.find('>')) + "-" + std::to_string( i );
+      void run_thread( size_t i, const on_except_t& on_except, const init_t& init, std::promise<void>& start_complete,
+                       std::atomic<uint32_t>& threads_remaining, std::exception_ptr& pending_exception, std::mutex& pending_exception_mutex ) {
+
+         std::string tn;
+
+         auto decrement_remaining = [&]() {
+            if( !--threads_remaining ) {
+               if( pending_exception )
+                  start_complete.set_exception( pending_exception );
+               else
+                  start_complete.set_value();
+            }
+         };
+
          try {
-            fc::set_os_thread_name( tn );
-            if ( init )
-               init();
+            try {
+               tn = boost::core::demangle(typeid(this).name());
+               auto offset = tn.rfind("::");
+               if (offset != std::string::npos)
+                  tn.erase(0, offset+2);
+               tn = tn.substr(0, tn.find('>')) + "-" + std::to_string( i );
+               fc::set_os_thread_name( tn );
+               if ( init )
+                  init();
+            } FC_LOG_AND_RETHROW()
+         }
+         catch( ... ) {
+            std::lock_guard<std::mutex> l( pending_exception_mutex );
+            pending_exception = std::current_exception();
+            decrement_remaining();
+            return;
+         }
+
+         decrement_remaining();
+
+         try {
             _ioc.run();
          } catch( const fc::exception& e ) {
             if( on_except ) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1329,7 +1329,6 @@ void producer_plugin_impl::plugin_startup() {
          }
 
          if (_ro_thread_pool_size > 0) {
-            std::atomic<uint32_t> num_threads_started = 0;
             _ro_thread_pool.start(
                _ro_thread_pool_size,
                [](const fc::exception& e) {
@@ -1338,20 +1337,7 @@ void producer_plugin_impl::plugin_startup() {
                },
                [&]() {
                   chain.init_thread_local_data();
-                  ++num_threads_started;
                });
-
-            // This will be changed with std::latch or std::atomic<>::wait
-            // when C++20 is used.
-            auto           time_slept_ms     = 0;
-            constexpr auto max_time_slept_ms = 1000;
-            while (num_threads_started.load() < _ro_thread_pool_size && time_slept_ms < max_time_slept_ms) {
-               std::this_thread::sleep_for(1ms);
-               ++time_slept_ms;
-            }
-            EOS_ASSERT(num_threads_started.load() == _ro_thread_pool_size, producer_exception,
-                       "read-only threads failed to start. num_threads_started: ${n}, time_slept_ms: ${t}ms",
-                       ("n", num_threads_started.load())("t", time_slept_ms));
 
             start_write_window();
          }


### PR DESCRIPTION
main merge of #1221 

> This change comes about due to investigation of #1216: for some reason in those logs the ROtrx threads were taking a very long time to start and the previous implementation would error out if the threads weren't started within a second.
> 
> afaict the only reason to allow a maximum of 1 second previously was simply a proxy to make sure they all started up successfully (a `chain.init_thread_local_data()` that threw would have not run `++num_threads_started`).
> 
> Refactor `named_thread_pool::start()` to simply wait forever for all the threads to complete their init (no matter if `chain.init_thread_local_data()` threw or not); and then if any init _did_ throw, rethrow one of those exceptions inside of `named_thread_pool::start()`.
> 
> Unfortunately it's worth noting during my testing of this change I discovered that the primary/likely reason this thread init will fail is uncatchable,
> 
> https://github.com/AntelopeIO/leap/blob/db132c5fd44e0b1c492e46e3f51e185cd5c59ed0/libraries/chain/include/eosio/chain/wasm_interface_private.hpp#L64