### PR TITLE
remove `FC_USE_PTHREAD_NAME_NP` & `pthread_getname_np()` usage

### DIFF
--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -104,7 +104,7 @@ namespace eosio { namespace chain {
                if (offset != std::string::npos)
                   tn.erase(0, offset+2);
                tn = tn.substr(0, tn.find('>')) + "-" + std::to_string( i );
-               fc::set_os_thread_name( tn );
+               fc::set_thread_name( tn );
                if ( init )
                   init();
             } FC_LOG_AND_RETHROW()

--- a/libraries/chain/platform_timer_asio_fallback.cpp
+++ b/libraries/chain/platform_timer_asio_fallback.cpp
@@ -30,7 +30,7 @@ platform_timer::platform_timer() {
       std::promise<void> p;
       auto f = p.get_future();
       checktime_thread = std::thread([&p]() {
-         fc::set_os_thread_name("checktime");
+         fc::set_thread_name("checktime");
          checktime_ios = std::make_unique<boost::asio::io_service>();
          boost::asio::io_service::work work(*checktime_ios);
          p.set_value();

--- a/libraries/chain/platform_timer_kqueue.cpp
+++ b/libraries/chain/platform_timer_kqueue.cpp
@@ -51,7 +51,7 @@ platform_timer::platform_timer() {
       FC_ASSERT(kevent64(kqueue_fd, &quit_event, 1, NULL, 0, KEVENT_FLAG_IMMEDIATE, NULL) == 0, "failed to create quit event");
 
       kevent_thread = std::thread([]() {
-         fc::set_os_thread_name("checktime");
+         fc::set_thread_name("checktime");
          while(true) {
             struct kevent64_s anEvent;
             int c = kevent64(kqueue_fd, NULL, 0, &anEvent, 1, 0, NULL);

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/code_cache.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/code_cache.cpp
@@ -48,7 +48,7 @@ code_cache_async::code_cache_async(const std::filesystem::path data_dir, const e
    wait_on_compile_monitor_message();
 
    _monitor_reply_thread = std::thread([this]() {
-      fc::set_os_thread_name("oc-monitor");
+      fc::set_thread_name("oc-monitor");
       _ctx.run();
    });
 }

--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -65,19 +65,6 @@ file( GLOB_RECURSE fc_headers ${CMAKE_CURRENT_SOURCE_DIR} *.hpp *.h )
 
 add_library(fc ${fc_sources} ${fc_headers})
 
-function(detect_thread_name)
-  include(CheckSymbolExists)
-  list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
-  list(APPEND CMAKE_REQUIRED_LIBRARIES "-pthread")
-  check_symbol_exists(pthread_setname_np pthread.h HAVE_PTHREAD_SETNAME_NP)
-  if(HAVE_PTHREAD_SETNAME_NP)
-    set_source_files_properties(src/log/logger_config.cpp PROPERTIES COMPILE_DEFINITIONS FC_USE_PTHREAD_NAME_NP)
-  endif()
-endfunction()
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-  detect_thread_name()
-endif()
-
 # Yuck: newer CMake files from boost iostreams will effectively target_link_libraries(Boost::iostreams z;bz2;lzma;zstd)
 #  without first "finding" those libraries. This resolves to simple -lz -lbz2 etc: it'll look for those libraries in the linker's
 #  library search path. This is most problematic on macOS where something like libzstd isn't in the standard search path. Historically

--- a/libraries/libfc/include/fc/log/logger_config.hpp
+++ b/libraries/libfc/include/fc/log/logger_config.hpp
@@ -73,7 +73,6 @@ namespace fc {
    void configure_logging( const std::filesystem::path& log_config );
    bool configure_logging( const logging_config& l );
 
-   void set_os_thread_name( const std::string& name );
    void set_thread_name( const std::string& name );
    const std::string& get_thread_name();
 }

--- a/libraries/libfc/src/log/gelf_appender.cpp
+++ b/libraries/libfc/src/log/gelf_appender.cpp
@@ -137,7 +137,7 @@ namespace fc
 
       my->thread = std::thread([this] {
         try {
-          fc::set_os_thread_name("gelf");
+          fc::set_thread_name("gelf");
           my->io_context.run();
         } catch (std::exception& ex) {
           fprintf(stderr, "GELF logger caught exception at %s:%d : %s\n", __FILE__, __LINE__, ex.what());

--- a/libraries/libfc/src/log/logger_config.cpp
+++ b/libraries/libfc/src/log/logger_config.cpp
@@ -10,6 +10,9 @@
 #include <fc/reflect/variant.hpp>
 #include <fc/exception/exception.hpp>
 
+#define BOOST_DLL_USE_STD_FS
+#include <boost/dll/runtime_symbol_info.hpp>
+
 namespace fc {
 
    log_config& log_config::get() {
@@ -133,26 +136,22 @@ namespace fc {
    }
 
    static thread_local std::string thread_name;
-   void set_os_thread_name( const std::string& name ) {
-#ifdef FC_USE_PTHREAD_NAME_NP
-      pthread_setname_np( pthread_self(), name.c_str() );
-#endif
-   }
+
    void set_thread_name( const std::string& name ) {
       thread_name = name;
+#if defined(__linux__) || defined(__FreeBSD__)
+      pthread_setname_np( pthread_self(), name.c_str() );
+#elif defined(__APPLE__)
+      pthread_setname_np( name.c_str() );
+#endif
    }
    const std::string& get_thread_name() {
-      if( thread_name.empty() ) {
-#ifdef FC_USE_PTHREAD_NAME_NP
-         char thr_name[64];
-         int rc = pthread_getname_np( pthread_self(), thr_name, 64 );
-         if( rc == 0 ) {
-            thread_name = thr_name;
+      if(thread_name.empty()) {
+         try {
+            thread_name = boost::dll::program_location().filename().generic_string();
+         } catch (...) {
+            thread_name = "unknown";
          }
-#else
-         static int thread_count = 0;
-         thread_name = std::string( "thread-" ) + std::to_string( thread_count++ );
-#endif
       }
       return thread_name;
    }

--- a/plugins/resource_monitor_plugin/resource_monitor_plugin.cpp
+++ b/plugins/resource_monitor_plugin/resource_monitor_plugin.cpp
@@ -128,7 +128,7 @@ public:
       }
 
       monitor_thread = std::thread( [this] {
-         fc::set_os_thread_name( "resmon" ); // console_appender uses 9 chars for thread name reporting.
+         fc::set_thread_name( "resmon" ); // console_appender uses 9 chars for thread name reporting.
          space_handler.space_monitor_loop();
 
          ctx.run();

--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -297,7 +297,7 @@ namespace eosio::trace_api {
 
    void slice_directory::start_maintenance_thread(log_handler log) {
       _maintenance_thread = std::thread([this, log=std::move(log)](){
-         fc::set_os_thread_name( "trace-mx" );
+         fc::set_thread_name( "trace-mx" );
          uint32_t last_lib = 0;
 
          while(true) {


### PR DESCRIPTION
This refactors the thread name stuff a bit to make it simpler (have gotten bitten here a few times lately such as #1283 and #1058)

* remove having both a `set_os_thread_name()` and `set_thread_name()` -- there is no reason setting the thread name shouldn't just set the OS thread name, having both of these (was `set_thread_name()` even used?) is just confusing
* add freebsd & macos thread name support
* remove the `HAVE_PTHREAD_SETNAME_NP` check; I think this was added at some point to resolve building on musl which didn't have `pthread_getname_np()` but while it does now,
* remove usage of `pthread_getname_np()` -- just not necessary to use this instead of referring to the existing `thread_local thread_name`