### PR TITLE
[4.0 -> main] P2P: fix head_num reporting

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3359,17 +3359,9 @@ namespace eosio {
       }
       switch (msg.known_trx.mode) {
       case none:
-<<<<<<< HEAD
-         break;
-      case last_irr_catch_up:
-      case catch_up : {
-         fc::unique_lock g_conn( conn_mtx );
-         last_handshake_recv.head_num = msg.known_blocks.pending;
-=======
       case last_irr_catch_up: {
-         std::unique_lock<std::mutex> g_conn( conn_mtx );
+         fc::unique_lock g_conn( conn_mtx );
          last_handshake_recv.head_num = std::max(msg.known_blocks.pending, last_handshake_recv.head_num);
->>>>>>> origin/release/4.0
          g_conn.unlock();
          break;
       }


### PR DESCRIPTION
P2P `notice_message.known_trx` `catch_up` does not report `head_num`, so do not update `head_num` reporting. `none` message does. Regardless only update `head_num` if a valid value.

Merges `release/4.0` into `main` including #1345 

Resolves #1328 