### PR TITLE
[3.1] `CMAKE_INSTALL_PREFIX=/usr` for pinned builds in CI

### DIFF
--- a/.github/workflows/pinned_build.yaml
+++ b/.github/workflows/pinned_build.yaml
@@ -44,6 +44,8 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
           ./scripts/install_deps.sh
       - name: Build Pinned Build
+        env:
+          LEAP_PINNED_INSTALL_PREFIX: /usr
         run: |
           ./scripts/pinned_build.sh deps build "$(nproc)"
       - name: Check and select artifact

--- a/scripts/pinned_build.sh
+++ b/scripts/pinned_build.sh
@@ -132,7 +132,7 @@ pushdir ${LEAP_DIR}
 
 # build Leap
 echo "Building Leap ${SCRIPT_DIR}"
-try cmake -DCMAKE_TOOLCHAIN_FILE=${SCRIPT_DIR}/pinned_toolchain.cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${LLVM_DIR}/lib/cmake -DCMAKE_PREFIX_PATH=${BOOST_DIR}/bin ${SCRIPT_DIR}/..
+try cmake -DCMAKE_TOOLCHAIN_FILE=${SCRIPT_DIR}/pinned_toolchain.cmake -DCMAKE_INSTALL_PREFIX=${LEAP_PINNED_INSTALL_PREFIX:-/usr/local} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${LLVM_DIR}/lib/cmake -DCMAKE_PREFIX_PATH=${BOOST_DIR}/bin ${SCRIPT_DIR}/..
 
 try make -j${JOBS}
 try cpack


### PR DESCRIPTION
All 3.1.x-4.0.x pinned build .deb binaries provided by the team were built with `CMAKE_INSTALL_PREFIX=/usr` as that's the proper installation location for binaries in a package. However, `pinned_build.sh` has this set to `/usr/local` instead -- the `/usr/local` to `/usr` switcharoo was performed via the old binary build system.

With the binary builds being moved to Github Actions, we need a way to continue to set `CMAKE_INSTALL_PREFIX=/usr` for these official builds. So, add a `LEAP_PINNED_INSTALL_PREFIX` environment variable knob to control this aspect of the `pinned_build.sh` script, and make use of that in the new action.