### PR TITLE
Revert back to non-oc execution for read-only trxs

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library( eosio_chain
 
               wast_to_wasm.cpp
               wasm_interface.cpp
+              wasm_interface_collection.cpp
               wasm_eosio_validation.cpp
               wasm_eosio_injection.cpp
               wasm_config.cpp

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -3,7 +3,7 @@
 #include <eosio/chain/controller.hpp>
 #include <eosio/chain/transaction_context.hpp>
 #include <eosio/chain/exceptions.hpp>
-#include <eosio/chain/wasm_interface.hpp>
+#include <eosio/chain/wasm_interface_collection.hpp>
 #include <eosio/chain/generated_transaction_object.hpp>
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/resource_limits.hpp>

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2692,8 +2692,8 @@ struct controller_impl {
       wasm_if_collect.init_thread_local_data(db, conf.state_dir, conf.eosvmoc_config, !conf.profile_accounts.empty());
    }
 
-   wasm_interface& get_wasm_interface() {
-      return wasm_if_collect.get_wasm_interface();
+   wasm_interface_collection& get_wasm_interface() {
+      return wasm_if_collect;
    }
 
    void code_block_num_last_used(const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, uint32_t block_num) {
@@ -3394,7 +3394,7 @@ const apply_handler* controller::find_apply_handler( account_name receiver, acco
    }
    return nullptr;
 }
-wasm_interface& controller::get_wasm_interface() {
+wasm_interface_collection& controller::get_wasm_interface() {
    return my->get_wasm_interface();
 }
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -40,6 +40,7 @@ namespace eosio { namespace chain {
    class account_object;
    class deep_mind_handler;
    class subjective_billing;
+   class wasm_interface_collection;
    using resource_limits::resource_limits_manager;
    using apply_handler = std::function<void(apply_context&)>;
    using forked_branch_callback = std::function<void(const branch_type&)>;
@@ -348,7 +349,7 @@ namespace eosio { namespace chain {
          */
 
          const apply_handler* find_apply_handler( account_name contract, scope_name scope, action_name act )const;
-         wasm_interface& get_wasm_interface();
+         wasm_interface_collection& get_wasm_interface();
 
       static chain_id_type extract_chain_id(snapshot_reader& snapshot);
 

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -46,7 +46,7 @@ namespace eosio { namespace chain {
             oc_none
          };
 
-         wasm_interface(vm_type vm, vm_oc_enable eosvmoc_tierup, const chainbase::database& d, const std::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, bool profile);
+         wasm_interface(vm_type vm, const chainbase::database& d, const std::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, bool profile);
          ~wasm_interface();
 
          // initialize exec per thread
@@ -61,19 +61,14 @@ namespace eosio { namespace chain {
          //indicate that a particular code probably won't be used after given block_num
          void code_block_num_last_used(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, const uint32_t& block_num);
 
-         //indicate the current LIB. evicts old cache entries
-         void current_lib(const uint32_t lib);
+         //indicate the current LIB. evicts old cache entries, each evicted entry is provided to callback
+         void current_lib(const uint32_t lib, const std::function<void(const digest_type&, uint8_t)>& callback);
 
          //Calls apply or error on a given code
          void apply(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context);
 
          //Returns true if the code is cached
          bool is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) const;
-
-         // If substitute_apply is set, then apply calls it before doing anything else. If substitute_apply returns true,
-         // then apply returns immediately.
-         std::function<bool(
-            const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, apply_context& context)> substitute_apply;
       private:
          unique_ptr<struct wasm_interface_impl> my;
    };

--- a/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
@@ -11,6 +11,8 @@ namespace eosio::chain {
     */
    class wasm_interface_collection {
       public:
+         inline static bool test_disable_tierup = false; // set by unittests to test tierup failing
+
          wasm_interface_collection(wasm_interface::vm_type vm, wasm_interface::vm_oc_enable eosvmoc_tierup,
                                    const chainbase::database& d, const std::filesystem::path& data_dir,
                                    const eosvmoc::config& eosvmoc_config, bool profile);

--- a/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
@@ -27,6 +27,14 @@ namespace eosio::chain {
             return *threaded_wasmifs[std::this_thread::get_id()];
          }
 
+         void apply(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context) {
+            get_wasm_interface().apply(code_hash, vm_type, vm_version, context);
+         }
+
+         bool is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) {
+            return get_wasm_interface().is_code_cached(code_hash, vm_type, vm_version);
+         }
+
          // update current lib of all wasm interfaces
          void current_lib(const uint32_t lib) {
             // producer_plugin has already asserted irreversible_block signal is called in write window

--- a/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
@@ -1,5 +1,10 @@
 #pragma once
 #include <eosio/chain/wasm_interface.hpp>
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+#include <eosio/chain/webassembly/eos-vm-oc.hpp>
+#else
+#define _REGISTER_EOSVMOC_INTRINSIC(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)
+#endif
 
 namespace eosio::chain {
 
@@ -8,16 +13,77 @@ namespace eosio::chain {
     */
    class wasm_interface_collection {
       public:
-         wasm_interface_collection(wasm_interface::vm_type vm, wasm_interface::vm_oc_enable eosvmoc_tierup,
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+       struct eosvmoc_tier {
+           eosvmoc_tier(const std::filesystem::path& d, const eosvmoc::config& c, const chainbase::database& db)
+                   : cc(d, c, db) {
+               // construct exec for the main thread
+               init_thread_local_data();
+           }
+
+           // Support multi-threaded execution.
+           void init_thread_local_data() {
+               exec = std::make_unique<eosvmoc::executor>(cc);
+           }
+
+           eosvmoc::code_cache_async cc;
+
+           // Each thread requires its own exec and mem. Defined in wasm_interface.cpp
+           thread_local static std::unique_ptr<eosvmoc::executor> exec;
+           thread_local static eosvmoc::memory mem;
+       };
+#endif
+
+       wasm_interface_collection(wasm_interface::vm_type vm, wasm_interface::vm_oc_enable eosvmoc_tierup,
                                    const chainbase::database& d, const std::filesystem::path& data_dir,
                                    const eosvmoc::config& eosvmoc_config, bool profile)
             : main_thread_id(std::this_thread::get_id())
             , wasm_runtime(vm)
             , eosvmoc_tierup(eosvmoc_tierup)
-            , wasmif(vm, eosvmoc_tierup, d, data_dir, eosvmoc_config, profile)
-         {}
+            , wasmif(vm, d, data_dir, eosvmoc_config, profile)
+         {
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+            if(eosvmoc_tierup != wasm_interface::vm_oc_enable::oc_none) {
+               EOS_ASSERT(vm != wasm_interface::vm_type::eos_vm_oc, wasm_exception, "You can't use EOS VM OC as the base runtime when tier up is activated");
+               eosvmoc.emplace(data_dir, eosvmoc_config, d);
+            }
+#endif
+         }
 
          void apply(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context) {
+            if(substitute_apply && substitute_apply(code_hash, vm_type, vm_version, context))
+               return;
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+            if(eosvmoc && (eosvmoc_tierup == wasm_interface::vm_oc_enable::oc_all || context.should_use_eos_vm_oc())) {
+               const chain::eosvmoc::code_descriptor* cd = nullptr;
+               chain::eosvmoc::code_cache_base::get_cd_failure failure = chain::eosvmoc::code_cache_base::get_cd_failure::temporary;
+               try {
+                  const bool high_priority = context.get_receiver().prefix() == chain::config::system_account_name;
+                  cd = eosvmoc->cc.get_descriptor_for_code(high_priority, code_hash, vm_version, context.control.is_write_window(), failure);
+               }
+               catch(...) {
+                  //swallow errors here, if EOS VM OC has gone in to the weeds we shouldn't bail: continue to try and run baseline
+                  //In the future, consider moving bits of EOS VM that can fire exceptions and such out of this call path
+                  static bool once_is_enough;
+                  if(!once_is_enough)
+                     elog("EOS VM OC has encountered an unexpected failure");
+                  once_is_enough = true;
+               }
+               if(cd) {
+                  if (!context.is_applying_block()) // read_only_trx_test.py looks for this log statement
+                     tlog("${a} speculatively executing ${h} with eos vm oc", ("a", context.get_receiver())("h", code_hash));
+                  eosvmoc->exec->execute(*cd, eosvmoc->mem, context);
+                  return;
+               }
+               else if (context.trx_context.is_read_only()) {
+                  if (failure == chain::eosvmoc::code_cache_base::get_cd_failure::temporary) {
+                     EOS_ASSERT(false, ro_trx_vm_oc_compile_temporary_failure, "get_descriptor_for_code failed with temporary failure");
+                  } else {
+                     EOS_ASSERT(false, ro_trx_vm_oc_compile_permanent_failure, "get_descriptor_for_code failed with permanent failure");
+                  }
+               }
+            }
+#endif
             if (is_on_main_thread()
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
                 || is_eos_vm_oc_enabled()
@@ -37,9 +103,17 @@ namespace eosio::chain {
          // update current lib of all wasm interfaces
          void current_lib(const uint32_t lib) {
             // producer_plugin has already asserted irreversible_block signal is called in write window
-            wasmif.current_lib(lib);
+            std::function<void(const digest_type& code_hash, uint8_t vm_version)> cb{};
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+            if(eosvmoc) {
+               cb = [&]( const digest_type& code_hash, uint8_t vm_version ) {
+                  eosvmoc->cc.free_code( code_hash, vm_version );
+               };
+            }
+#endif
+            wasmif.current_lib(lib, cb);
             for (auto& w: threaded_wasmifs) {
-               w.second->current_lib(lib);
+               w.second->current_lib(lib, cb);
             }
          }
 
@@ -50,13 +124,15 @@ namespace eosio::chain {
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
             if (is_eos_vm_oc_enabled()) {
                // EOSVMOC needs further initialization of its thread local data
+               if (eosvmoc)
+                  eosvmoc->init_thread_local_data();
                wasmif.init_thread_local_data();
             } else
 #endif
             {
                std::lock_guard g(threaded_wasmifs_mtx);
                // Non-EOSVMOC needs a wasmif per thread
-               threaded_wasmifs[std::this_thread::get_id()] = std::make_unique<wasm_interface>(wasm_runtime, eosvmoc_tierup, d, data_dir, eosvmoc_config, profile);
+               threaded_wasmifs[std::this_thread::get_id()] = std::make_unique<wasm_interface>(wasm_runtime, d, data_dir, eosvmoc_config, profile);
             }
          }
 
@@ -76,6 +152,10 @@ namespace eosio::chain {
             }
          }
 
+         // If substitute_apply is set, then apply calls it before doing anything else. If substitute_apply returns true,
+         // then apply returns immediately. Provided function must be multi-thread safe.
+         std::function<bool(const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, apply_context& context)> substitute_apply;
+
       private:
          bool is_on_main_thread() { return main_thread_id == std::this_thread::get_id(); };
 
@@ -87,6 +167,10 @@ namespace eosio::chain {
          wasm_interface wasmif;  // used by main thread and all threads for EOSVMOC
          std::mutex threaded_wasmifs_mtx;
          std::unordered_map<std::thread::id, std::unique_ptr<wasm_interface>> threaded_wasmifs; // one for each read-only thread, used by eos-vm and eos-vm-jit
+
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+         std::optional<eosvmoc_tier> eosvmoc;
+#endif
    };
 
 } // eosio::chain

--- a/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
@@ -23,7 +23,7 @@ namespace eosio::chain {
                 || is_eos_vm_oc_enabled()
 #endif
             ) {
-               wasmif.apply(code_hash, vm_type, vm_version, context);
+               return wasmif.apply(code_hash, vm_type, vm_version, context);
             }
             threaded_wasmifs[std::this_thread::get_id()]->apply(code_hash, vm_type, vm_version, context);
          }

--- a/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
@@ -5,6 +5,9 @@
 #else
 #define _REGISTER_EOSVMOC_INTRINSIC(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)
 #endif
+#include <mutex>
+#include <thread>
+#include <unordered_map>
 
 namespace eosio::chain {
 
@@ -13,86 +16,13 @@ namespace eosio::chain {
     */
    class wasm_interface_collection {
       public:
-#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-       struct eosvmoc_tier {
-           eosvmoc_tier(const std::filesystem::path& d, const eosvmoc::config& c, const chainbase::database& db)
-                   : cc(d, c, db) {
-               // construct exec for the main thread
-               init_thread_local_data();
-           }
-
-           // Support multi-threaded execution.
-           void init_thread_local_data() {
-               exec = std::make_unique<eosvmoc::executor>(cc);
-           }
-
-           eosvmoc::code_cache_async cc;
-
-           // Each thread requires its own exec and mem. Defined in wasm_interface.cpp
-           thread_local static std::unique_ptr<eosvmoc::executor> exec;
-           thread_local static eosvmoc::memory mem;
-       };
-#endif
-
-       wasm_interface_collection(wasm_interface::vm_type vm, wasm_interface::vm_oc_enable eosvmoc_tierup,
+         wasm_interface_collection(wasm_interface::vm_type vm, wasm_interface::vm_oc_enable eosvmoc_tierup,
                                    const chainbase::database& d, const std::filesystem::path& data_dir,
-                                   const eosvmoc::config& eosvmoc_config, bool profile)
-            : main_thread_id(std::this_thread::get_id())
-            , wasm_runtime(vm)
-            , eosvmoc_tierup(eosvmoc_tierup)
-            , wasmif(vm, d, data_dir, eosvmoc_config, profile)
-         {
-#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-            if(eosvmoc_tierup != wasm_interface::vm_oc_enable::oc_none) {
-               EOS_ASSERT(vm != wasm_interface::vm_type::eos_vm_oc, wasm_exception, "You can't use EOS VM OC as the base runtime when tier up is activated");
-               eosvmoc.emplace(data_dir, eosvmoc_config, d);
-            }
-#endif
-         }
+                                   const eosvmoc::config& eosvmoc_config, bool profile);
 
-         void apply(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context) {
-            if(substitute_apply && substitute_apply(code_hash, vm_type, vm_version, context))
-               return;
-#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-            if(eosvmoc && (eosvmoc_tierup == wasm_interface::vm_oc_enable::oc_all || context.should_use_eos_vm_oc())) {
-               const chain::eosvmoc::code_descriptor* cd = nullptr;
-               chain::eosvmoc::code_cache_base::get_cd_failure failure = chain::eosvmoc::code_cache_base::get_cd_failure::temporary;
-               try {
-                  const bool high_priority = context.get_receiver().prefix() == chain::config::system_account_name;
-                  cd = eosvmoc->cc.get_descriptor_for_code(high_priority, code_hash, vm_version, context.control.is_write_window(), failure);
-               }
-               catch(...) {
-                  //swallow errors here, if EOS VM OC has gone in to the weeds we shouldn't bail: continue to try and run baseline
-                  //In the future, consider moving bits of EOS VM that can fire exceptions and such out of this call path
-                  static bool once_is_enough;
-                  if(!once_is_enough)
-                     elog("EOS VM OC has encountered an unexpected failure");
-                  once_is_enough = true;
-               }
-               if(cd) {
-                  if (!context.is_applying_block()) // read_only_trx_test.py looks for this log statement
-                     tlog("${a} speculatively executing ${h} with eos vm oc", ("a", context.get_receiver())("h", code_hash));
-                  eosvmoc->exec->execute(*cd, eosvmoc->mem, context);
-                  return;
-               }
-               else if (context.trx_context.is_read_only()) {
-                  if (failure == chain::eosvmoc::code_cache_base::get_cd_failure::temporary) {
-                     EOS_ASSERT(false, ro_trx_vm_oc_compile_temporary_failure, "get_descriptor_for_code failed with temporary failure");
-                  } else {
-                     EOS_ASSERT(false, ro_trx_vm_oc_compile_permanent_failure, "get_descriptor_for_code failed with permanent failure");
-                  }
-               }
-            }
-#endif
-            if (is_on_main_thread()
-#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-                || is_eos_vm_oc_enabled()
-#endif
-            ) {
-               return wasmif.apply(code_hash, vm_type, vm_version, context);
-            }
-            threaded_wasmifs[std::this_thread::get_id()]->apply(code_hash, vm_type, vm_version, context);
-         }
+         ~wasm_interface_collection();
+
+         void apply(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context);
 
          // used for tests, only valid on main thread
          bool is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) {
@@ -101,40 +31,10 @@ namespace eosio::chain {
          }
 
          // update current lib of all wasm interfaces
-         void current_lib(const uint32_t lib) {
-            // producer_plugin has already asserted irreversible_block signal is called in write window
-            std::function<void(const digest_type& code_hash, uint8_t vm_version)> cb{};
-#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-            if(eosvmoc) {
-               cb = [&]( const digest_type& code_hash, uint8_t vm_version ) {
-                  eosvmoc->cc.free_code( code_hash, vm_version );
-               };
-            }
-#endif
-            wasmif.current_lib(lib, cb);
-            for (auto& w: threaded_wasmifs) {
-               w.second->current_lib(lib, cb);
-            }
-         }
+         void current_lib(const uint32_t lib);
 
          // only called from non-main threads (read-only trx execution threads) when producer_plugin starts them
-         void init_thread_local_data(const chainbase::database& d, const std::filesystem::path& data_dir,
-                                     const eosvmoc::config& eosvmoc_config, bool profile) {
-            EOS_ASSERT(!is_on_main_thread(), misc_exception, "init_thread_local_data called on the main thread");
-#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-            if (is_eos_vm_oc_enabled()) {
-               // EOSVMOC needs further initialization of its thread local data
-               if (eosvmoc)
-                  eosvmoc->init_thread_local_data();
-               wasmif.init_thread_local_data();
-            } else
-#endif
-            {
-               std::lock_guard g(threaded_wasmifs_mtx);
-               // Non-EOSVMOC needs a wasmif per thread
-               threaded_wasmifs[std::this_thread::get_id()] = std::make_unique<wasm_interface>(wasm_runtime, d, data_dir, eosvmoc_config, profile);
-            }
-         }
+         void init_thread_local_data(const chainbase::database& d, const std::filesystem::path& data_dir, const eosvmoc::config& eosvmoc_config, bool profile);
 
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
          bool is_eos_vm_oc_enabled() const {
@@ -142,15 +42,7 @@ namespace eosio::chain {
          }
 #endif
 
-         void code_block_num_last_used(const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, uint32_t block_num) {
-            // The caller of this function apply_eosio_setcode has already asserted that
-            // the transaction is not a read-only trx, which implies we are
-            // in write window. Safe to call threaded_wasmifs's code_block_num_last_used
-            wasmif.code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
-            for (auto& w: threaded_wasmifs) {
-               w.second->code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
-            }
-         }
+         void code_block_num_last_used(const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, uint32_t block_num);
 
          // If substitute_apply is set, then apply calls it before doing anything else. If substitute_apply returns true,
          // then apply returns immediately. Provided function must be multi-thread safe.
@@ -164,12 +56,12 @@ namespace eosio::chain {
          const wasm_interface::vm_type wasm_runtime;
          const wasm_interface::vm_oc_enable eosvmoc_tierup;
 
-         wasm_interface wasmif;  // used by main thread and all threads for EOSVMOC
+         wasm_interface wasmif;  // used by main thread
          std::mutex threaded_wasmifs_mtx;
          std::unordered_map<std::thread::id, std::unique_ptr<wasm_interface>> threaded_wasmifs; // one for each read-only thread, used by eos-vm and eos-vm-jit
 
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-         std::optional<eosvmoc_tier> eosvmoc;
+         std::unique_ptr<struct eosvmoc_tier> eosvmoc; // used by all threads
 #endif
    };
 

--- a/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_collection.hpp
@@ -1,10 +1,5 @@
 #pragma once
 #include <eosio/chain/wasm_interface.hpp>
-#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-#include <eosio/chain/webassembly/eos-vm-oc.hpp>
-#else
-#define _REGISTER_EOSVMOC_INTRINSIC(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)
-#endif
 #include <mutex>
 #include <thread>
 #include <unordered_map>

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -97,13 +97,7 @@ namespace eosio { namespace chain {
 #endif
       }
 
-      ~wasm_interface_impl() {
-         if(is_shutting_down)
-            for(wasm_cache_index::iterator it = wasm_instantiation_cache.begin(); it != wasm_instantiation_cache.end(); ++it)
-               wasm_instantiation_cache.modify(it, [](wasm_cache_entry& e) {
-                  e.module.release()->fast_shutdown();
-               });
-      }
+      ~wasm_interface_impl() = default;
 
       bool is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) const {
          wasm_cache_index::iterator it = wasm_instantiation_cache.find( boost::make_tuple(code_hash, vm_type, vm_version) );
@@ -162,7 +156,6 @@ namespace eosio { namespace chain {
          return it->module;
       }
 
-      bool is_shutting_down = false;
       std::unique_ptr<wasm_runtime_interface> runtime_interface;
 
       typedef boost::multi_index_container<

--- a/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
@@ -13,7 +13,6 @@ class apply_context;
 class wasm_instantiated_module_interface {
    public:
       virtual void apply(apply_context& context) = 0;
-      virtual void fast_shutdown() {}
 
       virtual ~wasm_instantiated_module_interface();
 };

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -70,7 +70,7 @@ namespace eosio { namespace chain {
       //there are a couple opportunties for improvement here--
       //Easy: Cache the Module created here so it can be reused for instantiaion
       //Hard: Kick off instantiation in a separate thread at this location
-	 }
+   }
 
    void wasm_interface::code_block_num_last_used(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, const uint32_t& block_num) {
       my->code_block_num_last_used(code_hash, vm_type, vm_version, block_num);

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -74,10 +74,6 @@ namespace eosio { namespace chain {
       //Hard: Kick off instantiation in a separate thread at this location
 	 }
 
-   void wasm_interface::indicate_shutting_down() {
-      my->is_shutting_down = true;
-   }
-
    void wasm_interface::code_block_num_last_used(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, const uint32_t& block_num) {
       my->code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
    }

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -32,16 +32,14 @@
 
 namespace eosio { namespace chain {
 
-   wasm_interface::wasm_interface(vm_type vm, vm_oc_enable eosvmoc_tierup, const chainbase::database& d, const std::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, bool profile)
-     : my( new wasm_interface_impl(vm, eosvmoc_tierup, d, data_dir, eosvmoc_config, profile) ) {}
+   wasm_interface::wasm_interface(vm_type vm, const chainbase::database& d, const std::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, bool profile)
+     : my( new wasm_interface_impl(vm, d, data_dir, eosvmoc_config, profile) ) {}
 
    wasm_interface::~wasm_interface() {}
 
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
    void wasm_interface::init_thread_local_data() {
-      if (my->eosvmoc)
-         my->eosvmoc->init_thread_local_data();
-      else if (my->wasm_runtime_time == wasm_interface::vm_type::eos_vm_oc && my->runtime_interface)
+      if (my->wasm_runtime_time == wasm_interface::vm_type::eos_vm_oc && my->runtime_interface)
          my->runtime_interface->init_thread_local_data();
    }
 #endif
@@ -78,44 +76,11 @@ namespace eosio { namespace chain {
       my->code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
    }
 
-   void wasm_interface::current_lib(const uint32_t lib) {
-      my->current_lib(lib);
+   void wasm_interface::current_lib(const uint32_t lib, const std::function<void(const digest_type&, uint8_t)>& callback) {
+      my->current_lib(lib, callback);
    }
 
    void wasm_interface::apply( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context ) {
-      if(substitute_apply && substitute_apply(code_hash, vm_type, vm_version, context))
-         return;
-#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-      if(my->eosvmoc && (my->eosvmoc_tierup == wasm_interface::vm_oc_enable::oc_all || context.should_use_eos_vm_oc())) {
-         const chain::eosvmoc::code_descriptor* cd = nullptr;
-         chain::eosvmoc::code_cache_base::get_cd_failure failure = chain::eosvmoc::code_cache_base::get_cd_failure::temporary;
-         try {
-            const bool high_priority = context.get_receiver().prefix() == chain::config::system_account_name;
-            cd = my->eosvmoc->cc.get_descriptor_for_code(high_priority, code_hash, vm_version, context.control.is_write_window(), failure);
-         }
-         catch(...) {
-            //swallow errors here, if EOS VM OC has gone in to the weeds we shouldn't bail: continue to try and run baseline
-            //In the future, consider moving bits of EOS VM that can fire exceptions and such out of this call path
-            static bool once_is_enough;
-            if(!once_is_enough)
-               elog("EOS VM OC has encountered an unexpected failure");
-            once_is_enough = true;
-         }
-         if(cd) {
-            if (!context.is_applying_block()) // read_only_trx_test.py looks for this log statement
-               tlog("${a} speculatively executing ${h} with eos vm oc", ("a", context.get_receiver())("h", code_hash));
-            my->eosvmoc->exec->execute(*cd, my->eosvmoc->mem, context);
-            return;
-         }
-         else if (context.trx_context.is_read_only()) {
-            if (failure == chain::eosvmoc::code_cache_base::get_cd_failure::temporary) {
-               EOS_ASSERT(false, ro_trx_vm_oc_compile_temporary_failure, "get_descriptor_for_code failed with temporary failure");
-            } else {
-               EOS_ASSERT(false, ro_trx_vm_oc_compile_permanent_failure, "get_descriptor_for_code failed with permanent failure");
-            }
-         }
-      }
-#endif
       my->get_instantiated_module(code_hash, vm_type, vm_version, context.trx_context)->apply(context);
    }
 
@@ -123,13 +88,8 @@ namespace eosio { namespace chain {
       return my->is_code_cached(code_hash, vm_type, vm_version);
    }
 
-   wasm_instantiated_module_interface::~wasm_instantiated_module_interface() {}
-   wasm_runtime_interface::~wasm_runtime_interface() {}
-
-#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-   thread_local std::unique_ptr<eosvmoc::executor> wasm_interface_impl::eosvmoc_tier::exec {};
-   thread_local eosvmoc::memory wasm_interface_impl::eosvmoc_tier::mem{ wasm_constraints::maximum_linear_memory/wasm_constraints::wasm_page_size };
-#endif
+   wasm_instantiated_module_interface::~wasm_instantiated_module_interface() = default;
+   wasm_runtime_interface::~wasm_runtime_interface() = default;
 
 std::istream& operator>>(std::istream& in, wasm_interface::vm_type& runtime) {
    std::string s;

--- a/libraries/chain/wasm_interface_collection.cpp
+++ b/libraries/chain/wasm_interface_collection.cpp
@@ -79,7 +79,8 @@ void wasm_interface_collection::apply(const digest_type& code_hash, const uint8_
        || is_eos_vm_oc_enabled()
 #endif
    ) {
-      return wasmif.apply(code_hash, vm_type, vm_version, context);
+      wasmif.apply(code_hash, vm_type, vm_version, context);
+      return;
    }
    threaded_wasmifs[std::this_thread::get_id()]->apply(code_hash, vm_type, vm_version, context);
 }

--- a/libraries/chain/wasm_interface_collection.cpp
+++ b/libraries/chain/wasm_interface_collection.cpp
@@ -1,4 +1,9 @@
 #include <eosio/chain/wasm_interface_collection.hpp>
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+#include <eosio/chain/webassembly/eos-vm-oc.hpp>
+#else
+#define _REGISTER_EOSVMOC_INTRINSIC(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)
+#endif
 
 namespace eosio::chain {
 

--- a/libraries/chain/wasm_interface_collection.cpp
+++ b/libraries/chain/wasm_interface_collection.cpp
@@ -48,7 +48,7 @@ void wasm_interface_collection::apply(const digest_type& code_hash, const uint8_
       return;
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
    if (eosvmoc && (eosvmoc_tierup == wasm_interface::vm_oc_enable::oc_all || context.should_use_eos_vm_oc())) {
-      const chain::eosvmoc::code_descriptor*          cd      = nullptr;
+      const chain::eosvmoc::code_descriptor* cd = nullptr;
       chain::eosvmoc::code_cache_base::get_cd_failure failure = chain::eosvmoc::code_cache_base::get_cd_failure::temporary;
       try {
          const bool high_priority = context.get_receiver().prefix() == chain::config::system_account_name;
@@ -66,12 +66,6 @@ void wasm_interface_collection::apply(const digest_type& code_hash, const uint8_
             tlog("${a} speculatively executing ${h} with eos vm oc", ("a", context.get_receiver())("h", code_hash));
          eosvmoc->exec->execute(*cd, eosvmoc->mem, context);
          return;
-      } else if (context.trx_context.is_read_only()) {
-         if (failure == chain::eosvmoc::code_cache_base::get_cd_failure::temporary) {
-            EOS_ASSERT(false, ro_trx_vm_oc_compile_temporary_failure, "get_descriptor_for_code failed with temporary failure");
-         } else {
-            EOS_ASSERT(false, ro_trx_vm_oc_compile_permanent_failure, "get_descriptor_for_code failed with permanent failure");
-         }
       }
    }
 #endif

--- a/libraries/chain/wasm_interface_collection.cpp
+++ b/libraries/chain/wasm_interface_collection.cpp
@@ -1,0 +1,10 @@
+#include <eosio/chain/wasm_interface_collection.hpp>
+
+namespace eosio { namespace chain {
+
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+   thread_local std::unique_ptr<eosvmoc::executor> wasm_interface_collection::eosvmoc_tier::exec {};
+   thread_local eosvmoc::memory wasm_interface_collection::eosvmoc_tier::mem{ wasm_constraints::maximum_linear_memory/wasm_constraints::wasm_page_size };
+#endif
+
+} } /// eosio::chain

--- a/libraries/chain/wasm_interface_collection.cpp
+++ b/libraries/chain/wasm_interface_collection.cpp
@@ -1,10 +1,134 @@
 #include <eosio/chain/wasm_interface_collection.hpp>
 
-namespace eosio { namespace chain {
+namespace eosio::chain {
 
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-   thread_local std::unique_ptr<eosvmoc::executor> wasm_interface_collection::eosvmoc_tier::exec {};
-   thread_local eosvmoc::memory wasm_interface_collection::eosvmoc_tier::mem{ wasm_constraints::maximum_linear_memory/wasm_constraints::wasm_page_size };
+struct eosvmoc_tier {
+   eosvmoc_tier(const std::filesystem::path& d, const eosvmoc::config& c, const chainbase::database& db)
+      : cc(d, c, db) {
+      // construct exec for the main thread
+      init_thread_local_data();
+   }
+
+   // Support multi-threaded execution.
+   void init_thread_local_data() {
+      exec = std::make_unique<eosvmoc::executor>(cc);
+   }
+
+   eosvmoc::code_cache_async cc;
+
+   // Each thread requires its own exec and mem. Defined in wasm_interface.cpp
+   thread_local static std::unique_ptr<eosvmoc::executor> exec;
+   thread_local static eosvmoc::memory mem;
+};
+
+thread_local std::unique_ptr<eosvmoc::executor> eosvmoc_tier::exec{};
+thread_local eosvmoc::memory eosvmoc_tier::mem{wasm_constraints::maximum_linear_memory / wasm_constraints::wasm_page_size};
 #endif
 
-} } /// eosio::chain
+wasm_interface_collection::wasm_interface_collection(wasm_interface::vm_type vm, wasm_interface::vm_oc_enable eosvmoc_tierup,
+                                                     const chainbase::database& d, const std::filesystem::path& data_dir,
+                                                     const eosvmoc::config& eosvmoc_config, bool profile)
+   : main_thread_id(std::this_thread::get_id())
+   , wasm_runtime(vm)
+   , eosvmoc_tierup(eosvmoc_tierup)
+   , wasmif(vm, d, data_dir, eosvmoc_config, profile) {
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+   if (eosvmoc_tierup != wasm_interface::vm_oc_enable::oc_none) {
+      EOS_ASSERT(vm != wasm_interface::vm_type::eos_vm_oc, wasm_exception, "You can't use EOS VM OC as the base runtime when tier up is activated");
+      eosvmoc = std::make_unique<eosvmoc_tier>(data_dir, eosvmoc_config, d);
+   }
+#endif
+}
+
+wasm_interface_collection::~wasm_interface_collection() = default;
+
+void wasm_interface_collection::apply(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context) {
+   if (substitute_apply && substitute_apply(code_hash, vm_type, vm_version, context))
+      return;
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+   if (eosvmoc && (eosvmoc_tierup == wasm_interface::vm_oc_enable::oc_all || context.should_use_eos_vm_oc())) {
+      const chain::eosvmoc::code_descriptor*          cd      = nullptr;
+      chain::eosvmoc::code_cache_base::get_cd_failure failure = chain::eosvmoc::code_cache_base::get_cd_failure::temporary;
+      try {
+         const bool high_priority = context.get_receiver().prefix() == chain::config::system_account_name;
+         cd = eosvmoc->cc.get_descriptor_for_code(high_priority, code_hash, vm_version, context.control.is_write_window(), failure);
+      } catch (...) {
+         // swallow errors here, if EOS VM OC has gone in to the weeds we shouldn't bail: continue to try and run baseline
+         // In the future, consider moving bits of EOS VM that can fire exceptions and such out of this call path
+         static bool once_is_enough;
+         if (!once_is_enough)
+            elog("EOS VM OC has encountered an unexpected failure");
+         once_is_enough = true;
+      }
+      if (cd) {
+         if (!context.is_applying_block()) // read_only_trx_test.py looks for this log statement
+            tlog("${a} speculatively executing ${h} with eos vm oc", ("a", context.get_receiver())("h", code_hash));
+         eosvmoc->exec->execute(*cd, eosvmoc->mem, context);
+         return;
+      } else if (context.trx_context.is_read_only()) {
+         if (failure == chain::eosvmoc::code_cache_base::get_cd_failure::temporary) {
+            EOS_ASSERT(false, ro_trx_vm_oc_compile_temporary_failure, "get_descriptor_for_code failed with temporary failure");
+         } else {
+            EOS_ASSERT(false, ro_trx_vm_oc_compile_permanent_failure, "get_descriptor_for_code failed with permanent failure");
+         }
+      }
+   }
+#endif
+   if (is_on_main_thread()
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+       || is_eos_vm_oc_enabled()
+#endif
+   ) {
+      return wasmif.apply(code_hash, vm_type, vm_version, context);
+   }
+   threaded_wasmifs[std::this_thread::get_id()]->apply(code_hash, vm_type, vm_version, context);
+}
+
+// update current lib of all wasm interfaces
+void wasm_interface_collection::current_lib(const uint32_t lib) {
+   // producer_plugin has already asserted irreversible_block signal is called in write window
+   std::function<void(const digest_type& code_hash, uint8_t vm_version)> cb{};
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+   if (eosvmoc) {
+      cb = [&](const digest_type& code_hash, uint8_t vm_version) {
+         eosvmoc->cc.free_code(code_hash, vm_version);
+      };
+   }
+#endif
+   wasmif.current_lib(lib, cb);
+   for (auto& w : threaded_wasmifs) {
+      w.second->current_lib(lib, cb);
+   }
+}
+
+// only called from non-main threads (read-only trx execution threads) when producer_plugin starts them
+void wasm_interface_collection::init_thread_local_data(const chainbase::database& d, const std::filesystem::path& data_dir,
+                                                       const eosvmoc::config& eosvmoc_config, bool profile) {
+   EOS_ASSERT(!is_on_main_thread(), misc_exception, "init_thread_local_data called on the main thread");
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+   if (is_eos_vm_oc_enabled()) {
+      // EOSVMOC needs further initialization of its thread local data
+      if (eosvmoc)
+         eosvmoc->init_thread_local_data();
+      wasmif.init_thread_local_data();
+   } else
+#endif
+   {
+      std::lock_guard g(threaded_wasmifs_mtx);
+      // Non-EOSVMOC needs a wasmif per thread
+      threaded_wasmifs[std::this_thread::get_id()] = std::make_unique<wasm_interface>(wasm_runtime, d, data_dir, eosvmoc_config, profile);
+   }
+}
+
+void wasm_interface_collection::code_block_num_last_used(const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, uint32_t block_num) {
+   // The caller of this function apply_eosio_setcode has already asserted that
+   // the transaction is not a read-only trx, which implies we are
+   // in write window. Safe to call threaded_wasmifs's code_block_num_last_used
+   wasmif.code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
+   for (auto& w : threaded_wasmifs) {
+      w.second->code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
+   }
+}
+
+} // namespace eosio::chain

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -201,10 +201,6 @@ class eos_vm_profiling_module : public wasm_instantiated_module_interface {
          }
       }
 
-      void fast_shutdown() override {
-         _prof.clear();
-      }
-
       profile_data* start(apply_context& context) {
          name account = context.get_receiver();
          if(!context.control.is_profiling(account)) return nullptr;

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1,6 +1,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <eosio/testing/tester.hpp>
+#include <eosio/chain/wasm_interface_collection.hpp>
 #include <eosio/chain/block_log.hpp>
 #include <eosio/chain/wast_to_wasm.hpp>
 #include <eosio/chain/eosio_contract.hpp>

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1177,8 +1177,6 @@ void chain_plugin_impl::plugin_shutdown() {
    accepted_transaction_connection.reset();
    applied_transaction_connection.reset();
    block_start_connection.reset();
-   if(app().is_quiting())
-      chain->get_wasm_interface().indicate_shutting_down();
    chain.reset();
 }
 

--- a/plugins/producer_plugin/test/CMakeLists.txt
+++ b/plugins/producer_plugin/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable( test_producer_plugin
         test_trx_full.cpp
         test_options.cpp
-        test_read_only_trx.cpp
         test_block_timing_util.cpp
         main.cpp
         )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,7 +76,7 @@ else()
 endif()
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
-add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
+add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output --catch_system_errors=no)
 
 add_test(NAME nodeos_sanity_test COMMAND tests/nodeos_run_test.py -v --sanity-test ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_sanity_test PROPERTY LABELS nonparallelizable_tests)

--- a/tests/read_only_trx_test.py
+++ b/tests/read_only_trx_test.py
@@ -100,6 +100,12 @@ def startCluster():
     specificExtraNodeosArgs={}
     # producer nodes will be mapped to 0 through pnodes-1, so the number pnodes is the no-producing API node
     specificExtraNodeosArgs[pnodes]=" --plugin eosio::net_api_plugin"
+    specificExtraNodeosArgs[pnodes]+=" --read-only-write-window-time-us "
+    specificExtraNodeosArgs[pnodes]+=" 10000 "
+    specificExtraNodeosArgs[pnodes]+=" --read-only-read-window-time-us "
+    specificExtraNodeosArgs[pnodes]+=" 490000 "
+    specificExtraNodeosArgs[pnodes]+=" --eos-vm-oc-cache-size-mb "
+    specificExtraNodeosArgs[pnodes]+=" 1 " # set small so there is churn
     specificExtraNodeosArgs[pnodes]+=" --read-only-threads "
     specificExtraNodeosArgs[pnodes]+=str(args.read_only_threads)
     if args.eos_vm_oc_enable:

--- a/unittests/test_utils.hpp
+++ b/unittests/test_utils.hpp
@@ -1,0 +1,143 @@
+#pragma once
+
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain_plugin/chain_plugin.hpp>
+#include <eosio/chain/application.hpp>
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/config.hpp>
+#include <eosio/chain/transaction.hpp>
+#include <eosio/chain/controller.hpp>
+
+#include <contracts.hpp>
+#include <future>
+#include <stdexcept>
+
+namespace eosio::test_utils {
+
+using namespace eosio::chain;
+using namespace eosio::chain::literals;
+
+struct testit {
+   uint64_t id;
+   explicit testit(uint64_t id = 0)
+      :id(id){}
+   static account_name get_account() {
+      return chain::config::system_account_name;
+   }
+   static action_name get_name() {
+      return "testit"_n;
+   }
+};
+
+// Corresponds to the reqactivated action of the bios contract.
+// See libraries/testing/contracts/eosio.bios/eosio.bios.hpp
+struct reqactivated {
+   chain::digest_type feature_digest;
+
+   explicit reqactivated(const chain::digest_type& fd)
+      :feature_digest(fd){};
+
+   static account_name get_account() {
+      return chain::config::system_account_name;
+   }
+   static action_name get_name() {
+      return "reqactivated"_n;
+   }
+};
+
+// Create a read-only trx that works with bios reqactivated action
+auto make_bios_ro_trx(eosio::chain::controller& control) {
+   const auto& pfm = control.get_protocol_feature_manager();
+   static auto feature_digest = pfm.get_builtin_digest(builtin_protocol_feature_t::replace_deferred);
+
+   signed_transaction trx;
+   trx.expiration = fc::time_point_sec{fc::time_point::now() + fc::seconds(30)};
+   vector<permission_level> no_auth{};
+   trx.actions.emplace_back( no_auth, reqactivated{*feature_digest} );
+   return std::make_shared<packed_transaction>( std::move(trx) );
+}
+
+// Push an input transaction to controller and return trx trace
+// If account is eosio then signs with the default private key
+auto push_input_trx(eosio::chain::controller& control, account_name account, signed_transaction& trx) {
+   trx.expiration = fc::time_point_sec{fc::time_point::now() + fc::seconds(30)};
+   trx.set_reference_block( control.head_block_id() );
+   if (account == config::system_account_name) {
+      auto default_priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("nathan")));
+      trx.sign(default_priv_key, control.get_chain_id());
+   } else {
+      trx.sign(testing::tester::get_private_key(account, "active"), control.get_chain_id());
+   }
+   auto ptrx = std::make_shared<packed_transaction>( trx, packed_transaction::compression_type::zlib );
+   auto fut = transaction_metadata::start_recover_keys( ptrx, control.get_thread_pool(), control.get_chain_id(), fc::microseconds::maximum(), transaction_metadata::trx_type::input );
+   auto r = control.push_transaction( fut.get(), fc::time_point::maximum(), fc::microseconds::maximum(), 0, false, 0 );
+   return r;
+}
+
+// Push setcode trx to controller and return trx trace
+auto set_code(eosio::chain::controller& control, account_name account, const vector<uint8_t>& wasm) {
+   signed_transaction trx;
+   trx.actions.emplace_back(std::vector<permission_level>{{account, config::active_name}},
+                            chain::setcode{
+                               .account = account,
+                               .vmtype = 0,
+                               .vmversion = 0,
+                               .code = bytes(wasm.begin(), wasm.end())
+                            });
+   return push_input_trx(control, account, trx);
+}
+
+void activate_protocol_features_set_bios_contract(appbase::scoped_app& app, chain_plugin* chain_plug) {
+   using namespace appbase;
+
+   std::promise<void> feature_promise;
+   std::future<void> feature_future = feature_promise.get_future();
+   app->executor().post( priority::high, exec_queue::read_write, [&chain_plug=chain_plug, &feature_promise](){
+      const auto& pfm = chain_plug->chain().get_protocol_feature_manager();
+      auto preactivate_feature_digest = pfm.get_builtin_digest(builtin_protocol_feature_t::preactivate_feature);
+      BOOST_CHECK( preactivate_feature_digest );
+      chain_plug->chain().preactivate_feature( *preactivate_feature_digest, false );
+      std::vector<builtin_protocol_feature_t> pfs{
+         builtin_protocol_feature_t::only_link_to_existing_permission,
+         builtin_protocol_feature_t::replace_deferred,
+         builtin_protocol_feature_t::no_duplicate_deferred_id,
+         builtin_protocol_feature_t::fix_linkauth_restriction,
+         builtin_protocol_feature_t::disallow_empty_producer_schedule,
+         builtin_protocol_feature_t::restrict_action_to_self,
+         builtin_protocol_feature_t::only_bill_first_authorizer,
+         builtin_protocol_feature_t::forward_setcode,
+         builtin_protocol_feature_t::get_sender,
+         builtin_protocol_feature_t::ram_restrictions,
+         builtin_protocol_feature_t::webauthn_key,
+         builtin_protocol_feature_t::wtmsig_block_signatures };
+      for (const auto t : pfs) {
+         auto feature_digest = pfm.get_builtin_digest(t);
+         BOOST_CHECK( feature_digest );
+         chain_plug->chain().preactivate_feature( *feature_digest, false );
+      }
+      feature_promise.set_value();
+   });
+
+   // Wait for next block
+   std::this_thread::sleep_for( std::chrono::milliseconds(config::block_interval_ms) );
+
+   if (feature_future.wait_for(std::chrono::seconds(5)) == std::future_status::timeout)
+      throw std::runtime_error("failed to preactivate features");
+
+   std::promise<void> setcode_promise;
+   std::future<void> setcode_future = setcode_promise.get_future();
+   app->executor().post( priority::high, exec_queue::read_write, [&chain_plug=chain_plug, &setcode_promise](){
+      auto r = set_code(chain_plug->chain(), config::system_account_name, testing::contracts::eosio_bios_wasm());
+      BOOST_CHECK(r->receipt && r->receipt->status == transaction_receipt_header::executed);
+      setcode_promise.set_value();
+   });
+
+   if (setcode_future.wait_for(std::chrono::seconds(5)) == std::future_status::timeout)
+      throw std::runtime_error("failed to setcode");
+}
+
+
+} // namespace eosio::test_utils
+
+FC_REFLECT( eosio::test_utils::testit, (id) )
+FC_REFLECT( eosio::test_utils::reqactivated, (feature_digest) )

--- a/unittests/test_utils.hpp
+++ b/unittests/test_utils.hpp
@@ -11,6 +11,7 @@
 #include <contracts.hpp>
 #include <future>
 #include <stdexcept>
+#include <thread>
 
 namespace eosio::test_utils {
 


### PR DESCRIPTION
When `eos-vm-oc-enable` is `auto` or `all` revert back to non-oc tier up when oc compile of read-only trx not ready.
* Refactors `eosvmoc_tier` into `wasm_interface_collection` so that all threads share the same `eosvmoc_tier` instead of having one per `wasm_interface`.
* Removes unneeded eos-vm fast shutdown.
* Fixes `substitute_apply` so it does not have to be set on each thread.

Resolves #1119 