### PR TITLE
Update net_plugin to support clang Thread Safety Analysis features

### DIFF
--- a/libraries/libfc/include/fc/mutex.hpp
+++ b/libraries/libfc/include/fc/mutex.hpp
@@ -167,13 +167,15 @@ public:
       mut->lock();
    }
 
+#if 0
    unique_lock(unique_lock&& o) noexcept ACQUIRE(o) 
       : mut(o.mut)
       , locked(o.locked) {
       o.locked = false;
       o.mut = nullptr;
    }
-
+#endif
+      
    // Assume mu is held, implicitly acquire *this and associate it with mu.
       unique_lock(M& mu, adopt_lock_t) REQUIRES(mu)
       : mut(&mu)

--- a/libraries/libfc/include/fc/mutex.hpp
+++ b/libraries/libfc/include/fc/mutex.hpp
@@ -161,13 +161,6 @@ public:
       mut->lock();
    }
 
-   unique_lock(unique_lock&& o) noexcept ACQUIRE(o) 
-      : mut(o.mut)
-      , locked(o.locked) {
-      o.locked = false;
-      o.mut = nullptr;
-   }
-      
    // Assume mu is held, implicitly acquire *this and associate it with mu.
    unique_lock(M& mu, adopt_lock_t) REQUIRES(mu)
       : mut(&mu)

--- a/libraries/libfc/include/fc/mutex.hpp
+++ b/libraries/libfc/include/fc/mutex.hpp
@@ -1,5 +1,4 @@
-#ifndef THREAD_SAFETY_ANALYSIS_MUTEX_HPP
-#define THREAD_SAFETY_ANALYSIS_MUTEX_HPP
+#pragma once
 
 // Enable thread safety attributes only with clang.
 // The attributes can be safely erased when compiling with other compilers.
@@ -162,14 +161,12 @@ public:
       mut->lock();
    }
 
-#if 0
    unique_lock(unique_lock&& o) noexcept ACQUIRE(o) 
       : mut(o.mut)
       , locked(o.locked) {
       o.locked = false;
       o.mut = nullptr;
    }
-#endif
       
    // Assume mu is held, implicitly acquire *this and associate it with mu.
    unique_lock(M& mu, adopt_lock_t) REQUIRES(mu)
@@ -218,5 +215,3 @@ public:
 };
 
 } // namespace fc
-
-#endif // THREAD_SAFETY_ANALYSIS_MUTEX_HPP

--- a/libraries/libfc/include/fc/mutex.hpp
+++ b/libraries/libfc/include/fc/mutex.hpp
@@ -115,14 +115,9 @@ public:
 };
 
 // Tag types for selecting a constructor.
-struct adopt_lock_t {
-} inline constexpr adopt_lock = {};
-struct defer_lock_t {
-} inline constexpr defer_lock = {};
-struct shared_lock_t {
-} inline constexpr shared_lock = {};
-struct try_to_lock_t {
-} inline constexpr try_to_lock = {};
+struct adopt_lock_t {} inline constexpr adopt_lock = {};
+struct defer_lock_t {} inline constexpr defer_lock = {};
+struct shared_lock_t {} inline constexpr shared_lock = {};
 
 // LockGuard is an RAII class that acquires a mutex in its constructor, and
 // releases it in its destructor.
@@ -177,7 +172,7 @@ public:
 #endif
       
    // Assume mu is held, implicitly acquire *this and associate it with mu.
-      unique_lock(M& mu, adopt_lock_t) REQUIRES(mu)
+   unique_lock(M& mu, adopt_lock_t) REQUIRES(mu)
       : mut(&mu)
       , locked(true) {}
 

