### PR TITLE
Remove some conversion operators

### DIFF
--- a/libraries/chain/authority.cpp
+++ b/libraries/chain/authority.cpp
@@ -1,7 +1,7 @@
 #include <eosio/chain/authority.hpp>
 
 namespace fc {
-   void to_variant(const eosio::chain::shared_public_key& var, fc::variant& vo) {
-      vo = var.to_string();
+   void to_variant(const eosio::chain::shared_public_key& var, fc::variant& vo, const fc::yield_function_t& yield) {
+      vo = var.to_string(yield);
    }
 } // namespace fc

--- a/libraries/chain/authority.cpp
+++ b/libraries/chain/authority.cpp
@@ -1,7 +1,7 @@
 #include <eosio/chain/authority.hpp>
 
 namespace fc {
-   void to_variant(const eosio::chain::shared_public_key& var, fc::variant& vo, const fc::yield_function_t& yield) {
-      vo = var.to_string(yield);
+   void to_variant(const eosio::chain::shared_public_key& var, fc::variant& vo) {
+      vo = var.to_string({});
    }
 } // namespace fc

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2440,7 +2440,7 @@ struct controller_impl {
             auth.accounts.push_back({{p.producer_name, config::active_name}, 1});
          }
 
-         if( static_cast<authority>(permission.auth) != auth ) { // TODO: use a more efficient way to check that authority has not changed
+         if( permission.auth != auth ) {
             db.modify(permission, [&]( auto& po ) {
                po.auth = auth;
             });

--- a/libraries/chain/include/eosio/chain/authority.hpp
+++ b/libraries/chain/include/eosio/chain/authority.hpp
@@ -212,10 +212,6 @@ struct authority {
 
    friend bool operator == ( const authority& lhs, const shared_authority& rhs );
 
-   friend bool operator != ( const authority& lhs, const authority& rhs ) {
-      return tie( lhs.threshold, lhs.keys, lhs.accounts, lhs.waits ) != tie( rhs.threshold, rhs.keys, rhs.accounts, rhs.waits );
-   }
-
    void sort_fields () {
       std::sort(std::begin(keys), std::end(keys));
       std::sort(std::begin(accounts), std::end(accounts));

--- a/libraries/chain/include/eosio/chain/authority.hpp
+++ b/libraries/chain/include/eosio/chain/authority.hpp
@@ -179,7 +179,7 @@ namespace config {
 struct shared_authority;
 
 struct authority {
-   explicit authority( public_key_type k, uint32_t delay_sec = 0 )
+   authority( public_key_type k, uint32_t delay_sec = 0 )
    :threshold(1),keys({{k,1}})
    {
       if( delay_sec > 0 ) {
@@ -341,7 +341,7 @@ inline bool validate( const Authority& auth ) {
 } } // namespace eosio::chain
 
 namespace fc {
-   void to_variant(const eosio::chain::shared_public_key& var, fc::variant& vo, const fc::yield_function_t& yield);
+   void to_variant(const eosio::chain::shared_public_key& var, fc::variant& vo);
 } // namespace fc
 
 FC_REFLECT(eosio::chain::permission_level_weight, (permission)(weight) )

--- a/libraries/chain/include/eosio/chain/authority.hpp
+++ b/libraries/chain/include/eosio/chain/authority.hpp
@@ -10,10 +10,10 @@ namespace eosio { namespace chain {
 using shared_public_key_data = std::variant<fc::ecc::public_key_shim, fc::crypto::r1::public_key_shim, shared_string>;
 
 struct shared_public_key {
-   shared_public_key( shared_public_key_data&& p ) :
+   explicit shared_public_key( shared_public_key_data&& p ) :
       pubkey(std::move(p)) {}
 
-   operator public_key_type() const {
+   public_key_type to_public_key() const {
       fc::crypto::public_key::storage_type public_key_storage;
       std::visit(overloaded {
          [&](const auto& k1r1) {
@@ -29,8 +29,8 @@ struct shared_public_key {
       return std::move(public_key_storage);
    }
 
-   std::string to_string() const {
-      return this->operator public_key_type().to_string();
+   std::string to_string(const fc::yield_function_t& yield) const {
+      return this->to_public_key().to_string(yield);
    }
 
    shared_public_key_data pubkey;
@@ -90,6 +90,8 @@ struct permission_level_weight {
    }
 };
 
+struct shared_key_weight;
+
 struct key_weight {
    public_key_type key;
    weight_type     weight;
@@ -97,6 +99,8 @@ struct key_weight {
    friend bool operator == ( const key_weight& lhs, const key_weight& rhs ) {
       return tie( lhs.key, lhs.weight ) == tie( rhs.key, rhs.weight );
    }
+
+   friend bool operator==( const key_weight& lhs, const shared_key_weight& rhs );
 
    friend bool operator < ( const key_weight& lhs, const key_weight& rhs ) {
       return tie( lhs.key, lhs.weight ) < tie( rhs.key, rhs.weight );
@@ -108,8 +112,8 @@ struct shared_key_weight {
    shared_key_weight(shared_public_key_data&& k, const weight_type& w) :
       key(std::move(k)), weight(w) {}
 
-   operator key_weight() const {
-      return key_weight{key, weight};
+   key_weight to_key_weight() const {
+      return key_weight{key.to_public_key(), weight};
    }
 
    static shared_key_weight convert(chainbase::allocator<char> allocator, const key_weight& k) {
@@ -137,6 +141,10 @@ struct shared_key_weight {
       return tie( lhs.key, lhs.weight ) == tie( rhs.key, rhs.weight );
    }
 };
+
+inline bool operator==( const key_weight& lhs, const shared_key_weight& rhs ) {
+   return tie( lhs.key, lhs.weight ) == tie( rhs.key, rhs.weight );
+}
 
 struct wait_weight {
    uint32_t     wait_sec;
@@ -168,8 +176,10 @@ namespace config {
    };
 }
 
+struct shared_authority;
+
 struct authority {
-   authority( public_key_type k, uint32_t delay_sec = 0 )
+   explicit authority( public_key_type k, uint32_t delay_sec = 0 )
    :threshold(1),keys({{k,1}})
    {
       if( delay_sec > 0 ) {
@@ -178,7 +188,7 @@ struct authority {
       }
    }
 
-   authority( permission_level p, uint32_t delay_sec = 0 )
+   explicit authority( permission_level p, uint32_t delay_sec = 0 )
    :threshold(1),accounts({{p,1}})
    {
       if( delay_sec > 0 ) {
@@ -200,6 +210,8 @@ struct authority {
       return tie( lhs.threshold, lhs.keys, lhs.accounts, lhs.waits ) == tie( rhs.threshold, rhs.keys, rhs.accounts, rhs.waits );
    }
 
+   friend bool operator == ( const authority& lhs, const shared_authority& rhs );
+
    friend bool operator != ( const authority& lhs, const authority& rhs ) {
       return tie( lhs.threshold, lhs.keys, lhs.accounts, lhs.waits ) != tie( rhs.threshold, rhs.keys, rhs.accounts, rhs.waits );
    }
@@ -213,7 +225,7 @@ struct authority {
 
 
 struct shared_authority {
-   shared_authority( chainbase::allocator<char> alloc )
+   explicit shared_authority( chainbase::allocator<char> alloc )
    :keys(alloc),accounts(alloc),waits(alloc){}
 
    shared_authority& operator=(const authority& a) {
@@ -233,14 +245,13 @@ struct shared_authority {
    shared_vector<permission_level_weight>     accounts;
    shared_vector<wait_weight>                 waits;
 
-   operator authority()const { return to_authority(); }
    authority to_authority()const {
       authority auth;
       auth.threshold = threshold;
       auth.keys.reserve(keys.size());
       auth.accounts.reserve(accounts.size());
       auth.waits.reserve(waits.size());
-      for( const auto& k : keys ) { auth.keys.emplace_back( k ); }
+      for( const auto& k : keys ) { auth.keys.emplace_back( k.to_key_weight() ); }
       for( const auto& a : accounts ) { auth.accounts.emplace_back( a ); }
       for( const auto& w : waits ) { auth.waits.emplace_back( w ); }
       return auth;
@@ -258,6 +269,16 @@ struct shared_authority {
       return accounts_size + waits_size + keys_size;
    }
 };
+
+inline bool operator==( const authority& lhs, const shared_authority& rhs ) {
+   return lhs.threshold == rhs.threshold &&
+          lhs.keys.size() == rhs.keys.size() &&
+          lhs.accounts.size() == rhs.accounts.size() &&
+          lhs.waits.size() == rhs.waits.size() &&
+          std::equal(lhs.keys.cbegin(), lhs.keys.cend(), rhs.keys.cbegin(), rhs.keys.cend()) &&
+          std::equal(lhs.accounts.cbegin(), lhs.accounts.cend(), rhs.accounts.cbegin(), rhs.accounts.cend()) &&
+          std::equal(lhs.waits.cbegin(), lhs.waits.cend(), rhs.waits.cbegin(), rhs.waits.cend());
+}
 
 namespace config {
    template<>
@@ -320,7 +341,7 @@ inline bool validate( const Authority& auth ) {
 } } // namespace eosio::chain
 
 namespace fc {
-   void to_variant(const eosio::chain::shared_public_key& var, fc::variant& vo);
+   void to_variant(const eosio::chain::shared_public_key& var, fc::variant& vo, const fc::yield_function_t& yield);
 } // namespace fc
 
 FC_REFLECT(eosio::chain::permission_level_weight, (permission)(weight) )

--- a/libraries/chain/include/eosio/chain/producer_schedule.hpp
+++ b/libraries/chain/include/eosio/chain/producer_schedule.hpp
@@ -144,7 +144,7 @@ namespace eosio { namespace chain {
          result.threshold = src.threshold;
          result.keys.reserve(src.keys.size());
          for (const auto& k: src.keys) {
-            result.keys.push_back(k);
+            result.keys.push_back(k.to_key_weight());
          }
 
          return result;

--- a/libraries/libfc/include/fc/crypto/private_key.hpp
+++ b/libraries/libfc/include/fc/crypto/private_key.hpp
@@ -24,7 +24,7 @@ namespace fc { namespace crypto {
          private_key() = default;
          private_key( private_key&& ) = default;
          private_key( const private_key& ) = default;
-         private_key& operator= (const private_key& ) = default;
+         private_key& operator=(const private_key& ) = default;
 
          public_key     get_public_key() const;
          signature      sign( const sha256& digest, bool require_canonical = true ) const;
@@ -47,7 +47,7 @@ namespace fc { namespace crypto {
 
          // serialize to/from string
          explicit private_key(const std::string& base58str);
-         std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
+         std::string to_string(const fc::yield_function_t& yield) const;
 
       private:
          storage_type _storage;
@@ -56,9 +56,8 @@ namespace fc { namespace crypto {
             :_storage(other_storage)
          {}
 
-         friend bool operator == ( const private_key& p1, const private_key& p2);
-         friend bool operator != ( const private_key& p1, const private_key& p2);
-         friend bool operator < ( const private_key& p1, const private_key& p2);
+         friend bool operator==( const private_key& p1, const private_key& p2 );
+         friend bool operator<( const private_key& p1, const private_key& p2 );
          friend struct reflector<private_key>;
    }; // private_key
 

--- a/libraries/libfc/include/fc/crypto/public_key.hpp
+++ b/libraries/libfc/include/fc/crypto/public_key.hpp
@@ -45,6 +45,7 @@ namespace fc { namespace crypto {
          storage_type _storage;
 
       private:
+         friend std::ostream& operator<<(std::ostream& s, const public_key& k);
          friend bool operator==( const public_key& p1, const public_key& p2);
          friend bool operator!=( const public_key& p1, const public_key& p2);
          friend bool operator<( const public_key& p1, const public_key& p2);

--- a/libraries/libfc/include/fc/crypto/public_key.hpp
+++ b/libraries/libfc/include/fc/crypto/public_key.hpp
@@ -40,15 +40,14 @@ namespace fc { namespace crypto {
 
          // serialize to/from string
          explicit public_key(const std::string& base58str);
-         std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
+         std::string to_string(const fc::yield_function_t& yield) const;
 
          storage_type _storage;
 
       private:
-         friend std::ostream& operator<< (std::ostream& s, const public_key& k);
-         friend bool operator == ( const public_key& p1, const public_key& p2);
-         friend bool operator != ( const public_key& p1, const public_key& p2);
-         friend bool operator < ( const public_key& p1, const public_key& p2);
+         friend bool operator==( const public_key& p1, const public_key& p2);
+         friend bool operator!=( const public_key& p1, const public_key& p2);
+         friend bool operator<( const public_key& p1, const public_key& p2);
          friend struct reflector<public_key>;
          friend class private_key;
    }; // public_key

--- a/libraries/libfc/src/crypto/private_key.cpp
+++ b/libraries/libfc/src/crypto/private_key.cpp
@@ -124,16 +124,11 @@ namespace fc { namespace crypto {
       return std::string(config::private_key_base_prefix) + "_" + data_str;
    }
 
-   std::ostream& operator<<(std::ostream& s, const private_key& k) {
-      s << "private_key(" << k.to_string() << ')';
-      return s;
-   }
-
-   bool operator == ( const private_key& p1, const private_key& p2) {
+   bool operator==( const private_key& p1, const private_key& p2 ) {
       return eq_comparator<private_key::storage_type>::apply(p1._storage, p2._storage);
    }
 
-   bool operator < ( const private_key& p1, const private_key& p2)
+   bool operator<( const private_key& p1, const private_key& p2 )
    {
       return less_comparator<private_key::storage_type>::apply(p1._storage, p2._storage);
    }

--- a/libraries/libfc/src/crypto/public_key.cpp
+++ b/libraries/libfc/src/crypto/public_key.cpp
@@ -84,6 +84,11 @@ namespace fc { namespace crypto {
       }
    }
 
+   std::ostream& operator<<(std::ostream& s, const public_key& k) {
+      s << "public_key(" << k.to_string({}) << ')';
+      return s;
+   }
+
    bool operator==( const public_key& p1, const public_key& p2) {
       return eq_comparator<public_key::storage_type>::apply(p1._storage, p2._storage);
    }

--- a/libraries/libfc/src/crypto/public_key.cpp
+++ b/libraries/libfc/src/crypto/public_key.cpp
@@ -84,20 +84,15 @@ namespace fc { namespace crypto {
       }
    }
 
-   std::ostream& operator<<(std::ostream& s, const public_key& k) {
-      s << "public_key(" << k.to_string() << ')';
-      return s;
-   }
-
-   bool operator == ( const public_key& p1, const public_key& p2) {
+   bool operator==( const public_key& p1, const public_key& p2) {
       return eq_comparator<public_key::storage_type>::apply(p1._storage, p2._storage);
    }
 
-   bool operator != ( const public_key& p1, const public_key& p2) {
+   bool operator!=( const public_key& p1, const public_key& p2) {
       return !(p1 == p2);
    }
 
-   bool operator < ( const public_key& p1, const public_key& p2)
+   bool operator<( const public_key& p1, const public_key& p2)
    {
       return less_comparator<public_key::storage_type>::apply(p1._storage, p2._storage);
    }

--- a/libraries/libfc/test/crypto/test_cypher_suites.cpp
+++ b/libraries/libfc/test/crypto/test_cypher_suites.cpp
@@ -15,8 +15,8 @@ BOOST_AUTO_TEST_CASE(test_k1) try {
    auto test_private_key = private_key(private_key_string);
    auto test_public_key = test_private_key.get_public_key();
 
-   BOOST_CHECK_EQUAL(private_key_string, test_private_key.to_string());
-   BOOST_CHECK_EQUAL(expected_public_key, test_public_key.to_string());
+   BOOST_CHECK_EQUAL(private_key_string, test_private_key.to_string({}));
+   BOOST_CHECK_EQUAL(expected_public_key, test_public_key.to_string({}));
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(test_r1) try {
@@ -25,8 +25,8 @@ BOOST_AUTO_TEST_CASE(test_r1) try {
    auto test_private_key = private_key(private_key_string);
    auto test_public_key = test_private_key.get_public_key();
 
-   BOOST_CHECK_EQUAL(private_key_string, test_private_key.to_string());
-   BOOST_CHECK_EQUAL(expected_public_key, test_public_key.to_string());
+   BOOST_CHECK_EQUAL(private_key_string, test_private_key.to_string({}));
+   BOOST_CHECK_EQUAL(expected_public_key, test_public_key.to_string({}));
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(test_k1_recovery) try {
@@ -37,9 +37,9 @@ BOOST_AUTO_TEST_CASE(test_k1_recovery) try {
    auto sig = key.sign(digest);
 
    auto recovered_pub = public_key(sig, digest);
-   std::cout << recovered_pub << std::endl;
+   std::cout << recovered_pub.to_string({}) << std::endl;
 
-   BOOST_CHECK_EQUAL(recovered_pub.to_string(), pub.to_string());
+   BOOST_CHECK_EQUAL(recovered_pub.to_string({}), pub.to_string({}));
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(test_r1_recovery) try {
@@ -50,31 +50,31 @@ BOOST_AUTO_TEST_CASE(test_r1_recovery) try {
    auto sig = key.sign(digest);
 
    auto recovered_pub = public_key(sig, digest);
-   std::cout << recovered_pub << std::endl;
+   std::cout << recovered_pub.to_string({}) << std::endl;
 
-   BOOST_CHECK_EQUAL(recovered_pub.to_string(), pub.to_string());
+   BOOST_CHECK_EQUAL(recovered_pub.to_string({}), pub.to_string({}));
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(test_k1_recyle) try {
    auto key = private_key::generate<ecc::private_key_shim>();
    auto pub = key.get_public_key();
-   auto pub_str = pub.to_string();
+   auto pub_str = pub.to_string({});
    auto recycled_pub = public_key(pub_str);
 
-   std::cout << pub << " -> " << recycled_pub << std::endl;
+   std::cout << pub.to_string({}) << " -> " << recycled_pub.to_string({}) << std::endl;
 
-   BOOST_CHECK_EQUAL(pub.to_string(), recycled_pub.to_string());
+   BOOST_CHECK_EQUAL(pub.to_string({}), recycled_pub.to_string({}));
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(test_r1_recyle) try {
    auto key = private_key::generate<r1::private_key_shim>();
    auto pub = key.get_public_key();
-   auto pub_str = pub.to_string();
+   auto pub_str = pub.to_string({});
    auto recycled_pub = public_key(pub_str);
 
-   std::cout << pub << " -> " << recycled_pub << std::endl;
+   std::cout << pub.to_string({}) << " -> " << recycled_pub.to_string({}) << std::endl;
 
-   BOOST_CHECK_EQUAL(pub.to_string(), recycled_pub.to_string());
+   BOOST_CHECK_EQUAL(pub.to_string({}), recycled_pub.to_string({}));
 } FC_LOG_AND_RETHROW();
 
 

--- a/libraries/state_history/include/eosio/state_history/serialization.hpp
+++ b/libraries/state_history/include/eosio/state_history/serialization.hpp
@@ -396,7 +396,7 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper<eosi
 
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper_stateless<eosio::chain::shared_key_weight>& obj) {
-   fc::raw::pack(ds, as_type<eosio::chain::public_key_type>(obj.obj.key));
+   fc::raw::pack(ds, as_type<eosio::chain::public_key_type>(obj.obj.key.to_public_key()));
    fc::raw::pack(ds, as_type<uint16_t>(obj.obj.weight));
    return ds;
 }

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -176,8 +176,7 @@ namespace eosio::chain_apis {
 
          // for each key, add this permission info's non-owning reference to the bimap for keys
          for (const auto& k: po.auth.keys) {
-            chain::public_key_type key = k.key;
-            key_bimap.insert(key_bimap_t::value_type {{std::move(key), k.weight}, pi});
+            key_bimap.insert(key_bimap_t::value_type {{k.key.to_public_key(), k.weight}, pi});
          }
       }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1050,8 +1050,8 @@ void producer_plugin::set_program_options(
          ("producer-name,p", boost::program_options::value<vector<string>>()->composing()->multitoken(),
           "ID of producer controlled by this node (e.g. inita; may specify multiple times)")
          ("signature-provider", boost::program_options::value<vector<string>>()->composing()->multitoken()->default_value(
-               {default_priv_key.get_public_key().to_string() + "=KEY:" + default_priv_key.to_string()},
-                default_priv_key.get_public_key().to_string() + "=KEY:" + default_priv_key.to_string()),
+               {default_priv_key.get_public_key().to_string({}) + "=KEY:" + default_priv_key.to_string({})},
+                default_priv_key.get_public_key().to_string({}) + "=KEY:" + default_priv_key.to_string({})),
                app().get_plugin<signature_provider_plugin>().signature_provider_help_text())
          ("greylist-account", boost::program_options::value<vector<string>>()->composing()->multitoken(),
           "account that can not access to extended CPU/NET virtual resources")

--- a/plugins/wallet_plugin/wallet.cpp
+++ b/plugins/wallet_plugin/wallet.cpp
@@ -181,8 +181,8 @@ public:
       else
          EOS_THROW(chain::unsupported_key_type_exception, "Key type \"${kt}\" not supported by software wallet", ("kt", key_type));
 
-      import_key(priv_key.to_string());
-      return priv_key.get_public_key().to_string();
+      import_key(priv_key.to_string({}));
+      return priv_key.get_public_key().to_string({});
    }
 
    bool load_wallet_file(string wallet_filename = "")

--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -12,8 +12,7 @@ constexpr auto password_prefix = "PW";
 
 std::string gen_password() {
    auto key = private_key_type::generate();
-   return password_prefix + key.to_string();
-
+   return password_prefix + key.to_string({});
 }
 
 bool valid_filename(const string& name) {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2466,7 +2466,7 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
 
          const char *sep = "";
          for ( auto it = p.required_auth.keys.begin(); it != p.required_auth.keys.end(); ++it ) {
-            std::cout << sep << it->weight << ' ' << it->key.to_string();
+            std::cout << sep << it->weight << ' ' << it->key.to_string({});
             sep = ", ";
          }
          for ( auto& acc : p.required_auth.accounts ) {
@@ -2841,8 +2841,8 @@ int main( int argc, char** argv ) {
       }
 
       auto pk    = r1 ? private_key_type::generate_r1() : private_key_type::generate();
-      auto privs = pk.to_string();
-      auto pubs  = pk.get_public_key().to_string();
+      auto privs = pk.to_string({});
+      auto pubs  = pk.get_public_key().to_string({});
       if (print_console) {
          std::cout << localized("Private key: ${key}", ("key",  privs) ) << std::endl;
          std::cout << localized("Public key: ${key}", ("key", pubs ) ) << std::endl;
@@ -3748,7 +3748,7 @@ int main( int argc, char** argv ) {
 
       fc::variants vs = {fc::variant(wallet_name), fc::variant(wallet_key)};
       call(wallet_url, wallet_import_key, vs);
-      std::cout << localized("imported private key for: ${pubkey}", ("pubkey", pubkey.to_string())) << std::endl;
+      std::cout << localized("imported private key for: ${pubkey}", ("pubkey", pubkey.to_string({}))) << std::endl;
    });
 
    // remove keys from wallet

--- a/tests/trx_generator/trx_generator.hpp
+++ b/tests/trx_generator/trx_generator.hpp
@@ -148,7 +148,7 @@ namespace eosio::testing {
          }
          ss << " ] keys: [ ";
          for(size_t i = 0; i < _priv_keys_vec.size(); ++i) {
-               ss << _priv_keys_vec.at(i).to_string();
+               ss << _priv_keys_vec.at(i).to_string({});
                if(i < _priv_keys_vec.size() - 1) {
                   ss << ", ";
                }

--- a/tests/wallet_tests.cpp
+++ b/tests/wallet_tests.cpp
@@ -32,12 +32,12 @@ BOOST_AUTO_TEST_CASE(wallet_test)
 
    auto priv = fc::crypto::private_key::generate();
    auto pub = priv.get_public_key();
-   auto wif = priv.to_string();
+   auto wif = priv.to_string({});
    wallet.import_key(wif);
    BOOST_CHECK_EQUAL(1u, wallet.list_keys().size());
 
    auto privCopy = wallet.get_private_key(pub);
-   BOOST_CHECK_EQUAL(wif, privCopy.to_string());
+   BOOST_CHECK_EQUAL(wif, privCopy.to_string({}));
 
    wallet.lock();
    BOOST_CHECK(wallet.is_locked());
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(wallet_test)
    BOOST_CHECK_EQUAL(1u, wallet2.list_keys().size());
 
    auto privCopy2 = wallet2.get_private_key(pub);
-   BOOST_CHECK_EQUAL(wif, privCopy2.to_string());
+   BOOST_CHECK_EQUAL(wif, privCopy2.to_string({}));
 
    std::filesystem::remove("wallet_test.json");
 } FC_LOG_AND_RETHROW() }
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(wallet_manager_test)
    // key3 was not automatically imported
    BOOST_CHECK(std::find(keys.cbegin(), keys.cend(), pub_pri_pair(key3)) == keys.cend());
 
-   wm.remove_key("test", pw, pub_pri_pair(key2).first.to_string());
+   wm.remove_key("test", pw, pub_pri_pair(key2).first.to_string({}));
    BOOST_CHECK_EQUAL(1u, wm.get_public_keys().size());
    keys = wm.list_keys("test", pw);
    BOOST_CHECK(std::find(keys.cbegin(), keys.cend(), pub_pri_pair(key2)) == keys.cend());
@@ -123,9 +123,9 @@ BOOST_AUTO_TEST_CASE(wallet_manager_test)
    BOOST_CHECK_EQUAL(2u, wm.get_public_keys().size());
    keys = wm.list_keys("test", pw);
    BOOST_CHECK(std::find(keys.cbegin(), keys.cend(), pub_pri_pair(key2)) != keys.cend());
-   BOOST_CHECK_THROW(wm.remove_key("test", pw, pub_pri_pair(key3).first.to_string()), fc::exception);
+   BOOST_CHECK_THROW(wm.remove_key("test", pw, pub_pri_pair(key3).first.to_string({})), fc::exception);
    BOOST_CHECK_EQUAL(2u, wm.get_public_keys().size());
-   BOOST_CHECK_THROW(wm.remove_key("test", "PWnogood", pub_pri_pair(key2).first.to_string()), wallet_invalid_password_exception);
+   BOOST_CHECK_THROW(wm.remove_key("test", "PWnogood", pub_pri_pair(key2).first.to_string({})), wallet_invalid_password_exception);
    BOOST_CHECK_EQUAL(2u, wm.get_public_keys().size());
 
    wm.lock("test");
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(wallet_manager_test)
       //now pluck out the private key from the wallet and see if the public key of said
       // private key matches what was returned earlier from the create_key() call
       private_key_type create_key_priv(wm.list_keys("testgen", pw).cbegin()->second);
-      BOOST_CHECK_EQUAL(create_key_pub.to_string(), create_key_priv.get_public_key().to_string());
+      BOOST_CHECK_EQUAL(create_key_pub.to_string({}), create_key_priv.get_public_key().to_string({}));
 
       wm.lock("testgen");
       BOOST_CHECK(std::filesystem::exists("testgen.wallet"));

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -961,9 +961,9 @@ BOOST_AUTO_TEST_CASE(updateauth_test)
    BOOST_TEST(updauth.auth.threshold == updateauth2.auth.threshold);
 
    BOOST_TEST_REQUIRE(updauth.auth.keys.size() == updateauth2.auth.keys.size());
-   BOOST_TEST((updauth.auth.keys[0].key == updateauth2.auth.keys[0].key));
+   BOOST_TEST(updauth.auth.keys[0].key == updateauth2.auth.keys[0].key);
    BOOST_TEST(updauth.auth.keys[0].weight == updateauth2.auth.keys[0].weight);
-   BOOST_TEST((updauth.auth.keys[1].key == updateauth2.auth.keys[1].key));
+   BOOST_TEST(updauth.auth.keys[1].key == updateauth2.auth.keys[1].key);
    BOOST_TEST(updauth.auth.keys[1].weight == updateauth2.auth.keys[1].weight);
 
    BOOST_TEST_REQUIRE(updauth.auth.accounts.size() == updateauth2.auth.accounts.size());
@@ -1081,9 +1081,9 @@ BOOST_AUTO_TEST_CASE(newaccount_test)
    BOOST_TEST(newacct.owner.threshold == newaccount2.owner.threshold);
 
    BOOST_TEST_REQUIRE(newacct.owner.keys.size() == newaccount2.owner.keys.size());
-   BOOST_TEST((newacct.owner.keys[0].key == newaccount2.owner.keys[0].key));
+   BOOST_TEST(newacct.owner.keys[0].key == newaccount2.owner.keys[0].key);
    BOOST_TEST(newacct.owner.keys[0].weight == newaccount2.owner.keys[0].weight);
-   BOOST_TEST((newacct.owner.keys[1].key == newaccount2.owner.keys[1].key));
+   BOOST_TEST(newacct.owner.keys[1].key == newaccount2.owner.keys[1].key);
    BOOST_TEST(newacct.owner.keys[1].weight == newaccount2.owner.keys[1].weight);
 
    BOOST_TEST_REQUIRE(newacct.owner.accounts.size() == newaccount2.owner.accounts.size());
@@ -1097,9 +1097,9 @@ BOOST_AUTO_TEST_CASE(newaccount_test)
    BOOST_TEST(newacct.active.threshold == newaccount2.active.threshold);
 
    BOOST_TEST_REQUIRE(newacct.active.keys.size() == newaccount2.active.keys.size());
-   BOOST_TEST((newacct.active.keys[0].key == newaccount2.active.keys[0].key));
+   BOOST_TEST(newacct.active.keys[0].key == newaccount2.active.keys[0].key);
    BOOST_TEST(newacct.active.keys[0].weight == newaccount2.active.keys[0].weight);
-   BOOST_TEST((newacct.active.keys[1].key == newaccount2.active.keys[1].key));
+   BOOST_TEST(newacct.active.keys[1].key == newaccount2.active.keys[1].key);
    BOOST_TEST(newacct.active.keys[1].weight == newaccount2.active.keys[1].weight);
 
    BOOST_TEST_REQUIRE(newacct.active.accounts.size() == newaccount2.active.accounts.size());

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -939,9 +939,9 @@ BOOST_AUTO_TEST_CASE(updateauth_test)
    BOOST_TEST(2147483145u == updauth.auth.threshold);
 
    BOOST_TEST_REQUIRE(2u == updauth.auth.keys.size());
-   BOOST_TEST("EOS65rXebLhtk2aTTzP4e9x1AQZs7c5NNXJp89W8R3HyaA6Zyd4im" == updauth.auth.keys[0].key.to_string());
+   BOOST_TEST("EOS65rXebLhtk2aTTzP4e9x1AQZs7c5NNXJp89W8R3HyaA6Zyd4im" == updauth.auth.keys[0].key.to_string({}));
    BOOST_TEST(57005u == updauth.auth.keys[0].weight);
-   BOOST_TEST("EOS5eVr9TVnqwnUBNwf9kwMTbrHvX5aPyyEG97dz2b2TNeqWRzbJf" == updauth.auth.keys[1].key.to_string());
+   BOOST_TEST("EOS5eVr9TVnqwnUBNwf9kwMTbrHvX5aPyyEG97dz2b2TNeqWRzbJf" == updauth.auth.keys[1].key.to_string({}));
    BOOST_TEST(57605u == updauth.auth.keys[1].weight);
 
    BOOST_TEST_REQUIRE(2u == updauth.auth.accounts.size());
@@ -961,9 +961,9 @@ BOOST_AUTO_TEST_CASE(updateauth_test)
    BOOST_TEST(updauth.auth.threshold == updateauth2.auth.threshold);
 
    BOOST_TEST_REQUIRE(updauth.auth.keys.size() == updateauth2.auth.keys.size());
-   BOOST_TEST(updauth.auth.keys[0].key == updateauth2.auth.keys[0].key);
+   BOOST_TEST((updauth.auth.keys[0].key == updateauth2.auth.keys[0].key));
    BOOST_TEST(updauth.auth.keys[0].weight == updateauth2.auth.keys[0].weight);
-   BOOST_TEST(updauth.auth.keys[1].key == updateauth2.auth.keys[1].key);
+   BOOST_TEST((updauth.auth.keys[1].key == updateauth2.auth.keys[1].key));
    BOOST_TEST(updauth.auth.keys[1].weight == updateauth2.auth.keys[1].weight);
 
    BOOST_TEST_REQUIRE(updauth.auth.accounts.size() == updateauth2.auth.accounts.size());
@@ -1043,9 +1043,9 @@ BOOST_AUTO_TEST_CASE(newaccount_test)
    BOOST_TEST(2147483145u == newacct.owner.threshold);
 
    BOOST_TEST_REQUIRE(2u == newacct.owner.keys.size());
-   BOOST_TEST("EOS65rXebLhtk2aTTzP4e9x1AQZs7c5NNXJp89W8R3HyaA6Zyd4im" == newacct.owner.keys[0].key.to_string());
+   BOOST_TEST("EOS65rXebLhtk2aTTzP4e9x1AQZs7c5NNXJp89W8R3HyaA6Zyd4im" == newacct.owner.keys[0].key.to_string({}));
    BOOST_TEST(57005u == newacct.owner.keys[0].weight);
-   BOOST_TEST("EOS5eVr9TVnqwnUBNwf9kwMTbrHvX5aPyyEG97dz2b2TNeqWRzbJf" == newacct.owner.keys[1].key.to_string());
+   BOOST_TEST("EOS5eVr9TVnqwnUBNwf9kwMTbrHvX5aPyyEG97dz2b2TNeqWRzbJf" == newacct.owner.keys[1].key.to_string({}));
    BOOST_TEST(57605u == newacct.owner.keys[1].weight);
 
    BOOST_TEST_REQUIRE(2u == newacct.owner.accounts.size());
@@ -1059,9 +1059,9 @@ BOOST_AUTO_TEST_CASE(newaccount_test)
    BOOST_TEST(2146483145u == newacct.active.threshold);
 
    BOOST_TEST_REQUIRE(2u == newacct.active.keys.size());
-   BOOST_TEST("EOS65rXebLhtk2aTTzP4e9x1AQZs7c5NNXJp89W8R3HyaA6Zyd4im" == newacct.active.keys[0].key.to_string());
+   BOOST_TEST("EOS65rXebLhtk2aTTzP4e9x1AQZs7c5NNXJp89W8R3HyaA6Zyd4im" == newacct.active.keys[0].key.to_string({}));
    BOOST_TEST(57005u == newacct.active.keys[0].weight);
-   BOOST_TEST("EOS5eVr9TVnqwnUBNwf9kwMTbrHvX5aPyyEG97dz2b2TNeqWRzbJf" == newacct.active.keys[1].key.to_string());
+   BOOST_TEST("EOS5eVr9TVnqwnUBNwf9kwMTbrHvX5aPyyEG97dz2b2TNeqWRzbJf" == newacct.active.keys[1].key.to_string({}));
    BOOST_TEST(57605u == newacct.active.keys[1].weight);
 
    BOOST_TEST_REQUIRE(2u == newacct.active.accounts.size());
@@ -1081,9 +1081,9 @@ BOOST_AUTO_TEST_CASE(newaccount_test)
    BOOST_TEST(newacct.owner.threshold == newaccount2.owner.threshold);
 
    BOOST_TEST_REQUIRE(newacct.owner.keys.size() == newaccount2.owner.keys.size());
-   BOOST_TEST(newacct.owner.keys[0].key == newaccount2.owner.keys[0].key);
+   BOOST_TEST((newacct.owner.keys[0].key == newaccount2.owner.keys[0].key));
    BOOST_TEST(newacct.owner.keys[0].weight == newaccount2.owner.keys[0].weight);
-   BOOST_TEST(newacct.owner.keys[1].key == newaccount2.owner.keys[1].key);
+   BOOST_TEST((newacct.owner.keys[1].key == newaccount2.owner.keys[1].key));
    BOOST_TEST(newacct.owner.keys[1].weight == newaccount2.owner.keys[1].weight);
 
    BOOST_TEST_REQUIRE(newacct.owner.accounts.size() == newaccount2.owner.accounts.size());
@@ -1097,9 +1097,9 @@ BOOST_AUTO_TEST_CASE(newaccount_test)
    BOOST_TEST(newacct.active.threshold == newaccount2.active.threshold);
 
    BOOST_TEST_REQUIRE(newacct.active.keys.size() == newaccount2.active.keys.size());
-   BOOST_TEST(newacct.active.keys[0].key == newaccount2.active.keys[0].key);
+   BOOST_TEST((newacct.active.keys[0].key == newaccount2.active.keys[0].key));
    BOOST_TEST(newacct.active.keys[0].weight == newaccount2.active.keys[0].weight);
-   BOOST_TEST(newacct.active.keys[1].key == newaccount2.active.keys[1].key);
+   BOOST_TEST((newacct.active.keys[1].key == newaccount2.active.keys[1].key));
    BOOST_TEST(newacct.active.keys[1].weight == newaccount2.active.keys[1].weight);
 
    BOOST_TEST_REQUIRE(newacct.active.accounts.size() == newaccount2.active.accounts.size());

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -62,19 +62,19 @@ BOOST_FIXTURE_TEST_CASE( delegate_auth, validating_tester ) { try {
                             { .permission = {"bob"_n,config::active_name}, .weight = 1}
                           });
 
-   auto original_auth = static_cast<authority>(control->get_authorization_manager().get_permission({"alice"_n, config::active_name}).auth);
+   auto original_auth = control->get_authorization_manager().get_permission({"alice"_n, config::active_name}).auth.to_authority();
    wdump((original_auth));
 
    set_authority( "alice"_n, config::active_name,  delegated_auth );
 
-   auto new_auth = static_cast<authority>(control->get_authorization_manager().get_permission({"alice"_n, config::active_name}).auth);
+   auto new_auth = control->get_authorization_manager().get_permission({"alice"_n, config::active_name}).auth.to_authority();
    wdump((new_auth));
    BOOST_CHECK_EQUAL((new_auth == delegated_auth), true);
 
    produce_block();
    produce_block();
 
-   auto auth = static_cast<authority>(control->get_authorization_manager().get_permission({"alice"_n, config::active_name}).auth);
+   auto auth = control->get_authorization_manager().get_permission({"alice"_n, config::active_name}).auth.to_authority();
    wdump((auth));
    BOOST_CHECK_EQUAL((new_auth == auth), true);
 
@@ -116,7 +116,8 @@ try {
       BOOST_TEST(auth.threshold == 1u);
       BOOST_TEST(auth.keys.size() == 1u);
       BOOST_TEST(auth.accounts.size() == 0u);
-      BOOST_TEST(auth.keys[0].key == new_owner_pub_key);
+      BOOST_TEST(auth.keys[0].key.to_string({}) == new_owner_pub_key.to_string({}));
+      BOOST_TEST((auth.keys[0].key == new_owner_pub_key));
       BOOST_TEST(auth.keys[0].weight == 1);
    }
 
@@ -137,7 +138,7 @@ try {
       BOOST_TEST(auth.threshold == 1u);
       BOOST_TEST(auth.keys.size() == 1u);
       BOOST_TEST(auth.accounts.size() == 0u);
-      BOOST_TEST(auth.keys[0].key == new_active_pub_key);
+      BOOST_TEST((auth.keys[0].key == new_active_pub_key));
       BOOST_TEST(auth.keys[0].weight == 1u);
    }
 
@@ -166,10 +167,10 @@ try {
    }
 
    // Update spending auth parent to be its own, should fail
-   BOOST_CHECK_THROW(chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("spending"),
+   BOOST_CHECK_THROW(chain.set_authority(name("alice"), name("spending"), authority{spending_pub_key}, name("spending"),
                                          { permission_level{name("alice"), name("spending")} }, { spending_priv_key }), action_validate_exception);
    // Update spending auth parent to be owner, should fail
-   BOOST_CHECK_THROW(chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("owner"),
+   BOOST_CHECK_THROW(chain.set_authority(name("alice"), name("spending"), authority{spending_pub_key}, name("owner"),
                                          { permission_level{name("alice"), name("spending")} }, { spending_priv_key }), action_validate_exception);
 
    // Remove spending auth
@@ -181,10 +182,10 @@ try {
    chain.produce_blocks();
 
    // Create new trading auth
-   chain.set_authority(name("alice"), name("trading"), trading_pub_key, name("active"),
+   chain.set_authority(name("alice"), name("trading"), authority{trading_pub_key}, name("active"),
                        { permission_level{name("alice"), name("active")} }, { new_active_priv_key });
    // Recreate spending auth again, however this time, it's under trading instead of owner
-   chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("trading"),
+   chain.set_authority(name("alice"), name("spending"), authority{spending_pub_key}, name("trading"),
                        { permission_level{name("alice"), name("trading")} }, { trading_priv_key });
    chain.produce_blocks();
 
@@ -208,7 +209,7 @@ try {
    BOOST_CHECK_THROW(chain.delete_authority(name("alice"), name("trading"),
                                             { permission_level{name("alice"), name("active")} }, { new_active_priv_key }), action_validate_exception);
    // Update trading parent to be spending, should fail since changing parent authority is not supported
-   BOOST_CHECK_THROW(chain.set_authority(name("alice"), name("trading"), trading_pub_key, name("spending"),
+   BOOST_CHECK_THROW(chain.set_authority(name("alice"), name("trading"), authority{trading_pub_key}, name("spending"),
                                          { permission_level{name("alice"), name("trading")} }, { trading_priv_key }), action_validate_exception);
 
    // Delete spending auth
@@ -249,7 +250,7 @@ BOOST_AUTO_TEST_CASE(update_auth_unknown_private_key) {
          BOOST_TEST(auth.threshold == 1u);
          BOOST_TEST(auth.keys.size() == 1u);
          BOOST_TEST(auth.accounts.size() == 0u);
-         BOOST_TEST(auth.keys[0].key == new_owner_pub_key);
+         BOOST_TEST((auth.keys[0].key == new_owner_pub_key));
          BOOST_TEST(auth.keys[0].weight == 1);
       }
    } FC_LOG_AND_RETHROW()
@@ -265,8 +266,8 @@ BOOST_AUTO_TEST_CASE(link_auths) { try {
    const auto scud_priv_key = chain.get_private_key(name("alice"), "scud");
    const auto scud_pub_key = scud_priv_key.get_public_key();
 
-   chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("active"));
-   chain.set_authority(name("alice"), name("scud"), scud_pub_key, name("spending"));
+   chain.set_authority(name("alice"), name("spending"), authority{spending_pub_key}, name("active"));
+   chain.set_authority(name("alice"), name("scud"), authority{scud_pub_key}, name("spending"));
 
    // Send req auth action with alice's spending key, it should fail
    BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("spending")} }, { spending_priv_key }), irrelevant_auth_exception);
@@ -308,7 +309,7 @@ BOOST_AUTO_TEST_CASE(link_then_update_auth) { try {
    const auto second_priv_key = chain.get_private_key(name("alice"), "second");
    const auto second_pub_key = second_priv_key.get_public_key();
 
-   chain.set_authority(name("alice"), name("first"), first_pub_key, name("active"));
+   chain.set_authority(name("alice"), name("first"), authority{first_pub_key}, name("active"));
 
    chain.link_authority(name("alice"), name("eosio"), name("first"), name("reqauth"));
    chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("first")} }, { first_priv_key });
@@ -316,7 +317,7 @@ BOOST_AUTO_TEST_CASE(link_then_update_auth) { try {
    chain.produce_blocks(13); // Wait at least 6 seconds for first push_reqauth transaction to expire.
 
    // Update "first" auth public key
-   chain.set_authority(name("alice"), name("first"), second_pub_key, name("active"));
+   chain.set_authority(name("alice"), name("first"), authority{second_pub_key}, name("active"));
    // Authority updated, using previous "first" auth should fail on linked auth
    BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("first")} }, { first_priv_key }), unsatisfied_authorization);
    // Using updated authority, should succeed
@@ -335,14 +336,14 @@ try {
    BOOST_TEST(joe_owner_authority.auth.threshold == 1u);
    BOOST_TEST(joe_owner_authority.auth.accounts.size() == 1u);
    BOOST_TEST(joe_owner_authority.auth.keys.size() == 1u);
-   BOOST_TEST(joe_owner_authority.auth.keys[0].key.to_string() == chain.get_public_key(name("joe"), "owner").to_string());
+   BOOST_TEST(joe_owner_authority.auth.keys[0].key.to_string({}) == chain.get_public_key(name("joe"), "owner").to_string({}));
    BOOST_TEST(joe_owner_authority.auth.keys[0].weight == 1u);
 
    const auto& joe_active_authority = chain.get<permission_object, by_owner>(boost::make_tuple(name("joe"), name("active")));
    BOOST_TEST(joe_active_authority.auth.threshold == 1u);
    BOOST_TEST(joe_active_authority.auth.accounts.size() == 1u);
    BOOST_TEST(joe_active_authority.auth.keys.size() == 1u);
-   BOOST_TEST(joe_active_authority.auth.keys[0].key.to_string() == chain.get_public_key(name("joe"), "active").to_string());
+   BOOST_TEST(joe_active_authority.auth.keys[0].key.to_string({}) == chain.get_public_key(name("joe"), "active").to_string({}));
    BOOST_TEST(joe_active_authority.auth.keys[0].weight == 1u);
 
    // Create duplicate name
@@ -372,8 +373,8 @@ BOOST_AUTO_TEST_CASE( any_auth ) { try {
    const auto spending_pub_key = spending_priv_key.get_public_key();
    const auto bob_spending_pub_key = spending_priv_key.get_public_key();
 
-   chain.set_authority(name("alice"), name("spending"), spending_pub_key, name("active"));
-   chain.set_authority(name("bob"), name("spending"), bob_spending_pub_key, name("active"));
+   chain.set_authority(name("alice"), name("spending"), authority{spending_pub_key}, name("active"));
+   chain.set_authority(name("bob"), name("spending"), authority{bob_spending_pub_key}, name("active"));
 
    /// this should fail because spending is not active which is default for reqauth
    BOOST_REQUIRE_THROW( chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("spending")} }, { spending_priv_key }),

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -117,7 +117,7 @@ try {
       BOOST_TEST(auth.keys.size() == 1u);
       BOOST_TEST(auth.accounts.size() == 0u);
       BOOST_TEST(auth.keys[0].key.to_string({}) == new_owner_pub_key.to_string({}));
-      BOOST_TEST((auth.keys[0].key == new_owner_pub_key));
+      BOOST_TEST(auth.keys[0].key == new_owner_pub_key);
       BOOST_TEST(auth.keys[0].weight == 1);
    }
 
@@ -138,7 +138,7 @@ try {
       BOOST_TEST(auth.threshold == 1u);
       BOOST_TEST(auth.keys.size() == 1u);
       BOOST_TEST(auth.accounts.size() == 0u);
-      BOOST_TEST((auth.keys[0].key == new_active_pub_key));
+      BOOST_TEST(auth.keys[0].key == new_active_pub_key);
       BOOST_TEST(auth.keys[0].weight == 1u);
    }
 
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(update_auth_unknown_private_key) {
          BOOST_TEST(auth.threshold == 1u);
          BOOST_TEST(auth.keys.size() == 1u);
          BOOST_TEST(auth.accounts.size() == 0u);
-         BOOST_TEST((auth.keys[0].key == new_owner_pub_key));
+         BOOST_TEST(auth.keys[0].key == new_owner_pub_key);
          BOOST_TEST(auth.keys[0].weight == 1);
       }
    } FC_LOG_AND_RETHROW()

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE( replace_producer_keys ) try {
    for(const auto& prod : head_ptr->active_schedule.producers) {
       BOOST_REQUIRE_EQUAL(std::get<block_signing_authority_v0>(prod.authority).threshold, expected_threshold);
       for(const auto& key : std::get<block_signing_authority_v0>(prod.authority).keys){
-         BOOST_REQUIRE_EQUAL(key.key, new_key);
+         BOOST_REQUIRE((key.key == new_key));
          BOOST_REQUIRE_EQUAL(key.weight, expected_key_weight);
        }
    }

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE( replace_producer_keys ) try {
    for(const auto& prod : head_ptr->active_schedule.producers) {
       BOOST_REQUIRE_EQUAL(std::get<block_signing_authority_v0>(prod.authority).threshold, expected_threshold);
       for(const auto& key : std::get<block_signing_authority_v0>(prod.authority).keys){
-         BOOST_REQUIRE((key.key == new_key));
+         BOOST_REQUIRE_EQUAL(key.key, new_key);
          BOOST_REQUIRE_EQUAL(key.weight, expected_key_weight);
        }
    }

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -943,7 +943,7 @@ BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
       // again, can be called multiple times, current implementation it is just an attribute of transaction_metadata
       const auto& keys2 = mtrx->recovered_keys();
       BOOST_CHECK_EQUAL(1u, keys2.size());
-      BOOST_CHECK((public_key == *keys2.begin()));
+      BOOST_CHECK_EQUAL(public_key, *keys2.begin());
 
       auto mtrx2 = fut2.get();
       const auto& keys3 = mtrx2->recovered_keys();

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -579,9 +579,9 @@ BOOST_AUTO_TEST_CASE(authority_checker)
    // Fails due to short recursion depth limit
    BOOST_TEST(!make_auth_checker(GetAuthority, 1, {d, e}).satisfied(A));
 
-   BOOST_TEST((b < a));
-   BOOST_TEST((b < c));
-   BOOST_TEST((a < c));
+   BOOST_TEST(b < a);
+   BOOST_TEST(b < c);
+   BOOST_TEST(a < c);
    {
       // valid key order: b < a < c
       A = authority(2, {key_weight{b, 1}, key_weight{a, 1}, key_weight{c, 1}});
@@ -776,11 +776,11 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    flat_set<public_key_type> keys;
    auto cpu_time1 = pkt.get_signed_transaction().get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
    BOOST_CHECK_EQUAL(1u, keys.size());
-   BOOST_CHECK((public_key == *keys.begin()));
+   BOOST_CHECK_EQUAL(public_key, *keys.begin());
    keys.clear();
    auto cpu_time2 = pkt.get_signed_transaction().get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
    BOOST_CHECK_EQUAL(1u, keys.size());
-   BOOST_CHECK((public_key == *keys.begin()));
+   BOOST_CHECK_EQUAL(public_key, *keys.begin());
 
    BOOST_CHECK(cpu_time1 > fc::microseconds(0));
    BOOST_CHECK(cpu_time2 > fc::microseconds(0));
@@ -823,7 +823,7 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    keys.clear();
    pkt4.get_signed_transaction().get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
    BOOST_CHECK_EQUAL(1u, keys.size());
-   BOOST_CHECK((public_key == *keys.begin()));
+   BOOST_CHECK_EQUAL(public_key, *keys.begin());
 
    // verify packed_transaction creation from packed data
    {
@@ -938,7 +938,7 @@ BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
       auto mtrx = fut.get();
       const auto& keys = mtrx->recovered_keys();
       BOOST_CHECK_EQUAL(1u, keys.size());
-      BOOST_CHECK((public_key == *keys.begin()));
+      BOOST_CHECK_EQUAL(public_key, *keys.begin());
 
       // again, can be called multiple times, current implementation it is just an attribute of transaction_metadata
       const auto& keys2 = mtrx->recovered_keys();
@@ -948,7 +948,7 @@ BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
       auto mtrx2 = fut2.get();
       const auto& keys3 = mtrx2->recovered_keys();
       BOOST_CHECK_EQUAL(1u, keys3.size());
-      BOOST_CHECK((public_key == *keys3.begin()));
+      BOOST_CHECK_EQUAL(public_key, *keys3.begin());
 
       thread_pool.stop();
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -579,9 +579,9 @@ BOOST_AUTO_TEST_CASE(authority_checker)
    // Fails due to short recursion depth limit
    BOOST_TEST(!make_auth_checker(GetAuthority, 1, {d, e}).satisfied(A));
 
-   BOOST_TEST(b < a);
-   BOOST_TEST(b < c);
-   BOOST_TEST(a < c);
+   BOOST_TEST((b < a));
+   BOOST_TEST((b < c));
+   BOOST_TEST((a < c));
    {
       // valid key order: b < a < c
       A = authority(2, {key_weight{b, 1}, key_weight{a, 1}, key_weight{c, 1}});
@@ -776,11 +776,11 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    flat_set<public_key_type> keys;
    auto cpu_time1 = pkt.get_signed_transaction().get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
    BOOST_CHECK_EQUAL(1u, keys.size());
-   BOOST_CHECK_EQUAL(public_key, *keys.begin());
+   BOOST_CHECK((public_key == *keys.begin()));
    keys.clear();
    auto cpu_time2 = pkt.get_signed_transaction().get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
    BOOST_CHECK_EQUAL(1u, keys.size());
-   BOOST_CHECK_EQUAL(public_key, *keys.begin());
+   BOOST_CHECK((public_key == *keys.begin()));
 
    BOOST_CHECK(cpu_time1 > fc::microseconds(0));
    BOOST_CHECK(cpu_time2 > fc::microseconds(0));
@@ -823,7 +823,7 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    keys.clear();
    pkt4.get_signed_transaction().get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
    BOOST_CHECK_EQUAL(1u, keys.size());
-   BOOST_CHECK_EQUAL(public_key, *keys.begin());
+   BOOST_CHECK((public_key == *keys.begin()));
 
    // verify packed_transaction creation from packed data
    {
@@ -938,17 +938,17 @@ BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
       auto mtrx = fut.get();
       const auto& keys = mtrx->recovered_keys();
       BOOST_CHECK_EQUAL(1u, keys.size());
-      BOOST_CHECK_EQUAL(public_key, *keys.begin());
+      BOOST_CHECK((public_key == *keys.begin()));
 
       // again, can be called multiple times, current implementation it is just an attribute of transaction_metadata
       const auto& keys2 = mtrx->recovered_keys();
       BOOST_CHECK_EQUAL(1u, keys2.size());
-      BOOST_CHECK_EQUAL(public_key, *keys2.begin());
+      BOOST_CHECK((public_key == *keys2.begin()));
 
       auto mtrx2 = fut2.get();
       const auto& keys3 = mtrx2->recovered_keys();
       BOOST_CHECK_EQUAL(1u, keys3.size());
-      BOOST_CHECK_EQUAL(public_key, *keys3.begin());
+      BOOST_CHECK((public_key == *keys3.begin()));
 
       thread_pool.stop();
 
@@ -1282,9 +1282,9 @@ BOOST_AUTO_TEST_CASE(public_key_from_hash) {
    auto test_public_key = test_private_key.get_public_key();
    fc::crypto::public_key eos_pk(expected_public_key);
 
-   BOOST_CHECK_EQUAL(private_key_string, test_private_key.to_string());
-   BOOST_CHECK_EQUAL(expected_public_key, test_public_key.to_string());
-   BOOST_CHECK_EQUAL(expected_public_key, eos_pk.to_string());
+   BOOST_CHECK_EQUAL(private_key_string, test_private_key.to_string({}));
+   BOOST_CHECK_EQUAL(expected_public_key, test_public_key.to_string({}));
+   BOOST_CHECK_EQUAL(expected_public_key, eos_pk.to_string({}));
 
    fc::ecc::public_key_data data;
    data.data[0] = 0x80; // not necessary, 0 also works

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_account_permission_creation_and_deletion) {
    BOOST_REQUIRE(ptr != nullptr);
 
    // Create new permission
-   chain.set_authority("newacc"_n, "mypermission"_n, ptr->auth,  "active"_n);
+   chain.set_authority("newacc"_n, "mypermission"_n, ptr->auth.to_authority(),  "active"_n);
 
    const permission_object* ptr_sub = authorization_manager.find_permission( {"newacc"_n, "mypermission"_n} );
    BOOST_REQUIRE(ptr_sub != nullptr);
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_account_permission_modification) {
       BOOST_REQUIRE_EQUAL(accounts_permissions[0].name.to_string(), "active");
       BOOST_REQUIRE_EQUAL(accounts_permissions[0].auth.keys.size(), 1u);
       if(key.which() != K1_storage_type_which_value)
-         BOOST_REQUIRE_EQUAL(public_key_to_string(accounts_permissions[0].auth.keys[0].key), key.to_string());
+         BOOST_REQUIRE_EQUAL(public_key_to_string(accounts_permissions[0].auth.keys[0].key), key.to_string({}));
       else
          BOOST_REQUIRE_EQUAL(public_key_to_string(accounts_permissions[0].auth.keys[0].key), "PUB_K1_12wkBET2rRgE8pahuaczxKbmv7ciehqsne57F9gtzf1PVb7Rf7o");
 
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_permission_link) {
    const auto spending_priv_key = chain.get_private_key("newacc"_n, "spending");
    const auto spending_pub_key = spending_priv_key.get_public_key();
 
-   chain.set_authority("newacc"_n, "spending"_n, spending_pub_key, "active"_n);
+   chain.set_authority("newacc"_n, "spending"_n, authority{spending_pub_key}, "active"_n);
    chain.link_authority("newacc"_n, "eosio"_n, "spending"_n, "reqauth"_n);
    chain.push_reqauth("newacc"_n, { permission_level{"newacc"_n, "spending"_n} }, { spending_priv_key });
 


### PR DESCRIPTION
This started as a PR to remove `operator<<` from `public_key` as `to_string()` which optionally takes a `yield` function should be used instead. In the process noticed some conversion operators that could be removed. Some of these changes are a bit opinionated, but this PR actually ends up making what I think is a good case for not using conversion operators. Note there are a few optimizations that were not obvious because the conversion operators "magically" provided a less than ideal implementation.

This PR does not remove `operator<<` from `public_key`  as that breaks tests in `libtester`. There are however, enough improvements that this PR is still worthwhile in my opinion.

I didn't add spaceship operators because this PR already changed more than I originally anticipated.