### PR TITLE
Update chainbase to tip (reduce memory usage)

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -624,8 +624,11 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
         resmon_plugin->monitor_directory(chain_config->state_dir);
       }
 
-      if( options.count( "chain-state-db-size-mb" ))
+      if( options.count( "chain-state-db-size-mb" )) {
          chain_config->state_size = options.at( "chain-state-db-size-mb" ).as<uint64_t>() * 1024 * 1024;
+         EOS_ASSERT( chain_config->state_size <= 8ull * 1024 * 1024 * 1024 * 1024, plugin_config_exception,
+                     "The maximum supported size for the chain state db is 8TiB" );
+      }
 
       if( options.count( "chain-state-db-guard-size-mb" ))
          chain_config->state_guard_size = options.at( "chain-state-db-guard-size-mb" ).as<uint64_t>() * 1024 * 1024;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -627,7 +627,7 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
       if( options.count( "chain-state-db-size-mb" )) {
          chain_config->state_size = options.at( "chain-state-db-size-mb" ).as<uint64_t>() * 1024 * 1024;
          EOS_ASSERT( chain_config->state_size <= 8ull * 1024 * 1024 * 1024 * 1024, plugin_config_exception,
-                     "The maximum supported size for the chain state db is 8TiB" );
+                     "The maximum supported size for the chain state db (chain-state-db-size-mb) is 8TiB" );
       }
 
       if( options.count( "chain-state-db-guard-size-mb" ))

--- a/tests/nodeos_under_min_avail_ram.py
+++ b/tests/nodeos_under_min_avail_ram.py
@@ -145,7 +145,7 @@ try:
     # min and max are subjective, just assigned to make sure that many small changes in nodeos don't 
     # result in the test not correctly validating behavior
     if count < 12 or count > 24:
-        strMsg="little" if count < 20 else "much"
+        strMsg="little" if count < 25 else "much"
         Utils.cmdError("Was able to send %d store actions which was too %s" % (count, strMsg))
         errorExit("Incorrect number of store actions sent")
 

--- a/tests/nodeos_under_min_avail_ram.py
+++ b/tests/nodeos_under_min_avail_ram.py
@@ -144,7 +144,7 @@ try:
 
     # min and max are subjective, just assigned to make sure that many small changes in nodeos don't 
     # result in the test not correctly validating behavior
-    if count < 5 or count > 20:
+    if count < 12 or count > 24:
         strMsg="little" if count < 20 else "much"
         Utils.cmdError("Was able to send %d store actions which was too %s" % (count, strMsg))
         errorExit("Incorrect number of store actions sent")


### PR DESCRIPTION
This updates the chainbase submodule to include the [memory reduction optimization](https://github.com/AntelopeIO/chainbase/pull/19). Description copied below.

### Reduce offset_node_base memory usage inside the RBtree of chainbase
This PR will reduce the chainbase memory usage

#### old implementation:
* `_parent`, `_left`, `_right`, `_color` consume 32 bytes together (8 bytes each).

#### new implementation
* `_parent`, `_left`, `_right`, `_color` consume 16 bytes (42 + 42 + 42 + 2 bits) together.
*  use -2 (instead of 2) as `erased_flag` since _color is a 2 bit signed int.

#### limitations:

* offset pointers `_parent`, `_left` & `_right` only have signed 42-bit each (so 41-bit absolute value), shifted by two bits thanks to alignment, implying a maximum of chainbase size of 2^43 = 8TB.
* `offset_node_base` objects must always be allocated within the same segment due to the 42-bit offset limit. Using a stack variable of `offset_node_base` is no longer valid (as stack address starts from 0x7fffxxxxxxxx which is too far away from heap addresses).
* possible minor performance impact due to misalignment and extra bit operation required. Or performance could possibly be better thanks to higher memory locality.

#### tested results:
using mainnet snapshot snapshot-308122667.bin.tar.gz:
* old chainbase memory usage: `28799134736`
* memory usage in this PR: `23136280976` (around 20% reduction)

[greg 8/21/2023] retested with the current PR version and confirmed the memory savings as reported by `curl -X POST http://127.0.0.1:8888/v1/db_size/get` after loading snapshot.