### PR TITLE
switch out `COMPILE_FLAGS` for `INCLUDE_DIRECTORIES` in fc's rapidjson cmake

### DIFF
--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -102,7 +102,7 @@ find_package(ZLIB REQUIRED)
 target_include_directories(fc PUBLIC include)
 
 # try and make this very clear that this json parser is intended only for webauthn parsing..
-set_source_files_properties(src/crypto/elliptic_webauthn.cpp PROPERTIES COMPILE_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/include/fc/crypto/webauthn_json/include")
+set_source_files_properties(src/crypto/elliptic_webauthn.cpp PROPERTIES INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include/fc/crypto/webauthn_json/include")
 
 if(WIN32)
   target_link_libraries( fc PUBLIC ws2_32 mswsock userenv )


### PR DESCRIPTION
`INCLUDE_DIRECTORIES` is clearly the more generic property to set in this case as it isn't specific to gcc/clang command line arguments.