### PR TITLE
Create stub workflow ph_backward_compatibility.yaml

### DIFF
--- a/.github/workflows/ph_backward_compatibility.yaml
+++ b/.github/workflows/ph_backward_compatibility.yaml
@@ -1,0 +1,21 @@
+name: "Performance Harness Backwards Compatibility"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: read
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tmp:
+    name: Stub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Workflow Stub
+        run: |
+          echo "Workflow Stub"


### PR DESCRIPTION
Creating a shell of the initial `ph_backward_compatibility.yaml` workflow to be merged quickly allowing development of actual workflow in follow-on branch.

Need to have workflow file merged before github will allow triggering it in a development branch.

Relates to: https://github.com/AntelopeIO/leap/issues/1156