--- a/libraries/libfc/include/fc/mutex.hpp
+++ b/libraries/libfc/include/fc/mutex.hpp
@@ -1,0 +1,225 @@
+#ifndef THREAD_SAFETY_ANALYSIS_MUTEX_HPP
+#define THREAD_SAFETY_ANALYSIS_MUTEX_HPP
+
+// Enable thread safety attributes only with clang.
+// The attributes can be safely erased when compiling with other compilers.
+#if defined(__clang__) && (!defined(SWIG))
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) __attribute__((x))
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) // no-op
+#endif
+
+#define CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+#define SCOPED_CAPABILITY THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+#define GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+#define PT_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+
+#define ACQUIRED_BEFORE(...) THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+
+#define ACQUIRED_AFTER(...) THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+
+#define REQUIRES(...) THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+#define REQUIRES_SHARED(...) THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
+#define ACQUIRE(...) THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+
+#define ACQUIRE_SHARED(...) THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+
+#define RELEASE(...) THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+
+#define RELEASE_SHARED(...) THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+
+#define RELEASE_GENERIC(...) THREAD_ANNOTATION_ATTRIBUTE__(release_generic_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE(...) THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE_SHARED(...) THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+
+#define EXCLUDES(...) THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+#define ASSERT_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+
+#define ASSERT_SHARED_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
+
+#define RETURN_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+#define NO_THREAD_SAFETY_ANALYSIS THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+#include <mutex>
+#include <shared_mutex>
+
+namespace fc {
+
+// Defines an annotated interface for mutexes.
+// These methods can be implemented to use any internal mutex implementation.
+class CAPABILITY("mutex") mutex {
+private:
+   std::mutex mutex_;
+
+public:
+   // Acquire/lock this mutex exclusively.  Only one thread can have exclusive
+   // access at any one time.  Write operations to guarded data require an
+   // exclusive lock.
+   void lock() ACQUIRE() { mutex_.lock(); }
+
+   // Release/unlock an exclusive mutex.
+   void unlock() RELEASE() { mutex_.unlock(); }
+
+   // Try to acquire the mutex.  Returns true on success, and false on failure.
+   bool try_lock() TRY_ACQUIRE(true) { return mutex_.try_lock(); }
+};
+
+// Defines an annotated interface for mutexes.
+// These methods can be implemented to use any internal mutex implementation.
+class CAPABILITY("shared_mutex") shared_mutex {
+private:
+   std::shared_mutex mutex_;
+
+public:
+   // Acquire/lock this mutex exclusively.  Only one thread can have exclusive
+   // access at any one time.  Write operations to guarded data require an
+   // exclusive lock.
+   void lock() ACQUIRE() { mutex_.lock(); }
+
+   // Acquire/lock this mutex for read operations, which require only a shared
+   // lock.  This assumes a multiple-reader, single writer semantics.  Multiple
+   // threads may acquire the mutex simultaneously as readers, but a writer
+   // must wait for all of them to release the mutex before it can acquire it
+   // exclusively.
+   void lock_shared() ACQUIRE_SHARED() { mutex_.lock_shared(); }
+
+   // Release/unlock an exclusive mutex.
+   void unlock() RELEASE() { mutex_.unlock(); }
+
+   // Release/unlock a shared mutex.
+   void unlock_shared() RELEASE_SHARED() { mutex_.unlock_shared(); }
+
+   // Try to acquire the mutex.  Returns true on success, and false on failure.
+   bool try_lock() TRY_ACQUIRE(true) { return mutex_.try_lock(); }
+
+   // Try to acquire the mutex for read operations.
+   bool try_lock_shared() TRY_ACQUIRE_SHARED(true) { return mutex_.try_lock_shared(); }
+
+   // Assert that this mutex is currently held by the calling thread.
+   // void AssertHeld() ASSERT_CAPABILITY(this);
+
+   // Assert that is mutex is currently held for read operations.
+   // void AssertReaderHeld() ASSERT_SHARED_CAPABILITY(this);
+
+   // For negative capabilities.
+   // const Mutex& operator!() const { return *this; }
+};
+
+// Tag types for selecting a constructor.
+struct adopt_lock_t {
+} inline constexpr adopt_lock = {};
+struct defer_lock_t {
+} inline constexpr defer_lock = {};
+struct shared_lock_t {
+} inline constexpr shared_lock = {};
+struct try_to_lock_t {
+} inline constexpr try_to_lock = {};
+
+// LockGuard is an RAII class that acquires a mutex in its constructor, and
+// releases it in its destructor.
+template <typename M>
+class SCOPED_CAPABILITY lock_guard {
+private:
+   M& mut;
+
+public:
+   // Acquire mu, implicitly acquire *this and associate it with mu.
+   lock_guard(M& mu) ACQUIRE(mu)
+      : mut(mu) {
+      mu.lock();
+   }
+
+   // Assume mu is held, implicitly acquire *this and associate it with mu.
+   lock_guard(M& mu, adopt_lock_t) REQUIRES(mu)
+      : mut(mu) {}
+
+   ~lock_guard() RELEASE() { mut.unlock(); }
+};
+
+// unique_lock is an RAII class that acquires a mutex in its constructor, and
+// releases it in its destructor.
+template <typename M>
+class SCOPED_CAPABILITY unique_lock {
+private:
+   using mutex_type = M;
+
+   M*   mut;
+   bool locked;
+
+public:
+   unique_lock() noexcept
+      : mut(nullptr)
+      , locked(false) {}
+
+   // Acquire mu, implicitly acquire *this and associate it with mu.
+   explicit unique_lock(M& mu) ACQUIRE(mu)
+      : mut(&mu)
+      , locked(true) {
+      mut->lock();
+   }
+
+   unique_lock(unique_lock&& o) noexcept 
+      : mut(o.mut)
+      , locked(o.locked) {
+      o.locked = false;
+      o.mut = nullptr;
+   }
+
+   // Assume mu is held, implicitly acquire *this and associate it with mu.
+      unique_lock(M& mu, adopt_lock_t) REQUIRES(mu)
+      : mut(&mu)
+      , locked(true) {}
+
+   // Assume mu is not held, implicitly acquire *this and associate it with mu.
+   unique_lock(M& mu, defer_lock_t) EXCLUDES(mu)
+      : mut(mu)
+      , locked(false) {}
+
+   // Release *this and all associated mutexes, if they are still held.
+   // There is no warning if the scope was already unlocked before.
+   ~unique_lock() RELEASE() {
+      if (locked)
+         mut->unlock();
+   }
+
+   // Acquire all associated mutexes exclusively.
+   void lock() ACQUIRE() {
+      mut->lock();
+      locked = true;
+   }
+
+   // Try to acquire all associated mutexes exclusively.
+   bool try_lock() TRY_ACQUIRE(true) { return locked = mut->try_lock(); }
+
+   // Release all associated mutexes. Warn on double unlock.
+   void unlock() RELEASE() {
+      mut->unlock();
+      locked = false;
+   }
+
+   mutex_type* release() noexcept {
+      mutex_type* res = mut;
+      mut             = nullptr;
+      locked          = false;
+      return res;
+   }
+
+   mutex_type* mutex() const noexcept { return mut; }
+
+   bool owns_lock() const noexcept { return locked; }
+
+   explicit operator bool() const noexcept { return locked; }
+};
+
+} // namespace fc
+
+#endif // THREAD_SAFETY_ANALYSIS_MUTEX_HPP

