### PR TITLE
[4.0] P2P excessive logging caused by message spamming

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1935,7 +1935,12 @@ namespace eosio {
                verify_catchup( c, msg.known_blocks.pending, id );
             } else {
                // we already have the block, so update peer with our view of the world
-               c->send_handshake();
+               auto chain_info = my_impl->get_chain_info();
+               std::unique_lock g_conn( c->conn_mtx );
+               if (chain_info.head_id != c->last_handshake_sent.head_id) { // no need to send handshake if nothing new to report
+                  g_conn.unlock();
+                  c->send_handshake();
+               }
             }
          }
       } else if (msg.known_blocks.mode == last_irr_catch_up) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1966,6 +1966,7 @@ namespace eosio {
          c->close();
       } else {
          g.unlock();
+         peer_dlog(c, "rejected block ${bn}, sending handshake", ("bn", blk_num));
          c->send_handshake();
       }
    }
@@ -3061,13 +3062,11 @@ namespace eosio {
       switch (msg.known_trx.mode) {
       case none:
          break;
-      case last_irr_catch_up: {
+      case last_irr_catch_up:
+      case catch_up : {
          std::unique_lock<std::mutex> g_conn( conn_mtx );
          last_handshake_recv.head_num = msg.known_blocks.pending;
          g_conn.unlock();
-         break;
-      }
-      case catch_up : {
          break;
       }
       case normal: {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -743,7 +743,7 @@ namespace eosio {
        * day routine and converts to a (at least) 64 bit integer.
        */
       static tstamp get_time() {
-         return std::chrono::system_clock::now().time_since_epoch().count();
+         return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
       }
       /** @} */
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -605,7 +605,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          // push the new block
          auto handle_error = [&](const auto& e)
          {
-            elog((e.to_detail_string()));
+            elog("Exception on block ${bn}: ${e}", ("bn", blk_num)("e", e.to_detail_string()));
             app().get_channel<channels::rejected_block>().publish( priority::medium, block );
             throw;
          };


### PR DESCRIPTION
Two main issues resolved by this PR.
* "Infinite" loop of `notice_message` <-> `handshake_message` when clock skew. The clock skew caused peer to keep trying to inform other that it has the blocks already.
* Handshakes were being sent to every peer anytime any peer connection was closed. This was introduced in 4.0.1 by #1171. This PR handles this case better by resetting `sync_next_expected_num` on rejected block instead of spamming all connections with handshakes.

These issues were already fixed in `main` by work on #1072.

Additional fixes in this PR backported from #1072 work:
* Includes fix for using `nanoseconds` resolution for `time_message`.
* Update known head block on `catch_up` `notice_message`. The information is provided might as well use it instead of waiting for a `handshake_message`.

Resolves #1240 