### PR TITLE
Require dry-run trxs to have authorization and add tests

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1014,8 +1014,8 @@ struct controller_impl {
       );
    }
 
-   sha256 calculate_integrity_hash() {
-      sha256::encoder enc;
+   fc::sha256 calculate_integrity_hash() {
+      fc::sha256::encoder enc;
       auto hash_writer = std::make_shared<integrity_hash_snapshot_writer>(enc);
       add_to_snapshot(hash_writer);
       hash_writer->finalize();
@@ -2091,7 +2091,7 @@ struct controller_impl {
                   } else {
                      packed_transaction_ptr ptrx( b, &pt ); // alias signed_block_ptr
                      auto fut = transaction_metadata::start_recover_keys(
-                           std::move( ptrx ), thread_pool.get_executor(), chain_id, microseconds::maximum(), transaction_metadata::trx_type::input  );
+                           std::move( ptrx ), thread_pool.get_executor(), chain_id, fc::microseconds::maximum(), transaction_metadata::trx_type::input  );
                      trx_metas.emplace_back( transaction_metadata_ptr{}, std::move( fut ) );
                   }
                }
@@ -3218,7 +3218,7 @@ block_id_type controller::get_block_id_for_num( uint32_t block_num )const { try 
    return id;
 } FC_CAPTURE_AND_RETHROW( (block_num) ) }
 
