### PR TITLE
[4.0 -> main] Fix incorrect serializing of std::optional when value is not provided - (GH #1189)

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -548,14 +548,15 @@ namespace eosio { namespace chain {
             bool disallow_additional_fields = false;
             for( uint32_t i = 0; i < st.fields.size(); ++i ) {
                const auto& field = st.fields[i];
-               if( vo.contains( string(field.name).c_str() ) ) {
+               bool present = vo.contains(string(field.name).c_str());
+               if( present || is_optional(field.type) ) {
                   if( disallow_additional_fields )
                      EOS_THROW( pack_exception, "Unexpected field '${f}' found in input object while processing struct '${p}'",
                                 ("f", ctx.maybe_shorten(field.name))("p", ctx.get_path_string()) );
                   {
                      auto h1 = ctx.push_to_path( impl::field_path_item{ .parent_struct_itr = s_itr, .field_ordinal = i } );
                      auto h2 = ctx.disallow_extensions_unless( &field == &st.fields.back() );
-                     _variant_to_binary(_remove_bin_extension(field.type), vo[field.name], ds, ctx);
+                     _variant_to_binary(_remove_bin_extension(field.type), present ? vo[field.name] : fc::variant(nullptr), ds, ctx);
                   }
                } else if( ends_with(field.type, "$") && ctx.extensions_allowed() ) {
                   disallow_additional_fields = true;

--- a/libraries/libfc/include/fc/time.hpp
+++ b/libraries/libfc/include/fc/time.hpp
@@ -12,7 +12,8 @@ namespace fc {
   class microseconds {
     public:
         constexpr explicit microseconds( int64_t c = 0) :_count(c){}
-        static constexpr microseconds maximum() { return microseconds(0x7fffffffffffffffll); }
+        static constexpr microseconds maximum() { return microseconds(std::numeric_limits<int64_t>::max()); }
+        static constexpr microseconds minimum() { return microseconds(std::numeric_limits<int64_t>::min()); }
         friend constexpr microseconds operator + (const  microseconds& l, const microseconds& r ) { return microseconds(l._count+r._count); }
         friend constexpr microseconds operator - (const  microseconds& l, const microseconds& r ) { return microseconds(l._count-r._count); }
 
@@ -52,12 +53,12 @@ namespace fc {
 
         // protect against overflow/underflow
         constexpr time_point& safe_add( const microseconds& m ) {
-           if (m.count() > 0 && elapsed > fc::microseconds::maximum() - m) {
+           if (m.count() > 0 && elapsed > microseconds::maximum() - m) {
               elapsed = microseconds::maximum();
-           } else if (m.count() < 0 && elapsed.count() < std::numeric_limits<int64_t >::min() - m.count()) {
-              elapsed = microseconds(std::numeric_limits<int64_t >::min());
+           } else if (m.count() < 0 && elapsed <  microseconds::minimum() - m) {
+              elapsed = microseconds::minimum();
            } else {
-             elapsed += m;
+              elapsed += m;
            }
            return *this;
         }
@@ -94,7 +95,7 @@ namespace fc {
         constexpr explicit time_point_sec( const time_point& t )
         :utc_seconds( t.time_since_epoch().count() / 1000000ll ){}
 
-        static constexpr time_point_sec maximum() { return time_point_sec(0xffffffff); }
+        static constexpr time_point_sec maximum() { return time_point_sec(std::numeric_limits<uint32_t>::max()); }
         static constexpr time_point_sec min() { return time_point_sec(0); }
 
         constexpr time_point to_time_point()const { return time_point( fc::seconds( utc_seconds) ); }

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -48,9 +48,7 @@ fc::microseconds max_serialization_time = fc::microseconds::maximum(); // don't 
 #endif
 
 static fc::time_point get_deadline() {
-   if (max_serialization_time == fc::microseconds::maximum())
-      return fc::time_point(fc::microseconds::maximum());
-   return fc::time_point::now() + max_serialization_time;
+   return fc::time_point::now().safe_add(max_serialization_time);
 }
 
 // verify that round trip conversion, via bytes, reproduces the exact same data


### PR DESCRIPTION
Resolves #1189 .

When serializing a std::optional field, and a value is not provided for the std::optional, we need to add into the serialization the flag specifying that a missing value is serialized. Prior to this PR, the flag was missing.