### PR TITLE
[4.0] Close connection on aysnc_read with a closed socket

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1242,7 +1242,7 @@ namespace eosio {
             try {
                c->buffer_queue.clear_out_queue();
                // May have closed connection and cleared buffer_queue
-               if( !c->socket_is_open() || socket != c->socket ) {
+               if( !c->socket->is_open() || socket != c->socket ) {
                   peer_ilog( c, "async write socket ${r} before callback", ("r", c->socket_is_open() ? "changed" : "closed") );
                   c->close();
                   return;
@@ -2488,7 +2488,7 @@ namespace eosio {
             boost::asio::bind_executor( strand,
               [conn = shared_from_this(), socket=socket]( boost::system::error_code ec, std::size_t bytes_transferred ) {
                // may have closed connection and cleared pending_message_buffer
-               if (!conn->socket_is_open() && conn->socket_open) { // if socket_open then close not called
+               if (!conn->socket->is_open() && conn->socket_is_open()) { // if socket_open then close not called
                   peer_dlog( conn, "async_read socket not open, closing");
                   conn->close();
                   return;


### PR DESCRIPTION
More paranoid socket shutdown when closing and `async_read` with a closed socket. Also cleanup logic on connection duplicate check. Reset `org` as it needs to be reset on close so new connection will `send_time` message correctly.

Resolves #1349 