-sha256 controller::calculate_integrity_hash() { try {
+fc::sha256 controller::calculate_integrity_hash() { try {
    return my->calculate_integrity_hash();
 } FC_LOG_AND_RETHROW() }
 

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -14,6 +14,7 @@ namespace chainbase { class database; }
 namespace eosio { namespace chain {
 
 class controller;
+class account_metadata_object;
 
 class apply_context {
    private:

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -6,8 +6,6 @@
 #include <chainbase/pinnable_mapped_file.hpp>
 #include <boost/signals2/signal.hpp>
 
-#include <eosio/chain/abi_serializer.hpp>
-#include <eosio/chain/account_object.hpp>
 #include <eosio/chain/snapshot.hpp>
 #include <eosio/chain/protocol_feature_manager.hpp>
 #include <eosio/chain/webassembly/eos-vm-oc/config.hpp>
@@ -259,7 +257,7 @@ namespace eosio { namespace chain {
          // thread-safe
          block_id_type get_block_id_for_num( uint32_t block_num )const;
 
-         sha256 calculate_integrity_hash();
+         fc::sha256 calculate_integrity_hash();
          void write_snapshot( const snapshot_writer_ptr& snapshot );
 
          bool sender_avoids_whitelist_blacklist_enforcement( account_name sender )const;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -1,4 +1,5 @@
 #include <eosio/chain/apply_context.hpp>
+#include <eosio/chain/account_object.hpp>
 #include <eosio/chain/transaction_context.hpp>
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/exceptions.hpp>
@@ -7,16 +8,6 @@
 #include <eosio/chain/transaction_object.hpp>
 #include <eosio/chain/global_property_object.hpp>
 #include <eosio/chain/deep_mind.hpp>
-
-#pragma push_macro("N")
-#undef N
-#include <boost/accumulators/accumulators.hpp>
-#include <boost/accumulators/statistics/stats.hpp>
-#include <boost/accumulators/statistics/min.hpp>
-#include <boost/accumulators/statistics/max.hpp>
-#include <boost/accumulators/statistics/weighted_mean.hpp>
-#include <boost/accumulators/statistics/weighted_variance.hpp>
-#pragma pop_macro("N")
 
 #include <chrono>
 
@@ -828,7 +819,7 @@ namespace eosio { namespace chain {
                actors.insert( auth.actor );
          }
       }
-      EOS_ASSERT( one_auth || is_transient(), tx_no_auths, "transaction must have at least one authorization" );
+      EOS_ASSERT( one_auth || is_read_only(), tx_no_auths, "transaction must have at least one authorization" );
 
       if( enforce_actor_whitelist_blacklist ) {
          control.check_actor_list( actors );

--- a/libraries/chain/webassembly/authorization.cpp
+++ b/libraries/chain/webassembly/authorization.cpp
@@ -1,6 +1,8 @@
 #include <eosio/chain/webassembly/interface.hpp>
 #include <eosio/chain/apply_context.hpp>
 
+#include <fc/io/datastream.hpp>
+
 namespace eosio { namespace chain { namespace webassembly {
    void interface::require_auth( account_name account ) const {
       context.require_authorization( account );
@@ -42,7 +44,7 @@ namespace eosio { namespace chain { namespace webassembly {
 
       auto s = fc::raw::pack_size(result);
       if (s <= packed_result.size()) {
-         datastream<char*> ds(packed_result.data(), s);
+         fc::datastream<char*> ds(packed_result.data(), s);
          fc::raw::pack(ds, result);
       }
       return s;

--- a/libraries/chain/webassembly/crypto.cpp
+++ b/libraries/chain/webassembly/crypto.cpp
@@ -2,6 +2,7 @@
 #include <eosio/chain/protocol_state_object.hpp>
 #include <eosio/chain/transaction_context.hpp>
 #include <eosio/chain/apply_context.hpp>
+#include <fc/io/datastream.hpp>
 #include <fc/crypto/modular_arithmetic.hpp>
 #include <fc/crypto/blake2.hpp>
 #include <fc/crypto/sha3.hpp>
@@ -25,8 +26,8 @@ namespace eosio { namespace chain { namespace webassembly {
                                        legacy_span<const char> pub ) const {
       fc::crypto::signature s;
       fc::crypto::public_key p;
-      datastream<const char*> ds( sig.data(), sig.size() );
-      datastream<const char*> pubds ( pub.data(), pub.size() );
+      fc::datastream<const char*> ds( sig.data(), sig.size() );
+      fc::datastream<const char*> pubds ( pub.data(), pub.size() );
 
       fc::raw::unpack( ds, s );
       fc::raw::unpack( pubds, p );
@@ -48,7 +49,7 @@ namespace eosio { namespace chain { namespace webassembly {
                                    legacy_span<const char> sig,
                                    legacy_span<char> pub ) const {
       fc::crypto::signature s;
-      datastream<const char*> ds( sig.data(), sig.size() );
+      fc::datastream<const char*> ds( sig.data(), sig.size() );
       fc::raw::unpack(ds, s);
 
       EOS_ASSERT(s.which() < context.db.get<protocol_state_object>().num_supported_key_types, unactivated_signature_type,
@@ -74,7 +75,7 @@ namespace eosio { namespace chain { namespace webassembly {
          // this will do one less copy for those keys while maintaining the rules of
          //    [0..33) dest sizes: assert (asserts in fc::raw::pack)
          //    [33..inf) dest sizes: return packed size (always 33)
-         datastream<char*> out_ds( pub.data(), pub.size() );
+         fc::datastream<char*> out_ds( pub.data(), pub.size() );
          fc::raw::pack(out_ds, recovered);
          return out_ds.tellp();
       }

--- a/libraries/chain/webassembly/permission.cpp
+++ b/libraries/chain/webassembly/permission.cpp
@@ -1,4 +1,5 @@
 #include <eosio/chain/webassembly/interface.hpp>
+#include <eosio/chain/account_object.hpp>
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/transaction_context.hpp>
 #include <eosio/chain/apply_context.hpp>

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -1,9 +1,12 @@
+#include <eosio/chain/account_object.hpp>
 #include <eosio/chain/webassembly/interface.hpp>
 #include <eosio/chain/global_property_object.hpp>
 #include <eosio/chain/protocol_state_object.hpp>
 #include <eosio/chain/transaction_context.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/apply_context.hpp>
+
+#include <fc/io/datastream.hpp>
 
 #include <vector>
 #include <set>
@@ -94,7 +97,7 @@ namespace eosio { namespace chain { namespace webassembly {
          return s;
 
       if ( s <= packed_parameters.size() ) {
-         datastream<char*> ds( packed_parameters.data(), s );
+         fc::datastream<char*> ds( packed_parameters.data(), s );
          fc::raw::pack(ds, version);
          fc::raw::pack(ds, params);
       }
@@ -102,7 +105,7 @@ namespace eosio { namespace chain { namespace webassembly {
    }
    void interface::set_wasm_parameters_packed( span<const char> packed_parameters ) {
       EOS_ASSERT(!context.trx_context.is_read_only(), wasm_execution_error, "set_wasm_parameters_packed not allowed in a readonly transaction");
-      datastream<const char*> ds( packed_parameters.data(), packed_parameters.size() );
+      fc::datastream<const char*> ds( packed_parameters.data(), packed_parameters.size() );
       uint32_t version;
       chain::wasm_config cfg;
       fc::raw::unpack(ds, version);
@@ -117,7 +120,7 @@ namespace eosio { namespace chain { namespace webassembly {
    }
    int64_t interface::set_proposed_producers( legacy_span<const char> packed_producer_schedule) {
       EOS_ASSERT(!context.trx_context.is_read_only(), wasm_execution_error, "set_proposed_producers not allowed in a readonly transaction");
-      datastream<const char*> ds( packed_producer_schedule.data(), packed_producer_schedule.size() );
+      fc::datastream<const char*> ds( packed_producer_schedule.data(), packed_producer_schedule.size() );
       std::vector<producer_authority> producers;
       std::vector<legacy::producer_key> old_version;
       fc::raw::unpack(ds, old_version);
@@ -137,7 +140,7 @@ namespace eosio { namespace chain { namespace webassembly {
       if (packed_producer_format == 0) {
          return set_proposed_producers(std::move(packed_producer_schedule));
       } else if (packed_producer_format == 1) {
-         datastream<const char*> ds( packed_producer_schedule.data(), packed_producer_schedule.size() );
+         fc::datastream<const char*> ds( packed_producer_schedule.data(), packed_producer_schedule.size() );
          vector<producer_authority> producers;
 
          fc::raw::unpack(ds, producers);
@@ -154,7 +157,7 @@ namespace eosio { namespace chain { namespace webassembly {
       if( packed_blockchain_parameters.size() == 0 ) return s;
 
       if ( s <= packed_blockchain_parameters.size() ) {
-         datastream<char*> ds( packed_blockchain_parameters.data(), s );
+         fc::datastream<char*> ds( packed_blockchain_parameters.data(), s );
          fc::raw::pack(ds, gpo.configuration.v0());
          return s;
       }
@@ -163,7 +166,7 @@ namespace eosio { namespace chain { namespace webassembly {
 
    void interface::set_blockchain_parameters_packed( legacy_span<const char> packed_blockchain_parameters ) {
       EOS_ASSERT(!context.trx_context.is_read_only(), wasm_execution_error, "set_blockchain_parameters_packed not allowed in a readonly transaction");
-      datastream<const char*> ds( packed_blockchain_parameters.data(), packed_blockchain_parameters.size() );
+      fc::datastream<const char*> ds( packed_blockchain_parameters.data(), packed_blockchain_parameters.size() );
       chain::chain_config_v0 cfg;
       fc::raw::unpack(ds, cfg);
       cfg.validate();
@@ -174,7 +177,7 @@ namespace eosio { namespace chain { namespace webassembly {
    }
    
    uint32_t interface::get_parameters_packed( span<const char> packed_parameter_ids, span<char> packed_parameters) const{
-      datastream<const char*> ds_ids( packed_parameter_ids.data(), packed_parameter_ids.size() );
+      fc::datastream<const char*> ds_ids( packed_parameter_ids.data(), packed_parameter_ids.size() );
 
       chain::chain_config cfg = context.control.get_global_properties().configuration;
       std::vector<fc::unsigned_int> ids;
@@ -188,14 +191,14 @@ namespace eosio { namespace chain { namespace webassembly {
                  chain::config_parse_error,
                  "get_parameters_packed: buffer size is smaller than ${size}", ("size", size));
       
-      datastream<char*> ds( packed_parameters.data(), size );
+      fc::datastream<char*> ds( packed_parameters.data(), size );
       fc::raw::pack( ds, config_range );
       return size;
    }
 
    void interface::set_parameters_packed( span<const char> packed_parameters ){
       EOS_ASSERT(!context.trx_context.is_read_only(), wasm_execution_error, "set_parameters_packed not allowed in a readonly transaction");
-      datastream<const char*> ds( packed_parameters.data(), packed_parameters.size() );
+      fc::datastream<const char*> ds( packed_parameters.data(), packed_parameters.size() );
 
       chain::chain_config cfg = context.control.get_global_properties().configuration;
       config_range config_range(cfg, {context.control});

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -1,5 +1,6 @@
 #include <eosio/chain/webassembly/eos-vm.hpp>
 #include <eosio/chain/webassembly/interface.hpp>
+#include <eosio/chain/account_object.hpp>
 #include <eosio/chain/apply_context.hpp>
 #include <eosio/chain/transaction_context.hpp>
 #include <eosio/chain/global_property_object.hpp>

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -1906,6 +1906,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
    // now push for real
    trace = chain.push_transaction(trx);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_CHECK_EQUAL(2u, gen_size);
 

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -1901,9 +1901,11 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
 
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key("tester"_n, "active"), chain.control->get_chain_id());
-   trace = chain.push_transaction(trx);
-   //wdump((fc::json::to_pretty_string(trace)));
+   // first push as a dry_run trx
+   trace = chain.push_transaction(trx, fc::time_point::maximum(), base_tester::DEFAULT_BILLED_CPU_TIME_US, false, transaction_metadata::trx_type::dry_run);
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
+   // now push for real
+   trace = chain.push_transaction(trx);
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_CHECK_EQUAL(2u, gen_size);
 

--- a/unittests/dry_run_trx_tests.cpp
+++ b/unittests/dry_run_trx_tests.cpp
@@ -1,0 +1,337 @@
+#include <eosio/chain/abi_serializer.hpp>
+#include <boost/test/unit_test.hpp>
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain/global_property_object.hpp>
+#include <fc/variant_object.hpp>
+#include <test_contracts.hpp>
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::testing;
+using namespace fc;
+
+using mvo = fc::mutable_variant_object;
+
+struct dry_run_trx_tester : validating_tester {
+   dry_run_trx_tester() {
+      produce_block();
+   };
+
+   void set_up_test_contract() {
+      create_accounts( {"noauthtable"_n, "alice"_n} );
+      set_code( "noauthtable"_n, test_contracts::no_auth_table_wasm() );
+      set_abi( "noauthtable"_n, test_contracts::no_auth_table_abi() );
+      produce_block();
+
+      insert_data = abi_ser.variant_to_binary( "insert", mutable_variant_object()
+         ("user", "alice") ("id", 1) ("age", 10),
+         abi_serializer::create_yield_function( abi_serializer_max_time ) );
+      getage_data = abi_ser.variant_to_binary("getage", mutable_variant_object()
+         ("user", "alice"),
+         abi_serializer::create_yield_function( abi_serializer_max_time ));
+      produce_block();
+   }
+
+   void send_action(const action& act) {
+      signed_transaction trx;
+      trx.actions.push_back( act );
+      set_transaction_headers( trx );
+      //trx.sign(get_private_key(config::system_account_name, "active"), control->get_chain_id());
+
+      push_transaction( trx, fc::time_point::maximum(), DEFAULT_BILLED_CPU_TIME_US, false, transaction_metadata::trx_type::dry_run );
+   }
+
+   auto send_db_api_transaction( action_name name, bytes data, const vector<permission_level>& auth={{"alice"_n, config::active_name}}, transaction_metadata::trx_type type=transaction_metadata::trx_type::input, uint32_t delay_sec=0 ) {
+      action act;
+      signed_transaction trx;
+
+      act.account = "noauthtable"_n;
+      act.name = name;
+      act.authorization = auth;
+      act.data = data;
+
+      trx.actions.push_back( act );
+      set_transaction_headers( trx );
+      trx.delay_sec = delay_sec;
+      if ( type == transaction_metadata::trx_type::input ) {
+         trx.sign(get_private_key("alice"_n, "active"), control->get_chain_id());
+      }
+
+      return push_transaction( trx, fc::time_point::maximum(), DEFAULT_BILLED_CPU_TIME_US, false, type );
+   }
+
+   void insert_a_record() {
+      auto res = send_db_api_transaction("insert"_n, insert_data);
+      BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
+      produce_block();
+   }
+
+   abi_serializer abi_ser{ json::from_string(test_contracts::no_auth_table_abi()).as<abi_def>(), abi_serializer::create_yield_function(abi_serializer_max_time )};
+   bytes insert_data;
+   bytes getage_data;
+};
+
+BOOST_AUTO_TEST_SUITE(dry_run_trx_tests)
+
+BOOST_FIXTURE_TEST_CASE(newaccount_test, dry_run_trx_tester) { try {
+   produce_blocks( 1 );
+
+   action act = {
+      {}, //vector<permission_level>{{config::system_account_name,config::active_name}}, // todo remove
+      newaccount{
+         .creator  = config::system_account_name,
+         .name     = "alice"_n,
+         .owner    = authority( get_public_key( "alice"_n, "owner" ) ),
+         .active   = authority( get_public_key( "alice"_n, "active" ) )
+      }
+   };
+
+   send_action(act); // should not throw
+   send_action(act); // should not throw
+   BOOST_CHECK_THROW(control->get_account("alice"_n), fc::exception); // not actually created
+
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(setcode_test, dry_run_trx_tester) { try {
+   produce_blocks( 1 );
+
+   std::vector<uint8_t> code(10);
+   action act = {
+      {}, setcode { "eosio"_n, 0, 0, bytes(code.begin(), code.end()) }
+   };
+
+   BOOST_CHECK_THROW( send_action(act), action_validate_exception );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(setabi_test, dry_run_trx_tester) { try {
+   produce_blocks( 1 );
+
+   std::vector<uint8_t> abi(10);
+   action act = {
+      {},
+      setabi {
+         .account = "alice"_n, .abi = bytes(abi.begin(), abi.end())
+      }
+   };
+
+   BOOST_CHECK_THROW( send_action(act), action_validate_exception );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(updateauth_test, dry_run_trx_tester) { try {
+   produce_blocks( 1 );
+
+   auto auth = authority( get_public_key( "alice"_n, "test" ) );
+   action act = {
+      vector<permission_level>{{config::system_account_name,config::active_name}},
+      updateauth {
+         .account = "alice"_n, .permission = "active"_n, .parent = "owner"_n, .auth  = auth
+      }
+   };
+
+   BOOST_CHECK_THROW( send_action(act), transaction_exception );
+} FC_LOG_AND_RETHROW() }
+
+
+BOOST_FIXTURE_TEST_CASE(deleteauth_test, dry_run_trx_tester) { try {
+   produce_blocks( 1 );
+
+   name account = "alice"_n;
+   name permission = "active"_n;
+   action act = {
+      vector<permission_level>{{config::system_account_name,config::active_name}},
+      deleteauth { account, permission }
+   };
+
+   BOOST_CHECK_THROW( send_action(act), transaction_exception );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(linkauth_test, dry_run_trx_tester) { try {
+   produce_blocks( 1 );
+
+   name account = "alice"_n;
+   name code = "eosio_token"_n;
+   name type = "transfer"_n;
+   name requirement = "first"_n;
+   action act = {
+      vector<permission_level>{{config::system_account_name,config::active_name}},
+      linkauth { account, code, type, requirement }
+   };
+
+   BOOST_CHECK_THROW( send_action(act), transaction_exception );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(unlinkauth_test, dry_run_trx_tester) { try {
+   produce_blocks( 1 );
+
+   name account = "alice"_n;
+   name code = "eosio_token"_n;
+   name type = "transfer"_n;
+   action act = {
+      vector<permission_level>{{config::system_account_name,config::active_name}},
+      unlinkauth { account, code, type }
+   };
+
+   BOOST_CHECK_THROW( send_action(act), transaction_exception );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(canceldelay_test, dry_run_trx_tester) { try {
+   produce_blocks( 1 );
+
+   permission_level canceling_auth { config::system_account_name,config::active_name };
+   transaction_id_type trx_id { "0718886aa8a3895510218b523d3d694280d1dbc1f6d30e173a10b2039fc894f1" };
+   action act = {
+      vector<permission_level>{{config::system_account_name,config::active_name}},
+      canceldelay { canceling_auth, trx_id }
+   };
+
+   BOOST_CHECK_THROW( send_action(act), transaction_exception );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(db_dry_run_mode_test, dry_run_trx_tester) { try {
+   set_up_test_contract();
+
+   insert_a_record();
+
+   //control->set_db_dry_run_mode();
+   // verify no write is allowed in read-only mode
+   BOOST_CHECK_THROW( create_account("bob"_n), std::exception );
+
+   // verify a read-only transaction in read-only mode
+   auto res = send_db_api_transaction("getage"_n, getage_data, {}, transaction_metadata::trx_type::dry_run);
+   BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
+   BOOST_CHECK_EQUAL(res->action_traces[0].return_value[0], 10);
+   //control->unset_db_dry_run_mode();
+
+   // verify db write is allowed in regular mode
+   BOOST_REQUIRE_NO_THROW( create_account("bob"_n) );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(db_insert_test, dry_run_trx_tester) { try {
+   set_up_test_contract();
+
+   // verify DB insert is not allowed by read-only transaction
+   BOOST_CHECK_THROW(send_db_api_transaction("insert"_n, insert_data, {}, transaction_metadata::trx_type::dry_run), table_operation_not_permitted);
+
+   // verify DB insert still works with non-read-only transaction after read-only
+   insert_a_record();
+   
+   // do a read-only transaction and verify the return value (age) is the same as inserted
+   auto res = send_db_api_transaction("getage"_n, getage_data, {}, transaction_metadata::trx_type::dry_run);
+   BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
+   BOOST_CHECK_EQUAL(res->action_traces[0].return_value[0], 10);
+   BOOST_CHECK_GT(res->net_usage, 0u);
+   BOOST_CHECK_GT(res->elapsed.count(), 0u);
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(auth_test, dry_run_trx_tester) { try {
+   set_up_test_contract();
+
+   // verify read-only transaction does not allow authorizations.
+   BOOST_CHECK_THROW(send_db_api_transaction("getage"_n, getage_data, {{"alice"_n, config::active_name}}, transaction_metadata::trx_type::dry_run), transaction_exception);
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(delay_sec_test, dry_run_trx_tester) { try {
+   set_up_test_contract();
+
+   // verify read-only transaction does not allow non-zero delay_sec.
+   BOOST_CHECK_THROW(send_db_api_transaction("getage"_n, getage_data, {}, transaction_metadata::trx_type::dry_run, 3), transaction_exception);
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(db_modify_test, dry_run_trx_tester) { try {
+   set_up_test_contract();
+
+   insert_a_record();
+
+   // verify DB update is not allowed by read-only transaction
+   auto modify_data = abi_ser.variant_to_binary("modify", mutable_variant_object()
+      ("user", "alice") ("age", 25),
+      abi_serializer::create_yield_function( abi_serializer_max_time )
+   );
+   BOOST_CHECK_THROW(send_db_api_transaction("modify"_n, modify_data, {}, transaction_metadata::trx_type::dry_run), table_operation_not_permitted);
+
+   // verify DB update still works in by non-read-only transaction
+   auto res = send_db_api_transaction("modify"_n, modify_data);
+   BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
+   produce_block();
+
+   // verify the value was successfully updated
+   res = send_db_api_transaction("getage"_n, getage_data, {}, transaction_metadata::trx_type::dry_run);
+   BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
+   BOOST_CHECK_EQUAL(res->action_traces[0].return_value[0], 25);
+
+   // verify DB update by secondary key is not allowed by read-only transaction
+   auto modifybyid_data = abi_ser.variant_to_binary("modifybyid", mutable_variant_object()
+      ("id", 1) ("age", 50),
+      abi_serializer::create_yield_function( abi_serializer_max_time )
+   );
+   BOOST_CHECK_THROW(send_db_api_transaction("modifybyid"_n, modifybyid_data, {}, transaction_metadata::trx_type::dry_run), table_operation_not_permitted);
+
+   // verify DB update by secondary key still works in by non-read-only transaction
+   res = send_db_api_transaction("modifybyid"_n, modifybyid_data);
+   BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
+   produce_block();
+
+   // verify the value was successfully updated
+   res = send_db_api_transaction("getage"_n, getage_data, {}, transaction_metadata::trx_type::dry_run);
+   BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
+   BOOST_CHECK_EQUAL(res->action_traces[0].return_value[0], 50);
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(db_erase_test, dry_run_trx_tester) { try {
+   set_up_test_contract();
+
+   insert_a_record();
+
+   // verify DB erase is not allowed by read-only transaction
+   auto erase_data = abi_ser.variant_to_binary("erase", mutable_variant_object()
+      ("user", "alice"),
+      abi_serializer::create_yield_function( abi_serializer_max_time )
+   );
+   BOOST_CHECK_THROW(send_db_api_transaction("erase"_n, erase_data, {}, transaction_metadata::trx_type::dry_run), table_operation_not_permitted);
+
+   // verify DB erase by secondary key is not allowed by read-only transaction
+   auto erasebyid_data = abi_ser.variant_to_binary("erasebyid", mutable_variant_object()
+      ("id", 1),
+      abi_serializer::create_yield_function( abi_serializer_max_time )
+   );
+   BOOST_CHECK_THROW(send_db_api_transaction("erasebyid"_n, erasebyid_data, {}, transaction_metadata::trx_type::dry_run), table_operation_not_permitted);
+
+   // verify DB erase still works in by non-read-only transaction
+   auto res = send_db_api_transaction("erase"_n, erase_data);
+   BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(sequence_numbers_test, dry_run_trx_tester) { try {
+   set_up_test_contract();
+
+   const auto& p = control->get_dynamic_global_properties();
+   auto receiver_account = control->db().find<account_metadata_object,by_name>("noauthtable"_n);
+   auto amo = control->db().find<account_metadata_object,by_name>("alice"_n);
+
+   // verify sequence numbers in state increment for non-read-only transactions
+   auto prev_global_action_sequence = p.global_action_sequence;
+   auto prev_recv_sequence = receiver_account->recv_sequence;
+   auto prev_auth_sequence = amo->auth_sequence; 
+
+   auto res = send_db_api_transaction("insert"_n, insert_data);
+   BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
+
+   BOOST_CHECK_EQUAL( prev_global_action_sequence + 1, p.global_action_sequence );
+   BOOST_CHECK_EQUAL( prev_recv_sequence + 1, receiver_account->recv_sequence );
+   BOOST_CHECK_EQUAL( prev_auth_sequence + 1, amo->auth_sequence );
+   
+   produce_block();
+
+   // verify sequence numbers in state do not change for read-only transactions
+   prev_global_action_sequence = p.global_action_sequence;
+   prev_recv_sequence = receiver_account->recv_sequence;
+   prev_auth_sequence = amo->auth_sequence; 
+
+   send_db_api_transaction("getage"_n, getage_data, {}, transaction_metadata::trx_type::dry_run);
+
+   BOOST_CHECK_EQUAL( prev_global_action_sequence, p.global_action_sequence );
+   BOOST_CHECK_EQUAL( prev_recv_sequence, receiver_account->recv_sequence );
+   BOOST_CHECK_EQUAL( prev_auth_sequence, amo->auth_sequence );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/dry_run_trx_tests.cpp
+++ b/unittests/dry_run_trx_tests.cpp
@@ -29,7 +29,6 @@ struct dry_run_trx_tester : validating_tester {
       getage_data = abi_ser.variant_to_binary("getage", mutable_variant_object()
          ("user", "alice"),
          abi_serializer::create_yield_function( abi_serializer_max_time ));
-      produce_block();
    }
 
    void send_action(const action& act, bool sign = false) {
@@ -115,6 +114,8 @@ BOOST_FIXTURE_TEST_CASE(newaccount_test, dry_run_trx_tester) { try {
    send_action(act, false); // should not throw
    send_action(act, false); // should not throw
    send_action(act, true); // should not throw
+   BOOST_CHECK_THROW(control->get_account("alice"_n), fc::exception); // not actually created
+   produce_blocks( 1 );
    BOOST_CHECK_THROW(control->get_account("alice"_n), fc::exception); // not actually created
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
Add requirement for dry-run/compute transactions to require authorization.
Add tests for dry-run/compute transactions.
Also some minor cleanup to unneeded includes.

Resolves #1083 