### PR TITLE
wrap `cfile`'s `fclose()` to avoid warning on latest glibc

### DIFF
--- a/libraries/libfc/include/fc/io/cfile.hpp
+++ b/libraries/libfc/include/fc/io/cfile.hpp
@@ -19,7 +19,11 @@
 namespace fc {
 
 namespace detail {
-   using unique_file = std::unique_ptr<FILE, decltype( &fclose )>;
+   static void close_file(FILE* f) {
+      fclose(f);
+   }
+
+   using unique_file = std::unique_ptr<FILE, decltype( &close_file )>;
 }
 
 class cfile_datastream;
@@ -32,7 +36,7 @@ class cfile {
    friend class temp_cfile;
 public:
    cfile()
-     : _file(nullptr, &fclose)
+     : _file(nullptr, &detail::close_file)
    {}
 
    cfile(cfile&& other)

--- a/libraries/libfc/include/fc/io/cfile.hpp
+++ b/libraries/libfc/include/fc/io/cfile.hpp
@@ -19,7 +19,7 @@
 namespace fc {
 
 namespace detail {
-   static void close_file(FILE* f) {
+   inline void close_file(FILE* f) {
       fclose(f);
    }
 

--- a/libraries/libfc/include/fc/io/cfile.hpp
+++ b/libraries/libfc/include/fc/io/cfile.hpp
@@ -19,7 +19,7 @@
 namespace fc {
 
 namespace detail {
-   inline void close_file(FILE* f) {
+   inline void close_file(FILE* f) noexcept {
       fclose(f);
    }
 


### PR DESCRIPTION
latest glibc adds a `__nonnull` attribute on `fclose()` which ends up causing a bunch of warnings,
```
libraries/libfc/include/fc/io/cfile.hpp:22:65: warning: ignoring attributes on template argument ‘int (*)(FILE*)’ [-Wignored-attributes]
   22 |    using unique_file = std::unique_ptr<FILE, decltype( &fclose )>;
```

Not really sure the best way of fixing this. Simply wrapping the call like this gets rid of the warning.