--- a/libraries/libfc/include/fc/mutex.hpp
+++ b/libraries/libfc/include/fc/mutex.hpp
@@ -167,7 +167,7 @@ public:
       mut->lock();
    }
 
-   unique_lock(unique_lock&& o) noexcept 
+   unique_lock(unique_lock&& o) noexcept ACQUIRE(o) 
       : mut(o.mut)
       , locked(o.locked) {
       o.locked = false;
@@ -206,7 +206,7 @@ public:
       locked = false;
    }
 
-   mutex_type* release() noexcept {
+   mutex_type* release() noexcept RETURN_CAPABILITY(this) {
       mutex_type* res = mut;
       mut             = nullptr;
       locked          = false;

--- a/plugins/net_plugin/CMakeLists.txt
+++ b/plugins/net_plugin/CMakeLists.txt
@@ -3,6 +3,10 @@ add_library( net_plugin
              net_plugin.cpp
              ${HEADERS} )
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(net_plugin PUBLIC -Wthread-safety)
+endif()
+
 target_link_libraries( net_plugin chain_plugin producer_plugin appbase fc )
 target_include_directories( net_plugin PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/../chain_interface/include  "${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/appbase/include")
 

--- a/plugins/net_plugin/CMakeLists.txt
+++ b/plugins/net_plugin/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library( net_plugin
              net_plugin.cpp
              ${HEADERS} )
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0)
   target_compile_options(net_plugin PUBLIC -Wthread-safety)
 endif()
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -227,7 +227,7 @@ namespace eosio {
       constexpr static auto stage_str( stages s );
       bool set_state( stages newstate );
       bool is_sync_required( uint32_t fork_head_block_num );
-      void request_next_chunk( fc::mutex *m, const connection_ptr& conn = connection_ptr() ) RELEASE(sync_mtx);
+      void request_next_chunk( const connection_ptr& conn = connection_ptr() ) RELEASE(sync_mtx);
       connection_ptr find_next_sync_node();
       void start_sync( const connection_ptr& c, uint32_t target );
       bool verify_catchup( const connection_ptr& c, uint32_t num, const block_id_type& id );
@@ -1867,7 +1867,8 @@ namespace eosio {
             // if starting to sync need to always start from lib as we might be on our own fork
             uint32_t lib_num = my_impl->get_chain_lib_num();
             sync_next_expected_num = std::max( lib_num + 1, sync_next_expected_num );
-            request_next_chunk( g.release() );
+            g.release();
+            request_next_chunk();
          }
       }
    }
