### PR TITLE
Add harden flags to pinned builds

### DIFF
--- a/scripts/pinned_toolchain.cmake
+++ b/scripts/pinned_toolchain.cmake
@@ -10,6 +10,9 @@ set(CMAKE_C_FLAGS_INIT "-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie")
 set(CMAKE_CXX_FLAGS_INIT "-nostdinc++ -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie")
 
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-stdlib=libc++ -nostdlib++ -pie")
+if(NOT APPLE)
+   string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT " -Wl,-z,relro,-z,now")
+endif()
 
 set(CMAKE_SHARED_LINKER_FLAGS_INIT "-stdlib=libc++ -nostdlib++")
 set(CMAKE_MODULE_LINKER_FLAGS_INIT "-stdlib=libc++ -nostdlib++")


### PR DESCRIPTION
Resolves #1238 

see [Relocation Read-Only (RELRO) doc](https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro).

Added back the same code that was in EOSIO 2.0, and verified that the pinned build works with this option on an ubuntu 22.04 VM.

```
...
123/129 Test   #96: snapshot_unit_test_eos-vm-oc .......................   Passed   23.22 sec
124/129 Test  #114: wasm_unit_test_eos-vm-oc ...........................   Passed   36.74 sec
125/129 Test   #18: api_unit_test_eos-vm-oc ............................   Passed   45.76 sec
126/129 Test   #13: test_resmon_plugin .................................   Passed   67.01 sec
127/129 Test  #111: wasm_config_unit_test_eos-vm-oc ....................   Passed   83.64 sec
128/129 Test #2046: trx_generator_tests ................................   Passed   92.57 sec
129/129 Test #2012: db_modes_test ......................................   Passed  130.15 sec

100% tests passed, 0 tests failed out of 129

Total Test time (real) = 130.18 sec
root@fc396b89b326:/leap/build# cat ../scripts/pinned_toolchain.cmake 
set(CLANG_DIR $ENV{CLANG_DIR})
set(CMAKE_C_COMPILER_WORKS 1)
set(CMAKE_CXX_COMPILER_WORKS 1)
set(CMAKE_C_COMPILER ${CLANG_DIR}/bin/clang)
set(CMAKE_CXX_COMPILER ${CLANG_DIR}/bin/clang++)

set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CLANG_DIR}/include/c++/v1 /usr/local/include /usr/include)

set(CMAKE_C_FLAGS_INIT "-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie")
set(CMAKE_CXX_FLAGS_INIT "-nostdinc++ -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie")

set(CMAKE_EXE_LINKER_FLAGS_INIT "-stdlib=libc++ -nostdlib++ -pie")
if(NOT APPLE)
   string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT " -Wl,-z,relro,-z,now")
endif()

set(CMAKE_SHARED_LINKER_FLAGS_INIT "-stdlib=libc++ -nostdlib++")
set(CMAKE_MODULE_LINKER_FLAGS_INIT "-stdlib=libc++ -nostdlib++")
set(CMAKE_CXX_STANDARD_LIBRARIES "${CLANG_DIR}/lib/libc++.a ${CLANG_DIR}/lib/libc++abi.a")
```

