### PR TITLE
set `DEBIAN_FRONTEND` & `TZ` globally during libtester job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -199,6 +199,9 @@ jobs:
         test: [build-tree, make-dev-install, deb-install]
     runs-on:  ["self-hosted", "enf-x86-midtier"]
     container: ${{ matrix.test != 'deb-install' && fromJSON(needs.build-base.outputs.p)[matrix.platform].image || matrix.platform == 'ubuntu20' && 'ubuntu:focal' || 'ubuntu:jammy' }}
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TZ: Etc/UTC
     steps:
       - name: Update Package Index & Upgrade Packages
         run: |
@@ -241,8 +244,6 @@ jobs:
       - if: ${{ matrix.test == 'deb-install' }}
         name: Install leap-dev Package
         run: |
-          export DEBIAN_FRONTEND='noninteractive'
-          export TZ='Etc/UTC'
           apt-get install -y ./*.deb
           rm ./*.deb
 


### PR DESCRIPTION
When installing .deb packages in CI, it can be hard to know in advance which package will also want to install the `tzdata` package which by default interactively prompts for the current time zone. We skip this prompt by setting environment variables `DEBIAN_FRONTEND` & `TZ`. But those variables were only set for one step in the libtester job, so if the `tzdata` package came along in a different step -- like it did in https://github.com/AntelopeIO/leap/actions/runs/5645037759/job/15291662020 -- it would result in the job getting stuck.

Move these variables to be defined globally during the entire libtester job.