### PR TITLE
[4.0 -> main] Fix for loading a snapshot with an empty block log but an existing fork database

### DIFF
--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -289,7 +289,7 @@ try:
     timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
 
     shipNode = cluster.getNode(0)
-    block_range = 800
+    block_range = 1000
     start_block_num = blockNum
     end_block_num = start_block_num + block_range
 


### PR DESCRIPTION
Additional test cases and fix for loading a snapshot without a block log. When loading a snapshot with a block log, the block log and fork database can be replayed if they start at or before the snapshot. If no block log exists, for example running with `--block-log-retain-blocks 0`, then the fork database can't be consider valid.

Includes a fix for new test introduced in https://github.com/AntelopeIO/leap/pull/1276 which failed during ci/cd. `ship_streamer.cpp` updated to correctly handle forks.

Corner case related to #1228

Merges `release/4.0` into `main` including #1299 