### PR TITLE
Tests: Add back old commented out unittests

### DIFF
--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -2915,69 +2915,43 @@ BOOST_FIXTURE_TEST_CASE(resource_limits_tests, validating_tester) {
    BOOST_CHECK_THROW(pushit(), wasm_exception);
 }
 
-#if 0
-/*************************************************************************************
- * privileged_tests test case
- *************************************************************************************/
-BOOST_FIXTURE_TEST_CASE(privileged_tests, tester) { try {
-	produce_blocks(2);
-	create_account( "testapi"_n );
-	create_account( "acc1"_n );
-	produce_blocks(100);
-	set_code( "testapi"_n, contracts::test_api_wasm() );
-	produce_blocks(1);
+BOOST_AUTO_TEST_CASE( set_producers_legacy ) { try {
+   fc::temp_directory tempdir;
+   validating_tester t( tempdir, true );
+   t.execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
 
-   {
-		signed_transaction trx;
+   vector<account_name> prods = {
+      "inita"_n,
+      "initb"_n,
+      "initc"_n,
+      "initd"_n,
+      "inite"_n,
+      "initf"_n,
+      "initg"_n,
+      "inith"_n,
+      "initi"_n,
+      "initj"_n,
+      "initk"_n,
+      "initl"_n,
+      "initm"_n,
+      "initn"_n,
+      "inito"_n,
+      "initp"_n,
+      "initq"_n,
+      "initr"_n,
+      "inits"_n,
+      "initt"_n,
+      "initu"_n
+   };
 
-      auto pl = vector<permission_level>{{config::system_account_name, config::active_name}};
-      action act(pl, test_chain_action<"setprods"_n>());
-      vector<producer_key> prod_keys = {
-                                          { "inita"_n, get_public_key( "inita"_n, "active" ) },
-                                          { "initb"_n, get_public_key( "initb"_n, "active" ) },
-                                          { "initc"_n, get_public_key( "initc"_n, "active" ) },
-                                          { "initd"_n, get_public_key( "initd"_n, "active" ) },
-                                          { "inite"_n, get_public_key( "inite"_n, "active" ) },
-                                          { "initf"_n, get_public_key( "initf"_n, "active" ) },
-                                          { "initg"_n, get_public_key( "initg"_n, "active" ) },
-                                          { "inith"_n, get_public_key( "inith"_n, "active" ) },
-                                          { "initi"_n, get_public_key( "initi"_n, "active" ) },
-                                          { "initj"_n, get_public_key( "initj"_n, "active" ) },
-                                          { "initk"_n, get_public_key( "initk"_n, "active" ) },
-                                          { "initl"_n, get_public_key( "initl"_n, "active" ) },
-                                          { "initm"_n, get_public_key( "initm"_n, "active" ) },
-                                          { "initn"_n, get_public_key( "initn"_n, "active" ) },
-                                          { "inito"_n, get_public_key( "inito"_n, "active" ) },
-                                          { "initp"_n, get_public_key( "initp"_n, "active" ) },
-                                          { "initq"_n, get_public_key( "initq"_n, "active" ) },
-                                          { "initr"_n, get_public_key( "initr"_n, "active" ) },
-                                          { "inits"_n, get_public_key( "inits"_n, "active" ) },
-                                          { "initt"_n, get_public_key( "initt"_n, "active" ) },
-                                          { "initu"_n, get_public_key( "initu"_n, "active" ) }
-                                       };
-      vector<char> data = fc::raw::pack(uint32_t(0));
-      vector<char> keys = fc::raw::pack(prod_keys);
-      data.insert( data.end(), keys.begin(), keys.end() );
-      act.data = data;
-      trx.actions.push_back(act);
+   t.create_accounts( prods );
+   t.produce_block();
 
-		set_tapos(trx);
-
-		auto sigs = trx.sign(get_private_key(config::system_account_name, "active"), control->get_chain_id());
-      trx.get_signature_keys(control->get_chain_id() );
-		auto res = push_transaction(trx);
-		BOOST_CHECK_EQUAL(res.status, transaction_receipt::executed);
-	}
-
-   CALL_TEST_FUNCTION( *this, "test_privileged", "test_is_privileged", {} );
-   BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( *this, "test_privileged", "test_is_privileged", {} ), transaction_exception,
-         [](const fc::exception& e) {
-            return expect_assert_message(e, "context.privileged: testapi does not have permission to call this API");
-         }
-       );
+   auto trace = t.set_producers_legacy(prods);
+   BOOST_REQUIRE(trace && trace->receipt);
+   BOOST_CHECK_EQUAL(trace->receipt->status, transaction_receipt::executed);
 
 } FC_LOG_AND_RETHROW() }
-#endif
 
 /*************************************************************************************
  * real_tests test cases

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -22,7 +22,7 @@ account_name get_expected_producer(const vector<producer_authority>& schedule, b
 // Check if two schedule is equal
 bool is_schedule_equal(const vector<producer_authority>& first, const vector<producer_authority>& second) {
    bool is_equal = first.size() == second.size();
-   for (uint32_t i = 0; i < first.size(); i++) {
+   for (uint32_t i = 0; i < first.size() && is_equal; i++) {
       is_equal = is_equal && first.at(i) == second.at(i);
    }
    return is_equal;

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -11,187 +11,122 @@ using mvo = fc::mutable_variant_object;
 
 BOOST_AUTO_TEST_SUITE(producer_schedule_tests)
 
-   // Calculate expected producer given the schedule and slot number
-   account_name get_expected_producer(const vector<producer_authority>& schedule, const uint64_t slot) {
-      const auto& index = (slot % (schedule.size() * config::producer_repetitions)) / config::producer_repetitions;
-      return schedule.at(index).producer_name;
-   };
+namespace {
 
-   // Check if two schedule is equal
-   bool is_schedule_equal(const vector<producer_authority>& first, const vector<producer_authority>& second) {
-      bool is_equal = first.size() == second.size();
-      for (uint32_t i = 0; i < first.size(); i++) {
-         is_equal = is_equal && first.at(i) == second.at(i);
-      }
-      return is_equal;
-   };
+// Calculate expected producer given the schedule and slot number
+account_name get_expected_producer(const vector<producer_authority>& schedule, block_timestamp_type t) {
+   const auto& index = (t.slot % (schedule.size() * config::producer_repetitions)) / config::producer_repetitions;
+   return schedule.at(index).producer_name;
+};
 
-   // Calculate the block num of the next round first block
-   // The new producer schedule will become effective when it's in the block of the next round first block
-   // However, it won't be applied until the effective block num is deemed irreversible
-   uint64_t calc_block_num_of_next_round_first_block(const controller& control){
-      auto res = control.head_block_num() + 1;
-      const auto blocks_per_round = control.head_block_state()->active_schedule.producers.size() * config::producer_repetitions;
-      while((res % blocks_per_round) != 0) {
-         res++;
-      }
-      return res;
-   };
-#if 0
-   BOOST_FIXTURE_TEST_CASE( verify_producer_schedule, validating_tester ) try {
+// Check if two schedule is equal
+bool is_schedule_equal(const vector<producer_authority>& first, const vector<producer_authority>& second) {
+   bool is_equal = first.size() == second.size();
+   for (uint32_t i = 0; i < first.size(); i++) {
+      is_equal = is_equal && first.at(i) == second.at(i);
+   }
+   return is_equal;
+};
 
-      // Utility function to ensure that producer schedule work as expected
-      const auto& confirm_schedule_correctness = [&](const vector<producer_key>& new_prod_schd, const uint64_t eff_new_prod_schd_block_num)  {
-         const uint32_t check_duration = 1000; // number of blocks
-         for (uint32_t i = 0; i < check_duration; ++i) {
-            const auto current_schedule = control->head_block_state()->active_schedule.producers;
-            const auto& current_absolute_slot = control->get_global_properties().proposed_schedule_block_num;
-            // Determine expected producer
-            const auto& expected_producer = get_expected_producer(current_schedule, *current_absolute_slot + 1);
+} // anonymous namespace
 
-            // The new schedule will only be applied once the effective block num is deemed irreversible
-            const bool is_new_schedule_applied = control->last_irreversible_block_num() > eff_new_prod_schd_block_num;
+BOOST_FIXTURE_TEST_CASE( verify_producer_schedule, validating_tester ) try {
 
-            // Ensure that we have the correct schedule at the right time
-            if (is_new_schedule_applied) {
-               BOOST_TEST(is_schedule_equal(new_prod_schd, current_schedule));
-            } else {
-               BOOST_TEST(!is_schedule_equal(new_prod_schd, current_schedule));
-            }
-
-            // Produce block
-            produce_block();
-
-            // Check if the producer is the same as what we expect
-            BOOST_TEST(control->head_block_producer() == expected_producer);
+   // Utility function to ensure that producer schedule work as expected
+   const auto& confirm_schedule_correctness = [&](const vector<producer_authority>& new_prod_schd, uint32_t expected_schd_ver)  {
+      const uint32_t check_duration = 1000; // number of blocks
+      bool scheduled_changed_to_new = false;
+      for (uint32_t i = 0; i < check_duration; ++i) {
+         const auto current_schedule = control->head_block_state()->active_schedule.producers;
+         if (is_schedule_equal(new_prod_schd, current_schedule)) {
+            scheduled_changed_to_new = true;
          }
-      };
 
-      // Create producer accounts
-      vector<account_name> producers = {
-              "inita", "initb", "initc", "initd", "inite", "initf", "initg",
-              "inith", "initi", "initj", "initk", "initl", "initm", "initn",
-              "inito", "initp", "initq", "initr", "inits", "initt", "initu"
-      };
-      create_accounts(producers);
+         // Produce block
+         produce_block();
 
-      // ---- Test first set of producers ----
-      // Send set prods action and confirm schedule correctness
-      set_producers(producers);
-      const auto first_prod_schd = get_producer_keys(producers);
-      const auto eff_first_prod_schd_block_num = calc_block_num_of_next_round_first_block(*control);
-      confirm_schedule_correctness(first_prod_schd, eff_first_prod_schd_block_num);
+         // Check if the producer is the same as what we expect
+         const auto block_time = control->head_block_time();
+         const auto& expected_producer = get_expected_producer(current_schedule, block_time);
+         BOOST_TEST(control->head_block_producer() == expected_producer);
 
-      // ---- Test second set of producers ----
-      vector<account_name> second_set_of_producer = {
-              producers[3], producers[6], producers[9], producers[12], producers[15], producers[18], producers[20]
-      };
-      // Send set prods action and confirm schedule correctness
-      set_producers(second_set_of_producer);
-      const auto second_prod_schd = get_producer_keys(second_set_of_producer);
-      const auto& eff_second_prod_schd_block_num = calc_block_num_of_next_round_first_block(*control);
-      confirm_schedule_correctness(second_prod_schd, eff_second_prod_schd_block_num);
+         if (scheduled_changed_to_new)
+            break;
+      }
 
-      // ---- Test deliberately miss some blocks ----
-      const int64_t num_of_missed_blocks = 5000;
-      produce_block(fc::microseconds(500 * 1000 * num_of_missed_blocks));
-      // Ensure schedule is still correct
-      confirm_schedule_correctness(second_prod_schd, eff_second_prod_schd_block_num);
-      produce_block();
+      BOOST_TEST(scheduled_changed_to_new);
 
-      // ---- Test third set of producers ----
-      vector<account_name> third_set_of_producer = {
-              producers[2], producers[5], producers[8], producers[11], producers[14], producers[17], producers[20],
-              producers[0], producers[3], producers[6], producers[9], producers[12], producers[15], producers[18],
-              producers[1], producers[4], producers[7], producers[10], producers[13], producers[16], producers[19]
-      };
-      // Send set prods action and confirm schedule correctness
-      set_producers(third_set_of_producer);
-      const auto third_prod_schd = get_producer_keys(third_set_of_producer);
-      const auto& eff_third_prod_schd_block_num = calc_block_num_of_next_round_first_block(*control);
-      confirm_schedule_correctness(third_prod_schd, eff_third_prod_schd_block_num);
+      const auto current_schd_ver = control->head_block_header().schedule_version;
+      BOOST_TEST(current_schd_ver == expected_schd_ver);
+   };
 
-   } FC_LOG_AND_RETHROW()
+   // Create producer accounts
+   vector<account_name> producers = {
+           "inita"_n, "initb"_n, "initc"_n, "initd"_n, "inite"_n, "initf"_n, "initg"_n,
+           "inith"_n, "initi"_n, "initj"_n, "initk"_n, "initl"_n, "initm"_n, "initn"_n,
+           "inito"_n, "initp"_n, "initq"_n, "initr"_n, "inits"_n, "initt"_n, "initu"_n
+   };
+   create_accounts(producers);
 
+   // ---- Test first set of producers ----
+   // Send set prods action and confirm schedule correctness
+   set_producers(producers);
+   const auto first_prod_schd = get_producer_authorities(producers);
+   confirm_schedule_correctness(first_prod_schd, 1);
 
-   BOOST_FIXTURE_TEST_CASE( verify_producers, validating_tester ) try {
+   // ---- Test second set of producers ----
+   vector<account_name> second_set_of_producer = {
+           producers[3], producers[6], producers[9], producers[12], producers[15], producers[18], producers[20]
+   };
+   // Send set prods action and confirm schedule correctness
+   set_producers(second_set_of_producer);
+   const auto second_prod_schd = get_producer_authorities(second_set_of_producer);
+   confirm_schedule_correctness(second_prod_schd, 2);
 
-      vector<account_name> valid_producers = {
-         "inita", "initb", "initc", "initd", "inite", "initf", "initg",
-         "inith", "initi", "initj", "initk", "initl", "initm", "initn",
-         "inito", "initp", "initq", "initr", "inits", "initt", "initu"
-      };
-      create_accounts(valid_producers);
-      set_producers(valid_producers);
+   // ---- Test deliberately miss some blocks ----
+   const int64_t num_of_missed_blocks = 5000;
+   produce_block(fc::microseconds(500 * 1000 * num_of_missed_blocks));
+   // Ensure schedule is still correct
+   confirm_schedule_correctness(second_prod_schd, 2);
+   produce_block();
 
-      // account initz does not exist
-      vector<account_name> nonexisting_producer = { "initz" };
-      BOOST_CHECK_THROW(set_producers(nonexisting_producer), wasm_execution_error);
+   // ---- Test third set of producers ----
+   vector<account_name> third_set_of_producer = {
+           producers[2], producers[5], producers[8], producers[11], producers[14], producers[17], producers[20],
+           producers[0], producers[3], producers[6], producers[9], producers[12], producers[15], producers[18],
+           producers[1], producers[4], producers[7], producers[10], producers[13], producers[16], producers[19]
+   };
+   // Send set prods action and confirm schedule correctness
+   set_producers(third_set_of_producer);
+   const auto third_prod_schd = get_producer_authorities(third_set_of_producer);
+   confirm_schedule_correctness(third_prod_schd, 3);
 
-      // replace initg with inita, inita is now duplicate
-      vector<account_name> invalid_producers = {
-         "inita", "initb", "initc", "initd", "inite", "initf", "inita",
-         "inith", "initi", "initj", "initk", "initl", "initm", "initn",
-         "inito", "initp", "initq", "initr", "inits", "initt", "initu"
-      };
+} FC_LOG_AND_RETHROW()
 
-      BOOST_CHECK_THROW(set_producers(invalid_producers), wasm_execution_error);
+BOOST_FIXTURE_TEST_CASE( verify_producers, validating_tester ) try {
 
-   } FC_LOG_AND_RETHROW()
+   vector<account_name> valid_producers = {
+      "inita"_n, "initb"_n, "initc"_n, "initd"_n, "inite"_n, "initf"_n, "initg"_n,
+      "inith"_n, "initi"_n, "initj"_n, "initk"_n, "initl"_n, "initm"_n, "initn"_n,
+      "inito"_n, "initp"_n, "initq"_n, "initr"_n, "inits"_n, "initt"_n, "initu"_n
+   };
+   create_accounts(valid_producers);
+   set_producers(valid_producers);
 
-   BOOST_FIXTURE_TEST_CASE( verify_header_schedule_version, validating_tester ) try {
+   // account initz does not exist
+   vector<account_name> nonexisting_producer = { "initz"_n };
+   BOOST_CHECK_THROW(set_producers(nonexisting_producer), wasm_execution_error);
 
-      // Utility function to ensure that producer schedule version in the header is correct
-      const auto& confirm_header_schd_ver_correctness = [&](const uint64_t expected_version, const uint64_t eff_new_prod_schd_block_num)  {
-         const uint32_t check_duration = 1000; // number of blocks
-         for (uint32_t i = 0; i < check_duration; ++i) {
-            // The new schedule will only be applied once the effective block num is deemed irreversible
-            const bool is_new_schedule_applied = control->last_irreversible_block_num() > eff_new_prod_schd_block_num;
+   // replace initg with inita, inita is now duplicate
+   vector<account_name> invalid_producers = {
+      "inita"_n, "initb"_n, "initc"_n, "initd"_n, "inite"_n, "initf"_n, "inita"_n,
+      "inith"_n, "initi"_n, "initj"_n, "initk"_n, "initl"_n, "initm"_n, "initn"_n,
+      "inito"_n, "initp"_n, "initq"_n, "initr"_n, "inits"_n, "initt"_n, "initu"_n
+   };
 
-            // Produce block
-            produce_block();
+   BOOST_CHECK_THROW(set_producers(invalid_producers), wasm_execution_error);
 
-            // Ensure that the head block header is updated at the right time
-            const auto current_schd_ver = control->head_block_header().schedule_version;
-            if (is_new_schedule_applied) {
-               BOOST_TEST(current_schd_ver == expected_version);
-            } else {
-               BOOST_TEST(current_schd_ver != expected_version);
-            }
-         }
-      };
-
-      // Create producer accounts
-      vector<account_name> producers = {
-              "inita", "initb", "initc", "initd", "inite", "initf", "initg",
-              "inith", "initi", "initj", "initk", "initl", "initm", "initn",
-              "inito", "initp", "initq", "initr", "inits", "initt", "initu"
-      };
-      create_accounts(producers);
-
-      // Send set prods action and confirm schedule correctness
-      set_producers(producers, 1);
-      const auto& eff_first_prod_schd_block_num = calc_block_num_of_next_round_first_block(*control);
-      // Confirm the version is correct
-      confirm_header_schd_ver_correctness(1, eff_first_prod_schd_block_num);
-
-      // Shuffle the producers and set the new one with smaller version
-      boost::range::random_shuffle(producers);
-      set_producers(producers, 0);
-      const auto& eff_second_prod_schd_block_num = calc_block_num_of_next_round_first_block(*control);
-      // Even though we set it with smaller version number, the version should be incremented instead
-      confirm_header_schd_ver_correctness(2, eff_second_prod_schd_block_num);
-
-      // Shuffle the producers and set the new one with much larger version number
-      boost::range::random_shuffle(producers);
-      set_producers(producers, 1000);
-      const auto& eff_third_prod_schd_block_num = calc_block_num_of_next_round_first_block(*control);
-      // Even though we set it with much large version number, the version should be incremented instead
-      confirm_header_schd_ver_correctness(3, eff_third_prod_schd_block_num);
-
-   } FC_LOG_AND_RETHROW()
-#endif
-
+} FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, validating_tester ) try {
    create_accounts( {"alice"_n,"bob"_n,"carol"_n} );

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -19,15 +19,6 @@ account_name get_expected_producer(const vector<producer_authority>& schedule, b
    return schedule.at(index).producer_name;
 };
 
-// Check if two schedule is equal
-bool is_schedule_equal(const vector<producer_authority>& first, const vector<producer_authority>& second) {
-   bool is_equal = first.size() == second.size();
-   for (uint32_t i = 0; i < first.size() && is_equal; i++) {
-      is_equal = is_equal && first.at(i) == second.at(i);
-   }
-   return is_equal;
-};
-
 } // anonymous namespace
 
 BOOST_FIXTURE_TEST_CASE( verify_producer_schedule, validating_tester ) try {
@@ -38,7 +29,7 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule, validating_tester ) try {
       bool scheduled_changed_to_new = false;
       for (uint32_t i = 0; i < check_duration; ++i) {
          const auto current_schedule = control->head_block_state()->active_schedule.producers;
-         if (is_schedule_equal(new_prod_schd, current_schedule)) {
+         if (new_prod_schd == current_schedule) {
             scheduled_changed_to_new = true;
          }
 

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -144,19 +144,19 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
       vector<int64_t> expected_limits;
       std::transform(std::begin(weights), std::end(weights), std::back_inserter(expected_limits), [total](const auto& v){
          uint128_t value = v;
-         uint128_t account_cpu_usage_average_window = config::account_cpu_usage_average_window_ms / config::block_interval_ms;
-         return (account_cpu_usage_average_window * config::default_max_block_cpu_usage * value) / total;
+         uint128_t account_cpu_usage_window = config::account_cpu_usage_average_window_ms / config::block_interval_ms;
+         return (account_cpu_usage_window * config::default_max_block_cpu_usage * value) / total;
       });
 
-      for (int64_t idx = 0; idx < weights.size(); idx++) {
+      for (size_t idx = 0; idx < weights.size(); ++idx) {
          const account_name account(idx + 100);
          initialize_account(account, false);
-         set_account_limits(account, -1, -1, weights.at(idx), false);
+         set_account_limits(account, -1, -1, weights[idx], false);
       }
 
       process_account_limit_updates();
 
-      for (int64_t idx = 0; idx < weights.size(); idx++) {
+      for (size_t idx = 0; idx < weights.size(); ++idx) {
          const account_name account(idx + 100);
          BOOST_CHECK_EQUAL(get_account_cpu_limit(account).first, expected_limits.at(idx));
 

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -136,33 +136,37 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
    } FC_LOG_AND_RETHROW();
 
    /**
-    * create 5 accounts with different weights, verify that the capacities are as expected and that usage properly enforces them
+    * create 12 accounts with different weights, verify that the capacities are as expected and that usage properly enforces them
     */
-
-
-// TODO: restore weighted capacity cpu tests
-#if 0
    BOOST_FIXTURE_TEST_CASE(weighted_capacity_cpu, resource_limits_fixture) try {
-      const vector<int64_t> weights = { 234, 511, 672, 800, 1213 };
-      const int64_t total = std::accumulate(std::begin(weights), std::end(weights), 0LL);
+      const vector<int64_t> weights = { 1, 3, 9, 234, 511, 672, 800, 1213, 4242, 77777, 888888, 999999 };
+      const uint128_t total = std::accumulate(std::begin(weights), std::end(weights), 0LL);
       vector<int64_t> expected_limits;
-      std::transform(std::begin(weights), std::end(weights), std::back_inserter(expected_limits), [total](const auto& v){ return v * config::default_max_block_cpu_usage / total; });
+      std::transform(std::begin(weights), std::end(weights), std::back_inserter(expected_limits), [total](const auto& v){
+         uint128_t value = v;
+         uint128_t account_cpu_usage_average_window = config::account_cpu_usage_average_window_ms / config::block_interval_ms;
+         return (account_cpu_usage_average_window * config::default_max_block_cpu_usage * value) / total;
+      });
 
       for (int64_t idx = 0; idx < weights.size(); idx++) {
          const account_name account(idx + 100);
-         initialize_account(account);
-         set_account_limits(account, -1, -1, weights.at(idx));
+         initialize_account(account, false);
+         set_account_limits(account, -1, -1, weights.at(idx), false);
       }
 
       process_account_limit_updates();
 
       for (int64_t idx = 0; idx < weights.size(); idx++) {
          const account_name account(idx + 100);
-         BOOST_CHECK_EQUAL(get_account_cpu_limit(account), expected_limits.at(idx));
+         BOOST_CHECK_EQUAL(get_account_cpu_limit(account).first, expected_limits.at(idx));
 
          {  // use the expected limit, should succeed ... roll it back
             auto s = start_session();
-            add_transaction_usage({account}, expected_limits.at(idx), 0, 0);
+            if (expected_limits.at(idx) <= config::default_max_block_cpu_usage) {
+               add_transaction_usage({account}, expected_limits.at(idx), 0, 0);
+            } else {
+               BOOST_REQUIRE_THROW(add_transaction_usage({account}, expected_limits.at(idx), 0, 0), block_resource_exhausted);
+            }
             s.undo();
          }
 
@@ -172,29 +176,37 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
    } FC_LOG_AND_RETHROW();
 
    /**
-    * create 5 accounts with different weights, verify that the capacities are as expected and that usage properly enforces them
+    * create 12 accounts with different weights, verify that the capacities are as expected and that usage properly enforces them
     */
    BOOST_FIXTURE_TEST_CASE(weighted_capacity_net, resource_limits_fixture) try {
-      const vector<int64_t> weights = { 234, 511, 672, 800, 1213 };
-      const int64_t total = std::accumulate(std::begin(weights), std::end(weights), 0LL);
+      const vector<int64_t> weights = { 1, 3, 9, 234, 511, 672, 800, 1213, 4242, 77777, 888888, 999999 };
+      const uint128_t total = std::accumulate(std::begin(weights), std::end(weights), 0LL);
       vector<int64_t> expected_limits;
-      std::transform(std::begin(weights), std::end(weights), std::back_inserter(expected_limits), [total](const auto& v){ return v * config::default_max_block_net_usage / total; });
+      std::transform(std::begin(weights), std::end(weights), std::back_inserter(expected_limits), [total](const auto& v){
+         uint128_t value = v;
+         uint128_t account_net_usage_average_window = config::account_net_usage_average_window_ms / config::block_interval_ms;
+         return (account_net_usage_average_window * config::default_max_block_net_usage * value) / total;
+      });
 
       for (int64_t idx = 0; idx < weights.size(); idx++) {
          const account_name account(idx + 100);
-         initialize_account(account);
-         set_account_limits(account, -1, weights.at(idx), -1 );
+         initialize_account(account, false);
+         set_account_limits(account, -1, weights.at(idx), -1, false);
       }
 
       process_account_limit_updates();
 
       for (int64_t idx = 0; idx < weights.size(); idx++) {
          const account_name account(idx + 100);
-         BOOST_CHECK_EQUAL(get_account_net_limit(account), expected_limits.at(idx));
+         BOOST_CHECK_EQUAL(get_account_net_limit(account).first, expected_limits.at(idx));
 
          {  // use the expected limit, should succeed ... roll it back
             auto s = start_session();
-            add_transaction_usage({account}, 0, expected_limits.at(idx), 0);
+            if (expected_limits.at(idx) <= config::default_max_block_net_usage) {
+               add_transaction_usage({account}, 0, expected_limits.at(idx), 0);
+            } else {
+               BOOST_REQUIRE_THROW(add_transaction_usage({account}, 0, expected_limits.at(idx), 0), block_resource_exhausted);
+            }
             s.undo();
          }
 
@@ -202,7 +214,6 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
          BOOST_REQUIRE_THROW(add_transaction_usage({account}, 0, expected_limits.at(idx) + 1, 0), tx_net_usage_exceeded);
       }
    } FC_LOG_AND_RETHROW();
-#endif
 
    BOOST_FIXTURE_TEST_CASE(enforce_block_limits_cpu, resource_limits_fixture) try {
       const account_name account(1);

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -2184,12 +2184,10 @@ BOOST_FIXTURE_TEST_CASE( negative_memory_grow, validating_tester ) try {
 
 } FC_LOG_AND_RETHROW()
 
-// TODO: restore net_usage_tests
-#if 0
 BOOST_FIXTURE_TEST_CASE(net_usage_tests, tester ) try {
    int count = 0;
    auto check = [&](int coderepeat, int max_net_usage)-> bool {
-      account_name account = "f_tests"_n + (count++) * 16;
+      account_name account{"f_tests"_n.to_uint64_t() + (count++) * 16};
       create_accounts({account});
 
       std::string code = R"=====(
@@ -2233,7 +2231,7 @@ BOOST_FIXTURE_TEST_CASE(net_usage_tests, tester ) try {
    };
    BOOST_REQUIRE_EQUAL(true, check(1024, 0)); // default behavior
    BOOST_REQUIRE_EQUAL(false, check(1024, 100)); // transaction max_net_usage too small
-   BOOST_REQUIRE_EQUAL(false, check(10240, 0)); // larger than global maximum
+   BOOST_REQUIRE_EQUAL(false, check(config::default_max_block_net_usage+1, 0)); // larger than global maximum
 
 } FC_LOG_AND_RETHROW()
 
@@ -2284,14 +2282,13 @@ BOOST_FIXTURE_TEST_CASE(weighted_net_usage_tests, tester ) try {
    BOOST_REQUIRE_EQUAL(true, check(128)); // no limits, should pass
 
    resource_limits_manager mgr = control->get_mutable_resource_limits_manager();
-   mgr.set_account_limits(account, -1, 1, -1); // set weight = 1 for account
+   mgr.set_account_limits(account, -1, 1, -1, false); // set weight = 1 for account
 
    BOOST_REQUIRE_EQUAL(true, check(128));
 
-   mgr.set_account_limits(acc2, -1, 1000, -1); // set a big weight for other account
+   mgr.set_account_limits(acc2, -1, 100000000, -1, false); // set a big weight for other account
    BOOST_REQUIRE_EQUAL(false, check(128));
 
 } FC_LOG_AND_RETHROW()
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Re-enable unittests which have been commented out since pre-launch of EOS.

Resolves #1111 