### PR TITLE
Test Fix: Controller calls only valid when building a block

### DIFF
--- a/plugins/chain_plugin/test/test_trx_retry_db.cpp
+++ b/plugins/chain_plugin/test/test_trx_retry_db.cpp
@@ -224,11 +224,15 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       std::promise<chain_plugin*> plugin_promise;
       std::future<chain_plugin*> plugin_fut = plugin_promise.get_future();
       std::thread app_thread( [&]() {
-         std::vector<const char*> argv = {"test"};
-         app->initialize( argv.size(), (char**) &argv[0] );
-         app->startup();
-         plugin_promise.set_value(app->find_plugin<chain_plugin>());
-         app->exec();
+         try {
+            std::vector<const char*> argv = {"test"};
+            app->initialize(argv.size(), (char**)&argv[0]);
+            app->startup();
+            plugin_promise.set_value(app->find_plugin<chain_plugin>());
+            app->exec();
+            return;
+         } FC_LOG_AND_DROP()
+         BOOST_CHECK(!"app threw exception see logged error");
       } );
       (void)plugin_fut.get(); // wait for app to be started
 

--- a/plugins/producer_plugin/test/test_options.cpp
+++ b/plugins/producer_plugin/test/test_options.cpp
@@ -30,17 +30,21 @@ BOOST_AUTO_TEST_CASE(state_dir) {
    std::promise<std::tuple<producer_plugin*, chain_plugin*>> plugin_promise;
    std::future<std::tuple<producer_plugin*, chain_plugin*>> plugin_fut = plugin_promise.get_future();
    std::thread app_thread( [&]() {
-      fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
-      std::vector<const char*> argv =
-         {"test",
-          "--data-dir",   temp_dir_str.c_str(),
-          "--state-dir",  custom_state_dir_str.c_str(),
-          "--config-dir", temp_dir_str.c_str(),
-          "-p", "eosio", "-e" };
-      app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
-      app->startup();
-      plugin_promise.set_value( {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
-      app->exec();
+      try {
+         fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
+         std::vector<const char*> argv =
+            {"test",
+             "--data-dir",   temp_dir_str.c_str(),
+             "--state-dir",  custom_state_dir_str.c_str(),
+             "--config-dir", temp_dir_str.c_str(),
+             "-p", "eosio", "-e" };
+         app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
+         app->startup();
+         plugin_promise.set_value( {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
+         app->exec();
+         return;
+      } FC_LOG_AND_DROP()
+      BOOST_CHECK(!"app threw exception see logged error");
    } );
 
    auto[prod_plug, chain_plug] = plugin_fut.get();

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -108,15 +108,19 @@ BOOST_AUTO_TEST_CASE(producer) {
       std::promise<std::tuple<producer_plugin*, chain_plugin*>> plugin_promise;
       std::future<std::tuple<producer_plugin*, chain_plugin*>> plugin_fut = plugin_promise.get_future();
       std::thread app_thread( [&]() {
-         fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
-         std::vector<const char*> argv =
-               {"test", "--data-dir", temp_dir_str.c_str(), "--config-dir", temp_dir_str.c_str(),
-                "-p", "eosio", "-e", "--disable-subjective-p2p-billing=true" };
-         app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
-         app->startup();
-         plugin_promise.set_value(
-               {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
-         app->exec();
+         try {
+            fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
+            std::vector<const char*> argv =
+                  {"test", "--data-dir", temp_dir_str.c_str(), "--config-dir", temp_dir_str.c_str(),
+                   "-p", "eosio", "-e", "--disable-subjective-p2p-billing=true" };
+            app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
+            app->startup();
+            plugin_promise.set_value(
+                  {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
+            app->exec();
+            return;
+         } FC_LOG_AND_DROP()
+         BOOST_CHECK(!"app threw exception see logged error");
       } );
 
       auto[prod_plug, chain_plug] = plugin_fut.get();

--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -111,6 +111,10 @@ void test_trxs_common(std::vector<const char*>& specific_args, bool test_disable
       plugin_promise.set_value( {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
       app->exec();
    } );
+   fc::scoped_exit<std::function<void()>> on_except = [&](){
+      if (app_thread.joinable())
+         app_thread.join();
+   };
 
    auto[prod_plug, chain_plug] = plugin_fut.get();
 

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -61,15 +61,19 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
          std::future<std::tuple<producer_plugin*, chain_plugin*>> plugin_fut = plugin_promise.get_future();
 
          std::thread app_thread([&]() {
-            fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
-            std::vector<const char*> argv =
-                  {"test", "--data-dir", temp.c_str(), "--config-dir", temp.c_str(),
-                   "-p", "eosio", "-e"};
-            app->initialize<chain_plugin, producer_plugin>(argv.size(), (char**) &argv[0]);
-            app->startup();
-            plugin_promise.set_value(
-                  {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()});
-            app->exec();
+            try {
+               fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
+               std::vector<const char*> argv =
+                     {"test", "--data-dir", temp.c_str(), "--config-dir", temp.c_str(),
+                      "-p", "eosio", "-e"};
+               app->initialize<chain_plugin, producer_plugin>(argv.size(), (char**) &argv[0]);
+               app->startup();
+               plugin_promise.set_value(
+                     {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()});
+               app->exec();
+               return;
+            } FC_LOG_AND_DROP()
+            BOOST_CHECK(!"app threw exception see logged error");
          });
 
          auto [prod_plug, chain_plug] = plugin_fut.get();

--- a/unittests/test_utils.hpp
+++ b/unittests/test_utils.hpp
@@ -4,11 +4,15 @@
 #include <eosio/chain_plugin/chain_plugin.hpp>
 #include <eosio/chain/application.hpp>
 #include <eosio/chain/types.hpp>
+#include <eosio/chain/trace.hpp>
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/transaction.hpp>
 #include <eosio/chain/controller.hpp>
 
+#include <fc/exception/exception.hpp>
+
 #include <contracts.hpp>
+#include <exception>
 #include <future>
 #include <stdexcept>
 #include <thread>
@@ -60,7 +64,7 @@ auto make_bios_ro_trx(eosio::chain::controller& control) {
 
 // Push an input transaction to controller and return trx trace
 // If account is eosio then signs with the default private key
-auto push_input_trx(eosio::chain::controller& control, account_name account, signed_transaction& trx) {
+auto push_input_trx(appbase::scoped_app& app, eosio::chain::controller& control, account_name account, signed_transaction& trx) {
    trx.expiration = fc::time_point_sec{fc::time_point::now() + fc::seconds(30)};
    trx.set_reference_block( control.head_block_id() );
    if (account == config::system_account_name) {
@@ -70,13 +74,42 @@ auto push_input_trx(eosio::chain::controller& control, account_name account, sig
       trx.sign(testing::tester::get_private_key(account, "active"), control.get_chain_id());
    }
    auto ptrx = std::make_shared<packed_transaction>( trx, packed_transaction::compression_type::zlib );
-   auto fut = transaction_metadata::start_recover_keys( ptrx, control.get_thread_pool(), control.get_chain_id(), fc::microseconds::maximum(), transaction_metadata::trx_type::input );
-   auto r = control.push_transaction( fut.get(), fc::time_point::maximum(), fc::microseconds::maximum(), 0, false, 0 );
-   return r;
+
+   std::promise<transaction_trace_ptr> trx_promise;
+   std::future<transaction_trace_ptr> trx_future = trx_promise.get_future();
+
+   app->executor().post( priority::low, exec_queue::read_write, [&ptrx, &app, &trx_promise]() {
+      app->get_method<plugin_interface::incoming::methods::transaction_async>()(ptrx,
+                                                                                false, // api_trx
+                                                                                transaction_metadata::trx_type::input, // trx_type
+                                                                                true, // return_failure_traces
+           [&trx_promise](const next_function_variant<transaction_trace_ptr>& result) {
+              if( std::holds_alternative<fc::exception_ptr>( result ) ) {
+                 try {
+                    std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();
+                 } catch(...) {
+                    trx_promise.set_exception(std::current_exception());
+                 }
+              } else if ( std::get<chain::transaction_trace_ptr>( result )->except ) {
+                 try {
+                    std::get<chain::transaction_trace_ptr>(result)->except->dynamic_rethrow_exception();
+                 } catch(...) {
+                    trx_promise.set_exception(std::current_exception());
+                 }
+              } else {
+                 trx_promise.set_value(std::get<chain::transaction_trace_ptr>(result));
+              }
+           });
+   });
+
+   if (trx_future.wait_for(std::chrono::seconds(5)) == std::future_status::timeout)
+      throw std::runtime_error("failed to execute trx: " + ptrx->get_transaction().actions.at(0).name.to_string() + " to account: " + account.to_string());
+
+   return trx_future.get();
 }
 
 // Push setcode trx to controller and return trx trace
-auto set_code(eosio::chain::controller& control, account_name account, const vector<uint8_t>& wasm) {
+auto set_code(appbase::scoped_app& app, eosio::chain::controller& control, account_name account, const vector<uint8_t>& wasm) {
    signed_transaction trx;
    trx.actions.emplace_back(std::vector<permission_level>{{account, config::active_name}},
                             chain::setcode{
@@ -85,56 +118,56 @@ auto set_code(eosio::chain::controller& control, account_name account, const vec
                                .vmversion = 0,
                                .code = bytes(wasm.begin(), wasm.end())
                             });
-   return push_input_trx(control, account, trx);
+   return push_input_trx(app, control, account, trx);
 }
 
 void activate_protocol_features_set_bios_contract(appbase::scoped_app& app, chain_plugin* chain_plug) {
    using namespace appbase;
 
-   std::promise<void> feature_promise;
-   std::future<void> feature_future = feature_promise.get_future();
-   app->executor().post( priority::high, exec_queue::read_write, [&chain_plug=chain_plug, &feature_promise](){
-      const auto& pfm = chain_plug->chain().get_protocol_feature_manager();
-      auto preactivate_feature_digest = pfm.get_builtin_digest(builtin_protocol_feature_t::preactivate_feature);
-      BOOST_CHECK( preactivate_feature_digest );
-      chain_plug->chain().preactivate_feature( *preactivate_feature_digest, false );
-      std::vector<builtin_protocol_feature_t> pfs{
-         builtin_protocol_feature_t::only_link_to_existing_permission,
-         builtin_protocol_feature_t::replace_deferred,
-         builtin_protocol_feature_t::no_duplicate_deferred_id,
-         builtin_protocol_feature_t::fix_linkauth_restriction,
-         builtin_protocol_feature_t::disallow_empty_producer_schedule,
-         builtin_protocol_feature_t::restrict_action_to_self,
-         builtin_protocol_feature_t::only_bill_first_authorizer,
-         builtin_protocol_feature_t::forward_setcode,
-         builtin_protocol_feature_t::get_sender,
-         builtin_protocol_feature_t::ram_restrictions,
-         builtin_protocol_feature_t::webauthn_key,
-         builtin_protocol_feature_t::wtmsig_block_signatures };
-      for (const auto t : pfs) {
-         auto feature_digest = pfm.get_builtin_digest(t);
-         BOOST_CHECK( feature_digest );
-         chain_plug->chain().preactivate_feature( *feature_digest, false );
-      }
-      feature_promise.set_value();
-   });
+   std::atomic<bool> feature_set = false;
+   // has to execute when pending block is not null
+   for (int tries = 0; tries < 100; ++tries) {
+      app->executor().post( priority::high, exec_queue::read_write, [&chain_plug=chain_plug, &feature_set](){
+         try {
+            if (!chain_plug->chain().is_building_block() || feature_set)
+               return;
+            const auto& pfm = chain_plug->chain().get_protocol_feature_manager();
+            auto preactivate_feature_digest = pfm.get_builtin_digest(builtin_protocol_feature_t::preactivate_feature);
+            BOOST_CHECK( preactivate_feature_digest );
+            chain_plug->chain().preactivate_feature( *preactivate_feature_digest, false );
+            std::vector<builtin_protocol_feature_t> pfs{
+               builtin_protocol_feature_t::only_link_to_existing_permission,
+               builtin_protocol_feature_t::replace_deferred,
+               builtin_protocol_feature_t::no_duplicate_deferred_id,
+               builtin_protocol_feature_t::fix_linkauth_restriction,
+               builtin_protocol_feature_t::disallow_empty_producer_schedule,
+               builtin_protocol_feature_t::restrict_action_to_self,
+               builtin_protocol_feature_t::only_bill_first_authorizer,
+               builtin_protocol_feature_t::forward_setcode,
+               builtin_protocol_feature_t::get_sender,
+               builtin_protocol_feature_t::ram_restrictions,
+               builtin_protocol_feature_t::webauthn_key,
+               builtin_protocol_feature_t::wtmsig_block_signatures };
+            for (const auto t : pfs) {
+               auto feature_digest = pfm.get_builtin_digest(t);
+               BOOST_CHECK( feature_digest );
+               chain_plug->chain().preactivate_feature( *feature_digest, false );
+            }
+            feature_set = true;
+            return;
+         } FC_LOG_AND_DROP()
+         BOOST_CHECK(!"exception setting protocol features");
+      });
+      if (feature_set)
+         break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+   }
 
    // Wait for next block
    std::this_thread::sleep_for( std::chrono::milliseconds(config::block_interval_ms) );
 
-   if (feature_future.wait_for(std::chrono::seconds(5)) == std::future_status::timeout)
-      throw std::runtime_error("failed to preactivate features");
-
-   std::promise<void> setcode_promise;
-   std::future<void> setcode_future = setcode_promise.get_future();
-   app->executor().post( priority::high, exec_queue::read_write, [&chain_plug=chain_plug, &setcode_promise](){
-      auto r = set_code(chain_plug->chain(), config::system_account_name, testing::contracts::eosio_bios_wasm());
-      BOOST_CHECK(r->receipt && r->receipt->status == transaction_receipt_header::executed);
-      setcode_promise.set_value();
-   });
-
-   if (setcode_future.wait_for(std::chrono::seconds(5)) == std::future_status::timeout)
-      throw std::runtime_error("failed to setcode");
+   auto r = set_code(app, chain_plug->chain(), config::system_account_name, testing::contracts::eosio_bios_wasm());
+   BOOST_CHECK(r->receipt && r->receipt->status == transaction_receipt_header::executed);
 }
 
 


### PR DESCRIPTION
When interacting with `controller` many calls including `push_transaction` & `preactivate_feature` require a pending block. Update `test_utils.hpp` used by `test_read_only_trx.cpp` to only interact with `controller` when it is building a block (has a pending block).

Included in this PR are try-catches around `application` `exec()` since it can throw and if the exceptions are not caught then the test `terminate`s making it very difficult to find the actual issue with the test.

Resolves #1435 