### PR TITLE
Cleanup pimpl idiom for `net_plugin`

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -383,7 +383,7 @@ namespace eosio {
       bool any_of_block_connections(UnaryPredicate&& p) const;
    };
 
-   class net_plugin_impl : public std::enable_shared_from_this<net_plugin_impl>, // 
+   class net_plugin_impl : public std::enable_shared_from_this<net_plugin_impl>,
                            public auto_bp_peering::bp_connection_manager<net_plugin_impl, connection> {
     public:
       std::atomic<uint32_t>            current_connection_id{0};
@@ -4000,8 +4000,6 @@ namespace eosio {
    }
 
    void net_plugin_impl::plugin_startup() {
-      try {
-
       fc_ilog( logger, "my node_id is ${id}", ("id", node_id ));
 
       producer_plug = app().find_plugin<producer_plugin>();
@@ -4081,12 +4079,6 @@ namespace eosio {
          my->update_chain_info();
          my->connections.connect_supplied_peers();
       });
-
-      } catch( ... ) {
-         // always want plugin_shutdown even on exception
-         plugin_shutdown();
-         throw;
-      }
    }
 
    void net_plugin::plugin_initialize( const variables_map& options ) {


### PR DESCRIPTION
Normally, for the pimpl idiom, the implementation resides in the private class, in our case `net_plugin_impl`.

Before this change, `plugin_initialize` and `plugin_startup` were defined in `net_plugin`, dereferencing members from `net_plugin_impl` through the `my` pointer.

This PR does not change what the code does, it should be 100% equivalent to what was there before (besides `handle_sigup()` being out of the try/catch block which I believe is inconsequential), however it moves the two member functions implementation within the `net_plugin_impl` class.

Also cleaned up `connection::_close()` which doesn't need to be static.