### PR TITLE
fix leaky EOS VM OC executor code mapping

### DIFF
--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
@@ -266,6 +266,7 @@ void executor::execute(const code_descriptor& code, memory& mem, apply_context& 
 
 executor::~executor() {
    arch_prctl(ARCH_SET_GS, nullptr);
+   munmap(code_mapping, code_mapping_size);
 }
 
 }}}


### PR DESCRIPTION
`executor`'s ctor creates a shared mapping to the code cache file it is passed,
https://github.com/AntelopeIO/leap/blob/e9ace457e46898e377df1e0a6d1fb8049d8cb5e2/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp#L146-L151
but its dtor doesn't unmap that mapping. That's sloppy and leaky. Easy enough to fix.

I'm not considering this for stable since realistically nodeos only ever creates one of these per thread for the entire lifetime of the application anyways.