### PR TITLE
IF: Check if input strings are invalid in conversion to public key or signature

### DIFF
--- a/libraries/libfc/src/crypto/bls_public_key.cpp
+++ b/libraries/libfc/src/crypto/bls_public_key.cpp
@@ -15,7 +15,7 @@ namespace fc::crypto::blslib {
 
       std::array<uint8_t, 96> bytes = fc::crypto::blslib::deserialize_base64<std::array<uint8_t, 96>>(data_str);
       
-      constexpr bool check = false; // default
+      constexpr bool check = true; // check if base64str is invalid
       constexpr bool raw = true;
       std::optional<bls12_381::g1> g1 = bls12_381::g1::fromAffineBytesLE(bytes, check, raw);
       FC_ASSERT(g1);

--- a/libraries/libfc/src/crypto/bls_signature.cpp
+++ b/libraries/libfc/src/crypto/bls_signature.cpp
@@ -17,7 +17,7 @@ namespace fc::crypto::blslib {
 
          std::array<uint8_t, 192> bytes = fc::crypto::blslib::deserialize_base64<std::array<uint8_t, 192>>(data_str);
 
-         constexpr bool check = false; // default
+         constexpr bool check = true; // check if base64str is invalid
          constexpr bool raw = true;
          std::optional<bls12_381::g2> g2 = bls12_381::g2::fromAffineBytesLE(bytes, check, raw);
          FC_ASSERT(g2);


### PR DESCRIPTION
When a string is converted to a public key or signature, check if the string is invalid.