### PR TITLE
[3.2] Report transaction failed if trx was exhausted in non-producing mode

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -654,7 +654,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                _unapplied_transactions.add_persisted( trx );
             }
 
-            exhausted = pr.block_exhausted; // transaction exhausted if block was exhausted
+            exhausted = pr.block_exhausted;
 
             if ( !in_producing_mode() && pr.trx_exhausted )
                exhausted = true;  // report transaction exhausted if trx was exhausted in non-producing mode (so we will restart

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -616,7 +616,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                                               bool persist_until_expired,
                                               bool return_failure_trace,
                                               next_function<transaction_trace_ptr> next) {
-         bool exhausted = false;
+         bool success = false;
          chain::controller& chain = chain_plug->chain();
          try {
             const auto& id = trx->id();
@@ -648,12 +648,18 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             const auto block_deadline = calculate_block_deadline( chain.pending_block_time() );
             push_result pr = push_transaction( block_deadline, trx, persist_until_expired, return_failure_trace, next );
 
-            exhausted = pr.block_exhausted;
+            bool exhausted = pr.block_exhausted;
             if( pr.trx_exhausted ) {
                _unapplied_transactions.add_incoming( trx, persist_until_expired, return_failure_trace, next );
             } else if( pr.persist ) {
                _unapplied_transactions.add_persisted( trx );
             }
+
+            success = !exhausted; // transaction failed if block was exhausted
+
+            if (!(_pending_block_mode == pending_block_mode::producing) && pr.trx_exhausted)
+               success = false;  // report transaction failed if trx was exhausted in non-producing mode (so we restart
+                                 // a speculative block to retry it immediately, instead of waiting to receive a new block)
 
          } catch ( const guard_exception& e ) {
             chain_plugin::handle_guard_exception(e);
@@ -663,7 +669,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             chain_plugin::handle_bad_alloc();
          } CATCH_AND_CALL(next);
 
-         return !exhausted;
+         return success;
       }
 
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -449,7 +449,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
       bool on_incoming_block(const signed_block_ptr& block, const std::optional<block_id_type>& block_id, const block_state_ptr& bsp) {
          auto& chain = chain_plug->chain();
-         if ( _pending_block_mode == pending_block_mode::producing ) {
+         if ( in_producing_mode() ) {
             fc_wlog( _log, "dropped incoming block #${num} id: ${id}",
                      ("num", block->block_num())("id", block_id ? (*block_id).str() : "UNKNOWN") );
             return false;
@@ -599,7 +599,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                   try {
                      auto result = future.get();
                      if( !self->process_incoming_transaction_async( result, persist_until_expired, return_failure_traces, next) ) {
-                        if( self->_pending_block_mode == pending_block_mode::producing ) {
+                        if( self->in_producing_mode() ) {
                            self->schedule_maybe_produce_block( true );
                         } else {
                            self->restart_speculative_block();
@@ -656,7 +656,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
             exhausted = pr.block_exhausted; // transaction exhausted if block was exhausted
 
-            if (!(_pending_block_mode == pending_block_mode::producing) && pr.trx_exhausted)
+            if ( !in_producing_mode() && pr.trx_exhausted )
                exhausted = true;  // report transaction exhausted if trx was exhausted in non-producing mode (so we will restart
                                   // a speculative block to retry it immediately, instead of waiting to receive a new block)
 
@@ -710,6 +710,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       void schedule_delayed_production_loop(const std::weak_ptr<producer_plugin_impl>& weak_this, std::optional<fc::time_point> wake_up_time);
       std::optional<fc::time_point> calculate_producer_wake_up_time( const block_timestamp_type& ref_block_time ) const;
 
+      bool in_producing_mode()   const { return _pending_block_mode == pending_block_mode::producing; }
+      bool in_speculating_mode() const { return _pending_block_mode == pending_block_mode::speculating; }
 };
 
 void new_chain_banner(const eosio::chain::controller& db)
@@ -1126,7 +1128,7 @@ void producer_plugin::resume() {
    // it is possible that we are only speculating because of this policy which we have now changed
    // re-evaluate that now
    //
-   if (my->_pending_block_mode == pending_block_mode::speculating) {
+   if (my->in_speculating_mode()) {
       my->abort_block();
       fc_ilog(_log, "Producer resumed. Scheduling production.");
       my->schedule_production_loop();
@@ -1168,7 +1170,7 @@ void producer_plugin::update_runtime_options(const runtime_options& options) {
       my->_incoming_defer_ratio = *options.incoming_defer_ratio;
    }
 
-   if (check_speculating && my->_pending_block_mode == pending_block_mode::speculating) {
+   if (check_speculating && my->in_speculating_mode()) {
       my->abort_block();
       my->schedule_production_loop();
    }
@@ -1608,7 +1610,7 @@ fc::time_point producer_plugin_impl::calculate_pending_block_time() const {
 }
 
 fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_point& block_time ) const {
-   if( _pending_block_mode == pending_block_mode::producing ) {
+   if( in_producing_mode() ) {
       bool last_block = ((block_timestamp_type( block_time ).slot % config::producer_repetitions) == config::producer_repetitions - 1);
       return block_time + fc::microseconds(last_block ? _last_block_time_offset_us : _produce_time_offset_us);
    } else {
@@ -1617,7 +1619,7 @@ fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_po
 }
 
 bool producer_plugin_impl::should_interrupt_start_block( const fc::time_point& deadline, uint32_t pending_block_num ) const {
-   if( _pending_block_mode == pending_block_mode::producing ) {
+   if( in_producing_mode() ) {
       return deadline <= fc::time_point::now();
    }
    // if we can produce then honor deadline so production starts on time
@@ -1677,7 +1679,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
       _pending_block_mode = pending_block_mode::speculating;
    }
 
-   if (_pending_block_mode == pending_block_mode::producing) {
+   if (in_producing_mode()) {
       // determine if our watermark excludes us from producing at this point
       if (current_watermark) {
          const block_timestamp_type block_timestamp{block_time};
@@ -1697,13 +1699,13 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
       }
    }
 
-   if (_pending_block_mode == pending_block_mode::speculating) {
+   if (in_speculating_mode()) {
       auto head_block_age = now - chain.head_block_time();
       if (head_block_age > fc::seconds(5))
          return start_block_result::waiting_for_block;
    }
 
-   if (_pending_block_mode == pending_block_mode::producing) {
+   if (in_producing_mode()) {
       const auto start_block_time = block_time - fc::microseconds( config::block_interval_us );
       if( now < start_block_time ) {
          fc_dlog(_log, "Not producing block waiting for production window ${n} ${bt}", ("n", pending_block_num)("bt", block_time) );
@@ -1725,7 +1727,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    try {
       uint16_t blocks_to_confirm = 0;
 
-      if (_pending_block_mode == pending_block_mode::producing) {
+      if (in_producing_mode()) {
          // determine how many blocks this producer can confirm
          // 1) if it is not a producer from this node, assume no confirmations (we will discard this block anyway)
          // 2) if it is a producer on this node that has never produced, the conservative approach is to assume no
@@ -1746,7 +1748,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
       abort_block();
 
       auto features_to_activate = chain.get_preactivated_protocol_features();
-      if( _pending_block_mode == pending_block_mode::producing && _protocol_features_to_activate.size() > 0 ) {
+      if( in_producing_mode() && _protocol_features_to_activate.size() > 0 ) {
          bool drop_features_to_activate = false;
          try {
             chain.validate_protocol_features( _protocol_features_to_activate );
@@ -1794,7 +1796,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    if( chain.is_building_block() ) {
       const auto& pending_block_signing_authority = chain.pending_block_signing_authority();
 
-      if (_pending_block_mode == pending_block_mode::producing && pending_block_signing_authority != scheduled_producer.authority) {
+      if (in_producing_mode() && pending_block_signing_authority != scheduled_producer.authority) {
          elog("Unexpected block signing authority, reverting to speculative mode! [expected: \"${expected}\", actual: \"${actual\"", ("expected", scheduled_producer.authority)("actual", pending_block_signing_authority));
          _pending_block_mode = pending_block_mode::speculating;
       }
@@ -1818,7 +1820,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
          if( !process_unapplied_trxs( preprocess_deadline ) )
             return start_block_result::exhausted;
 
-         if (_pending_block_mode == pending_block_mode::producing) {
+         if (in_producing_mode()) {
             auto scheduled_trx_deadline = preprocess_deadline;
             if (_max_scheduled_transaction_time_per_block_ms >= 0) {
                scheduled_trx_deadline = std::min<fc::time_point>(
@@ -1875,7 +1877,7 @@ bool producer_plugin_impl::remove_expired_trxs( const fc::time_point& deadline )
             }
    });
 
-   if( exhausted && _pending_block_mode == pending_block_mode::producing ) {
+   if( exhausted && in_producing_mode() ) {
       fc_wlog( _log, "Unable to process all expired transactions in unapplied queue before deadline, "
                      "Persistent expired ${persistent_expired}, Other expired ${other_expired}",
                ("persistent_expired", num_expired_persistent)("other_expired", num_expired_other) );
@@ -1978,7 +1980,7 @@ void producer_plugin_impl::log_trx_results( const packed_transaction_ptr& trx,
 
    bool except = except_ptr || (trace && trace->except);
    if (except) {
-      if (_pending_block_mode == pending_block_mode::producing) {
+      if (in_producing_mode()) {
          fc_dlog(_trx_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING tx: ${trx}",
                  ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())
                  ("trx", chain_plug->get_log_trx(trx->get_transaction())));
@@ -1999,7 +2001,7 @@ void producer_plugin_impl::log_trx_results( const packed_transaction_ptr& trx,
                  ("entire_trace", get_trace(trace, except_ptr)));
       }
    } else {
-      if (_pending_block_mode == pending_block_mode::producing) {
+      if (in_producing_mode()) {
          fc_dlog(_trx_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING tx: ${trx}",
                  ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())
                  ("trx", chain_plug->get_log_trx(trx->get_transaction())));
@@ -2053,15 +2055,14 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
    fc::microseconds max_trx_time = fc::milliseconds( _max_transaction_time_ms.load() );
    if( max_trx_time.count() < 0 ) max_trx_time = fc::microseconds::maximum();
 
-   bool disable_subjective_billing = ( _pending_block_mode == pending_block_mode::producing )
-                                     || disable_subjective_enforcement;
+   bool disable_subjective_billing = in_producing_mode() || disable_subjective_enforcement;
 
    int64_t sub_bill = 0;
    if( !disable_subjective_billing )
       sub_bill = _subjective_billing.get_subjective_bill( first_auth, fc::time_point::now() );
 
    auto prev_billed_cpu_time_us = trx->billed_cpu_time_us;
-   if( _pending_block_mode == pending_block_mode::producing && prev_billed_cpu_time_us > 0 ) {
+   if( in_producing_mode() && prev_billed_cpu_time_us > 0 ) {
       const auto& rl = chain.get_resource_limits_manager();
       if ( !_subjective_billing.is_account_disabled( first_auth ) && !rl.is_unlimited_cpu( first_auth ) ) {
          int64_t prev_billed_plus100_us = prev_billed_cpu_time_us + EOS_PERCENT( prev_billed_cpu_time_us, 100 * config::percent_1 );
@@ -2075,7 +2076,7 @@ producer_plugin_impl::push_transaction( const fc::time_point& block_deadline,
    if( trace->except ) {
       _time_tracker.add_fail_time(end - start);
       if( exception_is_exhausted( *trace->except ) ) {
-         if( _pending_block_mode == pending_block_mode::producing ) {
+         if( in_producing_mode() ) {
             fc_dlog(_trx_failed_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
                     ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())("txid", trx->id()));
          } else {
@@ -2141,10 +2142,8 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
       int num_applied = 0, num_failed = 0, num_processed = 0;
       auto unapplied_trxs_size = _unapplied_transactions.size();
       // unapplied and persisted do not have a next method to call
-      auto itr     = (_pending_block_mode == pending_block_mode::producing) ?
-                     _unapplied_transactions.unapplied_begin() : _unapplied_transactions.persisted_begin();
-      auto end_itr = (_pending_block_mode == pending_block_mode::producing) ?
-                     _unapplied_transactions.unapplied_end()   : _unapplied_transactions.persisted_end();
+      auto itr     = in_producing_mode() ? _unapplied_transactions.unapplied_begin() : _unapplied_transactions.persisted_begin();
+      auto end_itr = in_producing_mode() ? _unapplied_transactions.unapplied_end()   : _unapplied_transactions.persisted_end();
       while( itr != end_itr ) {
          if( should_interrupt_start_block( deadline, pending_block_num ) ) {
             exhausted = true;
@@ -2406,10 +2405,10 @@ void producer_plugin_impl::schedule_production_loop() {
    } else if (result == start_block_result::waiting_for_production) {
       // scheduled in start_block()
 
-   } else if (_pending_block_mode == pending_block_mode::producing) {
+   } else if (in_producing_mode()) {
       schedule_maybe_produce_block( result == start_block_result::exhausted );
 
-   } else if (_pending_block_mode == pending_block_mode::speculating && !_producers.empty() && !production_disabled_by_policy()){
+   } else if (in_speculating_mode() && !_producers.empty() && !production_disabled_by_policy()){
       chain::controller& chain = chain_plug->chain();
       fc_dlog(_log, "Speculative Block Created; Scheduling Speculative/Production Change");
       EOS_ASSERT( chain.is_building_block(), missing_pending_block_state, "speculating without pending_block_state" );
@@ -2526,7 +2525,7 @@ static auto maybe_make_debug_time_logger() -> std::optional<decltype(make_debug_
 void producer_plugin_impl::produce_block() {
    //ilog("produce_block ${t}", ("t", fc::time_point::now())); // for testing _produce_time_offset_us
    auto start = fc::time_point::now();
-   EOS_ASSERT(_pending_block_mode == pending_block_mode::producing, producer_exception, "called produce_block while not actually producing");
+   EOS_ASSERT(in_producing_mode(), producer_exception, "called produce_block while not actually producing");
    chain::controller& chain = chain_plug->chain();
    EOS_ASSERT(chain.is_building_block(), missing_pending_block_state, "pending_block_state does not exist but it should, another plugin may have corrupted it");
 


### PR DESCRIPTION
So we restart a speculative block to retry it immediately, instead of waiting to receive a new block.

Resolves #1247.