### PR TITLE
[3.2] fix `i256` key type conversion by initialize buffer before usage

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -821,7 +821,7 @@ public:
             // the following will convert the input to array of 2 uint128_t in little endian, i.e. 50f0fa8360ec998f4bb65b00c86282f5 fb54b91bfed2fe7fe39a92d999d002c5
             // which is the format used by secondary index
             chain::key256_t k;
-            uint8_t buffer[32];
+            uint8_t buffer[32] = {};
             boost::multiprecision::export_bits(v, buffer, 8, false);
             memcpy(&k[0], buffer + 16, 16);
             memcpy(&k[1], buffer, 16);


### PR DESCRIPTION
Thanks @learnforpractice. Back port of #1252 to `release/3.2`

fix `i256` key type conversion by initialize buffer before usage

`export_bits` doesn't fill every byte in the buffer, need to ensure that 'buffer' is initialized before usage:

https://github.com/boostorg/multiprecision/blob/5f81a78cdb38ea35f98ef7a655d2535773c1261b/include/boost/multiprecision/cpp_int/import_export.hpp#L236
