### PR TITLE
return `string` from test contract's `_abi()` call instead of `vector` to avoid non-null terminated `char*` access

### DIFF
--- a/libraries/testing/contracts.cpp.in
+++ b/libraries/testing/contracts.cpp.in
@@ -14,8 +14,8 @@ namespace eosio::testing {                                                      
    std::vector<std::uint8_t> contracts:: CN ## _wasm() {                                                                                                                      \
       return std::vector<std::uint8_t>(geosio_testing_contract_ ## CN ## _wasm_data, geosio_testing_contract_ ## CN ## _wasm_data + geosio_testing_contract_ ## CN ## _wasm_size); \
    }                                                                                                                                                                          \
-   std::vector<char> contracts:: CN ## _abi() {                                                                                                                               \
-      return std::vector<char>(geosio_testing_contract_ ## CN ## _abi_data, geosio_testing_contract_ ## CN ## _abi_data + geosio_testing_contract_ ## CN ## _abi_size);       \
+   std::string contracts:: CN ## _abi() {                                                                                                                                     \
+      return geosio_testing_contract_ ## CN ## _abi_data;                                                                                                                     \
    }                                                                                                                                                                          \
 }
 

--- a/libraries/testing/contracts.hpp.in
+++ b/libraries/testing/contracts.hpp.in
@@ -2,12 +2,13 @@
 
 #include <cstdint>
 #include <vector>
+#include <string>
 
 //contracts that need to be available by native contract unit testing's libtester need to be embedded
 // in to the library as the build directory may not exist after being 'make install'ed.
 #define MAKE_EMBD_WASM_ABI(CN)                                                              \
    static std::vector<std::uint8_t> CN ## _wasm();                                          \
