### PR TITLE
IF: Fix threading 1/2 (#1541) & qc_chain private:

### DIFF
--- a/libraries/chain/include/eosio/chain/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff.hpp
@@ -69,7 +69,7 @@ namespace eosio::chain {
       eosio::chain::extended_schedule schedule;
       map<fc::sha256, hs_proposal_message> proposals;
 
-      hs_proposal_message* get_proposal(const fc::sha256 &id) {
+      hs_proposal_message* get_proposal(const fc::sha256& id) {
          auto it = proposals.find(id);
          if (it == proposals.end())
             return nullptr;

--- a/libraries/chain/include/eosio/chain/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff.hpp
@@ -69,7 +69,7 @@ namespace eosio::chain {
       eosio::chain::extended_schedule schedule;
       map<fc::sha256, hs_proposal_message> proposals;
 
-      hs_proposal_message* get_proposal(const fc::sha256& id) {
+      const hs_proposal_message* get_proposal(const fc::sha256& id) const {
          auto it = proposals.find(id);
          if (it == proposals.end())
             return nullptr;

--- a/libraries/chain/include/eosio/chain/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff.hpp
@@ -68,6 +68,13 @@ namespace eosio::chain {
       eosio::chain::quorum_certificate current_qc;
       eosio::chain::extended_schedule schedule;
       map<fc::sha256, hs_proposal_message> proposals;
+
+      hs_proposal_message* get_proposal(const fc::sha256 &id) {
+         auto it = proposals.find(id);
+         if (it == proposals.end())
+            return nullptr;
+         return & it->second;
+      }
    };
 
    using hs_proposal_message_ptr = std::shared_ptr<hs_proposal_message>;

--- a/libraries/hotstuff/chain_pacemaker.cpp
+++ b/libraries/hotstuff/chain_pacemaker.cpp
@@ -112,13 +112,13 @@ namespace eosio { namespace hotstuff {
       return _chain->is_builtin_activated( builtin_protocol_feature_t::instant_finality );
    }
 
-   void chain_pacemaker::get_state(finalizer_state& fs, bool force) const {
+   void chain_pacemaker::get_state(finalizer_state& fs) const {
       if (! enabled())
          return;
 
       // lock-free state version check
       uint64_t current_state_version = _qc_chain.get_state_version();
-      if (force || _state_cache_version != current_state_version) {
+      if (_state_cache_version != current_state_version) {
          finalizer_state current_state;
          {
             csc prof("stat");

--- a/libraries/hotstuff/chain_pacemaker.cpp
+++ b/libraries/hotstuff/chain_pacemaker.cpp
@@ -124,11 +124,12 @@ namespace eosio { namespace hotstuff {
             csc prof("stat");
             std::lock_guard g( _hotstuff_global_mutex ); // lock IF engine to read state
             prof.core_in();
-            _qc_chain.get_state(current_state);
             current_state_version = _qc_chain.get_state_version(); // get potentially fresher version
+            if (_state_cache_version != current_state_version) 
+               _qc_chain.get_state(current_state);
             prof.core_out();
          }
-         {
+         if (_state_cache_version != current_state_version) {
             std::unique_lock ul(_state_cache_mutex); // lock cache for writing
             _state_cache = current_state;
             _state_cache_version = current_state_version;

--- a/libraries/hotstuff/chain_pacemaker.cpp
+++ b/libraries/hotstuff/chain_pacemaker.cpp
@@ -112,9 +112,31 @@ namespace eosio { namespace hotstuff {
       return _chain->is_builtin_activated( builtin_protocol_feature_t::instant_finality );
    }
 
-   void chain_pacemaker::get_state( finalizer_state& fs ) const {
-      if (enabled())
-         _qc_chain.get_state( fs ); // get_state() takes scare of finer-grained synchronization internally
+   void chain_pacemaker::get_state(finalizer_state& fs, bool force) const {
+      if (! enabled())
+         return;
+
+      // lock-free state version check
+      uint64_t current_state_version = _qc_chain.get_state_version();
+      if (force || _state_cache_version != current_state_version) {
+         finalizer_state current_state;
+         {
+            csc prof("stat");
+            std::lock_guard g( _hotstuff_global_mutex ); // lock IF engine to read state
+            prof.core_in();
+            _qc_chain.get_state(current_state);
+            current_state_version = _qc_chain.get_state_version(); // get potentially fresher version
+            prof.core_out();
+         }
+         {
+            std::unique_lock ul(_state_cache_mutex); // lock cache for writing
+            _state_cache = current_state;
+            _state_cache_version = current_state_version;
+         }
+      }
+
+      std::shared_lock sl(_state_cache_mutex); // lock cache for reading
+      fs = _state_cache;
    }
 
    name chain_pacemaker::get_proposer() {

--- a/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
@@ -23,7 +23,7 @@ namespace eosio::hotstuff {
       void on_hs_new_view_msg(const hs_new_view_message& msg); //new view msg event handler
       void on_hs_new_block_msg(const hs_new_block_message& msg); //new block msg event handler
 
-      void get_state( finalizer_state& fs ) const;
+      void get_state(finalizer_state& fs, bool force = false) const;
 
       //base_pacemaker interface functions
 
@@ -54,7 +54,11 @@ namespace eosio::hotstuff {
       // These requests can come directly from the net threads, or indirectly from a
       //   dedicated finalizer thread (TODO: discuss).
 #warning discuss
-      std::mutex              _hotstuff_global_mutex;
+      mutable std::mutex      _hotstuff_global_mutex;
+
+      mutable finalizer_state     _state_cache;
+      mutable std::shared_mutex   _state_cache_mutex;
+      mutable uint64_t            _state_cache_version = 0;
 
       chain::controller*      _chain = nullptr;
 

--- a/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
@@ -3,6 +3,8 @@
 #include <eosio/hotstuff/base_pacemaker.hpp>
 #include <eosio/hotstuff/qc_chain.hpp>
 
+#include <shared_mutex>
+
 namespace eosio::chain {
    class controller;
 }
@@ -23,7 +25,7 @@ namespace eosio::hotstuff {
       void on_hs_new_view_msg(const hs_new_view_message& msg); //new view msg event handler
       void on_hs_new_block_msg(const hs_new_block_message& msg); //new block msg event handler
 
-      void get_state(finalizer_state& fs, bool force = false) const;
+      void get_state(finalizer_state& fs) const;
 
       //base_pacemaker interface functions
 
@@ -56,9 +58,11 @@ namespace eosio::hotstuff {
 #warning discuss
       mutable std::mutex      _hotstuff_global_mutex;
 
-      mutable finalizer_state     _state_cache;
-      mutable std::shared_mutex   _state_cache_mutex;
-      mutable uint64_t            _state_cache_version = 0;
+      // _state_cache_mutex provides a R/W lock over _state_cache and _state_cache_version,
+      //   which implement a cache of the finalizer_state (_qc_chain::get_state()).
+      mutable std::shared_mutex      _state_cache_mutex;
+      mutable finalizer_state        _state_cache;
+      mutable std::atomic<uint64_t>  _state_cache_version = 0;
 
       chain::controller*      _chain = nullptr;
 

--- a/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
@@ -21,9 +21,6 @@
 #include <exception>
 #include <stdexcept>
 
-#include <mutex>
-#include <shared_mutex>
-
 // Enable this to swap the multi-index proposal store with std::map
 //#define QC_CHAIN_SIMPLE_PROPOSAL_STORE
 
@@ -44,7 +41,7 @@ namespace eosio::hotstuff {
 
       uint64_t get_state_version() const { return _state_version; } // calling this w/ thread sync is optional
 
-      name get_id() const { return _id; } // so far, only ever relevant in a test environment (no sync)
+      name get_id_i() const { return _id; } // so far, only ever relevant in a test environment (no sync)
 
       // Calls to the following methods should be thread-synchronized externally:
 
@@ -144,7 +141,7 @@ namespace eosio::hotstuff {
       bool _errors = true;
       name _id;
 
-      mutable uint64_t _state_version = 1;
+      mutable std::atomic<uint64_t> _state_version = 1;
 
 #ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
       // keep one proposal store (id -> proposal) by each height (height -> proposal store)

--- a/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
@@ -21,6 +21,8 @@
 #include <exception>
 #include <stdexcept>
 
+#include <mutex>
+#include <shared_mutex>
 
 // Enable this to swap the multi-index proposal store with std::map
 //#define QC_CHAIN_SIMPLE_PROPOSAL_STORE
@@ -31,6 +33,8 @@ namespace eosio::hotstuff {
    using namespace boost::multi_index;
    using namespace eosio::chain;
 
+   // Concurrency note: qc_chain is a single-threaded and lock-free decision engine.
+   //                   All thread synchronization, if any, is external.
    class qc_chain {
    public:
 
@@ -38,57 +42,27 @@ namespace eosio::hotstuff {
 
       qc_chain(name id, base_pacemaker* pacemaker, std::set<name> my_producers, bool info_logging, bool error_logging);
 
-#warning remove. bls12-381 key used for testing purposes
-      //todo : remove. bls12-381 key used for testing purposes
-      std::vector<uint8_t> _seed =
-         {  0,  50, 6,  244, 24,  199, 1,  25,  52,  88,  192,
-            19, 18, 12, 89,  6,   220, 18, 102, 58,  209, 82,
-            12, 62, 89, 110, 182, 9,   44, 20,  254, 22 };
+      uint64_t get_state_version() const { return _state_version; } // calling this w/ thread sync is optional
 
-      fc::crypto::blslib::bls_private_key _private_key = fc::crypto::blslib::bls_private_key(_seed);
+      name get_id() const { return _id; } // so far, only ever relevant in a test environment (no sync)
 
-      enum msg_type {
-         new_view = 1,
-         new_block = 2,
-         qc = 3,
-         vote = 4
-      };
+      // Calls to the following methods should be thread-synchronized externally:
 
-      bool _chained_mode = false;
+      void get_state(finalizer_state& fs) const;
 
-      fc::sha256 _b_leaf = NULL_PROPOSAL_ID;
-      fc::sha256 _b_lock = NULL_PROPOSAL_ID;
-      fc::sha256 _b_exec = NULL_PROPOSAL_ID;
+      void on_beat(); //handler for pacemaker beat()
 
-      fc::sha256 _b_finality_violation = NULL_PROPOSAL_ID;
+      void on_hs_vote_msg(const hs_vote_message& msg); //vote msg event handler
+      void on_hs_proposal_msg(const hs_proposal_message& msg); //proposal msg event handler
+      void on_hs_new_view_msg(const hs_new_view_message& msg); //new view msg event handler
+      void on_hs_new_block_msg(const hs_new_block_message& msg); //new block msg event handler
 
-      block_id_type _block_exec = NULL_BLOCK_ID;
+   private:
 
-      block_id_type _pending_proposal_block = NULL_BLOCK_ID;
-
-      uint32_t _v_height = 0;
-
-      eosio::chain::quorum_certificate _high_qc;
-      eosio::chain::quorum_certificate _current_qc;
-
-      eosio::chain::extended_schedule _schedule;
-
-      name _id;
-
-      base_pacemaker* _pacemaker = nullptr;
-
-      std::set<name> _my_producers;
-
-      bool _log = true;
-      bool _errors = true;
-
-      // returns nullptr if not found
-      const hs_proposal_message* get_proposal(const fc::sha256& proposal_id);
+      const hs_proposal_message* get_proposal(const fc::sha256& proposal_id); // returns nullptr if not found
 
       // returns false if proposal with that same ID already exists at the store of its height
       bool insert_proposal(const hs_proposal_message& proposal);
-
-      void get_state( finalizer_state& fs ) const;
 
       uint32_t positive_bits_count(fc::unsigned_int value);
 
@@ -119,9 +93,7 @@ namespace eosio::hotstuff {
 
       bool extends(const fc::sha256& descendant, const fc::sha256& ancestor); //verify that a proposal descends from another
 
-      void on_beat(); //handler for pacemaker beat()
-
-      void update_high_qc(const eosio::chain::quorum_certificate& high_qc); //check if update to our high qc is required
+      bool update_high_qc(const eosio::chain::quorum_certificate& high_qc); //check if update to our high qc is required
 
       void leader_rotation_check(); //check if leader rotation is required
 
@@ -134,31 +106,45 @@ namespace eosio::hotstuff {
       void send_hs_new_view_msg(const hs_new_view_message& msg); //send new view msg
       void send_hs_new_block_msg(const hs_new_block_message& msg); //send new block msg
 
-      void on_hs_vote_msg(const hs_vote_message& msg); //vote msg event handler
-      void on_hs_proposal_msg(const hs_proposal_message& msg); //proposal msg event handler
-      void on_hs_new_view_msg(const hs_new_view_message& msg); //new view msg event handler
-      void on_hs_new_block_msg(const hs_new_block_message& msg); //new block msg event handler
-
       void update(const hs_proposal_message& proposal); //update internal state
       void commit(const hs_proposal_message& proposal); //commit proposal (finality)
 
       void gc_proposals(uint64_t cutoff); //garbage collection of old proposals
 
-private:
+#warning remove. bls12-381 key used for testing purposes
+      //todo : remove. bls12-381 key used for testing purposes
+      std::vector<uint8_t> _seed =
+         {  0,  50, 6,  244, 24,  199, 1,  25,  52,  88,  192,
+            19, 18, 12, 89,  6,   220, 18, 102, 58,  209, 82,
+            12, 62, 89, 110, 182, 9,   44, 20,  254, 22 };
 
-      // This mutex synchronizes all writes to the data members of this qc_chain against
-      //   get_state() calls (which ultimately come from e.g. the HTTP plugin).
-      // This could result in a HTTP query that gets the state of the core while it is
-      //   in the middle of processing a given request, since this is not serializing
-      //   against high-level message or request processing borders.
-      // If that behavior is not desired, we can instead synchronize this against a
-      //   consistent past snapshot of the qc_chain's state for e.g. the HTTP plugin,
-      //   which would be updated at the end of processing every request to the core
-      //   that does alter the qc_chain (hotstuff protocol state).
-      // And if the chain_pacemaker::_hotstuff_global_mutex locking strategy is ever
-      //   changed, then this probably needs to be reviewed as well.
-      //
-      mutable std::mutex     _state_mutex;
+      fc::crypto::blslib::bls_private_key _private_key = fc::crypto::blslib::bls_private_key(_seed);
+
+      enum msg_type {
+         new_view = 1,
+         new_block = 2,
+         qc = 3,
+         vote = 4
+      };
+
+      bool _chained_mode = false;
+      block_id_type _block_exec = NULL_BLOCK_ID;
+      block_id_type _pending_proposal_block = NULL_BLOCK_ID;
+      fc::sha256 _b_leaf = NULL_PROPOSAL_ID;
+      fc::sha256 _b_lock = NULL_PROPOSAL_ID;
+      fc::sha256 _b_exec = NULL_PROPOSAL_ID;
+      fc::sha256 _b_finality_violation = NULL_PROPOSAL_ID;
+      eosio::chain::quorum_certificate _high_qc;
+      eosio::chain::quorum_certificate _current_qc;
+      uint32_t _v_height = 0;
+      eosio::chain::extended_schedule _schedule;
+      base_pacemaker* _pacemaker = nullptr;
+      std::set<name> _my_producers;
+      bool _log = true;
+      bool _errors = true;
+      name _id;
+
+      mutable uint64_t _state_version = 1;
 
 #ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
       // keep one proposal store (id -> proposal) by each height (height -> proposal store)

--- a/libraries/hotstuff/qc_chain.cpp
+++ b/libraries/hotstuff/qc_chain.cpp
@@ -75,7 +75,6 @@ namespace eosio { namespace hotstuff {
    }
 
    bool qc_chain::insert_proposal(const hs_proposal_message & proposal) {
-      std::lock_guard g( _state_mutex );
 #ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
       uint64_t proposal_height = proposal.get_height();
       ps_height_iterator psh_it = _proposal_stores_by_height.find( proposal_height );
@@ -99,8 +98,7 @@ namespace eosio { namespace hotstuff {
 #endif
    }
 
-   void qc_chain::get_state( finalizer_state& fs ) const {
-      std::lock_guard g( _state_mutex );
+   void qc_chain::get_state(finalizer_state& fs) const {
       fs.chained_mode           = _chained_mode;
       fs.b_leaf                 = _b_leaf;
       fs.b_lock                 = _b_lock;
@@ -238,7 +236,6 @@ namespace eosio { namespace hotstuff {
    }
 
    void qc_chain::reset_qc(const fc::sha256& proposal_id){
-      std::lock_guard g( _state_mutex );
 #ifdef QC_CHAIN_TRACE_DEBUG
       if (_log) ilog(" === ${id} resetting qc : ${proposal_id}", ("proposal_id" , proposal_id)("id", _id));
 #endif
@@ -347,10 +344,7 @@ namespace eosio { namespace hotstuff {
    }
 
    hs_vote_message qc_chain::sign_proposal(const hs_proposal_message & proposal, name finalizer){
-
-      std::unique_lock state_lock( _state_mutex );
       _v_height = proposal.get_height();
-      state_lock.unlock();
 
       digest_type digest = get_digest_to_sign(proposal.block_id, proposal.phase_counter, proposal.final_on_qc);
 
@@ -497,6 +491,8 @@ namespace eosio { namespace hotstuff {
       //check for leader change
       leader_rotation_check();
 
+      ++_state_version;
+
       //auto total_time = fc::time_point::now() - start;
       //if (_log) ilog(" ... process_proposal() total time : ${total_time}", ("total_time", total_time));
    }
@@ -530,14 +526,12 @@ namespace eosio { namespace hotstuff {
       // If quorum is already met, we don't need to do anything else. Otherwise, we aggregate the signature.
       if (!quorum_met){
 
-         std::unique_lock state_lock( _state_mutex );
          if (_current_qc.active_finalizers>0)
             _current_qc.active_agg_sig = fc::crypto::blslib::aggregate({_current_qc.active_agg_sig, vote.sig });
          else
             _current_qc.active_agg_sig = vote.sig;
 
          _current_qc.active_finalizers = update_bitset(_current_qc.active_finalizers, vote.finalizer);
-         state_lock.unlock();
 
          quorum_met = is_quorum_met(_current_qc, _schedule, *p);
 
@@ -549,9 +543,7 @@ namespace eosio { namespace hotstuff {
                            ("proposal_id", vote.proposal_id)
                            ("id", _id));
 
-            state_lock.lock();
             _current_qc.quorum_met = true;
-            state_lock.unlock();
 
             //ilog(" === update_high_qc : _current_qc ===");
             update_high_qc(_current_qc);
@@ -575,10 +567,8 @@ namespace eosio { namespace hotstuff {
 #ifdef QC_CHAIN_TRACE_DEBUG
                if (_log) ilog(" === ${id} setting _pending_proposal_block to null (process_vote)", ("id", _id));
 #endif
-               state_lock.lock();
                _pending_proposal_block = NULL_BLOCK_ID;
                _b_leaf = proposal_candidate.proposal_id;
-               state_lock.unlock();
 
                send_hs_proposal_msg(proposal_candidate);
 #ifdef QC_CHAIN_TRACE_DEBUG
@@ -586,6 +576,8 @@ namespace eosio { namespace hotstuff {
 #endif
             }
          }
+
+         ++_state_version;
       }
 
       //auto total_time = fc::time_point::now() - start;
@@ -596,7 +588,9 @@ namespace eosio { namespace hotstuff {
 #ifdef QC_CHAIN_TRACE_DEBUG
       if (_log) ilog(" === ${id} process_new_view === ${qc}", ("qc", msg.high_qc)("id", _id));
 #endif
-      update_high_qc(msg.high_qc);
+      if (update_high_qc(msg.high_qc)) {
+         ++_state_version;
+      }
    }
 
    void qc_chain::process_new_block(const hs_new_block_message & msg){
@@ -636,9 +630,7 @@ namespace eosio { namespace hotstuff {
                         ("quorum_met", _current_qc.quorum_met));
          if (_log) ilog(" === ${id} setting _pending_proposal_block to ${block_id} (on_beat)", ("id", _id)("block_id", msg.block_id));
 #endif
-         std::unique_lock state_lock( _state_mutex );
          _pending_proposal_block = msg.block_id;
-         state_lock.unlock();
 
       } else {
 
@@ -655,10 +647,8 @@ namespace eosio { namespace hotstuff {
 #ifdef QC_CHAIN_TRACE_DEBUG
          if (_log) ilog(" === ${id} setting _pending_proposal_block to null (process_new_block)", ("id", _id));
 #endif
-         std::unique_lock state_lock( _state_mutex );
          _pending_proposal_block = NULL_BLOCK_ID;
          _b_leaf = proposal_candidate.proposal_id;
-         state_lock.unlock();
 
          send_hs_proposal_msg(proposal_candidate);
 
@@ -666,6 +656,8 @@ namespace eosio { namespace hotstuff {
          if (_log) ilog(" === ${id} _b_leaf updated (on_beat): ${proposal_id}", ("proposal_id", proposal_candidate.proposal_id)("id", _id));
 #endif
       }
+
+      ++_state_version;
    }
 
    void qc_chain::send_hs_proposal_msg(const hs_proposal_message & msg){
@@ -773,7 +765,8 @@ namespace eosio { namespace hotstuff {
       }
    }
 
-   void qc_chain::update_high_qc(const eosio::chain::quorum_certificate & high_qc){
+   // returns true on state change (caller decides update on state version
+   bool qc_chain::update_high_qc(const eosio::chain::quorum_certificate & high_qc){
 
 #ifdef QC_CHAIN_TRACE_DEBUG
       ilog(" === check to update high qc ${proposal_id}", ("proposal_id", high_qc.proposal_id));
@@ -783,21 +776,20 @@ namespace eosio { namespace hotstuff {
 
       if (_high_qc.proposal_id == NULL_PROPOSAL_ID){
 
-         std::unique_lock state_lock( _state_mutex );
          _high_qc = high_qc;
          _b_leaf = _high_qc.proposal_id;
-         state_lock.unlock();
 
 #ifdef QC_CHAIN_TRACE_DEBUG
          if (_log) ilog(" === ${id} _b_leaf updated (update_high_qc) : ${proposal_id}", ("proposal_id", _high_qc.proposal_id)("id", _id));
 #endif
+         return true;
       } else {
          const hs_proposal_message *old_high_qc_prop = get_proposal( _high_qc.proposal_id );
          const hs_proposal_message *new_high_qc_prop = get_proposal( high_qc.proposal_id );
          if (old_high_qc_prop == nullptr)
-            return;
+            return false;
          if (new_high_qc_prop == nullptr)
-            return;
+            return false;
 
          if (new_high_qc_prop->get_height() > old_high_qc_prop->get_height()
              && is_quorum_met(high_qc, _schedule, *new_high_qc_prop))
@@ -808,21 +800,20 @@ namespace eosio { namespace hotstuff {
 #ifdef QC_CHAIN_TRACE_DEBUG
             ilog(" === updated high qc, now is : #${get_height}  ${proposal_id}", ("get_height", new_high_qc_prop->get_height())("proposal_id", new_high_qc_prop->proposal_id));
 #endif
-            std::unique_lock state_lock( _state_mutex );
             _high_qc = high_qc;
             _high_qc.quorum_met = true;
             _b_leaf = _high_qc.proposal_id;
-            state_lock.unlock();
 
 #ifdef QC_CHAIN_TRACE_DEBUG
             if (_log) ilog(" === ${id} _b_leaf updated (update_high_qc) : ${proposal_id}", ("proposal_id", _high_qc.proposal_id)("id", _id));
 #endif
+            return true;
          }
       }
+      return false;
    }
 
    void qc_chain::leader_rotation_check(){
-
       //verify if leader changed
 
       name current_leader = _pacemaker->get_leader();
@@ -843,9 +834,7 @@ namespace eosio { namespace hotstuff {
          if (_log) ilog(" === ${id} setting _pending_proposal_block to null (leader_rotation_check)", ("id", _id));
 #endif
 
-         std::unique_lock state_lock( _state_mutex );
          _pending_proposal_block = NULL_BLOCK_ID;
-         state_lock.unlock();
 
          hs_new_view_message new_view;
 
@@ -1034,9 +1023,7 @@ namespace eosio { namespace hotstuff {
 #ifdef QC_CHAIN_TRACE_DEBUG
          ilog("setting _b_lock to ${proposal_id}", ("proposal_id",b_1.proposal_id ));
 #endif
-         std::unique_lock state_lock( _state_mutex );
          _b_lock = b_1.proposal_id; //commit phase on b1
-         state_lock.unlock();
 
 #ifdef QC_CHAIN_TRACE_DEBUG
          if (_log) ilog(" === ${id} _b_lock updated : ${proposal_id}", ("proposal_id", b_1.proposal_id)("id", _id));
@@ -1078,9 +1065,7 @@ namespace eosio { namespace hotstuff {
                        ("proposal_id_1", b.proposal_id)
                        ("proposal_id_2", b_exec->proposal_id));
 
-               std::unique_lock state_lock( _state_mutex );
                _b_finality_violation = b.proposal_id;
-               state_lock.unlock();
 
                //protocol failure
                return;
@@ -1093,10 +1078,8 @@ namespace eosio { namespace hotstuff {
          ilog(" === last executed proposal : #${block_num} ${block_id}", ("block_num", b.block_num())("block_id", b.block_id));
 #endif
 
-         std::unique_lock state_lock( _state_mutex );
          _b_exec = b.proposal_id; //decide phase on b
          _block_exec = b.block_id;
-         state_lock.unlock();
 
          gc_proposals( b.get_height()-1);
       }
@@ -1110,7 +1093,6 @@ namespace eosio { namespace hotstuff {
 
    void qc_chain::gc_proposals(uint64_t cutoff){
       //ilog(" === garbage collection on old data");
-      std::lock_guard g( _state_mutex );
 #ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
       ps_height_iterator psh_it = _proposal_stores_by_height.begin();
       while (psh_it != _proposal_stores_by_height.end()) {

--- a/libraries/hotstuff/qc_chain.cpp
+++ b/libraries/hotstuff/qc_chain.cpp
@@ -590,8 +590,9 @@ namespace eosio { namespace hotstuff {
 #ifdef QC_CHAIN_TRACE_DEBUG
       if (_log) ilog(" === ${id} process_new_view === ${qc}", ("qc", msg.high_qc)("id", _id));
 #endif
-      if (update_high_qc(msg.high_qc)) {
-         ++_state_version; // should be OK; update_high_qc() should not throw
+      auto increment_version = fc::make_scoped_exit([this]() { ++_state_version; });
+      if (!update_high_qc(msg.high_qc)) {
+         increment_version.cancel();
       }
    }
 

--- a/libraries/hotstuff/test/test_hotstuff.cpp
+++ b/libraries/hotstuff/test/test_hotstuff.cpp
@@ -112,7 +112,7 @@ public:
       std::cout << "\n";
    }
 
-   void print_bp_state(name bp, std::string message){
+   void print_bp_state(name bp, std::string message) const {
 
       std::cout << "\n";
       std::cout << message;
@@ -121,21 +121,24 @@ public:
       auto qcc_entry = std::find_if(_qc_chains.begin(), _qc_chains.end(), [&](const auto& q){ return q.first == bp; });
 
       qc_chain & qcc = *qcc_entry->second.get();
-      const hs_proposal_message *leaf = qcc.get_proposal( qcc._b_leaf );
-      const hs_proposal_message *qc   = qcc.get_proposal( qcc._high_qc.proposal_id );
-      const hs_proposal_message *lock = qcc.get_proposal( qcc._b_lock );
-      const hs_proposal_message *exec = qcc.get_proposal( qcc._b_exec );
 
-      if (leaf != nullptr) std::cout << "  - " << bp.to_string() << " current _b_leaf is : " << qcc._b_leaf.str() << " block_num : " << leaf->block_num() << ", phase : " << unsigned(leaf->phase_counter) << "\n";
+      finalizer_state fs;
+      qcc.get_state(fs);
+      const hs_proposal_message *leaf = fs.get_proposal( fs.b_leaf );
+      const hs_proposal_message *qc   = fs.get_proposal( fs.high_qc.proposal_id );
+      const hs_proposal_message *lock = fs.get_proposal( fs.b_lock );
+      const hs_proposal_message *exec = fs.get_proposal( fs.b_exec );
+
+      if (leaf != nullptr) std::cout << "  - " << bp.to_string() << " current _b_leaf is : " << fs.b_leaf.str() << " block_num : " << leaf->block_num() << ", phase : " << unsigned(leaf->phase_counter) << "\n";
       else std::cout << "  - No b_leaf value " << "\n";
 
-      if (qc != nullptr) std::cout << "  - " << bp.to_string() << " current high_qc is : " << qcc._high_qc.proposal_id.str() << " block_num : " << qc->block_num() << ", phase : " << unsigned(qc->phase_counter) <<  "\n";
+      if (qc != nullptr) std::cout << "  - " << bp.to_string() << " current high_qc is : " << fs.high_qc.proposal_id.str() << " block_num : " << qc->block_num() << ", phase : " << unsigned(qc->phase_counter) <<  "\n";
       else std::cout << "  - No high_qc value " << "\n";
 
-      if (lock != nullptr) std::cout << "  - " << bp.to_string() << " current _b_lock is : " << qcc._b_lock.str() << " block_num : " << lock->block_num() << ", phase : " << unsigned(lock->phase_counter) <<  "\n";
+      if (lock != nullptr) std::cout << "  - " << bp.to_string() << " current _b_lock is : " << fs.b_lock.str() << " block_num : " << lock->block_num() << ", phase : " << unsigned(lock->phase_counter) <<  "\n";
       else std::cout << "  - No b_lock value " << "\n";
 
-      if (exec != nullptr) std::cout << "  - " << bp.to_string() << " current _b_exec is : " << qcc._b_exec.str() << " block_num : " << exec->block_num() << ", phase : " << unsigned(exec->phase_counter) <<  "\n";
+      if (exec != nullptr) std::cout << "  - " << bp.to_string() << " current _b_exec is : " << fs.b_exec.str() << " block_num : " << exec->block_num() << ", phase : " << unsigned(exec->phase_counter) <<  "\n";
       else std::cout << "  - No b_exec value " << "\n";
 
       std::cout << "\n";
@@ -191,7 +194,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_1) try {
    tpm.set_finalizers(unique_replicas);
 
    auto qcc_bpa = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpa"_n; });
+   finalizer_state fs_bpa;
+   qcc_bpa->second->get_state(fs_bpa);
    auto qcc_bpb = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpb"_n; });
+   finalizer_state fs_bpb;
+   qcc_bpb->second->get_state(fs_bpb);
 
    ht.print_bp_state("bpa"_n, "");
 
@@ -203,37 +210,41 @@ BOOST_AUTO_TEST_CASE(hotstuff_1) try {
 
    ht.print_bp_state("bpa"_n, "");
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on first block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on first block)
 
    tpm.dispatch(""); //send proposal to replicas (commit on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on first block)
 
    tpm.dispatch(""); //send proposal to replicas (decide on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
 
    tpm.dispatch(""); //propagating votes on new proposal (decide on first block)
 
@@ -243,51 +254,57 @@ BOOST_AUTO_TEST_CASE(hotstuff_1) try {
 
    tpm.dispatch(""); //send proposal to replicas (prepare on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (commit on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (decide on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
 
    tpm.dispatch(""); //send proposal to replicas (decide on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
 
    //check bpb as well
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
 } FC_LOG_AND_RETHROW();
 
@@ -307,7 +324,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
    tpm.set_finalizers(unique_replicas);
 
    auto qcc_bpa = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpa"_n; });
+   finalizer_state fs_bpa;
+   qcc_bpa->second->get_state(fs_bpa);
    auto qcc_bpb = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpb"_n; });
+   finalizer_state fs_bpb;
+   qcc_bpb->second->get_state(fs_bpb);
 
    tpm.set_current_block_id(ids[0]); //first block
 
@@ -315,19 +336,21 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
 
    tpm.dispatch(""); //send proposal to replicas (prepare on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on first block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.set_current_block_id(ids[1]); //second block
 
@@ -335,19 +358,21 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
 
    tpm.dispatch(""); //send proposal to replicas (prepare on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
 
    tpm.set_current_block_id(ids[2]); //second block
 
@@ -355,26 +380,29 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
 
    tpm.dispatch(""); //propagating votes on new proposal (prepare on third block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on third block)
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on third block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("0d77972a81cefce394736f23f8b4d97de3af5bd160376626bdd6a77de89ee324"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("0d77972a81cefce394736f23f8b4d97de3af5bd160376626bdd6a77de89ee324"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
 
    //check bpb as well
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
 } FC_LOG_AND_RETHROW();
 
@@ -394,8 +422,14 @@ BOOST_AUTO_TEST_CASE(hotstuff_3) try {
    tpm.set_finalizers(unique_replicas);
 
    auto qcc_bpa = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpa"_n; });
+   finalizer_state fs_bpa;
+   qcc_bpa->second->get_state(fs_bpa);
    auto qcc_bpb = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpb"_n; });
+   finalizer_state fs_bpb;
+   qcc_bpb->second->get_state(fs_bpb);
    auto qcc_bpc = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpc"_n; });
+   finalizer_state fs_bpc;
+   qcc_bpc->second->get_state(fs_bpc);
 
    tpm.set_current_block_id(ids[0]); //first block
 
@@ -403,28 +437,31 @@ BOOST_AUTO_TEST_CASE(hotstuff_3) try {
 
    tpm.dispatch(""); //send proposal to replicas (prepare on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on first block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on first block)
 
    tpm.dispatch(""); //send proposal to replicas (commit on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.set_next_leader("bpb"_n); //leader is set to rotate on next block
 
@@ -432,10 +469,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_3) try {
 
    tpm.dispatch(""); //send proposal to replicas (decide on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
 
    tpm.dispatch(""); //propagating votes on new proposal (decide on first block)
 
@@ -448,49 +486,55 @@ BOOST_AUTO_TEST_CASE(hotstuff_3) try {
 
    tpm.dispatch(""); //send proposal to replicas (prepare on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_leaf.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_leaf.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (commit on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_leaf.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (decide on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_leaf.str(), std::string("89f468a127dbadd81b59076067238e3e9c313782d7d83141b16d9da4f2c2b078"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("89f468a127dbadd81b59076067238e3e9c313782d7d83141b16d9da4f2c2b078"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
 
    //check bpa as well
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
 
    //check bpc as well
-   BOOST_CHECK_EQUAL(qcc_bpc->second->_high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(qcc_bpc->second->_b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(qcc_bpc->second->_b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   qcc_bpc->second->get_state(fs_bpc);
+   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
 } FC_LOG_AND_RETHROW();
 
@@ -510,8 +554,14 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
    tpm.set_finalizers(unique_replicas);
 
    auto qcc_bpa = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpa"_n; });
+   finalizer_state fs_bpa;
+   qcc_bpa->second->get_state(fs_bpa);
    auto qcc_bpb = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpb"_n; });
+   finalizer_state fs_bpb;
+   qcc_bpb->second->get_state(fs_bpb);
    auto qcc_bpi = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpi"_n; });
+   finalizer_state fs_bpi;
+   qcc_bpi->second->get_state(fs_bpi);
 
    tpm.set_current_block_id(ids[0]); //first block
 
@@ -519,19 +569,21 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
 
    tpm.dispatch(""); //send proposal to replicas (prepare on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on first block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on first block)
 
@@ -547,10 +599,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
 
    tpm.dispatch(""); //send proposal to replicas (commit on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.set_next_leader("bpi"_n); //leader is set to rotate on next block
 
@@ -558,10 +611,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
 
 //ht.print_bp_state("bpa"_n, "before reactivate");
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.activate("bpb"_n);
    tpm.activate("bpc"_n);
@@ -583,30 +637,33 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
 //ht.print_bp_state("bpi"_n, "");
 
 //ht.print_bp_state("bpa"_n, "");
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on second block)
 
 //ht.print_bp_state("bpa"_n, "");
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (commit on second block)
 
 //ht.print_bp_state("bpa"_n, "");
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on second block)
 
@@ -614,23 +671,26 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
 
 //ht.print_bp_state("bpa"_n, "");
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
 
 //ht.print_bp_state("bpb"_n, "");
    //check bpa as well
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
 
 //ht.print_bp_state("bpi"_n, "");
-   BOOST_CHECK_EQUAL(qcc_bpi->second->_high_qc.proposal_id.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
-   BOOST_CHECK_EQUAL(qcc_bpi->second->_b_lock.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(qcc_bpi->second->_b_exec.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   qcc_bpi->second->get_state(fs_bpi);
+   BOOST_CHECK_EQUAL(fs_bpi.high_qc.proposal_id.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
+   BOOST_CHECK_EQUAL(fs_bpi.b_lock.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
+   BOOST_CHECK_EQUAL(fs_bpi.b_exec.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
 } FC_LOG_AND_RETHROW();
 
@@ -699,6 +759,8 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    tpm2.set_finalizers(replica_set_2);
 
    auto qcc_bpe = std::find_if(ht1._qc_chains.begin(), ht1._qc_chains.end(), [&](const auto& q){ return q.first == "bpe"_n; });
+   finalizer_state fs_bpe;
+   qcc_bpe->second->get_state(fs_bpe);
    //auto qcc_bpf = std::find_if(ht2._qc_chains.begin(), ht2._qc_chains.end(), [&](const auto& q){ return q.first == "bpf"_n; });
 
    std::vector<test_pacemaker::hotstuff_message> msgs;
@@ -717,10 +779,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
 
 //ht1.print_bp_state("bpe"_n, "");
 
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpe->second->get_state(fs_bpe);
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm1.dispatch("");
    tpm1.dispatch("");
@@ -730,10 +793,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
 
 //ht1.print_bp_state("bpe"_n, "");
 
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpe->second->get_state(fs_bpe);
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm1.dispatch("");
    tpm1.dispatch("");
@@ -743,10 +807,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
 
 //ht1.print_bp_state("bpe"_n, "");
 
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   qcc_bpe->second->get_state(fs_bpe);
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
 
    tpm1.dispatch("");
    tpm1.dispatch("");
@@ -756,10 +821,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
 
 //ht1.print_bp_state("bpe"_n, "");
 
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_high_qc.proposal_id.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   qcc_bpe->second->get_state(fs_bpe);
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
 
    tpm1.set_current_block_id(ids[1]); //first block
    tpm2.set_current_block_id(alternate_ids[1]); //first block
@@ -775,10 +841,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
 
 //ht1.print_bp_state("bpe"_n, "");
 
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_leaf.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_high_qc.proposal_id.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_lock.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   qcc_bpe->second->get_state(fs_bpe);
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
 
    tpm1.pipe(tpm2.dispatch(""));
    tpm1.dispatch("");
@@ -788,10 +855,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
 
 //ht1.print_bp_state("bpe"_n, "");
 
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_leaf.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_high_qc.proposal_id.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_lock.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_exec.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   qcc_bpe->second->get_state(fs_bpe);
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
 
    tpm1.pipe(tpm2.dispatch(""));
    tpm1.dispatch("");
@@ -801,10 +869,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
 
 //ht1.print_bp_state("bpe"_n, "");
 
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   qcc_bpe->second->get_state(fs_bpe);
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
 
    tpm1.pipe(tpm2.dispatch(""));
    tpm1.dispatch("");
@@ -814,12 +883,13 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
 
 //ht1.print_bp_state("bpe"_n, "");
 
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_high_qc.proposal_id.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   qcc_bpe->second->get_state(fs_bpe);
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
 
-   BOOST_CHECK_EQUAL(qcc_bpe->second->_b_finality_violation.str(), std::string("5585accc44c753636d1381067c7f915d7fff2d33846aae04820abc055d952860"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_finality_violation.str(), std::string("5585accc44c753636d1381067c7f915d7fff2d33846aae04820abc055d952860"));
 
 } FC_LOG_AND_RETHROW();
 
@@ -839,8 +909,14 @@ BOOST_AUTO_TEST_CASE(hotstuff_6) try {
    tpm.set_finalizers(unique_replicas);
 
    auto qcc_bpa = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpa"_n; });
+   finalizer_state fs_bpa;
+   qcc_bpa->second->get_state(fs_bpa);
    auto qcc_bpb = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpb"_n; });
+   finalizer_state fs_bpb;
+   qcc_bpb->second->get_state(fs_bpb);
    auto qcc_bpc = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpc"_n; });
+   finalizer_state fs_bpc;
+   qcc_bpc->second->get_state(fs_bpc);
 
    tpm.set_current_block_id(ids[0]); //first block
 
@@ -850,28 +926,31 @@ BOOST_AUTO_TEST_CASE(hotstuff_6) try {
 
    tpm.dispatch(""); //send proposal to replicas (prepare on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on first block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on first block)
 
    tpm.dispatch(""); //send proposal to replicas (commit on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.set_next_leader("bpb"_n); //leader is set to rotate on next block
 
@@ -879,10 +958,11 @@ BOOST_AUTO_TEST_CASE(hotstuff_6) try {
 
    tpm.dispatch(""); //send proposal to replicas (decide on first block)
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
 
    tpm.dispatch(""); //propagating votes on new proposal (decide on first block)
 
@@ -897,49 +977,55 @@ BOOST_AUTO_TEST_CASE(hotstuff_6) try {
 
    tpm.dispatch(""); //send proposal to replicas (prepare on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_leaf.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_leaf.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (commit on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_leaf.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (decide on second block)
 
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_leaf.str(), std::string("89f468a127dbadd81b59076067238e3e9c313782d7d83141b16d9da4f2c2b078"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(qcc_bpb->second->_b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   qcc_bpb->second->get_state(fs_bpb);
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("89f468a127dbadd81b59076067238e3e9c313782d7d83141b16d9da4f2c2b078"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
 
    //check bpa as well
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   qcc_bpa->second->get_state(fs_bpa);
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
 
    //check bpc as well
-   BOOST_CHECK_EQUAL(qcc_bpc->second->_high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(qcc_bpc->second->_b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(qcc_bpc->second->_b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   qcc_bpc->second->get_state(fs_bpc);
+   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
 
-   BOOST_CHECK_EQUAL(qcc_bpa->second->_b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
 } FC_LOG_AND_RETHROW();
 

--- a/libraries/hotstuff/test/test_pacemaker.cpp
+++ b/libraries/hotstuff/test/test_pacemaker.cpp
@@ -179,7 +179,7 @@ namespace eosio::hotstuff {
       while (qc_itr != _qcc_store.end()){
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
-         if (qcc_ptr->_id != id && is_qc_chain_active(qcc_name) )
+         if (qcc_ptr->get_id() != id && is_qc_chain_active(qcc_name) )
             qcc_ptr->on_hs_proposal_msg(msg);
          qc_itr++;
       }
@@ -190,7 +190,7 @@ namespace eosio::hotstuff {
       while (qc_itr != _qcc_store.end()) {
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
-         if (qcc_ptr->_id != id && is_qc_chain_active(qcc_name) )
+         if (qcc_ptr->get_id() != id && is_qc_chain_active(qcc_name) )
             qcc_ptr->on_hs_vote_msg(msg);
          qc_itr++;
       }
@@ -201,7 +201,7 @@ namespace eosio::hotstuff {
       while (qc_itr != _qcc_store.end()) {
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
-         if (qcc_ptr->_id != id && is_qc_chain_active(qcc_name) )
+         if (qcc_ptr->get_id() != id && is_qc_chain_active(qcc_name) )
             qcc_ptr->on_hs_new_block_msg(msg);
          qc_itr++;
       }
@@ -212,7 +212,7 @@ namespace eosio::hotstuff {
       while (qc_itr != _qcc_store.end()){
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
-         if (qcc_ptr->_id != id && is_qc_chain_active(qcc_name) )
+         if (qcc_ptr->get_id() != id && is_qc_chain_active(qcc_name) )
             qcc_ptr->on_hs_new_view_msg(msg);
          qc_itr++;
       }

--- a/libraries/hotstuff/test/test_pacemaker.cpp
+++ b/libraries/hotstuff/test/test_pacemaker.cpp
@@ -179,7 +179,7 @@ namespace eosio::hotstuff {
       while (qc_itr != _qcc_store.end()){
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
-         if (qcc_ptr->get_id() != id && is_qc_chain_active(qcc_name) )
+         if (qcc_ptr->get_id_i() != id && is_qc_chain_active(qcc_name) )
             qcc_ptr->on_hs_proposal_msg(msg);
          qc_itr++;
       }
@@ -190,7 +190,7 @@ namespace eosio::hotstuff {
       while (qc_itr != _qcc_store.end()) {
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
-         if (qcc_ptr->get_id() != id && is_qc_chain_active(qcc_name) )
+         if (qcc_ptr->get_id_i() != id && is_qc_chain_active(qcc_name) )
             qcc_ptr->on_hs_vote_msg(msg);
          qc_itr++;
       }
@@ -201,7 +201,7 @@ namespace eosio::hotstuff {
       while (qc_itr != _qcc_store.end()) {
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
-         if (qcc_ptr->get_id() != id && is_qc_chain_active(qcc_name) )
+         if (qcc_ptr->get_id_i() != id && is_qc_chain_active(qcc_name) )
             qcc_ptr->on_hs_new_block_msg(msg);
          qc_itr++;
       }
@@ -212,7 +212,7 @@ namespace eosio::hotstuff {
       while (qc_itr != _qcc_store.end()){
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
-         if (qcc_ptr->get_id() != id && is_qc_chain_active(qcc_name) )
+         if (qcc_ptr->get_id_i() != id && is_qc_chain_active(qcc_name) )
             qcc_ptr->on_hs_new_view_msg(msg);
          qc_itr++;
       }


### PR DESCRIPTION
- Moved everything in qc_chain.hpp that is not an interface to private:
- Fixed test_hotstuff to use get_state() instead of accessing various (now) private fields
- Fixed test_pacemaker to use get_id() instead of accessing (now) private _id field
- Added get_proposal() helper method to finalizer_state struct in chain/hotstuff.hpp since finalizer_state is now used in tests, etc.
- Made qc_chain class lock-free; all thread synchronization is now done externally
- Solved concurrency get_finalizer_state vs. qc_chain updates by caching chain_pacemaker::get_state(); zero overhead on qc_chain state updating, low overhead on external state read (no global/write locks acquired on cache hits)

This addresses part of #1541 (get_state() caching) and in the process of doing that I had to solve the other issue we discussed in the meeting, which was moving everything that isn't an interface on qc_chain to private:, and that also rippled into the tests and then the finalizer_state struct (which got a new helper method).