### PR TITLE
Test Fix: performance test - use 475ms for max_transaction_cpu_usage

### DIFF
--- a/tests/performance_tests/genesis.json
+++ b/tests/performance_tests/genesis.json
@@ -11,7 +11,7 @@
     "context_free_discount_net_usage_den": 100,
     "max_block_cpu_usage": 500000,
     "target_block_cpu_usage_pct": 500,
-    "max_transaction_cpu_usage": 150000,
+    "max_transaction_cpu_usage": 475000,
     "min_transaction_cpu_usage": 0,
     "max_transaction_lifetime": 3600,
     "deferred_trx_expiration_window": 600,


### PR DESCRIPTION
All other integration tests use 475ms for genesis `max_transaction_cpu_usage`. Update performance tests to use the same value. Sometimes `setcode` of eosio system contract would fail in ci/cd as 150ms was not enough time to set the contract and abi.

Resolves #1390 