### PR TITLE
IF: Modify set_finalizer host function struct type

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -122,6 +122,7 @@ add_library( eosio_chain
              ${CHAIN_WEBASSEMBLY_SOURCES}
 
              authority.cpp
+             finalizer_set.cpp
              trace.cpp
              transaction_metadata.cpp
              protocol_state_object.cpp

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1980,6 +1980,7 @@ struct controller_impl {
    void set_finalizers_impl(const finalizer_set& fin_set) {
       // TODO store in chainbase
       current_finalizer_set = fin_set;
+      ++current_finalizer_set.generation;
    }
 
    /**

--- a/libraries/chain/finalizer_set.cpp
+++ b/libraries/chain/finalizer_set.cpp
@@ -13,15 +13,11 @@ namespace eosio::chain {
    finalizer_set::~finalizer_set() = default;
 
    finalizer_set::finalizer_set(const finalizer_set&) = default;
-   finalizer_set::finalizer_set(finalizer_set&&) = default;
+   finalizer_set::finalizer_set(finalizer_set&&) noexcept = default;
 
    finalizer_set& finalizer_set::operator=(const finalizer_set&) = default;
-   finalizer_set& finalizer_set::operator=(finalizer_set&&) = default;
+   finalizer_set& finalizer_set::operator=(finalizer_set&&) noexcept = default;
 
    auto finalizer_set::operator<=>(const finalizer_set&) const = default;
-
-
-   hs_finalizer_set_extension::hs_finalizer_set_extension(const finalizer_set& s)
-           : finalizer_set(s) {}
 
 } /// eosio::chain

--- a/libraries/chain/finalizer_set.cpp
+++ b/libraries/chain/finalizer_set.cpp
@@ -1,0 +1,27 @@
+#include <eosio/chain/finalizer_set.hpp>
+#include <eosio/chain/finalizer_authority.hpp>
+#include <fc/crypto/bls_public_key.hpp>
+
+namespace eosio::chain {
+
+   /**
+    * These definitions are all here to avoid including bls_public_key.hpp which includes <bls12-381/bls12-381.hpp>
+    * and pulls in bls12-381 types. This keeps bls12-381 out of libtester.
+    */
+
+   finalizer_set::finalizer_set() = default;
+   finalizer_set::~finalizer_set() = default;
+
+   finalizer_set::finalizer_set(const finalizer_set&) = default;
+   finalizer_set::finalizer_set(finalizer_set&&) = default;
+
+   finalizer_set& finalizer_set::operator=(const finalizer_set&) = default;
+   finalizer_set& finalizer_set::operator=(finalizer_set&&) = default;
+
+   auto finalizer_set::operator<=>(const finalizer_set&) const = default;
+
+
+   hs_finalizer_set_extension::hs_finalizer_set_extension(const finalizer_set& s)
+           : finalizer_set(s) {}
+
+} /// eosio::chain

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -133,7 +133,8 @@ static_assert(maximum_tracked_dpos_confirmations >= ((max_producers * 2 / 3) + 1
 /**
  * Maximum number of finalizers in the finalizer set
  */
-const static int max_finalizers = max_producers;
+const static size_t max_finalizers = 64*1024;
+const static size_t max_finalizer_description = 256;
 
 /**
  * The number of blocks produced per round is based upon all producers having a chance

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -134,7 +134,7 @@ static_assert(maximum_tracked_dpos_confirmations >= ((max_producers * 2 / 3) + 1
  * Maximum number of finalizers in the finalizer set
  */
 const static size_t max_finalizers = 64*1024;
-const static size_t max_finalizer_description = 256;
+const static size_t max_finalizer_description_size = 256;
 
 /**
  * The number of blocks produced per round is based upon all producers having a chance

--- a/libraries/chain/include/eosio/chain/finalizer_authority.hpp
+++ b/libraries/chain/include/eosio/chain/finalizer_authority.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <fc/crypto/bls_public_key.hpp>
+#include <string>
+
+namespace eosio::chain {
+
+   struct finalizer_authority {
+
+      std::string  description;
+      uint64_t     fweight = 0; // weight that this finalizer's vote has for meeting fthreshold
+      fc::crypto::blslib::bls_public_key  public_key;
+
+      auto operator<=>(const finalizer_authority&) const = default;
+   };
+
+} /// eosio::chain
+
+FC_REFLECT( eosio::chain::finalizer_authority, (description)(fweight)(public_key) )

--- a/libraries/chain/include/eosio/chain/finalizer_set.hpp
+++ b/libraries/chain/include/eosio/chain/finalizer_set.hpp
@@ -1,59 +1,49 @@
 #pragma once
 
-#include <eosio/chain/config.hpp>
 #include <eosio/chain/types.hpp>
-#include <chainbase/chainbase.hpp>
-#include <eosio/chain/authority.hpp>
-#include <eosio/chain/snapshot.hpp>
-
-#include <fc/crypto/bls_public_key.hpp>
 
 namespace eosio::chain {
 
-   struct finalizer_authority {
-
-      std::string  description;
-      uint64_t     fweight = 0; // weight that this finalizer's vote has for meeting fthreshold
-      fc::crypto::blslib::bls_public_key  public_key;
-
-      friend bool operator == ( const finalizer_authority& lhs, const finalizer_authority& rhs ) {
-         return tie( lhs.description, lhs.fweight, lhs.public_key ) == tie( rhs.description, rhs.fweight, rhs.public_key );
-      }
-      friend bool operator != ( const finalizer_authority& lhs, const finalizer_authority& rhs ) {
-         return !(lhs == rhs);
-      }
-   };
+   struct finalizer_authority;
 
    struct finalizer_set {
-      finalizer_set() = default;
+      finalizer_set();
+      ~finalizer_set();
 
-      finalizer_set( uint32_t version, uint64_t fthreshold, std::initializer_list<finalizer_authority> finalizers )
-      :version(version)
-      ,fthreshold(fthreshold)
-      ,finalizers(finalizers)
-      {}
+      finalizer_set(const finalizer_set&);
+      finalizer_set(finalizer_set&&);
+
+      finalizer_set& operator=(const finalizer_set&);
+      finalizer_set& operator=(finalizer_set&&);
 
       uint32_t                                       version = 0; ///< sequentially incrementing version number
       uint64_t                                       fthreshold = 0;  // vote fweight threshold to finalize blocks
       vector<finalizer_authority>                    finalizers; // Instant Finality voter set
 
-      friend bool operator == ( const finalizer_set& a, const finalizer_set& b )
-      {
-         if( a.version != b.version ) return false;
-         if( a.fthreshold != b.fthreshold ) return false;
-         if ( a.finalizers.size() != b.finalizers.size() ) return false;
-         for( uint32_t i = 0; i < a.finalizers.size(); ++i )
-            if( ! (a.finalizers[i] == b.finalizers[i]) ) return false;
-         return true;
-      }
+      auto operator<=>(const finalizer_set&) const;
+   };
 
-      friend bool operator != ( const finalizer_set& a, const finalizer_set& b )
-      {
-         return !(a==b);
-      }
+   using finalizer_set_ptr = std::shared_ptr<finalizer_set>;
+
+   /**
+    * Block Header Extension Compatibility
+    */
+   struct hs_finalizer_set_extension : finalizer_set {
+
+      static constexpr uint16_t extension_id() { return 2; } // TODO 3 instead?
+      static constexpr bool     enforce_unique() { return true; }
+
+      hs_finalizer_set_extension() = default;
+      hs_finalizer_set_extension(const hs_finalizer_set_extension&) = default;
+      hs_finalizer_set_extension( hs_finalizer_set_extension&& ) = default;
+
+      hs_finalizer_set_extension& operator=(const hs_finalizer_set_extension&) = default;
+      hs_finalizer_set_extension& operator=(hs_finalizer_set_extension&&) = default;
+
+      hs_finalizer_set_extension(const finalizer_set& s);
    };
 
 } /// eosio::chain
 
-FC_REFLECT( eosio::chain::finalizer_authority, (description)(fweight)(public_key) )
 FC_REFLECT( eosio::chain::finalizer_set, (version)(fthreshold)(finalizers) )
+FC_REFLECT_DERIVED( eosio::chain::hs_finalizer_set_extension, (eosio::chain::finalizer_set), )

--- a/libraries/chain/include/eosio/chain/finalizer_set.hpp
+++ b/libraries/chain/include/eosio/chain/finalizer_set.hpp
@@ -16,9 +16,9 @@ namespace eosio::chain {
       finalizer_set& operator=(const finalizer_set&);
       finalizer_set& operator=(finalizer_set&&);
 
-      uint32_t                                       version = 0; ///< sequentially incrementing version number
-      uint64_t                                       fthreshold = 0;  // vote fweight threshold to finalize blocks
-      vector<finalizer_authority>                    finalizers; // Instant Finality voter set
+      uint32_t                                       generation = 0; ///< sequentially incrementing version number
+      uint64_t                                       fthreshold = 0;  ///< vote fweight threshold to finalize blocks
+      std::vector<finalizer_authority>               finalizers; ///< Instant Finality voter set
 
       auto operator<=>(const finalizer_set&) const;
    };
@@ -45,5 +45,5 @@ namespace eosio::chain {
 
 } /// eosio::chain
 
-FC_REFLECT( eosio::chain::finalizer_set, (version)(fthreshold)(finalizers) )
+FC_REFLECT( eosio::chain::finalizer_set, (generation)(fthreshold)(finalizers) )
 FC_REFLECT_DERIVED( eosio::chain::hs_finalizer_set_extension, (eosio::chain::finalizer_set), )

--- a/libraries/chain/include/eosio/chain/finalizer_set.hpp
+++ b/libraries/chain/include/eosio/chain/finalizer_set.hpp
@@ -11,16 +11,16 @@ namespace eosio::chain {
       ~finalizer_set();
 
       finalizer_set(const finalizer_set&);
-      finalizer_set(finalizer_set&&);
+      finalizer_set(finalizer_set&&) noexcept;
 
       finalizer_set& operator=(const finalizer_set&);
-      finalizer_set& operator=(finalizer_set&&);
-
-      uint32_t                                       generation = 0; ///< sequentially incrementing version number
-      uint64_t                                       fthreshold = 0;  ///< vote fweight threshold to finalize blocks
-      std::vector<finalizer_authority>               finalizers; ///< Instant Finality voter set
+      finalizer_set& operator=(finalizer_set&&) noexcept;
 
       auto operator<=>(const finalizer_set&) const;
+
+      uint32_t                         generation = 0; ///< sequentially incrementing version number
+      uint64_t                         fthreshold = 0;  ///< vote fweight threshold to finalize blocks
+      std::vector<finalizer_authority> finalizers; ///< Instant Finality voter set
    };
 
    using finalizer_set_ptr = std::shared_ptr<finalizer_set>;
@@ -29,18 +29,8 @@ namespace eosio::chain {
     * Block Header Extension Compatibility
     */
    struct hs_finalizer_set_extension : finalizer_set {
-
       static constexpr uint16_t extension_id() { return 2; } // TODO 3 instead?
       static constexpr bool     enforce_unique() { return true; }
-
-      hs_finalizer_set_extension() = default;
-      hs_finalizer_set_extension(const hs_finalizer_set_extension&) = default;
-      hs_finalizer_set_extension( hs_finalizer_set_extension&& ) = default;
-
-      hs_finalizer_set_extension& operator=(const hs_finalizer_set_extension&) = default;
-      hs_finalizer_set_extension& operator=(hs_finalizer_set_extension&&) = default;
-
-      hs_finalizer_set_extension(const finalizer_set& s);
    };
 
 } /// eosio::chain

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -174,7 +174,7 @@ namespace eosio { namespace chain { namespace webassembly {
       EOS_ASSERT( finalizers.size() <= config::max_finalizers, wasm_execution_error, "Finalizer set exceeds the maximum finalizer count for this chain" );
       EOS_ASSERT( finalizers.size() > 0, wasm_execution_error, "Finalizer set cannot be empty" );
 
-      std::set<fc::crypto::blslib::bls_public_key> unique_finalizer_keys;
+      std::set<bls12_381::g1> unique_finalizer_keys;
       uint64_t f_weight_sum = 0;
 
       finalizer_set finset;
@@ -185,8 +185,10 @@ namespace eosio { namespace chain { namespace webassembly {
          f_weight_sum += f.fweight;
          std::optional<bls12_381::g1> pk = bls12_381::g1::fromJacobianBytesLE(f.public_key_g1_jacobian);
          EOS_ASSERT( pk, wasm_execution_error, "Invalid public key for: ${d}", ("d", f.description) );
-         finset.finalizers.push_back(finalizer_authority{.description = std::move(f.description), .fweight = f.fweight, .public_key{fc::crypto::blslib::bls_public_key{*pk}}});
-         unique_finalizer_keys.insert(finset.finalizers.back().public_key);
+         finset.finalizers.push_back(finalizer_authority{.description = std::move(f.description),
+                                                         .fweight = f.fweight,
+                                                         .public_key{fc::crypto::blslib::bls_public_key{*pk}}});
+         unique_finalizer_keys.insert(*pk);
       }
 
       EOS_ASSERT( finalizers.size() == unique_finalizer_keys.size(), wasm_execution_error, "Duplicate finalizer bls key in finalizer set" );

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -153,7 +153,7 @@ namespace eosio { namespace chain { namespace webassembly {
    }
 
    void interface::set_finalizers(span<const char> packed_finalizer_set) {
-      EOS_ASSERT(!context.trx_context.is_read_only(), wasm_execution_error, "set_proposed_finalizers not allowed in a readonly transaction");
+      EOS_ASSERT(!context.trx_context.is_read_only(), wasm_execution_error, "set_finalizers not allowed in a readonly transaction");
       fc::datastream<const char*> ds( packed_finalizer_set.data(), packed_finalizer_set.size() );
       finalizer_set finset;
       // contract finalizer_set does not include uint32_t generation
@@ -172,9 +172,9 @@ namespace eosio { namespace chain { namespace webassembly {
       uint64_t f_weight_sum = 0;
 
       for (const auto& f: finalizers) {
+         EOS_ASSERT( f.description.size() <= config::max_finalizer_description, wasm_execution_error, "Finalizer description greater than 256" );
          f_weight_sum += f.fweight;
          unique_finalizer_keys.insert(f.public_key);
-         EOS_ASSERT( f.description.size() <= config::max_finalizer_description, wasm_execution_error, "Finalizer description greater than 256" );
       }
 
       EOS_ASSERT( finalizers.size() == unique_finalizer_keys.size(), wasm_execution_error, "Duplicate finalizer bls key in finalizer set" );

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -6,6 +6,7 @@
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/apply_context.hpp>
 #include <eosio/chain/finalizer_set.hpp>
+#include <eosio/chain/finalizer_authority.hpp>
 
 #include <fc/io/datastream.hpp>
 
@@ -156,24 +157,21 @@ namespace eosio { namespace chain { namespace webassembly {
       fc::datastream<const char*> ds( packed_finalizer_set.data(), packed_finalizer_set.size() );
       finalizer_set finset;
       fc::raw::unpack(ds, finset);
-      vector<finalizer_authority> & finalizers = finset.finalizers;
+      vector<finalizer_authority>& finalizers = finset.finalizers;
 
       // TODO: check version and increment it or verify correct
       EOS_ASSERT( finalizers.size() <= config::max_finalizers, wasm_execution_error, "Finalizer set exceeds the maximum finalizer count for this chain" );
       EOS_ASSERT( finalizers.size() > 0, wasm_execution_error, "Finalizer set cannot be empty" );
 
       std::set<fc::crypto::blslib::bls_public_key> unique_finalizer_keys;
-#warning REVIEW: Is checking for unique finalizer descriptions at all relevant?
-      std::set<std::string> unique_finalizers;
       uint64_t f_weight_sum = 0;
 
       for (const auto& f: finalizers) {
          f_weight_sum += f.fweight;
          unique_finalizer_keys.insert(f.public_key);
-         unique_finalizers.insert(f.description);
+         EOS_ASSERT( f.description.size() <= 256, wasm_execution_error, "Finalizer description greater than 256" );
       }
 
-      EOS_ASSERT( finalizers.size() == unique_finalizers.size(), wasm_execution_error, "Duplicate finalizer description in finalizer set" );
       EOS_ASSERT( finalizers.size() == unique_finalizer_keys.size(), wasm_execution_error, "Duplicate finalizer bls key in finalizer set" );
       EOS_ASSERT( finset.fthreshold > f_weight_sum / 2, wasm_execution_error, "Finalizer set threshold cannot be met by finalizer weights" );
 

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -184,7 +184,7 @@ namespace eosio { namespace chain { namespace webassembly {
          f_weight_sum += f.fweight;
          std::optional<bls12_381::g1> pk = bls12_381::g1::fromJacobianBytesLE(f.public_key_g1_jacobian);
          EOS_ASSERT( pk, wasm_execution_error, "Invalid public key for: ${d}", ("d", f.description) );
-         finset.finalizers.push_back(finalizer_authority{.description = std::move(f.description), .fweight = f.fweight, .public_key{*pk}});
+         finset.finalizers.push_back(finalizer_authority{.description = std::move(f.description), .fweight = f.fweight, .public_key{fc::crypto::blslib::bls_public_key{*pk}}});
          unique_finalizer_keys.insert(finset.finalizers.back().public_key);
       }
 

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -159,8 +159,8 @@ namespace eosio { namespace chain { namespace webassembly {
       std::array<uint8_t, 144> public_key_g1_jacobian;
    };
    struct abi_finalizer_set {
-      uint64_t                        fthreshold = 0;
-      vector<abi_finalizer_authority> finalizers;
+      uint64_t                             fthreshold = 0;
+      std::vector<abi_finalizer_authority> finalizers;
    };
 
    void interface::set_finalizers(span<const char> packed_finalizer_set) {
@@ -169,7 +169,7 @@ namespace eosio { namespace chain { namespace webassembly {
       abi_finalizer_set abi_finset;
       fc::raw::unpack(ds, abi_finset);
 
-      vector<abi_finalizer_authority>& finalizers = abi_finset.finalizers;
+      std::vector<abi_finalizer_authority>& finalizers = abi_finset.finalizers;
 
       EOS_ASSERT( finalizers.size() <= config::max_finalizers, wasm_execution_error, "Finalizer set exceeds the maximum finalizer count for this chain" );
       EOS_ASSERT( finalizers.size() > 0, wasm_execution_error, "Finalizer set cannot be empty" );
@@ -180,7 +180,8 @@ namespace eosio { namespace chain { namespace webassembly {
       finalizer_set finset;
       finset.fthreshold = abi_finset.fthreshold;
       for (const auto& f: finalizers) {
-         EOS_ASSERT( f.description.size() <= config::max_finalizer_description, wasm_execution_error, "Finalizer description greater than 256" );
+         EOS_ASSERT( f.description.size() <= config::max_finalizer_description_size, wasm_execution_error,
+                     "Finalizer description greater than ${s}", ("s", config::max_finalizer_description_size) );
          f_weight_sum += f.fweight;
          std::optional<bls12_381::g1> pk = bls12_381::g1::fromJacobianBytesLE(f.public_key_g1_jacobian);
          EOS_ASSERT( pk, wasm_execution_error, "Invalid public key for: ${d}", ("d", f.description) );


### PR DESCRIPTION
- Rename `finalizer_set` `version` to `generation`.
- Changed `finalizer_set` `bls_public_key` to Jacobian little-endian encoding.
- Remove `generation` from `set_finalizers` host function parameter struct type.
- Add `hs_finalizer_set_extension` for block header extension.
- Move implementation of `finalizer_authority` and `finalizer_set` to source file to avoid including `bls12-381` headers into `libtester`.