### PR TITLE
[4.0] Removed "deprecated" from help for speculative read-mode

### DIFF
--- a/docs/01_nodeos/03_plugins/chain_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/chain_plugin/index.md
@@ -131,8 +131,7 @@ Config Options for eosio::chain_plugin:
                                         received via the P2P network are not
                                         relayed and transactions cannot be
                                         pushed via the chain API.
-                                        In "speculative" mode: (DEPRECATED:
-                                        head mode recommended) database
+                                        In "speculative" mode: database
                                         contains state changes by transactions
                                         in the blockchain up to the head block
                                         as well as some transactions not yet

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -294,7 +294,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "In \"head\" mode: database contains state changes up to the head block; transactions received by the node are relayed if valid.\n"
           "In \"irreversible\" mode: database contains state changes up to the last irreversible block; "
           "transactions received via the P2P network are not relayed and transactions cannot be pushed via the chain API.\n"
-          "In \"speculative\" mode: (DEPRECATED: head mode recommended) database contains state changes by transactions in the blockchain "
+          "In \"speculative\" mode: database contains state changes by transactions in the blockchain "
           "up to the head block as well as some transactions not yet included in the blockchain; transactions received by the node are relayed if valid.\n"
           )
          ( "api-accept-transactions", bpo::value<bool>()->default_value(true), "Allow API transactions to be evaluated and relayed if valid.")


### PR DESCRIPTION
Issue #980 restored `read-mode = speculative` but maintained the `DEPRECATED` statement in the help. Remove the `DEPRECATED` statement as `speculative` mode is a useful option for producer nodes. See https://github.com/AntelopeIO/leap/issues/1349#issuecomment-1615341482.