### PR TITLE
IF: Use FC logging framework for better management and consistency

### DIFF
--- a/libraries/hotstuff/chain_pacemaker.cpp
+++ b/libraries/hotstuff/chain_pacemaker.cpp
@@ -100,9 +100,10 @@ namespace eosio { namespace hotstuff {
 #endif
 //===============================================================================================
 
-   chain_pacemaker::chain_pacemaker(controller* chain, std::set<account_name> my_producers, bool info_logging, bool error_logging)
+   chain_pacemaker::chain_pacemaker(controller* chain, std::set<account_name> my_producers, const fc::logger& logger)
       : _chain(chain),
-        _qc_chain("default"_n, this, std::move(my_producers), info_logging, error_logging)
+        _qc_chain("default"_n, this, std::move(my_producers), logger),
+        _logger(logger)
    {
    }
 

--- a/libraries/hotstuff/chain_pacemaker.cpp
+++ b/libraries/hotstuff/chain_pacemaker.cpp
@@ -100,7 +100,7 @@ namespace eosio { namespace hotstuff {
 #endif
 //===============================================================================================
 
-   chain_pacemaker::chain_pacemaker(controller* chain, std::set<account_name> my_producers, const fc::logger& logger)
+   chain_pacemaker::chain_pacemaker(controller* chain, std::set<account_name> my_producers, fc::logger& logger)
       : _chain(chain),
         _qc_chain("default"_n, this, std::move(my_producers), logger),
         _logger(logger)

--- a/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
@@ -14,7 +14,7 @@ namespace eosio::hotstuff {
 
       //class-specific functions
 
-      chain_pacemaker(controller* chain, std::set<account_name> my_producers, const fc::logger& logger);
+      chain_pacemaker(controller* chain, std::set<account_name> my_producers, fc::logger& logger);
 
       void beat();
 
@@ -61,7 +61,7 @@ namespace eosio::hotstuff {
       qc_chain                _qc_chain;
 
       uint32_t                _quorum_threshold = 15; //FIXME/TODO: calculate from schedule
-      const fc::logger&       _logger;
+      fc::logger&             _logger;
 
    };
 

--- a/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
@@ -14,7 +14,7 @@ namespace eosio::hotstuff {
 
       //class-specific functions
 
-      chain_pacemaker(controller* chain, std::set<account_name> my_producers, bool info_logging, bool error_logging);
+      chain_pacemaker(controller* chain, std::set<account_name> my_producers, const fc::logger& logger);
 
       void beat();
 
@@ -61,6 +61,8 @@ namespace eosio::hotstuff {
       qc_chain                _qc_chain;
 
       uint32_t                _quorum_threshold = 15; //FIXME/TODO: calculate from schedule
+      const fc::logger&       _logger;
+
    };
 
 } // namespace eosio::hotstuff

--- a/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
@@ -36,7 +36,7 @@ namespace eosio::hotstuff {
 
       qc_chain() = delete;
 
-      qc_chain(name id, base_pacemaker* pacemaker, std::set<name> my_producers, const fc::logger& logger);
+      qc_chain(name id, base_pacemaker* pacemaker, std::set<name> my_producers, fc::logger& logger);
 
 #warning remove. bls12-381 key used for testing purposes
       //todo : remove. bls12-381 key used for testing purposes
@@ -160,7 +160,7 @@ private:
       //
       mutable std::mutex     _state_mutex;
 
-      const fc::logger&      _logger;
+      fc::logger&            _logger;
 
 #ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
       // keep one proposal store (id -> proposal) by each height (height -> proposal store)

--- a/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
@@ -36,7 +36,7 @@ namespace eosio::hotstuff {
 
       qc_chain() = delete;
 
-      qc_chain(name id, base_pacemaker* pacemaker, std::set<name> my_producers, bool info_logging, bool error_logging);
+      qc_chain(name id, base_pacemaker* pacemaker, std::set<name> my_producers, const fc::logger& logger);
 
 #warning remove. bls12-381 key used for testing purposes
       //todo : remove. bls12-381 key used for testing purposes
@@ -159,6 +159,8 @@ private:
       //   changed, then this probably needs to be reviewed as well.
       //
       mutable std::mutex     _state_mutex;
+
+      const fc::logger&      _logger;
 
 #ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
       // keep one proposal store (id -> proposal) by each height (height -> proposal store)

--- a/libraries/hotstuff/qc_chain.cpp
+++ b/libraries/hotstuff/qc_chain.cpp
@@ -310,12 +310,11 @@ namespace eosio { namespace hotstuff {
    }
 
 
-   qc_chain::qc_chain(name id, base_pacemaker* pacemaker, std::set<name> my_producers, bool info_logging, bool error_logging)
+   qc_chain::qc_chain(name id, base_pacemaker* pacemaker, std::set<name> my_producers, const fc::logger& logger)
       : _id(id),
         _pacemaker(pacemaker),
         _my_producers(std::move(my_producers)),
-        _log(info_logging),
-        _errors(error_logging)
+        _logger(logger)
    {
       if (_log) ilog(" === ${id} qc chain initialized ${my_producers}", ("my_producers", my_producers)("id", _id));
    }

--- a/libraries/hotstuff/test/test_hotstuff.cpp
+++ b/libraries/hotstuff/test/test_hotstuff.cpp
@@ -35,12 +35,14 @@ std::vector<name> unique_replicas {
    "bpp"_n, "bpq"_n, "bpr"_n,
    "bps"_n, "bpt"_n, "bpu"_n };
 
+fc::logger hotstuff_logger;
+
 class hotstuff_test_handler {
 public:
 
    std::vector<std::pair<name, std::shared_ptr<qc_chain>>> _qc_chains;
 
-   void initialize_qc_chains(test_pacemaker& tpm, std::vector<name> info_loggers, std::vector<name> error_loggers, std::vector<name> replicas){
+   void initialize_qc_chains(test_pacemaker& tpm, std::vector<name> replicas){
 
       _qc_chains.clear();
 
@@ -51,14 +53,7 @@ public:
       //_qc_chains.reserve( replicas.size() );
 
       for (name r : replicas) {
-
-         bool log = std::find(info_loggers.begin(), info_loggers.end(), r) != info_loggers.end();
-         bool err = std::find(error_loggers.begin(), error_loggers.end(), r) != error_loggers.end();
-
-         //If you want to force logging everything
-         //log = err = true;
-
-         qc_chain *qcc_ptr = new qc_chain(r, &tpm, {r}, log, err);
+         qc_chain *qcc_ptr = new qc_chain(r, &tpm, {r}, hotstuff_logger);
          std::shared_ptr<qc_chain> qcc_shared_ptr(qcc_ptr);
 
          _qc_chains.push_back( std::make_pair(r, qcc_shared_ptr) );
@@ -183,7 +178,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_1) try {
 
    hotstuff_test_handler ht;
 
-   ht.initialize_qc_chains(tpm, {"bpa"_n, "bpb"_n}, {"bpa"_n, "bpb"_n}, unique_replicas);
+   ht.initialize_qc_chains(tpm, unique_replicas);
 
    tpm.set_proposer("bpa"_n);
    tpm.set_leader("bpa"_n);
@@ -299,7 +294,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
 
    hotstuff_test_handler ht;
 
-   ht.initialize_qc_chains(tpm, {"bpa"_n}, {"bpa"_n}, unique_replicas);
+   ht.initialize_qc_chains(tpm, unique_replicas);
 
    tpm.set_proposer("bpa"_n);
    tpm.set_leader("bpa"_n);
@@ -386,7 +381,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_3) try {
 
    hotstuff_test_handler ht;
 
-   ht.initialize_qc_chains(tpm, {"bpa"_n, "bpb"_n}, {"bpa"_n, "bpb"_n},unique_replicas);
+   ht.initialize_qc_chains(tpm, unique_replicas);
 
    tpm.set_proposer("bpa"_n);
    tpm.set_leader("bpa"_n);
@@ -502,7 +497,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
 
    hotstuff_test_handler ht;
 
-   ht.initialize_qc_chains(tpm, {"bpa"_n, "bpb"_n}, {"bpa"_n, "bpb"_n}, unique_replicas);
+   ht.initialize_qc_chains(tpm, unique_replicas);
 
    tpm.set_proposer("bpa"_n);
    tpm.set_leader("bpa"_n);
@@ -684,9 +679,9 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    hotstuff_test_handler ht1;
    hotstuff_test_handler ht2;
 
-   ht1.initialize_qc_chains(tpm1, {"bpe"_n}, {"bpe"_n}, replica_set_1);
+   ht1.initialize_qc_chains(tpm1, replica_set_1);
 
-   ht2.initialize_qc_chains(tpm2, {}, {}, replica_set_2);
+   ht2.initialize_qc_chains(tpm2, replica_set_2);
 
    tpm1.set_proposer("bpe"_n); //honest leader
    tpm1.set_leader("bpe"_n);
@@ -831,7 +826,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_6) try {
 
    hotstuff_test_handler ht;
 
-   ht.initialize_qc_chains(tpm, {"bpa"_n, "bpb"_n}, {"bpa"_n, "bpb"_n},unique_replicas);
+   ht.initialize_qc_chains(tpm, unique_replicas);
 
    tpm.set_proposer("bpg"_n); // can be any proposer that's not the leader for this test
    tpm.set_leader("bpa"_n);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1116,9 +1116,7 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
 
 void chain_plugin::create_pacemaker(std::set<chain::account_name> my_producers) {
    EOS_ASSERT( !my->_chain_pacemaker, plugin_config_exception, "duplicate chain_pacemaker initialization" );
-   const bool info_logging = true;
-   const bool error_logging = true;
-   my->_chain_pacemaker.emplace(&chain(), std::move(my_producers), info_logging, error_logging);
+   my->_chain_pacemaker.emplace(&chain(), std::move(my_producers), hotstuff_logger);
 }
 
 void chain_plugin::plugin_initialize(const variables_map& options) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -40,6 +40,9 @@ FC_REFLECT(chainbase::environment, (debug)(os)(arch)(boost_version)(compiler) )
 const std::string deep_mind_logger_name("deep-mind");
 eosio::chain::deep_mind_handler _deep_mind_log;
 
+const std::string hotstuff_logger_name("hotstuff");
+fc::logger hotstuff_logger;
+
 namespace eosio {
 
 //declare operator<< and validate function for read_mode in the same namespace as read_mode itself
@@ -1194,6 +1197,7 @@ void chain_plugin::plugin_shutdown() {
 
 void chain_plugin::handle_sighup() {
    _deep_mind_log.update_logger( deep_mind_logger_name );
+   fc::logger::update( hotstuff_logger_name, hotstuff_logger );
 }
 
 chain_apis::read_write::read_write(controller& db,

--- a/programs/nodeos/logging.json
+++ b/programs/nodeos/logging.json
@@ -159,6 +159,15 @@
       "net"
       ]
     },{
+    "name": "hotstuff",
+    "level": "debug",
+    "enabled": true,
+    "additivity": false,
+    "appenders": [
+      "stderr",
+      "net"
+      ]
+    },{
       "name": "transaction",
       "level": "info",
       "enabled": true,


### PR DESCRIPTION
This PR sets up FC logging for hotstuff component such that logging can be controlled dynamically and is consistent with nodeos' other components. More refinements might be needed.

It
* creates a specific logging category for `hotstuff`,
* uses `fc_elog` for errors,
* uses `fc_tlog` for everything was inside `QC_CHAIN_TRACE_DEBUG`
* uses `fc_dlog` for the rest of the original `ilog`.