### PR TITLE
.gitignore: add exclusion for scripts/pinned_toolchain.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 !.cicd
 !package.cmake
 !CMakeModules/*.cmake
+!scripts/pinned_toolchain.cmake
 *.ninja
 \#*
 \.#*


### PR DESCRIPTION
the *.cmake wildcard in gitignore covers scripts/pinned_toolchain.cmake   which should not be ignored.