### PR TITLE
Blocklog: Return std::optional for head_id 

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -462,7 +462,11 @@ namespace eosio { namespace chain {
          inline static uint32_t  default_initial_version = block_log::max_supported_version;
 
          std::mutex       mtx;
-         std::optional<std::pair<signed_block_ptr, block_id_type>> head;
+         struct signed_block_with_id {
+            signed_block_ptr ptr;
+            block_id_type id;
+         };
+         std::optional<signed_block_with_id> head;
 
          virtual ~block_log_impl() = default;
 
@@ -497,7 +501,7 @@ namespace eosio { namespace chain {
             std::filesystem::remove(log_dir / "blocks.index");
          }
 
-         uint32_t first_block_num() final { return head ? head->first->block_num() : first_block_number; }
+         uint32_t first_block_num() final { return head ? head->ptr->block_num() : first_block_number; }
          void append(const signed_block_ptr& b, const block_id_type& id, const std::vector<char>& packed_block) final {
             update_head(b, id);
          }
@@ -584,7 +588,7 @@ namespace eosio { namespace chain {
          }
 
          uint64_t get_block_pos(uint32_t block_num) final {
-            if (!(head && block_num <= block_header::num_from_id(head->second) &&
+            if (!(head && block_num <= block_header::num_from_id(head->id) &&
                   block_num >= working_block_file_first_block_num()))
                return block_log::npos;
             index_file.seek(sizeof(uint64_t) * (block_num - index_first_block_num()));
@@ -700,7 +704,7 @@ namespace eosio { namespace chain {
             uint32_t num_blocks;
             this->block_file.seek_end(-sizeof(uint32_t));
             fc::raw::unpack(this->block_file, num_blocks);
-            return this->head->first->block_num() - num_blocks + 1;
+            return this->head->ptr->block_num() - num_blocks + 1;
          }
 
          void reset(uint32_t first_bnum, std::variant<genesis_state, chain_id_type>&& chain_context, uint32_t version) {
@@ -796,7 +800,7 @@ namespace eosio { namespace chain {
             size_t copy_from_pos = get_block_pos(first_block_num);
             block_file.seek_end(-sizeof(uint32_t));
             size_t         copy_sz           = block_file.tellp() - copy_from_pos;
-            const uint32_t num_blocks_in_log = chain::block_header::num_from_id(head->second) - first_block_num + 1;
+            const uint32_t num_blocks_in_log = chain::block_header::num_from_id(head->id) - first_block_num + 1;
 
             const size_t offset_bytes  = copy_from_pos - copy_to_pos;
             const size_t offset_blocks = first_block_num - index_first_block_num;
@@ -984,7 +988,7 @@ namespace eosio { namespace chain {
             block_file.close();
             index_file.close();
 
-            catalog.add(preamble.first_block_num, this->head->first->block_num(), block_file.get_file_path().parent_path(),
+            catalog.add(preamble.first_block_num, this->head->ptr->block_num(), block_file.get_file_path().parent_path(),
                         "blocks");
 
             using std::swap;
@@ -999,7 +1003,7 @@ namespace eosio { namespace chain {
 
             preamble.ver             = block_log::max_supported_version;
             preamble.chain_context   = preamble.chain_id();
-            preamble.first_block_num = this->head->first->block_num() + 1;
+            preamble.first_block_num = this->head->ptr->block_num() + 1;
             preamble.write_to(block_file);
          }
 
@@ -1010,7 +1014,7 @@ namespace eosio { namespace chain {
          }
 
          void post_append(uint64_t pos) final {
-            if (head->first->block_num() % stride == 0) {
+            if (head->ptr->block_num() % stride == 0) {
                split_log();
             }
          }
@@ -1113,7 +1117,7 @@ namespace eosio { namespace chain {
             if ((pos & prune_config.prune_threshold) != (end & prune_config.prune_threshold))
                num_blocks_in_log = prune(fc::log_level::debug);
             else
-               num_blocks_in_log = chain::block_header::num_from_id(head->second) - first_block_number + 1;
+               num_blocks_in_log = chain::block_header::num_from_id(head->id) - first_block_number + 1;
             fc::raw::pack(block_file, num_blocks_in_log);
          }
 
@@ -1134,7 +1138,7 @@ namespace eosio { namespace chain {
          uint32_t prune(const fc::log_level& loglevel) {
             if (!head)
                return 0;
-            const uint32_t head_num = chain::block_header::num_from_id(head->second);
+            const uint32_t head_num = chain::block_header::num_from_id(head->id);
             if (head_num - first_block_number < prune_config.prune_blocks)
                return head_num - first_block_number + 1;
 
@@ -1244,12 +1248,12 @@ namespace eosio { namespace chain {
 
    signed_block_ptr block_log::head() const {
       std::lock_guard g(my->mtx);
-      return my->head ? my->head->first : signed_block_ptr{};
+      return my->head ? my->head->ptr : signed_block_ptr{};
    }
 
    std::optional<block_id_type> block_log::head_id() const {
       std::lock_guard g(my->mtx);
-      return my->head ? my->head->second : std::optional<block_id_type>{};
+      return my->head ? my->head->id : std::optional<block_id_type>{};
    }
 
    uint32_t block_log::first_block_num() const {

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -462,8 +462,7 @@ namespace eosio { namespace chain {
          inline static uint32_t  default_initial_version = block_log::max_supported_version;
 
          std::mutex       mtx;
-         signed_block_ptr head;
-         std::optional<block_id_type> head_id;
+         std::optional<std::pair<signed_block_ptr, block_id_type>> head;
 
          virtual ~block_log_impl() = default;
 
@@ -482,16 +481,10 @@ namespace eosio { namespace chain {
 
          virtual signed_block_ptr read_head() = 0;
          void                     update_head(const signed_block_ptr& b, const std::optional<block_id_type>& id = {}) {
-            head = b;
-            if (id) {
-               head_id = *id;
-            } else {
-               if (head) {
-                  head_id = b->calculate_id();
-               } else {
-                  head_id = {};
-               }
-            }
+            if (b)
+               head = { b, id ? *id : b->calculate_id() };
+            else
+               head = {};
          }
       }; // block_log_impl
 
@@ -504,7 +497,7 @@ namespace eosio { namespace chain {
             std::filesystem::remove(log_dir / "blocks.index");
          }
 
-         uint32_t first_block_num() final { return head ? head->block_num() : first_block_number; }
+         uint32_t first_block_num() final { return head ? head->first->block_num() : first_block_number; }
          void append(const signed_block_ptr& b, const block_id_type& id, const std::vector<char>& packed_block) final {
             update_head(b, id);
          }
@@ -591,7 +584,7 @@ namespace eosio { namespace chain {
          }
 
          uint64_t get_block_pos(uint32_t block_num) final {
-            if (!(head_id && block_num <= block_header::num_from_id(*head_id) &&
+            if (!(head && block_num <= block_header::num_from_id(head->second) &&
                   block_num >= working_block_file_first_block_num()))
                return block_log::npos;
             index_file.seek(sizeof(uint64_t) * (block_num - index_first_block_num()));
@@ -707,7 +700,7 @@ namespace eosio { namespace chain {
             uint32_t num_blocks;
             this->block_file.seek_end(-sizeof(uint32_t));
             fc::raw::unpack(this->block_file, num_blocks);
-            return this->head->block_num() - num_blocks + 1;
+            return this->head->first->block_num() - num_blocks + 1;
          }
 
          void reset(uint32_t first_bnum, std::variant<genesis_state, chain_id_type>&& chain_context, uint32_t version) {
@@ -740,7 +733,6 @@ namespace eosio { namespace chain {
 
             this->reset(first_block_num, chain_id, block_log::max_supported_version);
             this->head.reset();
-            head_id = {};
          }
 
          void flush() final {
@@ -804,7 +796,7 @@ namespace eosio { namespace chain {
             size_t copy_from_pos = get_block_pos(first_block_num);
             block_file.seek_end(-sizeof(uint32_t));
             size_t         copy_sz           = block_file.tellp() - copy_from_pos;
-            const uint32_t num_blocks_in_log = chain::block_header::num_from_id(*head_id) - first_block_num + 1;
+            const uint32_t num_blocks_in_log = chain::block_header::num_from_id(head->second) - first_block_num + 1;
 
             const size_t offset_bytes  = copy_from_pos - copy_to_pos;
             const size_t offset_blocks = first_block_num - index_first_block_num;
@@ -992,7 +984,7 @@ namespace eosio { namespace chain {
             block_file.close();
             index_file.close();
 
-            catalog.add(preamble.first_block_num, this->head->block_num(), block_file.get_file_path().parent_path(),
+            catalog.add(preamble.first_block_num, this->head->first->block_num(), block_file.get_file_path().parent_path(),
                         "blocks");
 
             using std::swap;
@@ -1007,7 +999,7 @@ namespace eosio { namespace chain {
 
             preamble.ver             = block_log::max_supported_version;
             preamble.chain_context   = preamble.chain_id();
-            preamble.first_block_num = this->head->block_num() + 1;
+            preamble.first_block_num = this->head->first->block_num() + 1;
             preamble.write_to(block_file);
          }
 
@@ -1018,7 +1010,7 @@ namespace eosio { namespace chain {
          }
 
          void post_append(uint64_t pos) final {
-            if (head->block_num() % stride == 0) {
+            if (head->first->block_num() % stride == 0) {
                split_log();
             }
          }
@@ -1121,7 +1113,7 @@ namespace eosio { namespace chain {
             if ((pos & prune_config.prune_threshold) != (end & prune_config.prune_threshold))
                num_blocks_in_log = prune(fc::log_level::debug);
             else
-               num_blocks_in_log = chain::block_header::num_from_id(*head_id) - first_block_number + 1;
+               num_blocks_in_log = chain::block_header::num_from_id(head->second) - first_block_number + 1;
             fc::raw::pack(block_file, num_blocks_in_log);
          }
 
@@ -1142,7 +1134,7 @@ namespace eosio { namespace chain {
          uint32_t prune(const fc::log_level& loglevel) {
             if (!head)
                return 0;
-            const uint32_t head_num = chain::block_header::num_from_id(*head_id);
+            const uint32_t head_num = chain::block_header::num_from_id(head->second);
             if (head_num - first_block_number < prune_config.prune_blocks)
                return head_num - first_block_number + 1;
 
@@ -1252,12 +1244,12 @@ namespace eosio { namespace chain {
 
    signed_block_ptr block_log::head() const {
       std::lock_guard g(my->mtx);
-      return my->head;
+      return my->head ? my->head->first : signed_block_ptr{};
    }
 
    std::optional<block_id_type> block_log::head_id() const {
       std::lock_guard g(my->mtx);
-      return my->head_id;
+      return my->head ? my->head->second : std::optional<block_id_type>{};
    }
 
    uint32_t block_log::first_block_num() const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -416,10 +416,10 @@ struct controller_impl {
    void log_irreversible() {
       EOS_ASSERT( fork_db.root(), fork_database_exception, "fork database not properly initialized" );
 
-      const block_id_type log_head_id = blog.head_id();
-      const bool valid_log_head = !log_head_id.empty();
+      const std::optional<block_id_type> log_head_id = blog.head_id();
+      const bool valid_log_head = !!log_head_id;
 
-      const auto lib_num = valid_log_head ? block_header::num_from_id(log_head_id) : (blog.first_block_num() - 1);
+      const auto lib_num = valid_log_head ? block_header::num_from_id(*log_head_id) : (blog.first_block_num() - 1);
 
       auto root_id = fork_db.root()->id;
 

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -67,7 +67,7 @@ namespace eosio { namespace chain {
 
          signed_block_ptr read_head()const; //use blocklog
          signed_block_ptr head()const;
-         block_id_type head_id()const;
+         std::optional<block_id_type> head_id()const;
 
          uint32_t                first_block_num() const;
 

--- a/tests/block_log.cpp
+++ b/tests/block_log.cpp
@@ -67,7 +67,8 @@ struct block_log_fixture {
 
    void check_range_present(uint32_t first, uint32_t last) {
       BOOST_REQUIRE_EQUAL(log->first_block_num(), first);
-      BOOST_REQUIRE_EQUAL(eosio::chain::block_header::num_from_id(log->head_id()), last);
+      BOOST_REQUIRE(log->head_id());
+      BOOST_REQUIRE_EQUAL(eosio::chain::block_header::num_from_id(*log->head_id()), last);
       if(enable_read) {
          for(auto i = first; i <= last; i++) {
             std::vector<char> buff;


### PR DESCRIPTION
Minor refactor to make code cleaner/clearer. Return empty optional when block log does not have a current head.

Resolves #1289 