### PR TITLE
IF: Infrastructure for hs message filtering

### DIFF
--- a/libraries/chain/include/eosio/chain/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff.hpp
@@ -57,7 +57,7 @@ namespace eosio::chain {
 
    using hs_message = std::variant<hs_vote_message, hs_proposal_message, hs_new_block_message, hs_new_view_message>;
 
-   enum hs_message_warning : uint32_t {
+   enum class hs_message_warning {
       discarded,               // default code for dropped messages (irrelevant, redundant, ...)
       duplicate_signature,     // same message signature already seen
       invalid_signature,       // invalid message signature

--- a/libraries/chain/include/eosio/chain/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff.hpp
@@ -57,6 +57,13 @@ namespace eosio::chain {
 
    using hs_message = std::variant<hs_vote_message, hs_proposal_message, hs_new_block_message, hs_new_view_message>;
 
+   enum hs_message_warning : uint32_t {
+      discarded,               // default code for dropped messages (irrelevant, redundant, ...)
+      duplicate_signature,     // same message signature already seen
+      invalid_signature,       // invalid message signature
+      invalid                  // invalid message (other reason)
+   };
+
    struct finalizer_state {
       bool chained_mode = false;
       fc::sha256 b_leaf;

--- a/libraries/hotstuff/chain_pacemaker.cpp
+++ b/libraries/hotstuff/chain_pacemaker.cpp
@@ -120,13 +120,13 @@ namespace eosio { namespace hotstuff {
 
    void chain_pacemaker::register_bcast_function(std::function<void(const std::optional<uint32_t>&, const chain::hs_message&)> broadcast_hs_message) {
       FC_ASSERT(broadcast_hs_message, "on_hs_message must be provided");
-      std::lock_guard g( _hotstuff_global_mutex ); // not actually needed but doesn't hurt
+      // no need to std::lock_guard g( _hotstuff_global_mutex ); here since pre-comm init
       bcast_hs_message = std::move(broadcast_hs_message);
    }
 
    void chain_pacemaker::register_warn_function(std::function<void(const uint32_t, const chain::hs_message_warning&)> warning_hs_message) {
       FC_ASSERT(warning_hs_message, "must provide callback");
-      std::lock_guard g( _hotstuff_global_mutex ); // not actually needed but doesn't hurt
+      // no need to std::lock_guard g( _hotstuff_global_mutex ); here since pre-comm init
       warn_hs_message = std::move(warning_hs_message);
    }
 

--- a/libraries/hotstuff/chain_pacemaker.cpp
+++ b/libraries/hotstuff/chain_pacemaker.cpp
@@ -118,10 +118,16 @@ namespace eosio { namespace hotstuff {
       _head_block_state = chain->head_block_state();
    }
 
-   void chain_pacemaker::register_bcast_function(std::function<void(const chain::hs_message&)> broadcast_hs_message) {
+   void chain_pacemaker::register_bcast_function(std::function<void(const std::optional<uint32_t>&, const chain::hs_message&)> broadcast_hs_message) {
       FC_ASSERT(broadcast_hs_message, "on_hs_message must be provided");
       std::lock_guard g( _hotstuff_global_mutex ); // not actually needed but doesn't hurt
       bcast_hs_message = std::move(broadcast_hs_message);
+   }
+
+   void chain_pacemaker::register_warn_function(std::function<void(const uint32_t, const chain::hs_message_warning&)> warning_hs_message) {
+      FC_ASSERT(warning_hs_message, "must provide callback");
+      std::lock_guard g( _hotstuff_global_mutex ); // not actually needed but doesn't hurt
+      warn_hs_message = std::move(warning_hs_message);
    }
 
    void chain_pacemaker::get_state(finalizer_state& fs) const {
@@ -297,65 +303,69 @@ namespace eosio { namespace hotstuff {
       prof.core_out();
    }
 
-   void chain_pacemaker::send_hs_proposal_msg(const hs_proposal_message& msg, name id) {
-      bcast_hs_message(msg);
+   void chain_pacemaker::send_hs_proposal_msg(const hs_proposal_message& msg, name id, const std::optional<uint32_t>& exclude_peer) {
+      bcast_hs_message(exclude_peer, msg);
    }
 
-   void chain_pacemaker::send_hs_vote_msg(const hs_vote_message& msg, name id) {
-      bcast_hs_message(msg);
+   void chain_pacemaker::send_hs_vote_msg(const hs_vote_message& msg, name id, const std::optional<uint32_t>& exclude_peer) {
+      bcast_hs_message(exclude_peer, msg);
    }
 
-   void chain_pacemaker::send_hs_new_block_msg(const hs_new_block_message& msg, name id) {
-      bcast_hs_message(msg);
+   void chain_pacemaker::send_hs_new_block_msg(const hs_new_block_message& msg, name id, const std::optional<uint32_t>& exclude_peer) {
+      bcast_hs_message(exclude_peer, msg);
    }
 
-   void chain_pacemaker::send_hs_new_view_msg(const hs_new_view_message& msg, name id) {
-      bcast_hs_message(msg);
+   void chain_pacemaker::send_hs_new_view_msg(const hs_new_view_message& msg, name id, const std::optional<uint32_t>& exclude_peer) {
+      bcast_hs_message(exclude_peer, msg);
+   }
+
+   void chain_pacemaker::send_hs_message_warning(const uint32_t sender_peer, const chain::hs_message_warning code) {
+      warn_hs_message(sender_peer, code);
    }
 
    // called from net threads
-   void chain_pacemaker::on_hs_msg(const eosio::chain::hs_message &msg) {
+   void chain_pacemaker::on_hs_msg(const uint32_t connection_id, const eosio::chain::hs_message &msg) {
       std::visit(overloaded{
-              [this](const hs_vote_message& m) { on_hs_vote_msg(m); },
-              [this](const hs_proposal_message& m) { on_hs_proposal_msg(m); },
-              [this](const hs_new_block_message& m) { on_hs_new_block_msg(m); },
-              [this](const hs_new_view_message& m) { on_hs_new_view_msg(m); },
+            [this, connection_id](const hs_vote_message& m) { on_hs_vote_msg(connection_id, m); },
+            [this, connection_id](const hs_proposal_message& m) { on_hs_proposal_msg(connection_id, m); },
+            [this, connection_id](const hs_new_block_message& m) { on_hs_new_block_msg(connection_id, m); },
+            [this, connection_id](const hs_new_view_message& m) { on_hs_new_view_msg(connection_id, m); },
       }, msg);
    }
 
    // called from net threads
-   void chain_pacemaker::on_hs_proposal_msg(const hs_proposal_message& msg) {
+   void chain_pacemaker::on_hs_proposal_msg(const uint32_t connection_id, const hs_proposal_message& msg) {
       csc prof("prop");
       std::lock_guard g( _hotstuff_global_mutex );
       prof.core_in();
-      _qc_chain.on_hs_proposal_msg(msg);
+      _qc_chain.on_hs_proposal_msg(connection_id, msg);
       prof.core_out();
    }
 
    // called from net threads
-   void chain_pacemaker::on_hs_vote_msg(const hs_vote_message& msg) {
+   void chain_pacemaker::on_hs_vote_msg(const uint32_t connection_id, const hs_vote_message& msg) {
       csc prof("vote");
       std::lock_guard g( _hotstuff_global_mutex );
       prof.core_in();
-      _qc_chain.on_hs_vote_msg(msg);
+      _qc_chain.on_hs_vote_msg(connection_id, msg);
       prof.core_out();
    }
 
    // called from net threads
-   void chain_pacemaker::on_hs_new_block_msg(const hs_new_block_message& msg) {
+   void chain_pacemaker::on_hs_new_block_msg(const uint32_t connection_id, const hs_new_block_message& msg) {
       csc prof("nblk");
       std::lock_guard g( _hotstuff_global_mutex );
       prof.core_in();
-      _qc_chain.on_hs_new_block_msg(msg);
+      _qc_chain.on_hs_new_block_msg(connection_id, msg);
       prof.core_out();
    }
 
    // called from net threads
-   void chain_pacemaker::on_hs_new_view_msg(const hs_new_view_message& msg) {
+   void chain_pacemaker::on_hs_new_view_msg(const uint32_t connection_id, const hs_new_view_message& msg) {
       csc prof("view");
       std::lock_guard g( _hotstuff_global_mutex );
       prof.core_in();
-      _qc_chain.on_hs_new_view_msg(msg);
+      _qc_chain.on_hs_new_view_msg(connection_id, msg);
       prof.core_out();
    }
 

--- a/libraries/hotstuff/include/eosio/hotstuff/base_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/base_pacemaker.hpp
@@ -10,6 +10,7 @@ namespace eosio::chain {
    struct hs_vote_message;
    struct hs_new_view_message;
    struct hs_new_block_message;
+   enum hs_message_warning : uint32_t;
 }
 
 namespace eosio::hotstuff {
@@ -36,10 +37,12 @@ namespace eosio::hotstuff {
       virtual std::vector<chain::name> get_finalizers() = 0;
 
       //outbound communications; 'id' is the producer name (can be ignored if/when irrelevant to the implementer)
-      virtual void send_hs_proposal_msg(const chain::hs_proposal_message& msg, chain::name id) = 0;
-      virtual void send_hs_vote_msg(const chain::hs_vote_message& msg, chain::name id) = 0;
-      virtual void send_hs_new_view_msg(const chain::hs_new_view_message& msg, chain::name id) = 0;
-      virtual void send_hs_new_block_msg(const chain::hs_new_block_message& msg, chain::name id) = 0;
+      virtual void send_hs_proposal_msg(const chain::hs_proposal_message& msg, chain::name id, const std::optional<uint32_t>& exclude_peer = std::nullopt) = 0;
+      virtual void send_hs_vote_msg(const chain::hs_vote_message& msg, chain::name id, const std::optional<uint32_t>& exclude_peer = std::nullopt) = 0;
+      virtual void send_hs_new_view_msg(const chain::hs_new_view_message& msg, chain::name id, const std::optional<uint32_t>& exclude_peer = std::nullopt) = 0;
+      virtual void send_hs_new_block_msg(const chain::hs_new_block_message& msg, chain::name id, const std::optional<uint32_t>& exclude_peer = std::nullopt) = 0;
+
+      virtual void send_hs_message_warning(const uint32_t sender_peer, const chain::hs_message_warning code) = 0;
    };
 
 } // namespace eosio::hotstuff

--- a/libraries/hotstuff/include/eosio/hotstuff/base_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/base_pacemaker.hpp
@@ -2,16 +2,9 @@
 
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/name.hpp>
+#include <eosio/chain/hotstuff.hpp>
 
 #include <vector>
-
-namespace eosio::chain {
-   struct hs_proposal_message;
-   struct hs_vote_message;
-   struct hs_new_view_message;
-   struct hs_new_block_message;
-   enum hs_message_warning : uint32_t;
-}
 
 namespace eosio::hotstuff {
 

--- a/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
@@ -24,11 +24,12 @@ namespace eosio::hotstuff {
                       std::set<account_name> my_producers,
                       chain::bls_key_map_t finalizer_keys,
                       fc::logger& logger);
-      void register_bcast_function(std::function<void(const chain::hs_message&)> broadcast_hs_message);
+      void register_bcast_function(std::function<void(const std::optional<uint32_t>&, const chain::hs_message&)> broadcast_hs_message);
+      void register_warn_function(std::function<void(const uint32_t, const chain::hs_message_warning&)> warning_hs_message);
 
       void beat();
 
-      void on_hs_msg(const hs_message& msg);
+      void on_hs_msg(const uint32_t connection_id, const hs_message& msg);
 
       void get_state(finalizer_state& fs) const;
 
@@ -43,19 +44,21 @@ namespace eosio::hotstuff {
 
       uint32_t get_quorum_threshold();
 
-      void send_hs_proposal_msg(const hs_proposal_message& msg, name id);
-      void send_hs_vote_msg(const hs_vote_message& msg, name id);
-      void send_hs_new_view_msg(const hs_new_view_message& msg, name id);
-      void send_hs_new_block_msg(const hs_new_block_message& msg, name id);
+      void send_hs_proposal_msg(const hs_proposal_message& msg, name id, const std::optional<uint32_t>& exclude_peer);
+      void send_hs_vote_msg(const hs_vote_message& msg, name id, const std::optional<uint32_t>& exclude_peer);
+      void send_hs_new_view_msg(const hs_new_view_message& msg, name id, const std::optional<uint32_t>& exclude_peer);
+      void send_hs_new_block_msg(const hs_new_block_message& msg, name id, const std::optional<uint32_t>& exclude_peer);
+
+      void send_hs_message_warning(const uint32_t sender_peer, const chain::hs_message_warning code);
 
    private:
       void on_accepted_block( const block_state_ptr& blk );
       void on_irreversible_block( const block_state_ptr& blk );
 
-      void on_hs_proposal_msg(const hs_proposal_message& msg); //consensus msg event handler
-      void on_hs_vote_msg(const hs_vote_message& msg); //confirmation msg event handler
-      void on_hs_new_view_msg(const hs_new_view_message& msg); //new view msg event handler
-      void on_hs_new_block_msg(const hs_new_block_message& msg); //new block msg event handler
+      void on_hs_proposal_msg(const uint32_t connection_id, const hs_proposal_message& msg); //consensus msg event handler
+      void on_hs_vote_msg(const uint32_t connection_id, const hs_vote_message& msg); //confirmation msg event handler
+      void on_hs_new_view_msg(const uint32_t connection_id, const hs_new_view_message& msg); //new view msg event handler
+      void on_hs_new_block_msg(const uint32_t connection_id, const hs_new_block_message& msg); //new block msg event handler
    private:
 
       //FIXME/REMOVE: for testing/debugging only
@@ -84,7 +87,8 @@ namespace eosio::hotstuff {
       boost::signals2::scoped_connection _irreversible_block_connection;
 
       qc_chain                _qc_chain;
-      std::function<void(const chain::hs_message&)> bcast_hs_message;
+      std::function<void(const std::optional<uint32_t>&, const chain::hs_message&)> bcast_hs_message;
+      std::function<void(const uint32_t, const chain::hs_message_warning&)> warn_hs_message;
 
       uint32_t                _quorum_threshold = 15; //FIXME/TODO: calculate from schedule
       fc::logger&             _logger;

--- a/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
@@ -100,20 +100,20 @@ namespace eosio::hotstuff {
                chain::bls_key_map_t finalizer_keys,
                fc::logger& logger);
 
-      uint64_t get_state_version() const { return _state_version; } // calling this w/ thread sync is optional
+      uint64_t get_state_version() const { return _state_version; } // no lock required
 
-      name get_id_i() const { return _id; } // so far, only ever relevant in a test environment (no sync)
+      name get_id_i() const { return _id; } // only for testing
 
       // Calls to the following methods should be thread-synchronized externally:
 
       void get_state(finalizer_state& fs) const;
 
-      void on_beat(); //handler for pacemaker beat()
+      void on_beat();
 
-      void on_hs_vote_msg(const uint32_t connection_id, const hs_vote_message& msg); //vote msg event handler
-      void on_hs_proposal_msg(const uint32_t connection_id, const hs_proposal_message& msg); //proposal msg event handler
-      void on_hs_new_view_msg(const uint32_t connection_id, const hs_new_view_message& msg); //new view msg event handler
-      void on_hs_new_block_msg(const uint32_t connection_id, const hs_new_block_message& msg); //new block msg event handler
+      void on_hs_vote_msg(const uint32_t connection_id, const hs_vote_message& msg);
+      void on_hs_proposal_msg(const uint32_t connection_id, const hs_proposal_message& msg);
+      void on_hs_new_view_msg(const uint32_t connection_id, const hs_new_view_message& msg);
+      void on_hs_new_block_msg(const uint32_t connection_id, const hs_new_block_message& msg);
 
    private:
 
@@ -126,51 +126,59 @@ namespace eosio::hotstuff {
 
       hs_bitset update_bitset(const hs_bitset& finalizer_set, name finalizer);
 
-      digest_type get_digest_to_sign(const block_id_type& block_id, uint8_t phase_counter, const fc::sha256& final_on_qc); //get digest to sign from proposal data
+      //get digest to sign from proposal data
+      digest_type get_digest_to_sign(const block_id_type& block_id, uint8_t phase_counter, const fc::sha256& final_on_qc);
 
-      void reset_qc(const fc::sha256& proposal_id); //reset current internal qc
+      void reset_qc(const fc::sha256& proposal_id);
 
-      bool evaluate_quorum(const extended_schedule& es, const hs_bitset& finalizers, const fc::crypto::blslib::bls_signature& agg_sig, const hs_proposal_message& proposal); //evaluate quorum for a proposal
+      //evaluate quorum for a proposal
+      bool evaluate_quorum(const extended_schedule& es, const hs_bitset& finalizers, const fc::crypto::blslib::bls_signature& agg_sig, const hs_proposal_message& proposal);
 
-      // qc.quorum_met has to be updated by the caller (if it wants to) based on the return value of this method
-      bool is_quorum_met(const quorum_certificate& qc, const extended_schedule& schedule, const hs_proposal_message& proposal);  //check if quorum has been met over a proposal
+      //check if quorum has been met over a proposal
+      bool is_quorum_met(const quorum_certificate& qc, const extended_schedule& schedule, const hs_proposal_message& proposal);
 
-      hs_proposal_message new_proposal_candidate(const block_id_type& block_id, uint8_t phase_counter); //create new proposal message
-      hs_new_block_message new_block_candidate(const block_id_type& block_id); //create new block message
+      hs_proposal_message new_proposal_candidate(const block_id_type& block_id, uint8_t phase_counter);
+      hs_new_block_message new_block_candidate(const block_id_type& block_id);
 
-      bool am_i_proposer(); //check if I am the current proposer
-      bool am_i_leader(); //check if I am the current leader
-      bool am_i_finalizer(); //check if I am one of the current finalizers
+      bool am_i_proposer();
+      bool am_i_leader();
+      bool am_i_finalizer();
 
-      // is_loopback is used to check if the call is processing a self-receipt message (if so, never propagate it)
-      void process_proposal(const hs_proposal_message& msg, bool is_loopback = false); //handles proposal
-      void process_vote(const hs_vote_message& msg, bool is_loopback = false); //handles vote
-      void process_new_view(const hs_new_view_message& msg, bool is_loopback = false); //handles new view
-      void process_new_block(const hs_new_block_message& msg, bool is_loopback = false); //handles new block
+      // connection_id.has_value() when processing a non-loopback message
+      void process_proposal(const std::optional<uint32_t>& connection_id, const hs_proposal_message& msg);
+      void process_vote(const std::optional<uint32_t>& connection_id, const hs_vote_message& msg);
+      void process_new_view(const std::optional<uint32_t>& connection_id, const hs_new_view_message& msg);
+      void process_new_block(const std::optional<uint32_t>& connection_id, const hs_new_block_message& msg);
 
-      hs_vote_message sign_proposal(const hs_proposal_message& proposal, name finalizer); //sign proposal
+      hs_vote_message sign_proposal(const hs_proposal_message& proposal, name finalizer);
 
-      bool extends(const fc::sha256& descendant, const fc::sha256& ancestor); //verify that a proposal descends from another
+      //verify that a proposal descends from another
+      bool extends(const fc::sha256& descendant, const fc::sha256& ancestor);
 
-      bool update_high_qc(const quorum_certificate& high_qc); //check if update to our high qc is required
+      //update high qc if required
+      bool update_high_qc(const quorum_certificate& high_qc);
 
-      void leader_rotation_check(); //check if leader rotation is required
+      //rotate leader if required
+      void leader_rotation_check();
 
-      bool is_node_safe(const hs_proposal_message& proposal); //verify if a proposal should be signed
+      //verify if a proposal should be signed
+      bool is_node_safe(const hs_proposal_message& proposal);
 
-      std::vector<hs_proposal_message> get_qc_chain(const fc::sha256& proposal_id); //get 3-phase proposal justification
+      //get 3-phase proposal justification
+      std::vector<hs_proposal_message> get_qc_chain(const fc::sha256& proposal_id);
 
-      void send_hs_proposal_msg(const hs_proposal_message& msg, bool propagation = false); //send vote msg
-      void send_hs_vote_msg(const hs_vote_message& msg, bool propagation = false); //send proposal msg
-      void send_hs_new_view_msg(const hs_new_view_message& msg, bool propagation = false); //send new view msg
-      void send_hs_new_block_msg(const hs_new_block_message& msg, bool propagation = false); //send new block msg
+      // connection_id.has_value() when just propagating a received message
+      void send_hs_proposal_msg(const std::optional<uint32_t>& connection_id, const hs_proposal_message& msg);
+      void send_hs_vote_msg(const std::optional<uint32_t>& connection_id, const hs_vote_message& msg);
+      void send_hs_new_view_msg(const std::optional<uint32_t>& connection_id, const hs_new_view_message& msg);
+      void send_hs_new_block_msg(const std::optional<uint32_t>& connection_id, const hs_new_block_message& msg);
 
-      void send_hs_message_warning(const chain::hs_message_warning code = hs_message_warning::discarded); //use generic discard reason if none given
+      void send_hs_message_warning(const std::optional<uint32_t>& connection_id, const chain::hs_message_warning code);
 
-      void update(const hs_proposal_message& proposal); //update internal state
-      void commit(const hs_proposal_message& proposal); //commit proposal (finality)
+      void update(const hs_proposal_message& proposal);
+      void commit(const hs_proposal_message& proposal);
 
-      void gc_proposals(uint64_t cutoff); //garbage collection of old proposals
+      void gc_proposals(uint64_t cutoff);
 
 #warning remove. bls12-381 key used for testing purposes
       //todo : remove. bls12-381 key used for testing purposes
@@ -238,13 +246,6 @@ namespace eosio::hotstuff {
 
       proposal_store_type _proposal_store;  //internal proposals store
 #endif
-
-      // connection_id of the network peer that originally sent the message
-      //   being processed by the qc_chain. This is used to fill in the
-      //   exclude_peer parameter to the pacemaker when qc_chain is calling
-      //   the pacemaker to propagate that message, which the original sender
-      //   peer won't need to receive back.
-      std::optional<uint32_t> _sender_connection_id;
    };
 
 } /// eosio::hotstuff

--- a/libraries/hotstuff/include/eosio/hotstuff/test_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/test_pacemaker.hpp
@@ -57,10 +57,12 @@ namespace eosio { namespace hotstuff {
 
       uint32_t get_quorum_threshold();
 
-      void send_hs_proposal_msg(const hs_proposal_message & msg, name id);
-      void send_hs_vote_msg(const hs_vote_message & msg, name id);
-      void send_hs_new_block_msg(const hs_new_block_message & msg, name id);
-      void send_hs_new_view_msg(const hs_new_view_message & msg, name id);
+      void send_hs_proposal_msg(const hs_proposal_message & msg, name id, const std::optional<uint32_t>& exclude_peer);
+      void send_hs_vote_msg(const hs_vote_message & msg, name id, const std::optional<uint32_t>& exclude_peer);
+      void send_hs_new_block_msg(const hs_new_block_message & msg, name id, const std::optional<uint32_t>& exclude_peer);
+      void send_hs_new_view_msg(const hs_new_view_message & msg, name id, const std::optional<uint32_t>& exclude_peer);
+
+      void send_hs_message_warning(const uint32_t sender_peer, const chain::hs_message_warning code);
 
       std::vector<hotstuff_message> _pending_message_queue;
 

--- a/libraries/hotstuff/qc_chain.cpp
+++ b/libraries/hotstuff/qc_chain.cpp
@@ -290,7 +290,7 @@ namespace eosio::hotstuff {
       return v_msg;
    }
 
-   void qc_chain::process_proposal(const hs_proposal_message & proposal, bool is_loopback){
+   void qc_chain::process_proposal(const std::optional<uint32_t>& connection_id, const hs_proposal_message& proposal){
 
       //auto start = fc::time_point::now();
 
@@ -299,7 +299,7 @@ namespace eosio::hotstuff {
          const hs_proposal_message *jp = get_proposal( proposal.justify.proposal_id );
          if (jp == nullptr) {
             fc_elog(_logger, " *** ${id} proposal justification unknown : ${proposal_id}", ("id",_id)("proposal_id", proposal.justify.proposal_id));
-            send_hs_message_warning(); // example; to be tuned to actual need
+            send_hs_message_warning(connection_id, hs_message_warning::discarded); // example; to be tuned to actual need
             return; //can't recognize a proposal with an unknown justification
          }
       }
@@ -319,7 +319,7 @@ namespace eosio::hotstuff {
 
          }
 
-         send_hs_message_warning(); // example; to be tuned to actual need
+         send_hs_message_warning(connection_id, hs_message_warning::discarded); // example; to be tuned to actual need
          return; //already aware of proposal, nothing to do
       }
 
@@ -419,7 +419,7 @@ namespace eosio::hotstuff {
       update(proposal);
 
       for (auto &msg : msgs) {
-         send_hs_vote_msg(msg);
+         send_hs_vote_msg( std::nullopt, msg );
       }
 
       //check for leader change
@@ -429,7 +429,7 @@ namespace eosio::hotstuff {
       //fc_dlog(_logger, " ... process_proposal() total time : ${total_time}", ("total_time", total_time));
    }
 
-   void qc_chain::process_vote(const hs_vote_message & vote, bool is_loopback){
+   void qc_chain::process_vote(const std::optional<uint32_t>& connection_id, const hs_vote_message& vote){
 
       //auto start = fc::time_point::now();
 #warning check for duplicate or invalid vote. We will return in either case, but keep proposals for evidence of double signing
@@ -443,14 +443,14 @@ namespace eosio::hotstuff {
               ("finalizer", vote.finalizer)("value", _current_qc.get_active_finalizers_string()));
       // only leader need to take action on votes
       if (vote.proposal_id != _current_qc.get_proposal_id()) {
-         send_hs_message_warning(); // example; to be tuned to actual need
+         send_hs_message_warning(connection_id, hs_message_warning::discarded); // example; to be tuned to actual need
          return;
       }
 
       const hs_proposal_message *p = get_proposal( vote.proposal_id );
       if (p == nullptr) {
          fc_elog(_logger, " *** ${id} couldn't find proposal, vote : ${vote}", ("id",_id)("vote", vote));
-         send_hs_message_warning(); // example; to be tuned to actual need
+         send_hs_message_warning(connection_id, hs_message_warning::discarded); // example; to be tuned to actual need
          return;
       }
 
@@ -503,7 +503,7 @@ namespace eosio::hotstuff {
                _pending_proposal_block = {};
                _b_leaf = proposal_candidate.proposal_id;
 
-               send_hs_proposal_msg(proposal_candidate);
+               send_hs_proposal_msg( std::nullopt, proposal_candidate );
                fc_tlog(_logger, " === ${id} _b_leaf updated (process_vote): ${proposal_id}", ("proposal_id", proposal_candidate.proposal_id)("id", _id));
             }
          }
@@ -513,7 +513,7 @@ namespace eosio::hotstuff {
       //fc_tlog(_logger, " ... process_vote() total time : ${total_time}", ("total_time", total_time));
    }
 
-   void qc_chain::process_new_view(const hs_new_view_message & msg, bool is_loopback){
+   void qc_chain::process_new_view(const std::optional<uint32_t>& connection_id, const hs_new_view_message& msg){
       fc_tlog(_logger, " === ${id} process_new_view === ${qc}", ("qc", msg.high_qc)("id", _id));
       auto increment_version = fc::make_scoped_exit([this]() { ++_state_version; });
       if (!update_high_qc(quorum_certificate{msg.high_qc})) {
@@ -521,7 +521,7 @@ namespace eosio::hotstuff {
       }
    }
 
-   void qc_chain::process_new_block(const hs_new_block_message & msg, bool is_loopback){
+   void qc_chain::process_new_block(const std::optional<uint32_t>& connection_id, const hs_new_block_message& msg){
 
       // If I'm not a leader, I probably don't care about hs-new-block messages.
 #warning check for a need to gossip/rebroadcast even if it's not for us (maybe here, maybe somewhere else).
@@ -571,39 +571,39 @@ namespace eosio::hotstuff {
          _pending_proposal_block = {};
          _b_leaf = proposal_candidate.proposal_id;
 
-         send_hs_proposal_msg(proposal_candidate);
+         send_hs_proposal_msg( std::nullopt, proposal_candidate );
 
          fc_tlog(_logger, " === ${id} _b_leaf updated (on_beat): ${proposal_id}", ("proposal_id", proposal_candidate.proposal_id)("id", _id));
       }
    }
 
-   void qc_chain::send_hs_proposal_msg(const hs_proposal_message & msg, bool propagation){
+   void qc_chain::send_hs_proposal_msg(const std::optional<uint32_t>& connection_id, const hs_proposal_message & msg){
       fc_tlog(_logger, " === broadcast_hs_proposal ===");
-      _pacemaker->send_hs_proposal_msg(msg, _id, propagation ? _sender_connection_id : std::nullopt);
-      if (!propagation)
-         process_proposal(msg, true);
+      _pacemaker->send_hs_proposal_msg(msg, _id, connection_id);
+      if (!connection_id.has_value())
+         process_proposal( std::nullopt, msg );
    }
 
-   void qc_chain::send_hs_vote_msg(const hs_vote_message & msg, bool propagation){
+   void qc_chain::send_hs_vote_msg(const std::optional<uint32_t>& connection_id, const hs_vote_message & msg){
       fc_tlog(_logger, " === broadcast_hs_vote ===");
-      _pacemaker->send_hs_vote_msg(msg, _id, propagation ? _sender_connection_id : std::nullopt);
-      if (!propagation)
-         process_vote(msg, true);
+      _pacemaker->send_hs_vote_msg(msg, _id, connection_id);
+      if (!connection_id.has_value())
+         process_vote( std::nullopt, msg );
    }
 
-   void qc_chain::send_hs_new_view_msg(const hs_new_view_message & msg, bool propagation){
+   void qc_chain::send_hs_new_view_msg(const std::optional<uint32_t>& connection_id, const hs_new_view_message & msg){
       fc_tlog(_logger, " === broadcast_hs_new_view ===");
-      _pacemaker->send_hs_new_view_msg(msg, _id, propagation ? _sender_connection_id : std::nullopt);
+      _pacemaker->send_hs_new_view_msg(msg, _id, connection_id);
    }
 
-   void qc_chain::send_hs_new_block_msg(const hs_new_block_message & msg, bool propagation){
+   void qc_chain::send_hs_new_block_msg(const std::optional<uint32_t>& connection_id, const hs_new_block_message & msg){
       fc_tlog(_logger, " === broadcast_hs_new_block ===");
-      _pacemaker->send_hs_new_block_msg(msg, _id, propagation ? _sender_connection_id : std::nullopt);
+      _pacemaker->send_hs_new_block_msg(msg, _id, connection_id);
    }
 
-   void qc_chain::send_hs_message_warning(const chain::hs_message_warning code) {
-      EOS_ASSERT( _sender_connection_id.has_value() , chain_exception, "qc_chain processed a message without a sender" );
-      _pacemaker->send_hs_message_warning(_sender_connection_id.value(), code);
+   void qc_chain::send_hs_message_warning(const std::optional<uint32_t>& connection_id, const chain::hs_message_warning code) {
+      if (connection_id.has_value())
+         _pacemaker->send_hs_message_warning(connection_id.value(), code);
    }
 
    //extends predicate
@@ -642,8 +642,6 @@ namespace eosio::hotstuff {
    // Called from the main application thread
    void qc_chain::on_beat(){
 
-      _sender_connection_id = std::nullopt;
-
       // Non-proposing leaders do not care about on_beat(), because leaders react to a block proposal
       //   which comes from processing an incoming new block message from a proposer instead.
       // on_beat() is called by the pacemaker, which decides when it's time to check whether we are
@@ -668,7 +666,7 @@ namespace eosio::hotstuff {
 
          fc_tlog(_logger, " === I am a leader-proposer that is proposing a block for itself to lead");
          // Hardwired consumption by self; no networking.
-         process_new_block( block_candidate );
+         process_new_block( std::nullopt, block_candidate );
 
       } else {
 
@@ -676,7 +674,7 @@ namespace eosio::hotstuff {
          //   the network, until it reaches the leader.
 
          fc_tlog(_logger, " === broadcasting new block = #${block_num} ${proposal_id}", ("proposal_id", block_candidate.block_id)("block_num",(block_header::num_from_id(block_candidate.block_id))));
-         send_hs_new_block_msg( block_candidate );
+         send_hs_new_block_msg( std::nullopt, block_candidate );
       }
    }
 
@@ -744,7 +742,7 @@ namespace eosio::hotstuff {
 
          new_view.high_qc = _high_qc.to_msg();
 
-         send_hs_new_view_msg(new_view);
+         send_hs_new_view_msg( std::nullopt, new_view );
       }
    }
 
@@ -849,26 +847,22 @@ namespace eosio::hotstuff {
 
    //on proposal received, called from network thread
    void qc_chain::on_hs_proposal_msg(const uint32_t connection_id, const hs_proposal_message& msg) {
-      _sender_connection_id = connection_id;
-      process_proposal(msg);
+      process_proposal( std::optional<uint32_t>(connection_id), msg );
    }
 
    //on vote received, called from network thread
    void qc_chain::on_hs_vote_msg(const uint32_t connection_id, const hs_vote_message& msg) {
-      _sender_connection_id = connection_id;
-      process_vote(msg);
+      process_vote( std::optional<uint32_t>(connection_id), msg );
    }
 
    //on new view received, called from network thread
    void qc_chain::on_hs_new_view_msg(const uint32_t connection_id, const hs_new_view_message& msg) {
-      _sender_connection_id = connection_id;
-      process_new_view(msg);
+      process_new_view( std::optional<uint32_t>(connection_id), msg );
    }
 
    //on new block received, called from network thread
    void qc_chain::on_hs_new_block_msg(const uint32_t connection_id, const hs_new_block_message& msg) {
-      _sender_connection_id = connection_id;
-      process_new_block(msg);
+      process_new_block( std::optional<uint32_t>(connection_id), msg );
    }
 
    void qc_chain::update(const hs_proposal_message& proposal) {

--- a/libraries/hotstuff/test/test_pacemaker.cpp
+++ b/libraries/hotstuff/test/test_pacemaker.cpp
@@ -158,21 +158,23 @@ namespace eosio::hotstuff {
          _qcc_store.emplace( name, qcc_ptr );
    };
 
-   void test_pacemaker::send_hs_proposal_msg(const hs_proposal_message& msg, name id) {
+   void test_pacemaker::send_hs_proposal_msg(const hs_proposal_message& msg, name id, const std::optional<uint32_t>& exclude_peer) {
       _pending_message_queue.push_back(std::make_pair(id, msg));
    };
 
-   void test_pacemaker::send_hs_vote_msg(const hs_vote_message& msg, name id) {
+   void test_pacemaker::send_hs_vote_msg(const hs_vote_message& msg, name id, const std::optional<uint32_t>& exclude_peer) {
       _pending_message_queue.push_back(std::make_pair(id, msg));
    };
 
-   void test_pacemaker::send_hs_new_block_msg(const hs_new_block_message& msg, name id) {
+   void test_pacemaker::send_hs_new_block_msg(const hs_new_block_message& msg, name id, const std::optional<uint32_t>& exclude_peer) {
       _pending_message_queue.push_back(std::make_pair(id, msg));
    };
 
-   void test_pacemaker::send_hs_new_view_msg(const hs_new_view_message& msg, name id) {
+   void test_pacemaker::send_hs_new_view_msg(const hs_new_view_message& msg, name id, const std::optional<uint32_t>& exclude_peer) {
       _pending_message_queue.push_back(std::make_pair(id, msg));
    };
+
+   void test_pacemaker::send_hs_message_warning(const uint32_t sender_peer, const chain::hs_message_warning code) { }
 
    void test_pacemaker::on_hs_proposal_msg(const hs_proposal_message& msg, name id) {
       auto qc_itr = _qcc_store.begin();
@@ -180,7 +182,7 @@ namespace eosio::hotstuff {
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
          if (qcc_ptr->get_id_i() != id && is_qc_chain_active(qcc_name) )
-            qcc_ptr->on_hs_proposal_msg(msg);
+            qcc_ptr->on_hs_proposal_msg(0, msg);
          qc_itr++;
       }
    }
@@ -191,7 +193,7 @@ namespace eosio::hotstuff {
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
          if (qcc_ptr->get_id_i() != id && is_qc_chain_active(qcc_name) )
-            qcc_ptr->on_hs_vote_msg(msg);
+            qcc_ptr->on_hs_vote_msg(0, msg);
          qc_itr++;
       }
    }
@@ -202,7 +204,7 @@ namespace eosio::hotstuff {
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
          if (qcc_ptr->get_id_i() != id && is_qc_chain_active(qcc_name) )
-            qcc_ptr->on_hs_new_block_msg(msg);
+            qcc_ptr->on_hs_new_block_msg(0, msg);
          qc_itr++;
       }
    }
@@ -213,7 +215,7 @@ namespace eosio::hotstuff {
          const name                & qcc_name = qc_itr->first;
          std::shared_ptr<qc_chain> & qcc_ptr  = qc_itr->second;
          if (qcc_ptr->get_id_i() != id && is_qc_chain_active(qcc_name) )
-            qcc_ptr->on_hs_new_view_msg(msg);
+            qcc_ptr->on_hs_new_view_msg(0, msg);
          qc_itr++;
       }
    }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1122,11 +1122,15 @@ void chain_plugin::create_pacemaker(std::set<chain::account_name> my_producers, 
    my->_chain_pacemaker.emplace(&chain(), std::move(my_producers), std::move(finalizer_keys), hotstuff_logger);
 }
 
-void chain_plugin::register_pacemaker_bcast_function(std::function<void(const chain::hs_message&)> bcast_hs_message) {
+void chain_plugin::register_pacemaker_bcast_function(std::function<void(const std::optional<uint32_t>&, const chain::hs_message&)> bcast_hs_message) {
    EOS_ASSERT( my->_chain_pacemaker, plugin_config_exception, "chain_pacemaker not created" );
    my->_chain_pacemaker->register_bcast_function(std::move(bcast_hs_message));
 }
 
+void chain_plugin::register_pacemaker_warn_function(std::function<void(const uint32_t, const chain::hs_message_warning&)> warn_hs_message) {
+   EOS_ASSERT( my->_chain_pacemaker, plugin_config_exception, "chain_pacemaker not created" );
+   my->_chain_pacemaker->register_warn_function(std::move(warn_hs_message));
+}
 
 void chain_plugin::plugin_initialize(const variables_map& options) {
    handle_sighup(); // Sets loggers
@@ -2685,8 +2689,8 @@ read_only::get_finalizer_state(const get_finalizer_state_params&, const fc::time
 } // namespace chain_apis
 
 // called from net threads
-void chain_plugin::notify_hs_message( const hs_message& msg ) {
-   my->_chain_pacemaker->on_hs_msg(msg);
+void chain_plugin::notify_hs_message( const uint32_t connection_id, const hs_message& msg ) {
+   my->_chain_pacemaker->on_hs_msg(connection_id, msg);
 };
 
 void chain_plugin::notify_hs_block_produced() {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -1032,8 +1032,9 @@ public:
    const controller& chain() const;
 
    void create_pacemaker(std::set<chain::account_name> my_producers, chain::bls_key_map_t finalizer_keys);
-   void register_pacemaker_bcast_function(std::function<void(const chain::hs_message&)> bcast_hs_message);
-   void notify_hs_message( const chain::hs_message& msg );
+   void register_pacemaker_bcast_function(std::function<void(const std::optional<uint32_t>&, const chain::hs_message&)> bcast_hs_message);
+   void register_pacemaker_warn_function(std::function<void(const uint32_t, const chain::hs_message_warning&)> warn_hs_message);
+   void notify_hs_message( const uint32_t connection_id, const chain::hs_message& msg );
    void notify_hs_block_produced();
 
    chain::chain_id_type get_chain_id() const;


### PR DESCRIPTION
- connection ID of hs message sender (net plugin -> IF engine)
- connection ID to exclude when propagating (IF engine -> net plugin)
- added callback to warn of bad HS messages from a connection (IF engine -> net plugin)
- added sample use of the warning callback for discarded proposals and votes
- helpers on qc_chain to allow for easy message propagation (no propagation decisions added)
- no-ops for this feature added to test_pacemaker (which does not have multi-hop)

Closes #1605

Obsoletes PR #1583, which can be closed as a message propagation strategy (for closing #1548) will be decided and then implemented on top of the code in this PR (suggestion https://github.com/AntelopeIO/leap/pull/1583/files/e1cc627a75853e2929df25cbcc3ee4f76066ba37#r1316210590 can be implemented when we remove the qc_chain profiler).