### PR TITLE
on macOS do not consider `EINVAL` a fatal accept error in fc's listener; fixing keosd on macOS

### DIFF
--- a/libraries/libfc/include/fc/network/listener.hpp
+++ b/libraries/libfc/include/fc/network/listener.hpp
@@ -147,6 +147,10 @@ struct listener : std::enable_shared_from_this<T> {
 #ifdef ENONET
                                         || code == ENONET
 #endif
+#ifdef __APPLE__
+                                        //guard against failure of asio's internal SO_NOSIGPIPE call after accept()
+                                        || code == EINVAL
+#endif
       ) {
          // according to https://man7.org/linux/man-pages/man2/accept.2.html, reliable application should
          // retry when these error codes are returned


### PR DESCRIPTION
On macOS, asio will internally immediately `setsockopt(SO_NOSIGPIPE)` right after `accept()`ing a connection before dispatching the accept callback to user code (us). Googling around some will suggest that it may be possible for this call to fail with `EINVAL` if the connection has already failed. But, [more carefully constructed research](https://github.com/wahern/cqueues/blob/master/PORTING.md#so_nosigpipe-f_setnosigpipe) suggests that while `EINVAL` can occur from this call, it is not possible to occur in our use case: right after `accept()`.

Nevertheless, on macOS 13 `main`'s keosd is broken because for some reason an `EINVAL` is, best I can tell _spuriously_, occurring on this `setsockopt(SO_NOSIGPIPE)` call for the unix socket connection. Based on syscall traces, cleos makes a single `connect()` to the socket, but keosd then successfully `accept()`s, then fails with `EINVAL` on the `SO_NOSIGPIPE`, then successfully `accept()`s again, and then successfully `SO_NOSIGPIPE`! It's very perplexing behavior that deserves more investigation because it's hard to believe the underlying OS is buggy/racy in this regard.

Prior to the refactor of `listener` on `main` which is more pedantic about what error codes the accept loop retries on, `EINVAL` was non-fatal and the accept loop would simply retry again. This PR restores that behavior on macOS: an `EINVAL` will not shut down the listener and this allows keosd to be operational again.