### PR TITLE
[4.0] P2P: fix head_num reporting

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3089,14 +3089,14 @@ namespace eosio {
       }
       switch (msg.known_trx.mode) {
       case none:
-         break;
-      case last_irr_catch_up:
-      case catch_up : {
+      case last_irr_catch_up: {
          std::unique_lock<std::mutex> g_conn( conn_mtx );
-         last_handshake_recv.head_num = msg.known_blocks.pending;
+         last_handshake_recv.head_num = std::max(msg.known_blocks.pending, last_handshake_recv.head_num);
          g_conn.unlock();
          break;
       }
+      case catch_up:
+         break;
       case normal: {
          my_impl->dispatcher->recv_notice( shared_from_this(), msg, false );
       }


### PR DESCRIPTION
P2P `notice_message.known_trx` `catch_up` does not report `head_num`, so do not update `head_num` reporting. `none` message does. Regardless only update `head_num` if a valid value.

Resolves #1328 