### PR TITLE
[PH] Create stub workflow for manual dispatch performance harness runs

### DIFF
--- a/.github/workflows/performance_harness_run.yaml
+++ b/.github/workflows/performance_harness_run.yaml
@@ -1,0 +1,21 @@
+name: "Performance Harness Run"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: read
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tmp:
+    name: Stub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Workflow Stub
+        run: |
+          echo "Workflow Stub"


### PR DESCRIPTION
Creating a shell of the initial performance harness run workflow to be merged quickly allowing development of actual workflow in follow-on branch.

Need to have workflow file merged before github will allow triggering it in a development branch.