### PR TITLE
Create initial workflow file for Pinned Builds.

### DIFF
--- a/.github/workflows/pinned_build.yaml
+++ b/.github/workflows/pinned_build.yaml
@@ -1,0 +1,28 @@
+name: "Pinned Build"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: read
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  d:
+    name: Discover Platforms
+    runs-on: ubuntu-latest
+    outputs:
+      missing-platforms: ${{steps.discover.outputs.missing-platforms}}
+      p: ${{steps.discover.outputs.platforms}}
+    steps:
+      - name: Discover Platforms
+        id: discover
+        uses: AntelopeIO/discover-platforms-action@v1
+        with:
+          platform-file: .cicd/platforms.json
+          password: ${{secrets.GITHUB_TOKEN}}
+          package-name: builders

--- a/.github/workflows/pinned_build.yaml
+++ b/.github/workflows/pinned_build.yaml
@@ -12,17 +12,3 @@ defaults:
     shell: bash
 
 jobs:
-  d:
-    name: Discover Platforms
-    runs-on: ubuntu-latest
-    outputs:
-      missing-platforms: ${{steps.discover.outputs.missing-platforms}}
-      p: ${{steps.discover.outputs.platforms}}
-    steps:
-      - name: Discover Platforms
-        id: discover
-        uses: AntelopeIO/discover-platforms-action@v1
-        with:
-          platform-file: .cicd/platforms.json
-          password: ${{secrets.GITHUB_TOKEN}}
-          package-name: builders

--- a/.github/workflows/pinned_build.yaml
+++ b/.github/workflows/pinned_build.yaml
@@ -10,5 +10,3 @@ permissions:
 defaults:
   run:
     shell: bash
-
-jobs:

--- a/.github/workflows/pinned_build.yaml
+++ b/.github/workflows/pinned_build.yaml
@@ -10,3 +10,12 @@ permissions:
 defaults:
   run:
     shell: bash
+
+jobs:
+  Temp:
+    name: temp
+    runs-on: ubuntu-latest
+    steps:
+      - name: test
+        run: |
+          pwd


### PR DESCRIPTION
Creating a shell of the initial pinned_build.yaml workflow to be merged quickly allowing development of actual workflow in follow on branch.

Need to have workflow file merged before github will allow triggering it in a development branch.