### PR TITLE
[4.0 -> main] Docs: Additional nodeos --help info

### DIFF
--- a/docs/01_nodeos/03_plugins/chain_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/chain_plugin/index.md
@@ -192,13 +192,17 @@ Config Options for eosio::chain_plugin:
                                         feature. Setting above 0 enables this
                                         feature.
   --transaction-retry-interval-sec arg (=20)
-                                        How often, in seconds, to resend an
-                                        incoming transaction to network if not
+                                        How often, in seconds, to resend an 
+                                        incoming transaction to network if not 
                                         seen in a block.
+                                        Needs to be at least twice as large as 
+                                        p2p-dedup-cache-expire-time-sec.
   --transaction-retry-max-expiration-sec arg (=120)
-                                        Maximum allowed transaction expiration
-                                        for retry transactions, will retry
+                                        Maximum allowed transaction expiration 
+                                        for retry transactions, will retry 
                                         transactions up to this value.
+                                        Should be larger than 
+                                        transaction-retry-interval-sec.
   --transaction-finality-status-max-storage-size-gb arg
                                         Maximum size (in GiB) allowed to be
                                         allocated for the Transaction Finality

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -341,9 +341,11 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("transaction-retry-max-storage-size-gb", bpo::value<uint64_t>(),
           "Maximum size (in GiB) allowed to be allocated for the Transaction Retry feature. Setting above 0 enables this feature.")
          ("transaction-retry-interval-sec", bpo::value<uint32_t>()->default_value(20),
-          "How often, in seconds, to resend an incoming transaction to network if not seen in a block.")
+          "How often, in seconds, to resend an incoming transaction to network if not seen in a block.\n"
+          "Needs to be at least twice as large as p2p-dedup-cache-expire-time-sec.")
          ("transaction-retry-max-expiration-sec", bpo::value<uint32_t>()->default_value(120),
-          "Maximum allowed transaction expiration for retry transactions, will retry transactions up to this value.")
+          "Maximum allowed transaction expiration for retry transactions, will retry transactions up to this value.\n"
+          "Should be larger than transaction-retry-interval-sec.")
          ("transaction-finality-status-max-storage-size-gb", bpo::value<uint64_t>(),
           "Maximum size (in GiB) allowed to be allocated for the Transaction Finality Status feature. Setting above 0 enables this feature.")
          ("transaction-finality-status-success-duration-sec", bpo::value<uint64_t>()->default_value(config::default_max_transaction_finality_status_success_duration_sec),


### PR DESCRIPTION
Add additional help to `transaction-retry-interval-sec` & `transaction-retry-max-expiration-sec`

```
  --transaction-retry-interval-sec arg (=20)
                                        How often, in seconds, to resend an 
                                        incoming transaction to network if not 
                                        seen in a block.
                                        Needs to be at least twice as large as 
                                        p2p-dedup-cache-expire-time-sec.
  --transaction-retry-max-expiration-sec arg (=120)
                                        Maximum allowed transaction expiration 
                                        for retry transactions, will retry 
                                        transactions up to this value.
                                        Should be larger than 
                                        transaction-retry-interval-sec.
```

Merges `release/4.0` into `main` including #1350 

Resolves #1302 