### PR TITLE
Upgrade to asset-artifact-download-action@v3 in CI workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -249,7 +249,7 @@ jobs:
 
       # CDT
       - name: Download cdt
-        uses: AntelopeIO/asset-artifact-download-action@v2
+        uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: AntelopeIO
           repo: cdt
@@ -257,7 +257,6 @@ jobs:
           target: '${{needs.v.outputs.cdt-target}}'
           prereleases: ${{fromJSON(needs.v.outputs.cdt-prerelease)}}
           artifact-name: cdt_ubuntu_package_amd64
-          token: ${{github.token}}
       - name: Install cdt Packages
         run: |
           apt-get install -y ./*.deb

--- a/.github/workflows/ph_backward_compatibility.yaml
+++ b/.github/workflows/ph_backward_compatibility.yaml
@@ -42,13 +42,12 @@ jobs:
         run: |
           zstdcat build.tar.zst | tar x
       - name: Download Prev Leap Version
-        uses: AntelopeIO/asset-artifact-download-action@v2
+        uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: AntelopeIO
           repo: leap
           file: '(leap).*${{matrix.platform}}.04.*(x86_64|amd64).deb'
           target: '${{matrix.release}}'
-          token: ${{github.token}}
       - name: Install leap & replace binaries for PH use
         run: |
           apt-get update


### PR DESCRIPTION
Upgrade to asset-artifact-download-action@v3. More details can be found at AntelopeIO/asset-artifact-download-action#2; the main benefit from existing usage here is removal of the `token` line and reduced API usage when `target` is manually specified to a branch