### PR TITLE
[4.0 -> main] SHiP: Fix state-history-log-retain-blocks option handling

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -358,7 +358,7 @@ void state_history_plugin_impl::plugin_initialize(const variables_map& options) 
 
       state_history_log_config ship_log_conf;
       if (options.count("state-history-log-retain-blocks")) {
-         auto ship_log_prune_conf = ship_log_conf.emplace<state_history::prune_config>();
+         auto& ship_log_prune_conf = ship_log_conf.emplace<state_history::prune_config>();
          ship_log_prune_conf.prune_blocks = options.at("state-history-log-retain-blocks").as<uint32_t>();
          //the arbitrary limit of 1000 here is mainly so that there is enough buffer for newly applied forks to be delivered to clients
          // before getting pruned out. ideally pruning would have been smart enough to know not to prune reversible blocks

--- a/plugins/state_history_plugin/tests/plugin_config_test.cpp
+++ b/plugins/state_history_plugin/tests/plugin_config_test.cpp
@@ -21,3 +21,20 @@ BOOST_AUTO_TEST_CASE(state_history_plugin_default_tests) {
    BOOST_REQUIRE(config);
    BOOST_CHECK_EQUAL(config->max_retained_files, UINT32_MAX);
 }
+
+BOOST_AUTO_TEST_CASE(state_history_plugin_retain_blocks_tests) {
+   fc::temp_directory  tmp;
+   appbase::scoped_app app;
+
+   auto tmp_path = tmp.path().string();
+   std::array args = {"test_state_history",    "--trace-history", "--state-history-log-retain-blocks", "4242",
+                      "--disable-replay-opts", "--data-dir",      tmp_path.c_str()};
+
+   BOOST_CHECK(app->initialize<eosio::state_history_plugin>(args.size(), const_cast<char**>(args.data())));
+   auto& plugin = app->get_plugin<eosio::state_history_plugin>();
+
+   BOOST_REQUIRE(plugin.trace_log());
+   auto* config = std::get_if<eosio::state_history::prune_config>(&plugin.trace_log()->config());
+   BOOST_REQUIRE(config);
+   BOOST_CHECK_EQUAL(config->prune_blocks, 4242);
+}


### PR DESCRIPTION
Fix the handling of `state_history_plugin` option `state-history-log-retain-blocks` which was broken in 4.0.

Merges `release/4.0` #1241 into `main`
Resolves #1217 