### PR TITLE
Test Fix: Join thread on exception

### DIFF
--- a/plugins/chain_plugin/test/test_trx_retry_db.cpp
+++ b/plugins/chain_plugin/test/test_trx_retry_db.cpp
@@ -224,11 +224,15 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       std::promise<chain_plugin*> plugin_promise;
       std::future<chain_plugin*> plugin_fut = plugin_promise.get_future();
       std::thread app_thread( [&]() {
-         std::vector<const char*> argv = {"test"};
-         app->initialize( argv.size(), (char**) &argv[0] );
-         app->startup();
-         plugin_promise.set_value(app->find_plugin<chain_plugin>());
-         app->exec();
+         try {
+            std::vector<const char*> argv = {"test"};
+            app->initialize(argv.size(), (char**)&argv[0]);
+            app->startup();
+            plugin_promise.set_value(app->find_plugin<chain_plugin>());
+            app->exec();
+            return;
+         } FC_LOG_AND_DROP()
+         BOOST_CHECK(!"app threw exception see logged error");
       } );
       (void)plugin_fut.get(); // wait for app to be started
 

--- a/plugins/producer_plugin/test/test_options.cpp
+++ b/plugins/producer_plugin/test/test_options.cpp
@@ -30,17 +30,21 @@ BOOST_AUTO_TEST_CASE(state_dir) {
    std::promise<std::tuple<producer_plugin*, chain_plugin*>> plugin_promise;
    std::future<std::tuple<producer_plugin*, chain_plugin*>> plugin_fut = plugin_promise.get_future();
    std::thread app_thread( [&]() {
-      fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
-      std::vector<const char*> argv =
-         {"test",
-          "--data-dir",   temp_dir_str.c_str(),
-          "--state-dir",  custom_state_dir_str.c_str(),
-          "--config-dir", temp_dir_str.c_str(),
-          "-p", "eosio", "-e" };
-      app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
-      app->startup();
-      plugin_promise.set_value( {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
-      app->exec();
+      try {
+         fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
+         std::vector<const char*> argv =
+            {"test",
+             "--data-dir",   temp_dir_str.c_str(),
+             "--state-dir",  custom_state_dir_str.c_str(),
+             "--config-dir", temp_dir_str.c_str(),
+             "-p", "eosio", "-e" };
+         app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
+         app->startup();
+         plugin_promise.set_value( {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
+         app->exec();
+         return;
+      } FC_LOG_AND_DROP()
+      BOOST_CHECK(!"app threw exception see logged error");
    } );
 
    auto[prod_plug, chain_plug] = plugin_fut.get();

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -108,15 +108,19 @@ BOOST_AUTO_TEST_CASE(producer) {
       std::promise<std::tuple<producer_plugin*, chain_plugin*>> plugin_promise;
       std::future<std::tuple<producer_plugin*, chain_plugin*>> plugin_fut = plugin_promise.get_future();
       std::thread app_thread( [&]() {
-         fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
-         std::vector<const char*> argv =
-               {"test", "--data-dir", temp_dir_str.c_str(), "--config-dir", temp_dir_str.c_str(),
-                "-p", "eosio", "-e", "--disable-subjective-p2p-billing=true" };
-         app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
-         app->startup();
-         plugin_promise.set_value(
-               {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
-         app->exec();
+         try {
+            fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
+            std::vector<const char*> argv =
+                  {"test", "--data-dir", temp_dir_str.c_str(), "--config-dir", temp_dir_str.c_str(),
+                   "-p", "eosio", "-e", "--disable-subjective-p2p-billing=true" };
+            app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
+            app->startup();
+            plugin_promise.set_value(
+                  {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
+            app->exec();
+            return;
+         } FC_LOG_AND_DROP()
+         BOOST_CHECK(!"app threw exception see logged error");
       } );
 
       auto[prod_plug, chain_plug] = plugin_fut.get();

--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -111,6 +111,10 @@ void test_trxs_common(std::vector<const char*>& specific_args, bool test_disable
       plugin_promise.set_value( {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
       app->exec();
    } );
+   fc::scoped_exit<std::function<void()>> on_except = [&](){
+      if (app_thread.joinable())
+         app_thread.join();
+   };
 
    auto[prod_plug, chain_plug] = plugin_fut.get();
 

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -61,15 +61,19 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
          std::future<std::tuple<producer_plugin*, chain_plugin*>> plugin_fut = plugin_promise.get_future();
 
          std::thread app_thread([&]() {
-            fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
-            std::vector<const char*> argv =
-                  {"test", "--data-dir", temp.c_str(), "--config-dir", temp.c_str(),
-                   "-p", "eosio", "-e"};
-            app->initialize<chain_plugin, producer_plugin>(argv.size(), (char**) &argv[0]);
-            app->startup();
-            plugin_promise.set_value(
-                  {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()});
-            app->exec();
+            try {
+               fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
+               std::vector<const char*> argv =
+                     {"test", "--data-dir", temp.c_str(), "--config-dir", temp.c_str(),
+                      "-p", "eosio", "-e"};
+               app->initialize<chain_plugin, producer_plugin>(argv.size(), (char**) &argv[0]);
+               app->startup();
+               plugin_promise.set_value(
+                     {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()});
+               app->exec();
+               return;
+            } FC_LOG_AND_DROP()
+            BOOST_CHECK(!"app threw exception see logged error");
          });
 
          auto [prod_plug, chain_plug] = plugin_fut.get();


### PR DESCRIPTION
Avoid test `terminate` due to non-joined thread. I don't think this is the actual problem of #1435 as the test should not be throwing an exception. However, if it does throw we need to join the thread to prevent the test from just terminating.