### PR TITLE
[4.0] SHiP: Improve startup when large number of SHiP logs in retain directory

### DIFF
--- a/libraries/chain/include/eosio/chain/log_catalog.hpp
+++ b/libraries/chain/include/eosio/chain/log_catalog.hpp
@@ -150,7 +150,7 @@ struct log_catalog {
             auto name = it->second.filename_base;
             log_data.open(name.replace_extension("log"));
             log_index.open(name.replace_extension("index"));
-            active_index = std::distance(collection.begin(), it); //collection.index_of(it);
+            active_index = std::distance(collection.begin(), it);
             return log_index.nth_block_position(block_num - log_data.first_block_num());
          }
          return {};
@@ -219,9 +219,9 @@ struct log_catalog {
       if (collection.size() >= max_retained_files) {
          items_to_erase =
             max_retained_files > 0 ? collection.size() - max_retained_files : collection.size();
-         auto end = std::next( collection.begin(), items_to_erase);
+         auto last = std::next( collection.begin(), items_to_erase);
 
-         for (auto it = collection.begin(); it != end; ++it) {
+         for (auto it = collection.begin(); it != last; ++it) {
             auto orig_name = it->second.filename_base;
             if (archive_dir.empty()) {
                // delete the old files when no backup dir is specified
@@ -232,7 +232,7 @@ struct log_catalog {
                rename_bundle(orig_name, archive_dir / orig_name.filename());
             }
          }
-         collection.erase(collection.begin(), end);
+         collection.erase(collection.begin(), last);
          active_index = active_index == npos || active_index < items_to_erase
                         ? npos
                         : active_index - items_to_erase;

--- a/libraries/chain/include/eosio/chain/log_catalog.hpp
+++ b/libraries/chain/include/eosio/chain/log_catalog.hpp
@@ -2,7 +2,6 @@
 #include <fc/io/cfile.hpp>
 #include <fc/io/datastream.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/iostreams/device/mapped_file.hpp>
 #include <regex>
 #include <map>
 

--- a/libraries/chain/include/eosio/chain/log_catalog.hpp
+++ b/libraries/chain/include/eosio/chain/log_catalog.hpp
@@ -124,18 +124,13 @@ struct log_catalog {
       if (!bfs::exists(index_path))
          return false;
 
-      auto num_blocks_in_index = bfs::file_size(index_path) / sizeof(uint64_t);
-      if (num_blocks_in_index != log.num_blocks())
+      LogIndex log_i;
+      log_i.open(index_path);
+
+      if (log_i.num_blocks() != log.num_blocks())
          return false;
 
-      // make sure the last 8 bytes of index and log matches
-      fc::cfile index_file;
-      index_file.set_file_path(index_path);
-      index_file.open("r");
-      index_file.seek_end(-sizeof(uint64_t));
-      uint64_t pos;
-      index_file.read(reinterpret_cast<char*>(&pos), sizeof(pos));
-      return pos == log.last_block_position();
+      return log_i.back() == log.last_block_position();
    }
 
    std::optional<uint64_t> get_block_position(uint32_t block_num) {


### PR DESCRIPTION
Startup of `state_history_plugin` was very slow when large number of SHiP logs were in the `retain` directory. Almost all the performance slowness was due to use of `boost::flat_map` as it sorts and inserts into a `vector` on each insert. Changing to use a `std::map` provides much more reasonable performance on startup. Also included in this PR are additional small performance improvements to the scanning of the log/indexs during startup. For my test case, improved from 76 seconds to 7 seconds.


Resolves #1331 