### PR TITLE
Set EOS VM OC max mirroring pages to a small number for read-only threads

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/memory.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/memory.hpp
@@ -24,11 +24,10 @@ class memory {
       static constexpr uint64_t total_memory_per_slice = memory_prologue_size + UINT64_C(0x200000000) + UINT64_C(4096);
 
    public:
-      explicit memory(uint64_t max_pages);
+      explicit memory(uint64_t sliced_pages);
       ~memory();
       memory(const memory&) = delete;
       memory& operator=(const memory&) = delete;
-      void reset(uint64_t max_pages);
 
       uint8_t* const zero_page_memory_base() const { return zeropage_base; }
       uint8_t* const full_page_memory_base() const { return fullpage_base; }

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
@@ -60,9 +60,9 @@ void eosvmoc_runtime::init_thread_local_data() {
 }
 
 thread_local std::unique_ptr<eosvmoc::executor> eosvmoc_runtime::exec_thread_local {};
-// Set mirroring_pages_for_ro_thread to a small number to save upfront virtual memory
+// Set sliced_pages_for_ro_thread to a small number to save upfront virtual memory
 // consumption. Usage beyond this limit will be handled by mprotect.
-constexpr uint32_t mirroring_pages_for_ro_thread = 10;
-thread_local eosvmoc::memory eosvmoc_runtime::mem_thread_local{mirroring_pages_for_ro_thread};
+constexpr uint32_t sliced_pages_for_ro_thread = 10;
+thread_local eosvmoc::memory eosvmoc_runtime::mem_thread_local{sliced_pages_for_ro_thread};
 
 }}}}

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
@@ -60,6 +60,9 @@ void eosvmoc_runtime::init_thread_local_data() {
 }
 
 thread_local std::unique_ptr<eosvmoc::executor> eosvmoc_runtime::exec_thread_local {};
-thread_local eosvmoc::memory eosvmoc_runtime::mem_thread_local{ wasm_constraints::maximum_linear_memory/wasm_constraints::wasm_page_size };
+// Set mirroring_pages_for_ro_thread to a small number to save upfront virtual memory
+// consumption. Usage beyond this limit will be handled by mprotect.
+constexpr uint32_t mirroring_pages_for_ro_thread = 10;
+thread_local eosvmoc::memory eosvmoc_runtime::mem_thread_local{mirroring_pages_for_ro_thread};
 
 }}}}

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/memory.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/memory.cpp
@@ -11,9 +11,9 @@
 
 namespace eosio { namespace chain { namespace eosvmoc {
 
-memory::memory(uint64_t max_pages) {
-   uint64_t number_slices = max_pages + 1;
-   uint64_t wasm_memory_size = max_pages * wasm_constraints::wasm_page_size;
+memory::memory(uint64_t sliced_pages) {
+   uint64_t number_slices = sliced_pages + 1;
+   uint64_t wasm_memory_size = sliced_pages * wasm_constraints::wasm_page_size;
    int fd = syscall(SYS_memfd_create, "eosvmoc_mem", MFD_CLOEXEC);
    FC_ASSERT(fd >= 0, "Failed to create memory memfd");
    auto cleanup_fd = fc::make_scoped_exit([&fd](){close(fd);});
@@ -42,16 +42,6 @@ memory::memory(uint64_t max_pages) {
    const intrinsic_map_t& intrinsics = get_intrinsic_map();
    for(const auto& intrinsic : intrinsics)
       intrinsic_jump_table[-intrinsic.second.ordinal] = (uintptr_t)intrinsic.second.function_ptr;
-}
-
-void memory::reset(uint64_t max_pages) {
-   uint64_t old_max_pages = mapsize / memory::total_memory_per_slice - 1;
-   if(max_pages == old_max_pages) return;
-   memory new_memory{max_pages};
-   std::swap(mapbase, new_memory.mapbase);
-   std::swap(mapsize, new_memory.mapsize);
-   std::swap(zeropage_base, new_memory.zeropage_base);
-   std::swap(fullpage_base, new_memory.fullpage_base);
 }
 
 memory::~memory() {


### PR DESCRIPTION
A part of https://github.com/eosnetworkfoundation/product/issues/149.

Per the design in https://github.com/eosnetworkfoundation/product/blob/main/transactions/read-only/memory.md, to conserve virtual memory to support more threads, we need to reduce the threshold where EOS VM OC transitions from mirroring to `mprotect()`.

We plan to keep 528 pages (528 slices) for the main-thread memory (currently used for anything other then read-only transaction threads); this ensures maximum performance for EVM transactions. For each read-only thread, we set 10 pages (11 slices) (10 pages covers 99% native actions and 56% EVM actions, from data collected by in https://github.com/AntelopeIO/leap/issues/1159). 

With maximum 256 read-only threads , virtual memory required by OC is 26 TB (OC's main thread uses 4TB VM (by 529 slices) and the read-only threads use 22TB (256 * 11 * 8GB)). It is about 20% of total VM space in a 64-bit Linux machine (about 128TB).

The coding is much simpler.

Resolves https://github.com/AntelopeIO/leap/issues/645