### PR TITLE
[4.0] P2P: Use magnitude safe time types

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -7,9 +7,6 @@ namespace eosio {
    using namespace chain;
    using namespace fc;
 
-   static_assert(sizeof(std::chrono::system_clock::duration::rep) >= 8, "system_clock is expected to be at least 64 bits");
-   typedef std::chrono::system_clock::duration::rep tstamp;
-
    struct chain_size_message {
       uint32_t                   last_irreversible_block_num = 0;
       block_id_type              last_irreversible_block_id;
@@ -83,10 +80,10 @@ namespace eosio {
   };
 
   struct time_message {
-            tstamp  org{0};       //!< origin timestamp
-            tstamp  rec{0};       //!< receive timestamp
-            tstamp  xmt{0};       //!< transmit timestamp
-    mutable tstamp  dst{0};       //!< destination timestamp
+            int64_t  org{0};       //!< origin timestamp, in nanoseconds
+            int64_t  rec{0};       //!< receive timestamp, in nanoseconds
+            int64_t  xmt{0};       //!< transmit timestamp, in nanoseconds
+    mutable int64_t  dst{0};       //!< destination timestamp, in nanoseconds
   };
 
   enum id_list_modes {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1050,6 +1050,8 @@ namespace eosio {
       if( !shutdown) my_impl->sync_master->sync_reset_lib_num( self->shared_from_this(), true );
       peer_ilog( self, "closing" );
       self->cancel_wait();
+      self->latest_msg_time = std::chrono::system_clock::time_point::min();
+      self->latest_blk_time = std::chrono::system_clock::time_point::min();
 
       if( reconnect && !shutdown ) {
          my_impl->start_conn_timer( std::chrono::milliseconds( 100 ), connection_wptr() );


### PR DESCRIPTION
Use `std::chrono` types instead of `tstamp` so that magnitude is maintained. Fixes issue with heartbeat calculation being off on some machines causing pre-mature close of what it thought was a idle connection.

Resolves #1315 