### PR TITLE
Print non-default options on startup/shutdown

### DIFF
--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -29,12 +29,13 @@ using namespace eosio;
 namespace detail {
 
 void log_non_default_options(const std::vector<bpo::basic_option<char>>& options) {
+   using namespace std::string_literals;
    string result;
    for (const auto& op : options) {
       bool mask = false;
-      if (op.string_key == "signature-provider"
-          || op.string_key == "peer-private-key"
-          || op.string_key == "p2p-auto-bp-peer") {
+      if (op.string_key == "signature-provider"s
+          || op.string_key == "peer-private-key"s
+          || op.string_key == "p2p-auto-bp-peer"s) {
          mask = true;
       }
       std::string v;


### PR DESCRIPTION
Log all non-default command line options and `config.ini` options on startup and on program exit.

Example:
```
info  2023-07-17T16:59:13.936 nodeos    main.cpp:154                  operator()           ] nodeos version v4.1.0-dev v4.1.0-dev-d243f8569d5f8baf55bfb787a481530998a15d93-dirty
info  2023-07-17T16:59:13.936 nodeos    main.cpp:61                   log_non_default_opti ] Non-default options: data-dir = d, config-dir = mainconfig, enable-stale-production, producer-name = eosio, signature-provider = ***, chain-state-db-size-mb = 65536, p2p-peer-address = peer.main.alohaeos.com:9876, p2p-peer-address = p2p.eosargentina.io:9876, p2p-peer-address = p2p.genereos.io:9876, p2p-peer-address = eos.defibox.xyz:9876, p2p-peer-address = eos.edenia.cloud:9876, p2p-peer-address = p2p.eos.cryptolions.io:9876, p2p-peer-address = p2p.donates2eden.io:9876, p2p-peer-address = p2p.eos42.io:9876, p2p-peer-address = mainnet.eosamsterdam.net:9876, p2p-peer-address = mainnet.eosarabia.net:3571, p2p-peer-address = p2p2.eoseoul.io:30333, p2p-peer-address = p2p.eosflare.io:9876, p2p-peer-address = p2p.bitmars.one:8080, p2p-peer-address = p2p.eos.detroitledger.tech:1337, p2p-peer-address = peer.eosio.sg:9876, p2p-peer-address = eos.seed.eosnation.io:9876, p2p-peer-address = peer1.eosphere.io:9876, p2p-peer-address = p2p.eossweden.org:9876, p2p-peer-address = eos.p2p.eosusa.io:9882
info  2023-07-17T16:59:13.936 nodeos    main.cpp:231                  main                 ] nodeos successfully exiting
```

Requires https://github.com/AntelopeIO/appbase/pull/30
Resovles #1279 