@@ -1922,7 +1923,7 @@ namespace eosio {
    }
 
    // call with g_sync locked, called from conn's connection strand
-   void sync_manager::request_next_chunk( fc::mutex *, const connection_ptr& conn ) RELEASE(sync_mtx) {
+   void sync_manager::request_next_chunk( const connection_ptr& conn ) RELEASE(sync_mtx) {
       fc::lock_guard g(sync_mtx, fc::adopt_lock);
       auto chain_info = my_impl->get_chain_info();
 
@@ -2021,7 +2022,8 @@ namespace eosio {
       }
       sync_next_expected_num = std::max( chain_info.lib_num + 1, sync_next_expected_num );
 
-      request_next_chunk( g_sync.release(), c );
+      g_sync.release();
+      request_next_chunk( c );
    }
 
    // called from connection strand
@@ -2033,7 +2035,8 @@ namespace eosio {
       if( c == sync_source ) {
          c->cancel_sync(reason);
          sync_last_requested_num = 0;
-         request_next_chunk( g.release() );
+         g.release();
+         request_next_chunk();
       }
    }
 
@@ -2318,7 +2321,8 @@ namespace eosio {
                if (sync_next_expected_num > sync_last_requested_num && sync_last_requested_num < sync_known_lib_num) {
                   fc_dlog(logger, "Requesting range ahead, head: ${h} blk_num: ${bn} sync_next_expected_num ${nen} sync_last_requested_num: ${lrn}",
                           ("h", head)("bn", blk_num)("nen", sync_next_expected_num)("lrn", sync_last_requested_num));
-                  request_next_chunk(g_sync.release());
+                  g_sync.release();
+                  request_next_chunk();
                }
             }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1876,7 +1876,9 @@ namespace eosio {
       fc_dlog(logger, "Number connections ${s}, sync_next_expected_num: ${e}, sync_known_lib_num: ${l}",
               ("s", my_impl->connections.number_connections())("e", sync_next_expected_num)("l", sync_known_lib_num));
       deque<connection_ptr> conns;
-      my_impl->connections.for_each_block_connection([&](const auto& c) REQUIRES(sync_mtx) {
+      my_impl->connections.for_each_block_connection([sync_next_expected_num = sync_next_expected_num,
+                                                      sync_known_lib_num = sync_known_lib_num,
+                                                      &conns](const auto& c) {
          if (c->should_sync_from(sync_next_expected_num, sync_known_lib_num)) {
             conns.push_back(c);
          }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -842,7 +842,7 @@ namespace eosio {
       boost::asio::steady_timer        response_expected_timer GUARDED_BY(response_expected_timer_mtx);
 
       alignas(hardware_destructive_interference_size)
-      std::atomic<go_away_reason>           no_retry{no_reason};
+      std::atomic<go_away_reason>      no_retry{no_reason};
 
       alignas(hardware_destructive_interference_size)
       mutable fc::mutex                conn_mtx; //< mtx for last_req .. remote_endpoint_ip

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -216,8 +216,8 @@ namespace eosio {
       uint32_t       sync_next_expected_num  GUARDED_BY(sync_mtx) {0};  // the next block number we need from peer
       connection_ptr sync_source             GUARDED_BY(sync_mtx);      // connection we are currently syncing from
 
-      const uint32_t sync_req_span           GUARDED_BY(sync_mtx) {0};
-      const uint32_t sync_peer_limit         GUARDED_BY(sync_mtx) {0};
+      const uint32_t sync_req_span {0};
+      const uint32_t sync_peer_limit {0};
 
       alignas(hardware_destructive_interference_size)
       std::atomic<stages> sync_state{in_sync};

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -845,14 +845,14 @@ namespace eosio {
       std::atomic<go_away_reason>           no_retry{no_reason};
 
       alignas(hardware_destructive_interference_size)
-      mutable std::mutex               conn_mtx; //< mtx for last_req .. remote_endpoint_ip
-      std::optional<request_message>   last_req;
-      handshake_message                last_handshake_recv;
-      handshake_message                last_handshake_sent;
-      block_id_type                    fork_head;
-      uint32_t                         fork_head_num{0};
-      fc::time_point                   last_close;
-      string                           remote_endpoint_ip;
+      mutable fc::mutex                conn_mtx; //< mtx for last_req .. remote_endpoint_ip
+      std::optional<request_message>   last_req            GUARDED_BY(conn_mtx);
+      handshake_message                last_handshake_recv GUARDED_BY(conn_mtx);
+      handshake_message                last_handshake_sent GUARDED_BY(conn_mtx);
+      block_id_type                    fork_head           GUARDED_BY(conn_mtx);
+      uint32_t                         fork_head_num       GUARDED_BY(conn_mtx) {0};
+      fc::time_point                   last_close          GUARDED_BY(conn_mtx);
+      string                           remote_endpoint_ip  GUARDED_BY(conn_mtx);
 
       connection_status get_status()const;
 
@@ -1004,7 +1004,7 @@ namespace eosio {
       bool incoming() const { return peer_address().empty(); } // thread safe becuase of peer_address
       bool incoming_and_handshake_received() const {
          if (!incoming()) return false;
-         std::lock_guard g_conn( conn_mtx );
+         fc::lock_guard g_conn( conn_mtx );
          return !last_handshake_recv.p2p_address.empty();
       }
    }; // class connection
@@ -1160,7 +1160,7 @@ namespace eosio {
       log_remote_endpoint_port = ec ? unknown : std::to_string(rep.port());
       local_endpoint_ip = ec2 ? unknown : lep.address().to_string();
       local_endpoint_port = ec2 ? unknown : std::to_string(lep.port());
-      std::lock_guard g_conn( conn_mtx );
+      fc::lock_guard g_conn( conn_mtx );
       remote_endpoint_ip = log_remote_endpoint_ip;
    }
 
@@ -1212,7 +1212,7 @@ namespace eosio {
       stat.connecting = state() == connection_state::connecting;
       stat.syncing = peer_syncing_from_us;
       stat.is_bp_peer = is_bp_connection;
-      std::lock_guard g( conn_mtx );
+      fc::lock_guard g( conn_mtx );
       stat.last_handshake = last_handshake_recv;
       return stat;
    }
@@ -1297,7 +1297,7 @@ namespace eosio {
       ++self->consecutive_immediate_connection_close;
       bool has_last_req = false;
       {
-         std::lock_guard g_conn( self->conn_mtx );
+         fc::lock_guard g_conn( self->conn_mtx );
          has_last_req = self->last_req.has_value();
          self->last_handshake_recv = handshake_message();
          self->last_handshake_sent = handshake_message();
@@ -1335,7 +1335,7 @@ namespace eosio {
       }
 
       if( logger.is_enabled( fc::log_level::debug ) ) {
-         std::unique_lock g_conn( conn_mtx );
+         fc::unique_lock g_conn( conn_mtx );
          if( last_handshake_recv.generation >= 1 ) {
             peer_dlog( this, "maybe truncating branch at = ${h}:${id}",
                        ("h", block_header::num_from_id(last_handshake_recv.head_id))("id", last_handshake_recv.head_id) );
@@ -1414,7 +1414,7 @@ namespace eosio {
       if (closed())
          return;
       strand.post( [c = shared_from_this()]() {
-         std::unique_lock g_conn( c->conn_mtx );
+         fc::unique_lock g_conn( c->conn_mtx );
          if( c->populate_handshake( c->last_handshake_sent ) ) {
             static_assert( std::is_same_v<decltype( c->sent_handshake_count ), int16_t>, "INT16_MAX based on int16_t" );
             if( c->sent_handshake_count == INT16_MAX ) c->sent_handshake_count = 1; // do not wrap
@@ -1854,7 +1854,7 @@ namespace eosio {
          // Determine current LIB of remaining peers as our sync_known_lib_num.
          uint32_t highest_lib_num = 0;
          my_impl->connections.for_each_block_connection( [&highest_lib_num]( const auto& cc ) {
-            std::lock_guard g_conn( cc->conn_mtx );
+            fc::lock_guard g_conn( cc->conn_mtx );
             if( cc->current() && cc->last_handshake_recv.last_irreversible_block_num > highest_lib_num ) {
                highest_lib_num = cc->last_handshake_recv.last_irreversible_block_num;
             }
@@ -2159,7 +2159,7 @@ namespace eosio {
       request_message req;
       req.req_blocks.mode = catch_up;
       auto is_fork_head_greater = [num, &id, &req]( const auto& cc ) {
-         std::lock_guard g_conn( cc->conn_mtx );
+         fc::lock_guard g_conn( cc->conn_mtx );
          if( cc->fork_head_num > num || cc->fork_head == id ) {
             req.req_blocks.mode = none;
             return true;
@@ -2182,7 +2182,7 @@ namespace eosio {
             return false;
          set_state( head_catchup );
          {
-            std::lock_guard g_conn( c->conn_mtx );
+            fc::lock_guard g_conn( c->conn_mtx );
             c->fork_head = id;
             c->fork_head_num = num;
          }
@@ -2191,7 +2191,7 @@ namespace eosio {
       } else {
          peer_ilog( c, "none notice while in ${s}, fork head num = ${fhn}, id ${id}...",
                   ("s", stage_str( sync_state ))("fhn", num)("id", id.str().substr(8,16)) );
-         std::lock_guard g_conn( c->conn_mtx );
+         fc::lock_guard g_conn( c->conn_mtx );
          c->fork_head = block_id_type();
          c->fork_head_num = 0;
       }
@@ -2223,7 +2223,7 @@ namespace eosio {
       } else if (msg.known_blocks.mode == last_irr_catch_up) {
          {
             c->peer_lib_num = msg.known_trx.pending;
-            std::lock_guard g_conn( c->conn_mtx );
+            fc::lock_guard g_conn( c->conn_mtx );
             c->last_handshake_recv.last_irreversible_block_num = msg.known_trx.pending;
          }
          sync_reset_lib_num(c, false);
@@ -2270,14 +2270,14 @@ namespace eosio {
          block_id_type null_id;
          bool set_state_to_head_catchup = false;
          my_impl->connections.for_each_block_connection( [&null_id, blk_num, &blk_id, &c, &set_state_to_head_catchup]( const auto& cp ) {
-            std::unique_lock g_cp_conn( cp->conn_mtx );
+            fc::unique_lock g_cp_conn( cp->conn_mtx );
             uint32_t fork_head_num = cp->fork_head_num;
             block_id_type fork_head_id = cp->fork_head;
             g_cp_conn.unlock();
             if( fork_head_id == null_id ) {
                // continue
             } else if( fork_head_num < blk_num || fork_head_id == blk_id ) {
-               std::lock_guard g_conn( c->conn_mtx );
+               fc::lock_guard g_conn( c->conn_mtx );
                c->fork_head = null_id;
                c->fork_head_num = 0;
             } else {
@@ -2445,7 +2445,7 @@ namespace eosio {
 
    // called from c's connection strand
    void dispatch_manager::recv_block(const connection_ptr& c, const block_id_type& id, uint32_t bnum) {
-      std::unique_lock g( c->conn_mtx );
+      fc::unique_lock g( c->conn_mtx );
       if (c &&
           c->last_req &&
           c->last_req->req_blocks.mode != none &&
@@ -2516,7 +2516,7 @@ namespace eosio {
       request_message last_req;
       block_id_type bid;
       {
-         std::lock_guard g_c_conn( c->conn_mtx );
+         fc::lock_guard g_c_conn( c->conn_mtx );
          if( !c->last_req ) {
             return;
          }
@@ -2535,7 +2535,7 @@ namespace eosio {
             return false;
 
          {
-            std::lock_guard guard( conn->conn_mtx );
+            fc::lock_guard guard( conn->conn_mtx );
             if( conn->last_req ) {
                return false;
             }
@@ -2546,7 +2546,7 @@ namespace eosio {
             conn->strand.post( [conn, last_req{std::move(last_req)}]() {
                conn->enqueue( last_req );
                conn->fetch_wait();
-               std::lock_guard g_conn_conn( conn->conn_mtx );
+               fc::lock_guard g_conn_conn( conn->conn_mtx );
                conn->last_req = last_req;
             } );
             return true;
@@ -2589,7 +2589,7 @@ namespace eosio {
 
       if( consecutive_immediate_connection_close > def_max_consecutive_immediate_connection_close || no_retry == benign_other ) {
          fc::microseconds connector_period = my_impl->connections.get_connector_period();
-         std::lock_guard g( c->conn_mtx );
+         fc::lock_guard g( conn_mtx );
          if( last_close == fc::time_point() || last_close > fc::time_point::now() - connector_period ) {
             return true; // true so doesn't remove from valid connections
          }
@@ -2669,7 +2669,7 @@ namespace eosio {
                if (conn->socket_is_open()) {
                   if (conn->peer_address().empty()) {
                      ++visitors;
-                     std::lock_guard g_conn(conn->conn_mtx);
+                     fc::lock_guard g_conn(conn->conn_mtx);
                      if (paddr_str == conn->remote_endpoint_ip) {
                         ++from_addr;
                      }
@@ -2890,7 +2890,7 @@ namespace eosio {
       if( !my_impl->sync_master->syncing_from_peer() ) { // guard against peer thinking it needs to send us old blocks
          uint32_t lib_num = my_impl->get_chain_lib_num();
          if( blk_num < lib_num ) {
-            std::unique_lock g( conn_mtx );
+            fc::unique_lock g( conn_mtx );
             const auto last_sent_lib = last_handshake_sent.last_irreversible_block_num;
             g.unlock();
             peer_ilog( this, "received block ${n} less than ${which}lib ${lib}",
@@ -3082,7 +3082,7 @@ namespace eosio {
 
       peer_lib_num = msg.last_irreversible_block_num;
       peer_head_block_num = msg.head_num;
-      std::unique_lock g_conn( conn_mtx );
+      fc::unique_lock g_conn( conn_mtx );
       last_handshake_recv = msg;
       g_conn.unlock();
 
@@ -3123,7 +3123,7 @@ namespace eosio {
             auto is_duplicate = [&](const auto& check) {
                if(check.get() == this)
                   return false;
-               std::unique_lock g_check_conn( check->conn_mtx );
+               fc::unique_lock g_check_conn( check->conn_mtx );
                fc_dlog( logger, "dup check: connected ${c}, ${l} =? ${r}",
                         ("c", check->connected())("l", check->last_handshake_recv.node_id)("r", msg.node_id) );
                if(check->connected() && check->last_handshake_recv.node_id == msg.node_id) {
@@ -3312,7 +3312,7 @@ namespace eosio {
       org = 0;
       rec = 0;
 
-      std::unique_lock g_conn( conn_mtx );
+      fc::unique_lock g_conn( conn_mtx );
       if( last_handshake_recv.generation == 0 ) {
          g_conn.unlock();
          send_handshake();
@@ -3343,7 +3343,7 @@ namespace eosio {
       case none:
          break;
       case last_irr_catch_up: {
-         std::unique_lock g_conn( conn_mtx );
+         fc::unique_lock g_conn( conn_mtx );
          last_handshake_recv.head_num = msg.known_blocks.pending;
          g_conn.unlock();
          break;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -211,13 +211,13 @@ namespace eosio {
 
       alignas(hardware_destructive_interference_size)
       fc::mutex      sync_mtx;
-      uint32_t       sync_known_lib_num  GUARDED_BY(sync_mtx) {0};       // highest known lib num from currently connected peers
+      uint32_t       sync_known_lib_num      GUARDED_BY(sync_mtx) {0};  // highest known lib num from currently connected peers
       uint32_t       sync_last_requested_num GUARDED_BY(sync_mtx) {0};  // end block number of the last requested range, inclusive
-      uint32_t       sync_next_expected_num GUARDED_BY(sync_mtx) {0};   // the next block number we need from peer
-      connection_ptr sync_source;                 // connection we are currently syncing from
+      uint32_t       sync_next_expected_num  GUARDED_BY(sync_mtx) {0};  // the next block number we need from peer
+      connection_ptr sync_source             GUARDED_BY(sync_mtx);      // connection we are currently syncing from
 
-      const uint32_t       sync_req_span GUARDED_BY(sync_mtx) {0};
-      const uint32_t       sync_peer_limit GUARDED_BY(sync_mtx) {0};
+      const uint32_t sync_req_span           GUARDED_BY(sync_mtx) {0};
+      const uint32_t sync_peer_limit         GUARDED_BY(sync_mtx) {0};
 
       alignas(hardware_destructive_interference_size)
       std::atomic<stages> sync_state{in_sync};

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1989,7 +1989,6 @@ namespace eosio {
       }
       if( !request_sent ) {
          sync_source.reset();
-         g_sync.unlock();
          fc_wlog(logger, "Unable to request range, sending handshakes to everyone");
          send_handshakes();
       }
@@ -4089,7 +4088,7 @@ namespace eosio {
       }
 
       {
-         fc::lock_guard g( my->keepalive_timer_mtx );
+         fc::lock_guard g( keepalive_timer_mtx );
          keepalive_timer = std::make_unique<boost::asio::steady_timer>( thread_pool.get_executor() );
       }
 


### PR DESCRIPTION
Resolves #1230 

Newer versions of clang support a Google developed tool called "Thread Safety Analysis". Here is the [doc](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html).

Thread safety analysis works very much like a type system for multi-threaded programs. In addition to declaring the type of data (e.g. int, float, etc.), the programmer can (optionally) declare how access to that data is controlled in a multi-threaded environment. For example:

```
#include "mutex.h"

class BankAccount {
private:
  Mutex mu;
  int   balance GUARDED_BY(mu);

  void depositImpl(int amount) {
    balance += amount;       // WARNING! Cannot write balance without locking mu.
  }

  void withdrawImpl(int amount) REQUIRES(mu) {
    balance -= amount;       // OK. Caller must have locked mu.
  }

public:
  void withdraw(int amount) {
    mu.Lock();
    withdrawImpl(amount);    // OK.  We've locked mu.
  }                          // WARNING!  Failed to unlock mu.

  void transferFrom(BankAccount& b, int amount) {
    mu.Lock();
    b.withdrawImpl(amount);  // WARNING!  Calling withdrawImpl() requires locking b.mu.
    depositImpl(amount);     // OK.  depositImpl() has no requirements.
    mu.Unlock();
  }
};
```

The analysis is completely static (i.e. compile-time); there is no run-time overhead. I think our code robustness would greatly benefit to have these checks occur whenever the code is compiled with clang. In addition, these attributes are a useful documentation of the expected access controls.

This PR adds the access annotations for `net_plugin`. 

I had to change the calling parameters for `sync_manager::request_next_chunk()`. Unfortunately there is an issue in the thread safety analysis code which issues incorrect warnings when a class managing locks `adopts` a lock. I submitted a [LLVM issue](https://github.com/llvm/llvm-project/issues/63239) for this. 