### PR TITLE
IF: Add thread safety to chain_pacemaker access of chain state

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -30,6 +30,7 @@ namespace eosio { namespace chain {
    using hs_new_view_message_ptr = std::shared_ptr<hs_new_view_message>;
    using hs_new_block_message_ptr = std::shared_ptr<hs_new_block_message>;
    struct finalizer_authority;
+   struct finalizer_set;
 
    class authorization_manager;
 
@@ -307,8 +308,8 @@ namespace eosio { namespace chain {
 
          int64_t set_proposed_producers( vector<producer_authority> producers );
 
-         void set_finalizers( uint64_t fthreshold, vector<finalizer_authority> finalizers );
-         std::pair<uint64_t, vector<finalizer_authority>> get_finalizers() const;
+         void set_finalizers( const finalizer_set& fin_set );
+         const finalizer_set& get_finalizers() const;
 
          bool light_validation_allowed() const;
          bool skip_auth_check()const;

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -158,6 +158,7 @@ namespace eosio { namespace chain { namespace webassembly {
       fc::raw::unpack(ds, finset);
       vector<finalizer_authority> & finalizers = finset.finalizers;
 
+      // TODO: check version and increment it or verify correct
       EOS_ASSERT( finalizers.size() <= config::max_finalizers, wasm_execution_error, "Finalizer set exceeds the maximum finalizer count for this chain" );
       EOS_ASSERT( finalizers.size() > 0, wasm_execution_error, "Finalizer set cannot be empty" );
 
@@ -177,7 +178,7 @@ namespace eosio { namespace chain { namespace webassembly {
       EOS_ASSERT( finalizers.size() == unique_finalizer_keys.size(), wasm_execution_error, "Duplicate finalizer bls key in finalizer set" );
       EOS_ASSERT( finset.fthreshold > f_weight_sum / 2, wasm_execution_error, "Finalizer set threshold cannot be met by finalizer weights" );
 
-      context.control.set_finalizers( finset.fthreshold, std::move(finalizers) );
+      context.control.set_finalizers( finset );
    }
 
    uint32_t interface::get_blockchain_parameters_packed( legacy_span<char> packed_blockchain_parameters ) const {

--- a/libraries/hotstuff/chain_pacemaker.cpp
+++ b/libraries/hotstuff/chain_pacemaker.cpp
@@ -105,18 +105,12 @@ namespace eosio { namespace hotstuff {
         _qc_chain("default"_n, this, std::move(my_producers), logger),
         _logger(logger)
    {
-   }
-
-   // Called internally by the chain_pacemaker to decide whether it should do something or not, based on feature activation.
-   // Only methods called by the outside need to call this; methods called by qc_chain only don't need to check for enable().
-   bool chain_pacemaker::enabled() const {
-      return _chain->is_builtin_activated( builtin_protocol_feature_t::instant_finality );
+      _accepted_block_connection = chain->accepted_block.connect( [this]( const block_state_ptr& blk ) {
+         on_accepted_block( blk );
+      } );
    }
 
    void chain_pacemaker::get_state(finalizer_state& fs) const {
-      if (! enabled())
-         return;
-
       // lock-free state version check
       uint64_t current_state_version = _qc_chain.get_state_version();
       if (_state_cache_version != current_state_version) {
@@ -139,12 +133,6 @@ namespace eosio { namespace hotstuff {
 
       std::shared_lock sl(_state_cache_mutex); // lock cache for reading
       fs = _state_cache;
-   }
-
-   name chain_pacemaker::get_proposer() {
-      const block_state_ptr& hbs = _chain->head_block_state();
-      name n = hbs->header.producer;
-      return n;
    }
 
    name chain_pacemaker::debug_leader_remap(name n) {
@@ -212,9 +200,22 @@ namespace eosio { namespace hotstuff {
       return n;
    }
 
+   // called from main thread
+   void chain_pacemaker::on_accepted_block( const block_state_ptr& blk ) {
+      std::scoped_lock g( _chain_state_mutex );
+      _head_block_state = blk;
+      _finalizer_set = _chain->get_finalizers(); // TODO get from chainbase or from block_state
+   }
+
+   name chain_pacemaker::get_proposer() {
+      std::scoped_lock g( _chain_state_mutex );
+      return _head_block_state->header.producer;
+   }
+
    name chain_pacemaker::get_leader() {
-      const block_state_ptr& hbs = _chain->head_block_state();
-      name n = hbs->header.producer;
+      std::unique_lock g( _chain_state_mutex );
+      name n = _head_block_state->header.producer;
+      g.unlock();
 
       // FIXME/REMOVE: testing leader/proposer separation
       n = debug_leader_remap(n);
@@ -223,10 +224,11 @@ namespace eosio { namespace hotstuff {
    }
 
    name chain_pacemaker::get_next_leader() {
-      const block_state_ptr& hbs = _chain->head_block_state();
-      block_timestamp_type next_block_time = hbs->header.timestamp.next();
-      producer_authority p_auth = hbs->get_scheduled_producer(next_block_time);
+      std::unique_lock g( _chain_state_mutex );
+      block_timestamp_type next_block_time = _head_block_state->header.timestamp.next();
+      producer_authority p_auth = _head_block_state->get_scheduled_producer(next_block_time);
       name n = p_auth.producer_name;
+      g.unlock();
 
       // FIXME/REMOVE: testing leader/proposer separation
       n = debug_leader_remap(n);
@@ -249,11 +251,11 @@ namespace eosio { namespace hotstuff {
       // - list of string finalizer descriptions instead of eosio name now
       // - also return the keys for each finalizer, not just name/description so qc_chain can use them
       //
-      auto [threshold, finalizers] = _chain->get_finalizers();
+      std::unique_lock g( _chain_state_mutex );
+      const auto& fin_set = _chain->get_finalizers(); // TODO use
 
       // Old code: get eosio::name from the producer schedule
-      const block_state_ptr& hbs = _chain->head_block_state();
-      const std::vector<producer_authority>& pa_list = hbs->active_schedule.producers;
+      const std::vector<producer_authority>& pa_list = _head_block_state->active_schedule.producers;
       std::vector<name> pn_list;
       pn_list.reserve(pa_list.size());
       std::transform(pa_list.begin(), pa_list.end(),
@@ -263,17 +265,16 @@ namespace eosio { namespace hotstuff {
    }
 
    block_id_type chain_pacemaker::get_current_block_id() {
-      return _chain->head_block_id();
+      std::scoped_lock g( _chain_state_mutex );
+      return _head_block_state->id;
    }
 
    uint32_t chain_pacemaker::get_quorum_threshold() {
       return _quorum_threshold;
    }
 
+   // called from the main application thread
    void chain_pacemaker::beat() {
-      if (! enabled())
-         return;
-
       csc prof("beat");
       std::lock_guard g( _hotstuff_global_mutex );
       prof.core_in();
@@ -302,9 +303,6 @@ namespace eosio { namespace hotstuff {
    }
 
    void chain_pacemaker::on_hs_proposal_msg(const hs_proposal_message& msg) {
-      if (! enabled())
-         return;
-
       csc prof("prop");
       std::lock_guard g( _hotstuff_global_mutex );
       prof.core_in();
@@ -313,9 +311,6 @@ namespace eosio { namespace hotstuff {
    }
 
    void chain_pacemaker::on_hs_vote_msg(const hs_vote_message& msg) {
-      if (! enabled())
-         return;
-
       csc prof("vote");
       std::lock_guard g( _hotstuff_global_mutex );
       prof.core_in();
@@ -324,9 +319,6 @@ namespace eosio { namespace hotstuff {
    }
 
    void chain_pacemaker::on_hs_new_block_msg(const hs_new_block_message& msg) {
-      if (! enabled())
-         return;
-
       csc prof("nblk");
       std::lock_guard g( _hotstuff_global_mutex );
       prof.core_in();
@@ -335,9 +327,6 @@ namespace eosio { namespace hotstuff {
    }
 
    void chain_pacemaker::on_hs_new_view_msg(const hs_new_view_message& msg) {
-      if (! enabled())
-         return;
-
       csc prof("view");
       std::lock_guard g( _hotstuff_global_mutex );
       prof.core_in();

--- a/libraries/hotstuff/include/eosio/hotstuff/base_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/base_pacemaker.hpp
@@ -30,8 +30,6 @@ namespace eosio::hotstuff {
 
       virtual chain::block_id_type get_current_block_id() = 0;
 
-      //hotstuff getters. todo : implement relevant setters as host functions
-#warning hotstuff getters. todo : implement relevant setters as host functions
       virtual chain::name get_proposer() = 0;
       virtual chain::name get_leader() = 0;
       virtual chain::name get_next_leader() = 0;

--- a/libraries/hotstuff/qc_chain.cpp
+++ b/libraries/hotstuff/qc_chain.cpp
@@ -674,6 +674,7 @@ namespace eosio { namespace hotstuff {
    }
 
    // Invoked when we could perhaps make a proposal to the network (or to ourselves, if we are the leader).
+   // Called from the main application thread
    void qc_chain::on_beat(){
 
       // Non-proposing leaders do not care about on_beat(), because leaders react to a block proposal

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2692,7 +2692,9 @@ void chain_plugin::notify_hs_new_block_message( const hs_new_block_message& msg 
 };
 
 void chain_plugin::notify_hs_block_produced() {
-   my->_chain_pacemaker->beat();
+   if (chain().is_builtin_activated( builtin_protocol_feature_t::instant_finality )) {
+      my->_chain_pacemaker->beat();
+   }
 }
 
 fc::variant chain_plugin::get_log_trx_trace(const transaction_trace_ptr& trx_trace ) const {


### PR DESCRIPTION
Connect `chain_pacemaker` to `controller` `accepted_block` signal.
Protect access to cached `chain_pacemaker` chain state via a mutex.

Resolves #1541 Part 2/2 See https://github.com/AntelopeIO/leap/pull/1550 for Part 1/2.