### PR TITLE
Add support for '--plugin' to cluster_launcher.py

### DIFF
--- a/tests/TestHarness/TestHelper.py
+++ b/tests/TestHarness/TestHelper.py
@@ -19,14 +19,14 @@ class AppArgs:
             self.choices=choices
             self.action=action
 
-    def add(self, flag, type, help, default, choices=None):
-        arg=self.AppArg(flag, help, type=type, default=default, choices=choices)
+    def add(self, flag, type, help, default=None, action=None, choices=None):
+        arg=self.AppArg(flag, help, action=action, type=type, default=default, choices=choices)
         self.args.append(arg)
-
 
     def add_bool(self, flag, help, action='store_true'):
         arg=self.AppArg(flag, help, action=action)
         self.args.append(arg)
+
 
 # pylint: disable=too-many-instance-attributes
 class TestHelper(object):
@@ -121,7 +121,7 @@ class TestHelper(object):
             appArgsGrp = thParser.add_argument_group(title=None if suppressHelp else appArgsGrpTitle, description=None if suppressHelp else appArgsGrpdescription)
             for arg in applicationSpecificArgs.args:
                 if arg.type is not None:
-                    appArgsGrp.add_argument(arg.flag, type=arg.type, help=argparse.SUPPRESS if suppressHelp else arg.help, choices=arg.choices, default=arg.default)
+                    appArgsGrp.add_argument(arg.flag, action=arg.action, type=arg.type, help=argparse.SUPPRESS if suppressHelp else arg.help, choices=arg.choices, default=arg.default)
                 else:
                     appArgsGrp.add_argument(arg.flag, help=argparse.SUPPRESS if suppressHelp else arg.help, action=arg.action)
 

--- a/tests/cluster_launcher.py
+++ b/tests/cluster_launcher.py
@@ -45,7 +45,7 @@ try:
     if args.plugin:
         extraNodeosArgs = ''.join([i+j for i,j in zip([' --plugin '] * len(args.plugin), args.plugin)])
     else:
-        extraNodeosArgs = None
+        extraNodeosArgs = []
     if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, topo=topo, delay=delay, 
                       extraNodeosArgs=extraNodeosArgs) is False:
         errorExit("Failed to stand up eos cluster.")

--- a/tests/cluster_launcher.py
+++ b/tests/cluster_launcher.py
@@ -42,7 +42,10 @@ try:
     Print(f'producing nodes: {pnodes}, topology: {topo}, delay between nodes launch: {delay} second{"s" if delay != 1 else ""}')
 
     Print("Stand up cluster")
-    extraNodeosArgs = ''.join([i+j for i,j in zip([' --plugin '] * len(args.plugin), args.plugin)])
+    if args.plugin:
+        extraNodeosArgs = ''.join([i+j for i,j in zip([' --plugin '] * len(args.plugin), args.plugin)])
+    else:
+        extraNodeosArgs = None
     if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, topo=topo, delay=delay, 
                       extraNodeosArgs=extraNodeosArgs) is False:
         errorExit("Failed to stand up eos cluster.")

--- a/tests/cluster_launcher.py
+++ b/tests/cluster_launcher.py
@@ -45,7 +45,7 @@ try:
     if args.plugin:
         extraNodeosArgs = ''.join([i+j for i,j in zip([' --plugin '] * len(args.plugin), args.plugin)])
     else:
-        extraNodeosArgs = []
+        extraNodeosArgs = ''
     if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, topo=topo, delay=delay, 
                       extraNodeosArgs=extraNodeosArgs) is False:
         errorExit("Failed to stand up eos cluster.")

--- a/tests/cluster_launcher.py
+++ b/tests/cluster_launcher.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from TestHarness import Cluster, TestHelper, Utils, WalletMgr
+from TestHarness.TestHelper import AppArgs
 
 ###############################################################
 # cluster_launcher
@@ -13,9 +14,13 @@ from TestHarness import Cluster, TestHelper, Utils, WalletMgr
 Print=Utils.Print
 errorExit=Utils.errorExit
 
-args=TestHelper.parse_args({"-p","-d","-s","--keep-logs"
+appArgs = AppArgs()
+appArgs.add(flag="--plugin",action='append',type=str,help="Run nodes with additional plugins")
+
+args=TestHelper.parse_args({"-p","-n","-d","-s","--keep-logs"
                             ,"--dump-error-details","-v"
-                            ,"--leave-running","--unshared"})
+                            ,"--leave-running","--unshared"},
+                            applicationSpecificArgs=appArgs)
 pnodes=args.p
 delay=args.d
 topo=args.s
@@ -37,7 +42,9 @@ try:
     Print(f'producing nodes: {pnodes}, topology: {topo}, delay between nodes launch: {delay} second{"s" if delay != 1 else ""}')
 
     Print("Stand up cluster")
-    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, topo=topo, delay=delay) is False:
+    extraNodeosArgs = ''.join([i+j for i,j in zip([' --plugin '] * len(args.plugin), args.plugin)])
+    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, topo=topo, delay=delay, 
+                      extraNodeosArgs=extraNodeosArgs) is False:
         errorExit("Failed to stand up eos cluster.")
 
     testSuccessful=True


### PR DESCRIPTION
The `cluster_launcher.py` test script is a convenient way to start up a local cluster for testing using the `--leave-running` flag.  This PR adds a `--plugin` command line option which can be repeated as necessary and will be passed to all nodes as `extraNodeosArgs`.

Required completing support for AppArgs 'action'.