### PR TITLE
[3.2 -> 4.0] Emit correct trace id for deferred trx before replace_deferred protocol feature activation

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1180,7 +1180,7 @@ struct controller_impl {
 
       transaction_checktime_timer trx_timer(timer);
       const packed_transaction trx( std::move( etrx ) );
-      transaction_context trx_context( self, trx, std::move(trx_timer), start );
+      transaction_context trx_context( self, trx, trx.id(), std::move(trx_timer), start );
 
       if (auto dm_logger = get_deep_mind_logger(trx_context.is_transient())) {
          dm_logger->on_onerror(etrx);
@@ -1346,7 +1346,7 @@ struct controller_impl {
       uint32_t cpu_time_to_bill_us = billed_cpu_time_us;
 
       transaction_checktime_timer trx_timer( timer );
-      transaction_context trx_context( self, *trx->packed_trx(), std::move(trx_timer) );
+      transaction_context trx_context( self, *trx->packed_trx(), gtrx.trx_id, std::move(trx_timer) );
       trx_context.leeway =  fc::microseconds(0); // avoid stealing cpu resource
       trx_context.block_deadline = block_deadline;
       trx_context.max_transaction_time_subjective = max_transaction_time;
@@ -1560,7 +1560,7 @@ struct controller_impl {
 
          const signed_transaction& trn = trx->packed_trx()->get_signed_transaction();
          transaction_checktime_timer trx_timer(timer);
-         transaction_context trx_context(self, *trx->packed_trx(), std::move(trx_timer), start, trx->get_trx_type());
+         transaction_context trx_context(self, *trx->packed_trx(), trx->id(), std::move(trx_timer), start, trx->get_trx_type());
          if ((bool)subjective_cpu_leeway && self.is_speculative_block()) {
             trx_context.leeway = *subjective_cpu_leeway;
          }

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -37,6 +37,7 @@ namespace eosio { namespace chain {
 
          transaction_context( controller& c,
                               const packed_transaction& t,
+                              const transaction_id_type& trx_id, // trx_id diff than t.id() before replace_deferred
                               transaction_checktime_timer&& timer,
                               fc::time_point start = fc::time_point::now(),
                               transaction_metadata::trx_type type = transaction_metadata::trx_type::input);
@@ -127,6 +128,7 @@ namespace eosio { namespace chain {
 
          controller&                                 control;
          const packed_transaction&                   packed_trx;
+         const transaction_id_type&                  id;
          std::optional<chainbase::database::session> undo_session;
          transaction_trace_ptr                       trace;
          fc::time_point                              start;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -46,11 +46,13 @@ namespace eosio { namespace chain {
 
    transaction_context::transaction_context( controller& c,
                                              const packed_transaction& t,
+                                             const transaction_id_type& trx_id,
                                              transaction_checktime_timer&& tmr,
                                              fc::time_point s,
                                              transaction_metadata::trx_type type)
    :control(c)
    ,packed_trx(t)
+   ,id(trx_id)
    ,undo_session()
    ,trace(std::make_shared<transaction_trace>())
    ,start(s)
@@ -62,7 +64,7 @@ namespace eosio { namespace chain {
       if (!c.skip_db_sessions() && !is_read_only()) {
          undo_session.emplace(c.mutable_db().start_undo_session(true));
       }
-      trace->id = packed_trx.id();
+      trace->id = id;
       trace->block_num = c.head_block_num() + 1;
       trace->block_time = c.pending_block_time();
       trace->producer_block_id = c.pending_producer_block_id();
@@ -295,7 +297,7 @@ namespace eosio { namespace chain {
 
       init( initial_net_usage );
       if ( !is_read_only() ) {
-         record_transaction( packed_trx.id(), trx.expiration );
+         record_transaction( id, trx.expiration );
       }
    }
 
@@ -753,7 +755,7 @@ namespace eosio { namespace chain {
 
       uint32_t trx_size = 0;
       const auto& cgto = control.mutable_db().create<generated_transaction_object>( [&]( auto& gto ) {
-        gto.trx_id      = packed_trx.id();
+        gto.trx_id      = id;
         gto.payer       = first_auth;
         gto.sender      = account_name(); /// delayed transactions have no sender
         gto.sender_id   = transaction_id_to_sender_id( gto.trx_id );

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -414,6 +414,14 @@ BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
    cfg.disable_all_subjective_mitigations = true;
    c.init( cfg );
 
+   transaction_trace_ptr trace;
+   auto h = c.control->applied_transaction.connect( [&](std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> x) {
+      auto& t = std::get<0>(x);
+      if( t && !eosio::chain::is_onblock(*t)) {
+         trace = t;
+      }
+   } );
+
    BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n ), alice_ram_usage0 );
 
    c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
@@ -450,6 +458,8 @@ BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
 
    dtrxs = c.get_scheduled_transactions();
    BOOST_CHECK_EQUAL( dtrxs.size(), 0 );
+   // must be equal before builtin_protocol_feature_t::replace_deferred to support replay of blocks before activation
+   BOOST_CHECK( first_dtrx_id.str() == trace->id.str() );
 
    c.produce_block();
 
@@ -508,6 +518,13 @@ BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
    dtrxs = c.get_scheduled_transactions();
    BOOST_CHECK_EQUAL( dtrxs.size(), 1 );
    BOOST_CHECK_EQUAL( first_dtrx_id2, dtrxs[0] );
+
+   c.produce_block();
+
+   dtrxs = c.get_scheduled_transactions();
+   BOOST_CHECK_EQUAL( dtrxs.size(), 0 );
+   // Not equal after builtin_protocol_feature_t::replace_deferred activated
+   BOOST_CHECK( first_dtrx_id2.str() != trace->id.str() );
 
 } FC_LOG_AND_RETHROW()
 


### PR DESCRIPTION
Before protocol feature `replace_deferred` is activated the trx id of the scheduled transaction can differ from the packed_transaction that is executed. This PR restores the behavior of tracking and reporting in transaction traces the scheduled transaction id instead of the packed_transaction id. This was not a consensus error but rather the wrong trx id was being reported in transaction traces for scheduled transactions before the on-chain activation of `replaced_deferred`. This manifested itself by confusing SHiP in recording the scheduled transactions reported in a block.

Merges `release/3.2` into `release/4.0` including #1379 

Resolves #1354 