### PR TITLE
[3.2] Fix incorrect serializing of std::optional when value is not provided - (GH #1189)

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -535,14 +535,15 @@ namespace eosio { namespace chain {
             bool disallow_additional_fields = false;
             for( uint32_t i = 0; i < st.fields.size(); ++i ) {
                const auto& field = st.fields[i];
-               if( vo.contains( string(field.name).c_str() ) ) {
+               bool present = vo.contains(string(field.name).c_str());
+               if( present || is_optional(field.type) ) {
                   if( disallow_additional_fields )
                      EOS_THROW( pack_exception, "Unexpected field '${f}' found in input object while processing struct '${p}'",
                                 ("f", ctx.maybe_shorten(field.name))("p", ctx.get_path_string()) );
                   {
                      auto h1 = ctx.push_to_path( impl::field_path_item{ .parent_struct_itr = s_itr, .field_ordinal = i } );
                      auto h2 = ctx.disallow_extensions_unless( &field == &st.fields.back() );
-                     _variant_to_binary(_remove_bin_extension(field.type), vo[field.name], ds, ctx);
+                     _variant_to_binary(_remove_bin_extension(field.type), present ? vo[field.name] : fc::variant(nullptr), ds, ctx);
                   }
                } else if( ends_with(field.type, "$") && ctx.extensions_allowed() ) {
                   disallow_additional_fields = true;

--- a/libraries/libfc/include/fc/time.hpp
+++ b/libraries/libfc/include/fc/time.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdint.h>
 #include <fc/string.hpp>
+#include <limits>
 
 #ifdef _MSC_VER
   #pragma warning (push)
@@ -11,7 +12,7 @@ namespace fc {
   class microseconds {
     public:
         constexpr explicit microseconds( int64_t c = 0) :_count(c){}
-        static constexpr microseconds maximum() { return microseconds(0x7fffffffffffffffll); }
+        static constexpr microseconds maximum() { return microseconds(std::numeric_limits<int64_t>::max()); }
         friend constexpr microseconds operator + (const  microseconds& l, const microseconds& r ) { return microseconds(l._count+r._count); }
         friend constexpr microseconds operator - (const  microseconds& l, const microseconds& r ) { return microseconds(l._count-r._count); }
 

--- a/libraries/libfc/include/fc/time.hpp
+++ b/libraries/libfc/include/fc/time.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <stdint.h>
 #include <fc/string.hpp>
-#include <limits>
 
 #ifdef _MSC_VER
   #pragma warning (push)
@@ -12,7 +11,7 @@ namespace fc {
   class microseconds {
     public:
         constexpr explicit microseconds( int64_t c = 0) :_count(c){}
-        static constexpr microseconds maximum() { return microseconds(std::numeric_limits<int64_t>::max()); }
+        static constexpr microseconds maximum() { return microseconds(0x7fffffffffffffffll); }
         friend constexpr microseconds operator + (const  microseconds& l, const microseconds& r ) { return microseconds(l._count+r._count); }
         friend constexpr microseconds operator - (const  microseconds& l, const microseconds& r ) { return microseconds(l._count-r._count); }
 

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -1937,6 +1937,92 @@ BOOST_AUTO_TEST_CASE(abi_type_loop)
 
 } FC_LOG_AND_RETHROW() }
 
+BOOST_AUTO_TEST_CASE(abi_std_optional)
+{ try {
+   const char* repeat_abi = R"=====(
+   {
+    "version": "eosio::abi/1.2",
+    "types": [],
+    "structs": [
+        {
+            "name": "fees",
+            "base": "",
+            "fields": [
+                {
+                    "name": "gas_price",
+                    "type": "uint64?"
+                },
+                {
+                    "name": "miner_cut",
+                    "type": "uint32?"
+                },
+                {
+                    "name": "bridge_fee",
+                    "type": "uint32?"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "fees",
+            "type": "fees",
+            "ricardian_contract": ""
+        }
+    ],
+    "tables": [],
+    "ricardian_clauses": [],
+    "variants": [],
+    "action_results": []
+   }
+   )=====";
+
+   abi_serializer abis(fc::json::from_string(repeat_abi).as<abi_def>(), abi_serializer::create_yield_function( max_serialization_time ));
+   {
+      // check conversion when all optional members are provided
+      std::string test_data = R"=====(
+      {
+        "gas_price" : "42",
+        "miner_cut" : "2",
+        "bridge_fee" : "2"
+      }
+      )=====";
+
+      auto var = fc::json::from_string(test_data);
+      verify_byte_round_trip_conversion(abis, "fees", var);
+   }
+
+   {
+      // check conversion when the first optional members is missing
+      std::string test_data = R"=====(
+      {
+        "miner_cut" : "2",
+        "bridge_fee" : "2"
+      }
+      )=====";
+
+      auto var = fc::json::from_string(test_data);
+      verify_byte_round_trip_conversion(abis, "fees", var);
+   }
+
+   {
+      // check conversion when the first optional members is missing
+      std::string test_data = R"=====(
+      {
+        "gas_price" : "42",
+        "miner_cut" : "2",
+        "bridge_fee" : "2"
+      }
+      )=====";
+
+      auto var = fc::json::from_string(test_data);
+      verify_byte_round_trip_conversion(abis, "fees", var);
+   }
+
+   
+
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_CASE(abi_type_redefine)
 { try {
    // inifinite loop in types

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -2010,7 +2010,6 @@ BOOST_AUTO_TEST_CASE(abi_std_optional)
       std::string test_data = R"=====(
       {
         "gas_price" : "42",
-        "miner_cut" : "2",
         "bridge_fee" : "2"
       }
       )=====";
@@ -2019,7 +2018,29 @@ BOOST_AUTO_TEST_CASE(abi_std_optional)
       verify_byte_round_trip_conversion(abis, "fees", var);
    }
 
-   
+   {
+      // check conversion when all optional members are provided
+      std::string test_data = R"=====(
+      {
+        "gas_price" : "42",
+        "miner_cut" : "2",
+      }
+      )=====";
+
+      auto var = fc::json::from_string(test_data);
+      verify_byte_round_trip_conversion(abis, "fees", var);
+   }
+
+   {
+      // check conversion when all optional members are provided
+      std::string test_data = R"=====(
+      {
+      }
+      )=====";
+
+      auto var = fc::json::from_string(test_data);
+      verify_byte_round_trip_conversion(abis, "fees", var);
+   }
 
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -1993,7 +1993,7 @@ BOOST_AUTO_TEST_CASE(abi_std_optional)
    }
 
    {
-      // check conversion when the first optional members is missing
+      // check conversion when the first optional member is missing
       std::string test_data = R"=====(
       {
         "miner_cut" : "2",
@@ -2006,7 +2006,7 @@ BOOST_AUTO_TEST_CASE(abi_std_optional)
    }
 
    {
-      // check conversion when the first optional members is missing
+      // check conversion when the second optional member is missing
       std::string test_data = R"=====(
       {
         "gas_price" : "42",
@@ -2019,7 +2019,7 @@ BOOST_AUTO_TEST_CASE(abi_std_optional)
    }
 
    {
-      // check conversion when all optional members are provided
+      // check conversion when the last optional member is missing
       std::string test_data = R"=====(
       {
         "gas_price" : "42",
@@ -2032,7 +2032,7 @@ BOOST_AUTO_TEST_CASE(abi_std_optional)
    }
 
    {
-      // check conversion when all optional members are provided
+      // check conversion when all optional members are missing
       std::string test_data = R"=====(
       {
       }


### PR DESCRIPTION
When serializing a `std::optional` field, and a value is not provided for the `std::optional`, we need to add into the serialization the flag specifying that a missing value is serialized. Prior to this PR, the flag was missing.