### PR TITLE
no longer eagerly use tcmalloc if it's found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,9 +159,10 @@ endif()
 
 message( STATUS "Using '${EOSIO_ROOT_KEY}' as public key for 'eosio' account" )
 
-find_package( Gperftools QUIET )
-if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling Leap with TCMalloc")
+option(ENABLE_TCMALLOC "use tcmalloc (requires gperftools)" OFF)
+if( ENABLE_TCMALLOC )
+    find_package( Gperftools REQUIRED )
+    message( STATUS "Compiling Leap with TCMalloc")
     #if doing this by the book, simply link_libraries( ${GPERFTOOLS_TCMALLOC} ) here. That will
     #give the performance benefits of tcmalloc but since it won't be linked last
     #the heap profiler & checker may not be accurate. This here is rather undocumented behavior

--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -14,12 +14,6 @@ if (LLVM_DIR STREQUAL "" OR NOT LLVM_DIR)
    set(LLVM_DIR @LLVM_DIR@)
 endif()
 
-find_package( Gperftools QUIET )
-if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling tests with TCMalloc")
-    list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
-endif()
-
 if(NOT "@LLVM_FOUND@" STREQUAL "")
    find_package(LLVM @LLVM_VERSION@ EXACT REQUIRED CONFIG)
    llvm_map_components_to_libnames(LLVM_LIBS support core passes mcjit native DebugInfoDWARF orcjit)

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -12,12 +12,6 @@ if (LLVM_DIR STREQUAL "" OR NOT LLVM_DIR)
    set(LLVM_DIR @LLVM_DIR@)
 endif()
 
-find_package( Gperftools QUIET )
-if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling tests with TCMalloc")
-    list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
-endif()
-
 if(NOT "@LLVM_FOUND@" STREQUAL "")
    find_package(LLVM @LLVM_VERSION@ EXACT REQUIRED CONFIG)
    llvm_map_components_to_libnames(LLVM_LIBS support core passes mcjit native DebugInfoDWARF orcjit)


### PR DESCRIPTION
Since EOSIO 1.0 tcmalloc (from gperftools) would be used if it was found during cmake configuration. Despite that, we've never once had tcmalloc enabled in any sort of CI. I know in certain historical configurations, such as Ubuntu 16.04, the tcmalloc available from the standard package repo caused a dead lock in one of the unit tests (of course, the fault certainly could be have in the test, hard to say).

The benefit of using tcmalloc is supposed improved performance, but we don't have any recent data (or maybe any data ever) to back up that claim.

It seems a little reckless to eagerly enable features like this that we don't actually test ourselves. So move tcmalloc usage behind a cmake option that is defaulted to `off`. Using tcmalloc is still useful for leap developers due to its profiler, etc.

A nice side effect is this may improve the reliability of the proposed automatic database migration approach too.