### PR TITLE
Disable building leap-dev.deb package by default

### DIFF
--- a/.github/workflows/build_base.yaml
+++ b/.github/workflows/build_base.yaml
@@ -77,7 +77,7 @@ jobs:
           run: |
             # https://github.com/actions/runner/issues/2033
             chown -R $(id -u):$(id -g) $PWD
-            cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -GNinja
+            cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_LEAP_DEV_DEB=On -GNinja
             cmake --build build
             tar -pc --exclude "*.o" build | zstd --long -T0 -9 > build.tar.zst
         - name: Upload builddir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,5 +293,7 @@ add_custom_target(dev-install
 
 include(doxygen)
 
+option(ENABLE_LEAP_DEV_DEB "Enable building the leap-dev .deb package" OFF)
+
 include(package.cmake)
 include(CPack)

--- a/package.cmake
+++ b/package.cmake
@@ -53,9 +53,10 @@ endif()
 set(CPACK_DEBIAN_PACKAGE_CONFLICTS "eosio, mandel")
 set(CPACK_RPM_PACKAGE_CONFLICTS "eosio, mandel")
 
-#only consider "base" and "dev" components for per-component packages
-get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)
-list(REMOVE_ITEM CPACK_COMPONENTS_ALL "Unspecified")
+set(CPACK_COMPONENTS_ALL "base")
+if(ENABLE_LEAP_DEV_DEB)
+   list(APPEND CPACK_COMPONENTS_ALL "dev")
+endif()
 
 #enable per component packages for .deb; ensure main package is just "leap", not "leap-base", and make the dev package have "leap-dev" at the front not the back
 set(CPACK_DEB_COMPONENT_INSTALL ON)


### PR DESCRIPTION
A leap-dev.deb package is currently generated alongside the leap.deb package when performing a `make package` (as our README suggests). This leap-dev.deb, similarly to the `make dev-install` target, contains the files required for "native contract unit testing" a.k.a. libtester. afaik we don’t document this leap-dev.deb, nor do we include it as part of leap’s release assets. Instead, it’s used for punting around libtester in various Antelope CI use cases so that leap doesn’t need to always be rebuilt; for example, eos-system-contracts CI uses leap-dev.deb for its unit tests so that it doesn’t need to build leap just to run the system contract unit tests.

Unfortunately adding boost to leap-dev.deb is increasing the time it takes to perform `make package` significantly: from 30 seconds to 7 minutes. If we leave the README instructions as `make package`, it’ll take some users longer to build the .deb packages than building the software!

Because the sole use case of leap-dev.deb is Antelope CI usage, disable building leap-dev.deb by default, and just enable it in leap’s CI.