### PR TITLE
Remove *.s from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.bc
 *.wast
 *.wast.hpp
-*.s
 *.dot
 *.abi.hpp
 *.cmake


### PR DESCRIPTION
*.s extension is:

> An S file is a generic source code file that contains the source for a computer program. It may be written in a number of different programming languages, but is commonly used for storing Assembly code.

Not sure why it was in the git ignore list.

Thanks to @Parth2412 for pointing this out: https://github.com/AntelopeIO/leap/pull/1361#issuecomment-1618521836

Resolves #1457 