### PR TITLE
[4.0 -> main] Fix for loading snapshot with empty block log

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -497,19 +497,21 @@ namespace eosio { namespace chain {
 
       /// Would remove pre-existing block log and index, never write blocks into disk.
       struct empty_block_log final : block_log_impl {
+         uint32_t first_block_number = std::numeric_limits<uint32_t>::max();
+
          explicit empty_block_log(const std::filesystem::path& log_dir) {
             std::filesystem::remove(log_dir / "blocks.log");
             std::filesystem::remove(log_dir / "blocks.index");
          }
 
-         uint32_t first_block_num() final { return head ? head->block_num() : 1; }
+         uint32_t first_block_num() final { return head ? head->block_num() : first_block_number; }
          void append(const signed_block_ptr& b, const block_id_type& id, const std::vector<char>& packed_block) final {
             update_head(b, id);
          }
 
          uint64_t get_block_pos(uint32_t block_num) final { return block_log::npos; }
          void reset(const genesis_state& gs, const signed_block_ptr& first_block) final { update_head(first_block); }
-         void reset(const chain_id_type& chain_id, uint32_t first_block_num) final {}
+         void reset(const chain_id_type& chain_id, uint32_t first_block_num) final { first_block_number = first_block_num; }
          void flush() final {}
 
          signed_block_ptr read_block_by_num(uint32_t block_num) final { return {}; };

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -427,7 +427,8 @@ struct controller_impl {
          EOS_ASSERT( root_id == log_head_id, fork_database_exception, "fork database root does not match block log head" );
       } else {
          EOS_ASSERT( fork_db.root()->block_num == lib_num, fork_database_exception,
-                     "empty block log expects the first appended block to build off a block that is not the fork database root. root block number: ${block_num}, lib: ${lib_num}", ("block_num", fork_db.root()->block_num) ("lib_num", lib_num) );
+                     "The first block ${lib_num} when starting with an empty block log should be the block after fork database root ${bn}.",
+                     ("lib_num", lib_num)("bn", fork_db.root()->block_num) );
       }
 
       const auto fork_head = fork_db_head();

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -530,31 +530,63 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_blo
    }
 
    chain.control->abort_block();
+   {
+      // create a new snapshot child
+      auto writer = SNAPSHOT_SUITE::get_writer();
+      chain.control->write_snapshot(writer);
+      auto snapshot = SNAPSHOT_SUITE::finalize(writer);
 
-   // create a new snapshot child
-   auto writer = SNAPSHOT_SUITE::get_writer();
-   chain.control->write_snapshot(writer);
-   auto snapshot = SNAPSHOT_SUITE::finalize(writer);
+      // create a new child at this snapshot
+      int ordinal = 1;
 
-   // create a new child at this snapshot
-   int ordinal = 1;
-   snapshotted_tester snap_chain(chain.get_config(), SNAPSHOT_SUITE::get_reader(snapshot), ordinal++);
-   verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
-   auto block = chain.produce_block();
-   chain.control->abort_block();
-   snap_chain.push_block(block);
-   verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
+      snapshotted_tester snap_chain(chain.get_config(), SNAPSHOT_SUITE::get_reader(snapshot), ordinal++);
+      verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
+      auto block = chain.produce_block();
+      chain.control->abort_block();
+      snap_chain.push_block(block);
+      verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
 
-   snap_chain.close();
-   auto cfg = snap_chain.get_config();
-   // restart chain with truncated block log and existing state, but no genesis state (chain_id)
-   snap_chain.open();
-   verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
+      snap_chain.close();
+      auto cfg = snap_chain.get_config();
+      // restart chain with truncated block log and existing state, but no genesis state (chain_id)
+      snap_chain.open();
+      verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
 
-   block = chain.produce_block();
-   chain.control->abort_block();
-   snap_chain.push_block(block);
-   verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
+      block = chain.produce_block();
+      chain.control->abort_block();
+      snap_chain.push_block(block);
+      verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
+   }
+   // test with empty block log
+   {
+      // create a new snapshot child
+      auto writer = SNAPSHOT_SUITE::get_writer();
+      chain.control->write_snapshot(writer);
+      auto snapshot = SNAPSHOT_SUITE::finalize(writer);
+
+      // create a new child at this snapshot
+      int ordinal = 2;
+      auto chain_cfg = chain.get_config();
+      chain_cfg.blog = eosio::chain::empty_blocklog_config{}; // use empty block log
+      snapshotted_tester snap_chain(chain_cfg, SNAPSHOT_SUITE::get_reader(snapshot), ordinal++);
+      verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
+      auto block = chain.produce_block();
+      chain.control->abort_block();
+      snap_chain.push_block(block);
+      verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
+
+      snap_chain.close();
+      auto cfg = snap_chain.get_config();
+      // restart chain with truncated block log and existing state, but no genesis state (chain_id)
+      snap_chain.open();
+      verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
+
+      block = chain.produce_block();
+      chain.control->abort_block();
+      snap_chain.push_block(block);
+      verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *snap_chain.control);
+   }
+
 }
 
 BOOST_AUTO_TEST_CASE(json_snapshot_validity_test)


### PR DESCRIPTION
When running with an empty block log, `--block-log-retain-blocks 0`, it was not possible to load a snapshot. Implement `empty_block_log::reset` to correctly handle provided `first_block_num`.

Merges `release/4.0` into `main` including #1285 

Resolves #1228 