### PR TITLE
negate after converting to unsigned to avoid UB on minimum signed value

### DIFF
--- a/libraries/chain/webassembly/console.cpp
+++ b/libraries/chain/webassembly/console.cpp
@@ -47,7 +47,7 @@ namespace eosio { namespace chain { namespace webassembly {
 			unsigned __int128 val_magnitude;
 
 			if( is_negative )
-				val_magnitude = static_cast<unsigned __int128>(-*val); // Works even if val is at the lowest possible value of a int128_t
+				val_magnitude = -static_cast<unsigned __int128>(*val); // Works even if val is at the lowest possible value of a int128_t
 			else
 				val_magnitude = static_cast<unsigned __int128>(*val);
 

--- a/libraries/chain/webassembly/console.cpp
+++ b/libraries/chain/webassembly/console.cpp
@@ -46,6 +46,7 @@ namespace eosio { namespace chain { namespace webassembly {
 			bool is_negative = (*val < 0);
 			unsigned __int128 val_magnitude;
 
+			// negate after conversion to unsigned to avoid possible integer overflow
 			if( is_negative )
 				val_magnitude = -static_cast<unsigned __int128>(*val); // Works even if val is at the lowest possible value of a int128_t
 			else

--- a/libraries/wasm-jit/Source/WAST/ParseNumbers.cpp
+++ b/libraries/wasm-jit/Source/WAST/ParseNumbers.cpp
@@ -239,7 +239,7 @@ bool tryParseInt(ParseState& state,UnsignedInt& outUnsignedInt,I64 minSignedValu
 		return false;
 	};
 
-	outUnsignedInt = isNegative ? -UnsignedInt(I64(u64)) : UnsignedInt(u64);
+	outUnsignedInt = isNegative ? -UnsignedInt(u64) : UnsignedInt(u64);
 		
 	++state.nextToken;
 	WAVM_ASSERT_THROW(nextChar <= state.string + state.nextToken->begin);

--- a/libraries/wasm-jit/Source/WAST/ParseNumbers.cpp
+++ b/libraries/wasm-jit/Source/WAST/ParseNumbers.cpp
@@ -229,7 +229,7 @@ bool tryParseInt(ParseState& state,UnsignedInt& outUnsignedInt,I64 minSignedValu
 	{
 	case t_decimalInt:
 		isNegative = parseSign(nextChar);
-		u64 = parseDecimalUnsignedInt(nextChar,state,isNegative ? U64(-minSignedValue) : maxUnsignedValue,"int literal");
+		u64 = parseDecimalUnsignedInt(nextChar,state,isNegative ? -U64(minSignedValue) : maxUnsignedValue,"int literal");
 		break;
 	case t_hexInt:
 		isNegative = parseSign(nextChar);
@@ -239,7 +239,7 @@ bool tryParseInt(ParseState& state,UnsignedInt& outUnsignedInt,I64 minSignedValu
 		return false;
 	};
 
-	outUnsignedInt = isNegative ? UnsignedInt(-I64(u64)) : UnsignedInt(u64);
+	outUnsignedInt = isNegative ? -UnsignedInt(I64(u64)) : UnsignedInt(u64);
 		
 	++state.nextToken;
 	WAVM_ASSERT_THROW(nextChar <= state.string + state.nextToken->begin);


### PR DESCRIPTION
Negating the minimum value of a signed integer is undefined behavior since the resulting value cannot be represented by the type (results in a signed overflow). However, casting to an unsigned and then negating that _is_ defined behavior, and I believe the appropriate solution here, as both of those operations are well defined for all inputs.