### PR TITLE
[3.2] Output-dir should be required for extract-blocks subcommand of leap-util

### DIFF
--- a/programs/leap-util/actions/blocklog.cpp
+++ b/programs/leap-util/actions/blocklog.cpp
@@ -88,7 +88,7 @@ void blocklog_actions::setup(CLI::App& app) {
    extract_blocks->add_option("--blocks-dir", opt->blocks_dir, "The location of the blocks directory (absolute path or relative to the current directory).");
    extract_blocks->add_option("--first,-f", opt->first_block, "The first block number to keep.")->required();
    extract_blocks->add_option("--last,-l", opt->last_block, "The last block number to keep.")->required();
-   extract_blocks->add_option("--output-dir", opt->output_dir, "The output directory for the block log extracted from blocks-dir.");
+   extract_blocks->add_option("--output-dir", opt->output_dir, "The output directory for the block log extracted from blocks-dir.")->required();
 
    // subcommand - smoke test
    auto* smoke_test = sub->add_subcommand("smoke-test", "Quick test that blocks.log and blocks.index are well formed and agree with each other.")->callback([err_guard]() { err_guard(&blocklog_actions::smoke_test); });


### PR DESCRIPTION
This PR addresses https://github.com/AntelopeIO/leap/issues/1239, in particular fact that multiple sub-commands under "blocklog" produce output in output-dir and it has no default value, so it should be mandatory to request this value from user.