### PR TITLE
[3.1 -> 3.2] Pinned Builds manual dispatch workflow in CI

### DIFF
--- a/.github/workflows/pinned_build.yaml
+++ b/.github/workflows/pinned_build.yaml
@@ -53,6 +53,7 @@ jobs:
           name: leap-${{matrix.platform}}-pinned-amd64
           path: build/leap_*.deb
       - name: Run Parallel Tests
+        if: ${{ matrix.platform != 'ubuntu18' }}
         run: |
           cd build
           ctest --output-on-failure -j $(nproc) -LE "(nonparallelizable_tests|long_running_tests)" --timeout 420

--- a/.github/workflows/pinned_build.yaml
+++ b/.github/workflows/pinned_build.yaml
@@ -1,0 +1,58 @@
+name: "Pinned Build"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: read
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  Build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu18, ubuntu20, ubuntu22]
+    runs-on: ["self-hosted", "enf-x86-beefy-long"]
+    container: ${{ matrix.platform == 'ubuntu18' && 'ubuntu:bionic' || matrix.platform == 'ubuntu20' && 'ubuntu:focal' || 'ubuntu:jammy' }}
+    steps:
+      - name: Conditionally update git repo
+        if: ${{ matrix.platform == 'ubuntu18' }}
+        run: |
+          apt-get update
+          apt-get install -y software-properties-common
+          apt-get update
+          add-apt-repository ppa:git-core/ppa
+      - name: Update and Install git
+        run: |
+          apt-get update
+          apt-get install -y git
+          git --version
+      - name: Clone leap
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          # https://github.com/actions/runner/issues/2033
+          chown -R $(id -u):$(id -g) $PWD
+          ./scripts/install_deps.sh
+      - name: Build Pinned Build
+        env:
+          LEAP_PINNED_INSTALL_PREFIX: /usr
+        run: |
+          ./scripts/pinned_build.sh deps build "$(nproc)"
+      - name: Upload package
+        uses: actions/upload-artifact@v3
+        with:
+          name: leap-${{matrix.platform}}-pinned-amd64
+          path: build/leap-3*.deb
+      - name: Run Parallel Tests
+        run: |
+          cd build
+          ctest --output-on-failure -j $(nproc) -LE "(nonparallelizable_tests|long_running_tests)" --timeout 420

--- a/.github/workflows/pinned_build.yaml
+++ b/.github/workflows/pinned_build.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: leap-${{matrix.platform}}-pinned-amd64
-          path: build/leap-3*.deb
+          path: build/leap_*.deb
       - name: Run Parallel Tests
         run: |
           cd build

--- a/scripts/pinned_build.sh
+++ b/scripts/pinned_build.sh
@@ -132,7 +132,7 @@ pushdir ${LEAP_DIR}
 
 # build Leap
 echo "Building Leap ${SCRIPT_DIR}"
-try cmake -DCMAKE_TOOLCHAIN_FILE=${SCRIPT_DIR}/pinned_toolchain.cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${LLVM_DIR}/lib/cmake -DCMAKE_PREFIX_PATH=${BOOST_DIR}/bin ${SCRIPT_DIR}/..
+try cmake -DCMAKE_TOOLCHAIN_FILE=${SCRIPT_DIR}/pinned_toolchain.cmake -DCMAKE_INSTALL_PREFIX=${LEAP_PINNED_INSTALL_PREFIX:-/usr/local} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${LLVM_DIR}/lib/cmake -DCMAKE_PREFIX_PATH=${BOOST_DIR}/bin ${SCRIPT_DIR}/..
 
 try make -j${JOBS}
 try cpack


### PR DESCRIPTION
Pinned builds run in GitHub Actions

Resolves: https://github.com/AntelopeIO/leap/issues/735