### PR TITLE
[3.2] Ignore http error on remote_endpoint() causing terminate

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_listener.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_listener.hpp
@@ -110,7 +110,9 @@ private:
             fail(ec, "accept", self->plugin_state_->logger, "closing connection");
          } else {
             // Create the session object and run it
-            std::string remote_endpoint = boost::lexical_cast<std::string>(self->socket_.remote_endpoint());
+            boost::system::error_code re_ec;
+            auto re = self->socket_.remote_endpoint(re_ec);
+            std::string remote_endpoint = re_ec ? "unknown" : boost::lexical_cast<std::string>(re);
             std::make_shared<session_type>(
                   std::move(self->socket_),
                   self->plugin_state_,


### PR DESCRIPTION
`remote_endpoint()` call was generating error `Transport endpoint is not connected`. This call is only used for logging of the remote endpoint. Ignore the error and log `unknown` for the remote endpoint. This prevents an uncaught exception in 3.2 and an exit of the http thread pool in 4.0+.

Already fixed in 4.0+ via: https://github.com/AntelopeIO/leap/pull/1175

Resolves #1418 