-   static std::vector<char> CN ## _abi();
+   static std::string CN ## _abi();
 
 namespace eosio {
    namespace testing {

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -307,7 +307,7 @@ namespace eosio { namespace testing {
 
          void              set_code( account_name name, const char* wast, const private_key_type* signer = nullptr );
          void              set_code( account_name name, const vector<uint8_t> wasm, const private_key_type* signer = nullptr  );
-         void              set_abi( account_name name, const char* abi_json, const private_key_type* signer = nullptr );
+         void              set_abi( account_name name, const std::string& abi_json, const private_key_type* signer = nullptr );
 
          bool is_code_cached( account_name name ) const;
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -966,7 +966,7 @@ namespace eosio { namespace testing {
    } FC_CAPTURE_AND_RETHROW( (account) )
 
 
-   void base_tester::set_abi( account_name account, const char* abi_json, const private_key_type* signer ) {
+   void base_tester::set_abi( account_name account, const std::string& abi_json, const private_key_type* signer ) {
       auto abi = fc::json::from_string(abi_json).template as<abi_def>();
       signed_transaction trx;
       trx.actions.emplace_back( vector<permission_level>{{account,config::active_name}},
@@ -1105,17 +1105,17 @@ namespace eosio { namespace testing {
 
    void base_tester::set_before_preactivate_bios_contract() {
       set_code(config::system_account_name, contracts::before_preactivate_eosio_bios_wasm());
-      set_abi(config::system_account_name, contracts::before_preactivate_eosio_bios_abi().data());
+      set_abi(config::system_account_name, contracts::before_preactivate_eosio_bios_abi());
    }
 
    void base_tester::set_before_producer_authority_bios_contract() {
       set_code(config::system_account_name, contracts::before_producer_authority_eosio_bios_wasm());
-      set_abi(config::system_account_name, contracts::before_producer_authority_eosio_bios_abi().data());
+      set_abi(config::system_account_name, contracts::before_producer_authority_eosio_bios_abi());
    }
 
    void base_tester::set_bios_contract() {
       set_code(config::system_account_name, contracts::eosio_bios_wasm());
-      set_abi(config::system_account_name, contracts::eosio_bios_abi().data());
+      set_abi(config::system_account_name, contracts::eosio_bios_abi());
    }
 
 

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -43,7 +43,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, validating_tester ) try {
 
    // setup contract and abi
    set_code( "asserter"_n, test_contracts::asserter_wasm() );
-   set_abi( "asserter"_n, test_contracts::asserter_abi().data() );
+   set_abi( "asserter"_n, test_contracts::asserter_abi() );
    produce_blocks(1);
 
    auto resolver = [&,this]( const account_name& name ) -> std::optional<abi_serializer> {
@@ -101,7 +101,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, validating_tester ) try {
    BOOST_TEST(block_str.find("011253686f756c64204e6f742041737365727421") != std::string::npos); //action data
 
    // set an invalid abi (int8->xxxx)
-   std::string abi2 = test_contracts::asserter_abi().data();
+   std::string abi2 = test_contracts::asserter_abi();
    auto pos = abi2.find("int8");
    BOOST_TEST(pos != std::string::npos);
    abi2.replace(pos, 4, "xxxx");

--- a/tests/get_table_seckey_tests.cpp
+++ b/tests/get_table_seckey_tests.cpp
@@ -40,7 +40,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
 
    // setup contract and abi
    set_code( "test"_n, test_contracts::get_table_seckey_test_wasm() );
-   set_abi( "test"_n, test_contracts::get_table_seckey_test_abi().data() );
+   set_abi( "test"_n, test_contracts::get_table_seckey_test_abi() );
    produce_block();
 
    chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -74,7 +74,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, validating_tester ) try {
    produce_block();
 
    set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
-   set_abi( "eosio.token"_n, test_contracts::eosio_token_abi().data() );
+   set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
    produce_blocks(1);
 
    // create currency
@@ -146,7 +146,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
    produce_block();
 
    set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
-   set_abi( "eosio.token"_n, test_contracts::eosio_token_abi().data() );
+   set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
    produce_blocks(1);
 
    // create currency
@@ -326,7 +326,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, validating_tester ) try {
    produce_block();
 
    set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
-   set_abi( "eosio.token"_n, test_contracts::eosio_token_abi().data() );
+   set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
    produce_blocks(1);
 
    // create currency
@@ -342,7 +342,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, validating_tester ) try {
    produce_blocks(1);
 
    set_code( config::system_account_name, test_contracts::eosio_system_wasm() );
-   set_abi( config::system_account_name, test_contracts::eosio_system_abi().data() );
+   set_abi( config::system_account_name, test_contracts::eosio_system_abi() );
 
    base_tester::push_action(config::system_account_name, "init"_n,
                             config::system_account_name,  mutable_variant_object()
@@ -456,7 +456,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
 
    // setup contract and abi
    set_code( "test"_n, test_contracts::get_table_test_wasm() );
-   set_abi( "test"_n, test_contracts::get_table_test_abi().data() );
+   set_abi( "test"_n, test_contracts::get_table_test_abi() );
    produce_block();
 
    // Init some data

--- a/tests/test_chain_plugin.cpp
+++ b/tests/test_chain_plugin.cpp
@@ -193,7 +193,7 @@ public:
                          "eosio.bpay"_n, "eosio.vpay"_n, "eosio.saving"_n, "eosio.names"_n, "eosio.rex"_n });
 
        set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
-       set_abi( "eosio.token"_n, test_contracts::eosio_token_abi().data() );
+       set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
 
        {
            const auto& accnt = control->db().get<account_object,by_name>( "eosio.token"_n );
@@ -207,7 +207,7 @@ public:
        BOOST_CHECK_EQUAL( core_from_string("1000000000.0000"), get_balance( name("eosio") ) );
 
        set_code( config::system_account_name, test_contracts::eosio_system_wasm() );
-       set_abi( config::system_account_name, test_contracts::eosio_system_abi().data() );
+       set_abi( config::system_account_name, test_contracts::eosio_system_abi() );
 
        base_tester::push_action(config::system_account_name, "init"_n,
                                 config::system_account_name,  mutable_variant_object()

--- a/tests/test_snapshot_information.cpp
+++ b/tests/test_snapshot_information.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_snapshot_information, SNAPSHOT_SUITE, snapsho
    chain.create_account("snapshot"_n);
    chain.produce_blocks(1);
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
-   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi().data());
+   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
    chain.produce_blocks(1);
 
    auto block = chain.produce_block();

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -382,7 +382,7 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, validating_tester) { try {
    set_code( config::system_account_name, contracts::eosio_bios_wasm() );
 
    set_code( "test"_n, contracts::eosio_bios_wasm() );
-   set_abi( "test"_n, contracts::eosio_bios_abi().data() );
+   set_abi( "test"_n, contracts::eosio_bios_abi() );
 	set_code( "test"_n, test_contracts::payloadless_wasm() );
 
    call_doit_and_check( "test"_n, "test"_n, [&]( const transaction_trace_ptr& res ) {
@@ -1896,7 +1896,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
 
    chain.create_accounts( {contract_account, test_account} );
    chain.set_code( contract_account, test_contracts::deferred_test_wasm() );
-   chain.set_abi( contract_account, test_contracts::deferred_test_abi().data() );
+   chain.set_abi( contract_account, test_contracts::deferred_test_abi() );
    chain.produce_block();
 
    BOOST_REQUIRE_EQUAL(0, index.size());
@@ -2106,9 +2106,9 @@ BOOST_FIXTURE_TEST_CASE(db_tests, validating_tester) { try {
    create_account( "testapi2"_n );
    produce_blocks(10);
    set_code( "testapi"_n, test_contracts::test_api_db_wasm() );
-   set_abi(  "testapi"_n, test_contracts::test_api_db_abi().data() );
+   set_abi(  "testapi"_n, test_contracts::test_api_db_abi() );
    set_code( "testapi2"_n, test_contracts::test_api_db_wasm() );
-   set_abi(  "testapi2"_n, test_contracts::test_api_db_abi().data() );
+   set_abi(  "testapi2"_n, test_contracts::test_api_db_abi() );
    produce_blocks(1);
 
    push_action( "testapi"_n, "pg"_n,  "testapi"_n, mutable_variant_object() ); // primary_i64_general
@@ -2266,7 +2266,7 @@ BOOST_FIXTURE_TEST_CASE(multi_index_tests, validating_tester) { try {
    create_account( "testapi"_n );
    produce_blocks(1);
    set_code( "testapi"_n, test_contracts::test_api_multi_index_wasm() );
-   set_abi( "testapi"_n, test_contracts::test_api_multi_index_abi().data() );
+   set_abi( "testapi"_n, test_contracts::test_api_multi_index_abi() );
    produce_blocks(1);
 
    auto check_failure = [this]( action_name a, const char* expected_error_msg ) {

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -59,7 +59,7 @@ class bootseq_tester : public validating_tester {
 public:
    void deploy_contract( bool call_init = true ) {
       set_code( config::system_account_name, test_contracts::eosio_system_wasm() );
-      set_abi( config::system_account_name, test_contracts::eosio_system_abi().data() );
+      set_abi( config::system_account_name, test_contracts::eosio_system_abi() );
       if( call_init ) {
          base_tester::push_action(config::system_account_name, "init"_n,
                                   config::system_account_name,  mutable_variant_object()
@@ -158,7 +158,7 @@ public:
          return get_currency_balance("eosio.token"_n, symbol(CORE_SYMBOL), act);
     }
 
-    void set_code_abi(const account_name& account, const vector<uint8_t>& wasm, const char* abi, const private_key_type* signer = nullptr) {
+    void set_code_abi(const account_name& account, const vector<uint8_t>& wasm, const std::string& abi, const private_key_type* signer = nullptr) {
        wdump((account));
         set_code(account, wasm, signer);
         set_abi(account, abi, signer);
@@ -186,15 +186,15 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         //  - eosio (code: eosio.bios) (already set by tester constructor)
         //  - eosio.msig (code: eosio.msig)
         //  - eosio.token (code: eosio.token)
-        // set_code_abi("eosio.msig"_n, contracts::eosio_msig_wasm(), contracts::eosio_msig_abi().data());//, &eosio_active_pk);
-        // set_code_abi("eosio.token"_n, contracts::eosio_token_wasm(), contracts::eosio_token_abi().data()); //, &eosio_active_pk);
+        // set_code_abi("eosio.msig"_n, contracts::eosio_msig_wasm(), contracts::eosio_msig_abi());//, &eosio_active_pk);
+        // set_code_abi("eosio.token"_n, contracts::eosio_token_wasm(), contracts::eosio_token_abi()); //, &eosio_active_pk);
 
         set_code_abi("eosio.msig"_n,
                      test_contracts::eosio_msig_wasm(),
-                     test_contracts::eosio_msig_abi().data());//, &eosio_active_pk);
+                     test_contracts::eosio_msig_abi());//, &eosio_active_pk);
         set_code_abi("eosio.token"_n,
                      test_contracts::eosio_token_wasm(),
-                     test_contracts::eosio_token_abi().data()); //, &eosio_active_pk);
+                     test_contracts::eosio_token_abi()); //, &eosio_active_pk);
 
         // Set privileged for eosio.msig and eosio.token
         set_privileged("eosio.msig"_n);

--- a/unittests/crypto_primitives_tests.cpp
+++ b/unittests/crypto_primitives_tests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE( alt_bn128_add_test ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi() );
    c.produce_block();
 
    using test_add = std::tuple<std::string, std::string, int32_t, std::string>;
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE( alt_bn128_mul_test ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi() );
    c.produce_block();
 
    using test_mul = std::tuple<std::string, std::string, int32_t, std::string>;
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE( alt_bn128_pair_test ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi() );
    c.produce_block();
 
    using g1g2_pair = std::vector<std::string>;
@@ -427,7 +427,7 @@ BOOST_AUTO_TEST_CASE( modexp_test ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi() );
    c.produce_block();
 
    using modexp_test = std::tuple<std::vector<string>, int32_t, std::string>;
@@ -517,7 +517,7 @@ BOOST_AUTO_TEST_CASE( modexp_subjective_limit_test ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi() );
    c.produce_block();
 
    auto exponent = h2bin("010001");
@@ -591,7 +591,7 @@ BOOST_AUTO_TEST_CASE( blake2f_test ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi() );
    c.produce_block();
 
    using compress_test = std::tuple<std::vector<string>, int32_t, std::string>;
@@ -718,7 +718,7 @@ BOOST_AUTO_TEST_CASE( keccak256_test ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi() );
    c.produce_block();
 
    using test_keccak256 = std::tuple<std::string, std::string>;
@@ -769,7 +769,7 @@ BOOST_AUTO_TEST_CASE( sha3_test ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi() );
    c.produce_block();
 
    using test_sha3 = std::tuple<std::string, std::string>;
@@ -820,7 +820,7 @@ BOOST_AUTO_TEST_CASE( k1_recover_test ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::crypto_primitives_test_abi() );
    c.produce_block();
 
    using test_k1_recover = std::tuple<std::string, std::string, int32_t, std::string>;

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -64,7 +64,7 @@ class currency_tester : public validating_tester {
       }
 
       currency_tester()
-         :validating_tester(),abi_ser(json::from_string(test_contracts::eosio_token_abi().data()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ))
+         :validating_tester(),abi_ser(json::from_string(test_contracts::eosio_token_abi()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ))
       {
          create_account( "eosio.token"_n);
          set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
@@ -398,7 +398,7 @@ BOOST_FIXTURE_TEST_CASE( test_proxy, currency_tester ) try {
    set_code("proxy"_n, test_contracts::proxy_wasm());
    produce_blocks(1);
 
-   abi_serializer proxy_abi_ser(json::from_string(test_contracts::proxy_abi().data()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ));
+   abi_serializer proxy_abi_ser(json::from_string(test_contracts::proxy_abi()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ));
 
    // set up proxy owner
    {
@@ -454,7 +454,7 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, currency_tester ) try {
    set_code("bob"_n, test_contracts::proxy_wasm());
    produce_blocks(1);
 
-   abi_serializer proxy_abi_ser(json::from_string(test_contracts::proxy_abi().data()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ));
+   abi_serializer proxy_abi_ser(json::from_string(test_contracts::proxy_abi()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ));
 
    // set up proxy owner
    {

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -509,7 +509,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -653,7 +653,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -844,7 +844,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -1041,7 +1041,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -1243,7 +1243,7 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -1432,7 +1432,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -1621,7 +1621,7 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -1753,7 +1753,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    chain.produce_blocks(10);
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -1990,7 +1990,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
    chain.produce_blocks();
 
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);
@@ -2276,7 +2276,7 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_execute ) { try {
 
    chain.create_account("eosio.token"_n);
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
-   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
    chain.produce_blocks();
    chain.create_account("tester"_n);

--- a/unittests/eosio.token_tests.cpp
+++ b/unittests/eosio.token_tests.cpp
@@ -27,7 +27,7 @@ public:
       produce_blocks( 2 );
 
       set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
-      set_abi( "eosio.token"_n, test_contracts::eosio_token_abi().data() );
+      set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
 
       produce_blocks();
 

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -34,7 +34,7 @@ public:
       produce_blocks( 100 );
 
       set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
-      set_abi( "eosio.token"_n, test_contracts::eosio_token_abi().data() );
+      set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
 
       {
          const auto& accnt = control->db().get<account_object,by_name>( "eosio.token"_n );
@@ -48,7 +48,7 @@ public:
       BOOST_REQUIRE_EQUAL( core_from_string("1000000000.0000"), get_balance( name("eosio") ) );
 
       set_code( config::system_account_name, test_contracts::eosio_system_wasm() );
-      set_abi( config::system_account_name, test_contracts::eosio_system_abi().data() );
+      set_abi( config::system_account_name, test_contracts::eosio_system_abi() );
 
       base_tester::push_action(config::system_account_name, "init"_n,
                             config::system_account_name,  mutable_variant_object()
@@ -415,7 +415,7 @@ public:
          );
 
          set_code( "eosio.msig"_n, test_contracts::eosio_msig_wasm() );
-         set_abi( "eosio.msig"_n, test_contracts::eosio_msig_abi().data() );
+         set_abi( "eosio.msig"_n, test_contracts::eosio_msig_abi() );
 
          produce_blocks();
          const auto& accnt = control->db().get<account_object,by_name>( "eosio.msig"_n );

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    auto r2 = c.create_accounts( {"eosio.token"_n} );
    wdump((fc::json::to_pretty_string(r2)));
    c.set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
-   c.set_abi( "eosio.token"_n, test_contracts::eosio_token_abi().data() );
+   c.set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
    c.produce_blocks(10);
 
 

--- a/unittests/get_block_num_tests.cpp
+++ b/unittests/get_block_num_tests.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE( get_block_num ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::get_block_num_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::get_block_num_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::get_block_num_test_abi() );
    c.produce_block();
 
    c.push_action( tester1_account, "testblock"_n, tester1_account, mutable_variant_object()

--- a/unittests/params_tests.cpp
+++ b/unittests/params_tests.cpp
@@ -20,7 +20,7 @@ public:
    void setup(){
       //set parameters intrinsics are priviledged so we need system account here
       set_code(config::system_account_name, eosio::testing::test_contracts::params_test_wasm());
-      set_abi(config::system_account_name, eosio::testing::test_contracts::params_test_abi().data());
+      set_abi(config::system_account_name, eosio::testing::test_contracts::params_test_abi());
       produce_block();
    }
 

--- a/unittests/payloadless_tests.cpp
+++ b/unittests/payloadless_tests.cpp
@@ -28,7 +28,7 @@ BOOST_FIXTURE_TEST_CASE( test_doit, payloadless_tester ) {
    
    create_accounts( {"payloadless"_n} );
    set_code( "payloadless"_n, test_contracts::payloadless_wasm() );
-   set_abi( "payloadless"_n, test_contracts::payloadless_abi().data() );
+   set_abi( "payloadless"_n, test_contracts::payloadless_abi() );
 
    auto trace = push_action("payloadless"_n, "doit"_n, "payloadless"_n, mutable_variant_object());
    auto msg = trace->action_traces.front().console;
@@ -41,7 +41,7 @@ BOOST_FIXTURE_TEST_CASE( test_abi_serializer, payloadless_tester ) {
 
    create_accounts( {"payloadless"_n} );
    set_code( "payloadless"_n, test_contracts::payloadless_wasm() );
-   set_abi( "payloadless"_n, test_contracts::payloadless_abi().data() );
+   set_abi( "payloadless"_n, test_contracts::payloadless_abi() );
 
    fc::variant pretty_trx = fc::mutable_variant_object()
       ("actions", fc::variants({

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE( activate_preactivate_feature ) try {
 
    // But the old bios contract can still be set.
    c.set_code( config::system_account_name, contracts::before_preactivate_eosio_bios_wasm() );
-   c.set_abi( config::system_account_name, contracts::before_preactivate_eosio_bios_abi().data() );
+   c.set_abi( config::system_account_name, contracts::before_preactivate_eosio_bios_abi() );
 
    auto t = c.control->pending_block_time();
    c.control->abort_block();
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
    c.produce_block();
    c.create_accounts( {"alice"_n, "bob"_n, "test"_n} );
    c.set_code( "test"_n, test_contracts::deferred_test_wasm() );
-   c.set_abi( "test"_n, test_contracts::deferred_test_abi().data() );
+   c.set_abi( "test"_n, test_contracts::deferred_test_abi() );
    c.produce_block();
 
    auto alice_ram_usage0 = c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n );
@@ -534,7 +534,7 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
    c.produce_block();
    c.create_accounts( {"alice"_n, "test"_n} );
    c.set_code( "test"_n, test_contracts::deferred_test_wasm() );
-   c.set_abi( "test"_n, test_contracts::deferred_test_abi().data() );
+   c.set_abi( "test"_n, test_contracts::deferred_test_abi() );
    c.produce_block();
 
    push_blocks( c, c2 );
@@ -808,10 +808,10 @@ BOOST_AUTO_TEST_CASE( restrict_action_to_self_test ) { try {
 
    c.create_accounts( {"testacc"_n, "acctonotify"_n, "alice"_n} );
    c.set_code( "testacc"_n, test_contracts::restrict_action_test_wasm() );
-   c.set_abi( "testacc"_n, test_contracts::restrict_action_test_abi().data() );
+   c.set_abi( "testacc"_n, test_contracts::restrict_action_test_abi() );
 
    c.set_code( "acctonotify"_n, test_contracts::restrict_action_test_wasm() );
-   c.set_abi( "acctonotify"_n, test_contracts::restrict_action_test_abi().data() );
+   c.set_abi( "acctonotify"_n, test_contracts::restrict_action_test_abi() );
 
    // Before the protocol feature is preactivated
    // - Sending inline action to self = no problem
@@ -1046,9 +1046,9 @@ BOOST_AUTO_TEST_CASE( get_sender_test ) { try {
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::get_sender_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::get_sender_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::get_sender_test_abi() );
    c.set_code( tester2_account, test_contracts::get_sender_test_wasm() );
-   c.set_abi( tester2_account, test_contracts::get_sender_test_abi().data() );
+   c.set_abi( tester2_account, test_contracts::get_sender_test_abi() );
    c.produce_block();
 
    BOOST_CHECK_EXCEPTION(  c.push_action( tester1_account, "sendinline"_n, tester1_account, mutable_variant_object()
@@ -1089,10 +1089,10 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    c.create_accounts( {tester1_account, tester2_account, alice_account, bob_account} );
    c.produce_block();
    c.set_code( tester1_account, test_contracts::ram_restrictions_test_wasm() );
-   c.set_abi( tester1_account, test_contracts::ram_restrictions_test_abi().data() );
+   c.set_abi( tester1_account, test_contracts::ram_restrictions_test_abi() );
    c.produce_block();
    c.set_code( tester2_account, test_contracts::ram_restrictions_test_wasm() );
-   c.set_abi( tester2_account, test_contracts::ram_restrictions_test_abi().data() );
+   c.set_abi( tester2_account, test_contracts::ram_restrictions_test_abi() );
    c.produce_block();
 
    // Basic setup

--- a/unittests/ram_tests.cpp
+++ b/unittests/ram_tests.cpp
@@ -49,7 +49,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
 
    for (auto i = 0; i < 10; ++i) {
       try {
-         set_abi( "testram11111"_n, test_contracts::test_ram_limit_abi().data() );
+         set_abi( "testram11111"_n, test_contracts::test_ram_limit_abi() );
          break;
       } catch (const ram_usage_exceeded&) {
          init_request_bytes += increment_contract_bytes;
@@ -59,7 +59,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
    }
    produce_blocks(10);
    set_code( "testram22222"_n, test_contracts::test_ram_limit_wasm() );
-   set_abi( "testram22222"_n, test_contracts::test_ram_limit_abi().data() );
+   set_abi( "testram22222"_n, test_contracts::test_ram_limit_abi() );
    produce_blocks(10);
 
    auto total = get_total_stake( "testram11111"_n );

--- a/unittests/read_only_trx_tests.cpp
+++ b/unittests/read_only_trx_tests.cpp
@@ -20,7 +20,7 @@ struct read_only_trx_tester : validating_tester {
    void set_up_test_contract() {
       create_accounts( {"noauthtable"_n, "alice"_n} );
       set_code( "noauthtable"_n, test_contracts::no_auth_table_wasm() );
-      set_abi( "noauthtable"_n, test_contracts::no_auth_table_abi().data() );
+      set_abi( "noauthtable"_n, test_contracts::no_auth_table_abi() );
       produce_block();
 
       insert_data = abi_ser.variant_to_binary( "insert", mutable_variant_object()
@@ -65,7 +65,7 @@ struct read_only_trx_tester : validating_tester {
       produce_block();
    }
 
-   abi_serializer abi_ser{ json::from_string(test_contracts::no_auth_table_abi().data()).as<abi_def>(), abi_serializer::create_yield_function(abi_serializer_max_time )};
+   abi_serializer abi_ser{ json::from_string(test_contracts::no_auth_table_abi()).as<abi_def>(), abi_serializer::create_yield_function(abi_serializer_max_time )};
    bytes insert_data;
    bytes getage_data;
 };

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_exhaustive_snapshot, SNAPSHOT_SUITE, snapshot
    // Set code and increment the first account
    chain.produce_blocks(1);
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
-   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi().data());
+   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
    chain.produce_blocks(1);
    chain.push_action("snapshot"_n, "increment"_n, "snapshot"_n, mutable_variant_object()
          ( "value", 1 )
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_exhaustive_snapshot, SNAPSHOT_SUITE, snapshot
    // Set code and increment the second account
    chain.produce_blocks(1);
    chain.set_code("snapshot1"_n, test_contracts::snapshot_test_wasm());
-   chain.set_abi("snapshot1"_n, test_contracts::snapshot_test_abi().data());
+   chain.set_abi("snapshot1"_n, test_contracts::snapshot_test_abi());
    chain.produce_blocks(1);
    // increment the test contract
    chain.push_action("snapshot1"_n, "increment"_n, "snapshot1"_n, mutable_variant_object()
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_replay_over_snapshot, SNAPSHOT_SUITE, snapsho
    chain.create_account("snapshot"_n);
    chain.produce_blocks(1);
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
-   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi().data());
+   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
    chain.produce_blocks(1);
    chain.control->abort_block();
 
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_chain_id_in_snapshot, SNAPSHOT_SUITE, snapsho
    chain.create_account("snapshot"_n);
    chain.produce_blocks(1);
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
-   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi().data());
+   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
    chain.produce_blocks(1);
    chain.control->abort_block();
 
@@ -395,7 +395,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_compatible_versions, SNAPSHOT_SUITE, snapshot
       chain.create_account("snapshot"_n);
       chain.produce_blocks(1);
       chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
-      chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi().data());
+      chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
       chain.produce_blocks(1);
       chain.control->abort_block();
 
@@ -513,7 +513,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_blo
    chain.create_account("snapshot"_n);
    chain.produce_blocks(1);
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
-   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi().data());
+   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
    chain.produce_blocks(1);
    chain.control->abort_block();
 
@@ -598,7 +598,7 @@ BOOST_AUTO_TEST_CASE(json_snapshot_validity_test)
    chain.create_account("snapshot"_n);
    chain.produce_blocks(1);
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
-   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi().data());
+   chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
    chain.produce_blocks(10);
    chain.control->abort_block();
 

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_contract) {
    chain.create_account("tester"_n);
 
    chain.set_code("tester"_n, test_contracts::get_table_test_wasm());
-   chain.set_abi("tester"_n, test_contracts::get_table_test_abi().data());
+   chain.set_abi("tester"_n, test_contracts::get_table_test_abi());
 
    chain.produce_block();
 
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_resources_history) {
    chain.produce_blocks( 100 );
 
    chain.set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
-   chain.set_abi( "eosio.token"_n, test_contracts::eosio_token_abi().data() );
+   chain.set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
 
    chain.produce_block();
 
@@ -400,7 +400,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_resources_history) {
    chain.produce_blocks(10);
 
    chain.set_code( config::system_account_name, test_contracts::eosio_system_wasm() );
-   chain.set_abi( config::system_account_name, test_contracts::eosio_system_abi().data() );
+   chain.set_abi( config::system_account_name, test_contracts::eosio_system_abi() );
 
    chain.push_action(config::system_account_name, "init"_n, config::system_account_name,
                         mutable_variant_object()
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_resources_history) {
       chain.create_account("tester"_n);
 
       chain.set_code("tester"_n, test_contracts::get_table_test_wasm());
-      chain.set_abi("tester"_n, test_contracts::get_table_test_abi().data());
+      chain.set_abi("tester"_n, test_contracts::get_table_test_abi());
 
       chain.produce_blocks(2);
 
@@ -583,7 +583,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_resources_history) {
 
       c.create_accounts({"alice"_n, "test"_n});
       c.set_code("test"_n, test_contracts::deferred_test_wasm());
-      c.set_abi("test"_n, test_contracts::deferred_test_abi().data());
+      c.set_abi("test"_n, test_contracts::deferred_test_abi());
       c.produce_block();
 
       c.push_action("test"_n, "defercall"_n, "alice"_n,

--- a/unittests/test_contracts.hpp.in
+++ b/unittests/test_contracts.hpp.in
@@ -10,10 +10,10 @@
       fc::read_file_contents("${CMAKE_BINARY_DIR}/unittests/" #D "/" #C "/" #C ".wasm", s); \
       return std::vector<uint8_t>(s.begin(), s.end());                                      \
    }                                                                                        \
-   static std::vector<char> CN ## _abi() {                                                  \
+   static std::string CN ## _abi() {                                                        \
       std::string s;                                                                        \
       fc::read_file_contents("${CMAKE_BINARY_DIR}/unittests/" #D "/" #C "/" #C ".abi", s);  \
-      return std::vector<char>(s.begin(), s.end());                                         \
+      return s;                                                                             \
    }
 
 namespace eosio {

--- a/unittests/wasm_config_tests.cpp
+++ b/unittests/wasm_config_tests.cpp
@@ -23,7 +23,7 @@ namespace data = boost::unit_test::data;
 namespace {
 struct wasm_config_tester : validating_tester {
    wasm_config_tester() {
-      set_abi(config::system_account_name, test_contracts::wasm_config_bios_abi().data());
+      set_abi(config::system_account_name, test_contracts::wasm_config_bios_abi());
       set_code(config::system_account_name, test_contracts::wasm_config_bios_wasm());
       bios_abi_ser = *get_resolver()(config::system_account_name);
    }

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -163,7 +163,7 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, validating_tester ) try {
    produce_block();
 
    set_code("asserter"_n, test_contracts::asserter_wasm());
-   set_abi("asserter"_n, test_contracts::asserter_abi().data());
+   set_abi("asserter"_n, test_contracts::asserter_abi());
    produce_blocks(1);
 
    auto resolver = [&,this]( const account_name& name ) -> std::optional<abi_serializer> {
@@ -1029,7 +1029,7 @@ BOOST_FIXTURE_TEST_CASE(noop, validating_tester) try {
 
    set_code("noop"_n, test_contracts::noop_wasm());
 
-   set_abi("noop"_n, test_contracts::noop_abi().data());
+   set_abi("noop"_n, test_contracts::noop_abi());
    const auto& accnt  = control->db().get<account_object,by_name>("noop"_n);
    abi_def abi;
    BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -39,7 +39,7 @@ class whitelist_blacklist_tester {
 
          chain->create_accounts({"eosio.token"_n, "alice"_n, "bob"_n, "charlie"_n});
          chain->set_code("eosio.token"_n, test_contracts::eosio_token_wasm() );
-         chain->set_abi("eosio.token"_n, test_contracts::eosio_token_abi().data() );
+         chain->set_abi("eosio.token"_n, test_contracts::eosio_token_abi() );
          chain->push_action( "eosio.token"_n, "create"_n, "eosio.token"_n, mvo()
               ( "issuer", "eosio.token" )
               ( "maximum_supply", "1000000.00 TOK" )
@@ -179,12 +179,12 @@ BOOST_AUTO_TEST_CASE( contract_whitelist ) { try {
    test.chain->produce_blocks();
 
    test.chain->set_code("bob"_n, test_contracts::eosio_token_wasm() );
-   test.chain->set_abi("bob"_n, test_contracts::eosio_token_abi().data() );
+   test.chain->set_abi("bob"_n, test_contracts::eosio_token_abi() );
 
    test.chain->produce_blocks();
 
    test.chain->set_code("charlie"_n, test_contracts::eosio_token_wasm() );
-   test.chain->set_abi("charlie"_n, test_contracts::eosio_token_abi().data() );
+   test.chain->set_abi("charlie"_n, test_contracts::eosio_token_abi() );
 
    test.chain->produce_blocks();
 
@@ -228,12 +228,12 @@ BOOST_AUTO_TEST_CASE( contract_blacklist ) { try {
    test.chain->produce_blocks();
 
    test.chain->set_code("bob"_n, test_contracts::eosio_token_wasm() );
-   test.chain->set_abi("bob"_n, test_contracts::eosio_token_abi().data() );
+   test.chain->set_abi("bob"_n, test_contracts::eosio_token_abi() );
 
    test.chain->produce_blocks();
 
    test.chain->set_code("charlie"_n, test_contracts::eosio_token_wasm() );
-   test.chain->set_abi("charlie"_n, test_contracts::eosio_token_abi().data() );
+   test.chain->set_abi("charlie"_n, test_contracts::eosio_token_abi() );
 
    test.chain->produce_blocks();
 
@@ -271,12 +271,12 @@ BOOST_AUTO_TEST_CASE( action_blacklist ) { try {
    test.chain->produce_blocks();
 
    test.chain->set_code("bob"_n, test_contracts::eosio_token_wasm() );
-   test.chain->set_abi("bob"_n, test_contracts::eosio_token_abi().data() );
+   test.chain->set_abi("bob"_n, test_contracts::eosio_token_abi() );
 
    test.chain->produce_blocks();
 
    test.chain->set_code("charlie"_n, test_contracts::eosio_token_wasm() );
-   test.chain->set_abi("charlie"_n, test_contracts::eosio_token_abi().data() );
+   test.chain->set_abi("charlie"_n, test_contracts::eosio_token_abi() );
 
    test.chain->produce_blocks();
 
@@ -332,9 +332,9 @@ BOOST_AUTO_TEST_CASE( deferred_blacklist_failure ) { try {
    tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    tester1.chain->produce_blocks();
    tester1.chain->set_code( "bob"_n, test_contracts::deferred_test_wasm() );
-   tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi().data() );
+   tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "charlie"_n, test_contracts::deferred_test_wasm() );
-   tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi().data() );
+   tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->produce_blocks();
 
    tester1.chain->push_action( "bob"_n, "defercall"_n, "alice"_n, mvo()
@@ -385,9 +385,9 @@ BOOST_AUTO_TEST_CASE( blacklist_onerror ) { try {
    tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    tester1.chain->produce_blocks();
    tester1.chain->set_code( "bob"_n, test_contracts::deferred_test_wasm() );
-   tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi().data() );
+   tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "charlie"_n, test_contracts::deferred_test_wasm() );
-   tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi().data() );
+   tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->produce_blocks();
 
    tester1.chain->push_action( "bob"_n, "defercall"_n, "alice"_n, mvo()
@@ -423,11 +423,11 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
    tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    tester1.chain->produce_blocks();
    tester1.chain->set_code( "alice"_n, test_contracts::deferred_test_wasm() );
-   tester1.chain->set_abi( "alice"_n,  test_contracts::deferred_test_abi().data() );
+   tester1.chain->set_abi( "alice"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "bob"_n, test_contracts::deferred_test_wasm() );
-   tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi().data() );
+   tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "charlie"_n, test_contracts::deferred_test_wasm() );
-   tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi().data() );
+   tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->produce_blocks();
 
    auto auth = authority(eosio::testing::base_tester::get_public_key(name("alice"), "active"));
@@ -569,11 +569,11 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
    tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    tester1.chain->produce_blocks();
    tester1.chain->set_code( "alice"_n, test_contracts::deferred_test_wasm() );
-   tester1.chain->set_abi( "alice"_n,  test_contracts::deferred_test_abi().data() );
+   tester1.chain->set_abi( "alice"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "bob"_n, test_contracts::deferred_test_wasm() );
-   tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi().data() );
+   tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "charlie"_n, test_contracts::deferred_test_wasm() );
-   tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi().data() );
+   tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->produce_blocks();
 
    auto auth = authority(eosio::testing::base_tester::get_public_key(name("alice"), "active"));


### PR DESCRIPTION
When the unittests get the ABI for a test contract,
https://github.com/AntelopeIO/leap/blob/339d98eed107b9fd94736988996082c7002fa52a/unittests/test_contracts.hpp.in#L13-L17
`fc::read_file_contents` will read the file's contents in to `s`. There is no null terminator at the end of the file since it's just a JSON text file, so `s` contains no null terminator in its set data. C++11 of course does define that `s.data()` is null terminated, and `*(s.begin() + s.size()) == '\0'`, but when `std::vector<char>(s.begin(), s.end())` is called, a vector is constructed with `s`'s contents without that implicit null terminator; just the set data of `s` which does not have the null terminator.

Later on, this function may be called like
https://github.com/AntelopeIO/leap/blob/339d98eed107b9fd94736988996082c7002fa52a/tests/chain_plugin_tests.cpp#L46
This is thus passing a non-null terminated `char*` from the `vector` to,
https://github.com/AntelopeIO/leap/blob/339d98eed107b9fd94736988996082c7002fa52a/libraries/testing/tester.cpp#L969-L970
where the call to `fc::json::from_string(abi_json)` constructs a std::string from a non-null terminated `char*`

We might be able to spot fix this creating the `vector` by `std::vector<char>(s.begin(), s.end()+1)`, or by `s.push_back('\0')` before constructing the `vector`. But a better improvement imo, even though it touches a lot of files in clean up, is to just plumb through a `string` everywhere. That type better represents a JSON ABI string.