### PR TITLE
[4.0 -> main] Test: Fix ship test to wait on correct transaction

### DIFF
--- a/tests/ship_streamer_test.py
+++ b/tests/ship_streamer_test.py
@@ -129,7 +129,7 @@ try:
     nonProdNode.waitForTransBlockIfNeeded(trans, True, exitOnError=True)
     for account in accounts:
         Print(f"Transfer funds {transferAmount} from account {cluster.eosioAccount.name} to {account.name}")
-        nonProdNode.transferFunds(cluster.eosioAccount, account, transferAmount, "test transfer", waitForTransBlock=False)
+        trans=nonProdNode.transferFunds(cluster.eosioAccount, account, transferAmount, "test transfer", waitForTransBlock=False)
     nonProdNode.waitForTransBlockIfNeeded(trans, True, exitOnError=True)
     for account in accounts:
         trans=nonProdNode.delegatebw(account, 20000000.0000, 20000000.0000, waitForTransBlock=False, exitOnError=True)


### PR DESCRIPTION
`state_history_plugin` test `ship_streamer_test.py` was not waiting on the correct transaction to be included in a block.

Merges `release/4.0` into `main` including #1388 

Resolves #1383 