### PR TITLE
Improve snapshot test reliability

### DIFF
--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
                      auto& pending = it->pending_snapshots;
                      if (pending.size()==1) {
                         // pending snapshot block number
-                        auto pbn = fuzzy_start ? it->start_block_num : pending.begin()->head_block_num;
+                        auto pbn = pending.begin()->head_block_num;
 
                         // first pending snapshot
                         auto ps_start = (spacing != 0) ? (spacing + (pbn%spacing)) : pbn;

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -89,15 +89,18 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
                      auto& pending = it->pending_snapshots;
                      if (pending.size()==1) {
                         // pending snapshot block number
-                        auto pbn = pending.begin()->head_block_num;
+                        auto pbn = fuzzy_start ? it->start_block_num : pending.begin()->head_block_num;
 
                         // first pending snapshot
                         auto ps_start = (spacing != 0) ? (spacing + (pbn%spacing)) : pbn;
                         
-                        // this will happen only when snapshot sheduled with no start block specified
-                        auto deviation = fuzzy_start ? ps_start - it->start_block_num - spacing : 0;
-
-                        BOOST_CHECK_EQUAL(block_num, ps_start - deviation);
+                        if (!fuzzy_start) {
+                           BOOST_CHECK_EQUAL(block_num, ps_start);
+                        }
+                        else {
+                           auto diff = block_num > ps_start ? block_num - ps_start : ps_start - block_num;
+                           BOOST_CHECK(diff <= 5); // accept +/- 5 blocks if start block not specified
+                        }                       
                      }
                      return true;
                   }

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -98,8 +98,8 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
                            BOOST_CHECK_EQUAL(block_num, ps_start);
                         }
                         else {
-                           auto diff = block_num > ps_start ? block_num - ps_start : ps_start - block_num;
-                           BOOST_CHECK(diff <= 5); // accept +/- 5 blocks if start block not specified
+                           int diff = block_num - ps_start;
+                           BOOST_CHECK(std::abs(diff) <= 5); // accept +/- 5 blocks if start block not specified
                         }                       
                      }
                      return true;


### PR DESCRIPTION
Resolves https://github.com/AntelopeIO/leap/issues/1286. Unfortunately previous fix still (rarely) failed due to fact that scheduling without specifying start block can still lead to +1 or +2 in pending snapshot depending on environment factors and implemented mitigation logic was not sufficient. This time it is bulletproof :)