### PR TITLE
skip `bad_alloc_test` when ASAN enabled

### DIFF
--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -1206,6 +1206,14 @@ BOOST_AUTO_TEST_CASE(stable_priority_queue_test) {
 }
 
 // test that std::bad_alloc is being thrown
+// ASAN warns "exceeds maximum supported size", so skip when ASAN enabled
+// gcc sets __SANITIZE_ADDRESS__, but clang uses __has_feature(), when ASAN enabled
+#if defined(__has_feature) && !defined(__SANITIZE_ADDRESS__)
+   #if __has_feature(address_sanitizer)
+      #define __SANITIZE_ADDRESS__ 1
+   #endif
+#endif
+#ifndef __SANITIZE_ADDRESS__
 BOOST_AUTO_TEST_CASE(bad_alloc_test) {
    tester t; // force a controller to be constructed and set the new_handler
    int* ptr = nullptr;
@@ -1215,6 +1223,7 @@ BOOST_AUTO_TEST_CASE(bad_alloc_test) {
    BOOST_CHECK_THROW( fail(), std::bad_alloc );
    BOOST_CHECK( ptr == nullptr );
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(named_thread_pool_test) {
    {


### PR DESCRIPTION
`bad_alloc_test` causes ASAN to complain,
> ERROR: AddressSanitizer: requested allocation size 0x1ffffffffffffffc (0x2000000000001000 after adjustments for alignment, red zones etc.) exceeds maximum supported size of 0x10000000000 (thread T0)

We can disable this rule globally via `allocator_may_return_null=1`, but it's better to just disable this simple test when ASAN is enabled. Unfortunately disabling it ends up being a little verbose since GCC & clang indicate its enablement differently.