### PR TITLE
Do not print version and non-default args for help

### DIFF
--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -173,6 +173,7 @@ int main(int argc, char** argv)
       if(!app->initialize<chain_plugin, net_plugin, producer_plugin, resource_monitor_plugin>(argc, argv, initialize_logging)) {
          const auto& opts = app->get_options();
          if( opts.count("help") || opts.count("version") || opts.count("full-version") || opts.count("print-default-config") ) {
+            on_exit.cancel();
             return SUCCESS;
          }
          return INITIALIZE_FAIL;


### PR DESCRIPTION
For the options that `nodeos` expects and just reports: `help`, `version`, `full-version`, `print-default-config`, do not log the non-default options and version.

Resolves #1446 