### PR TITLE
IF: Use bls12_381::pop_prove to generate POP and add get_pop_str method to libfc

### DIFF
--- a/libraries/libfc/include/fc/crypto/bls_private_key.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_private_key.hpp
@@ -28,9 +28,7 @@ namespace fc::crypto::blslib {
 
          bls_public_key     get_public_key() const;
          bls_signature      sign( const std::vector<uint8_t>& message ) const;
-
-         // Returns proof of possession
-         bls_signature      pop_proof() const;
+         bls_signature      proof_of_possession() const;
 
          static bls_private_key generate();
 

--- a/libraries/libfc/include/fc/crypto/bls_private_key.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_private_key.hpp
@@ -28,6 +28,7 @@ namespace fc::crypto::blslib {
 
          bls_public_key     get_public_key() const;
          bls_signature      sign( const std::vector<uint8_t>& message ) const;
+         std::string        get_pop_str() const;
 
          static bls_private_key generate();
 

--- a/libraries/libfc/include/fc/crypto/bls_private_key.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_private_key.hpp
@@ -28,7 +28,9 @@ namespace fc::crypto::blslib {
 
          bls_public_key     get_public_key() const;
          bls_signature      sign( const std::vector<uint8_t>& message ) const;
-         std::string        get_pop_str() const;
+
+         // Returns proof of possession
+         bls_signature      pop_proof() const;
 
          static bls_private_key generate();
 

--- a/libraries/libfc/src/crypto/bls_private_key.cpp
+++ b/libraries/libfc/src/crypto/bls_private_key.cpp
@@ -13,7 +13,7 @@ namespace fc::crypto::blslib {
       return bls_public_key(pk);
    }
 
-   bls_signature bls_private_key::pop_proof() const
+   bls_signature bls_private_key::proof_of_possession() const
    {
       bls12_381::g2 proof = bls12_381::pop_prove(_sk);
       return bls_signature(proof);

--- a/libraries/libfc/src/crypto/bls_private_key.cpp
+++ b/libraries/libfc/src/crypto/bls_private_key.cpp
@@ -13,6 +13,14 @@ namespace fc::crypto::blslib {
       return bls_public_key(pk);
    }
 
+   std::string bls_private_key::get_pop_str() const
+   {
+      bls12_381::g2 proof = bls12_381::pop_prove(_sk);
+      constexpr bool raw = true;
+      std::array<uint8_t, 192> bytes = proof.toAffineBytesLE(raw);
+      return fc::crypto::blslib::serialize_base64<std::array<uint8_t, 192>>(bytes);
+   }
+
    bls_signature bls_private_key::sign( const std::vector<uint8_t>& message ) const
    {
       bls12_381::g2 sig = bls12_381::sign(_sk, message);

--- a/libraries/libfc/src/crypto/bls_private_key.cpp
+++ b/libraries/libfc/src/crypto/bls_private_key.cpp
@@ -13,12 +13,10 @@ namespace fc::crypto::blslib {
       return bls_public_key(pk);
    }
 
-   std::string bls_private_key::get_pop_str() const
+   bls_signature bls_private_key::pop_proof() const
    {
       bls12_381::g2 proof = bls12_381::pop_prove(_sk);
-      constexpr bool raw = true;
-      std::array<uint8_t, 192> bytes = proof.toAffineBytesLE(raw);
-      return fc::crypto::blslib::serialize_base64<std::array<uint8_t, 192>>(bytes);
+      return bls_signature(proof);
    }
 
    bls_signature bls_private_key::sign( const std::vector<uint8_t>& message ) const

--- a/programs/leap-util/actions/bls.cpp
+++ b/programs/leap-util/actions/bls.cpp
@@ -54,13 +54,13 @@ int bls_actions::create_key() {
    const bls_private_key private_key = bls_private_key::generate();
    const bls_public_key public_key = private_key.get_public_key();
 
-   // generate pop
-   const std::string pop_str = private_key.get_pop_str();
+   // generate proof of possession
+   const bls_signature pop = private_key.pop_proof();
 
    // prepare output
    std::string out_str = "Private key: " + private_key.to_string({}) + "\n";
    out_str += "Public key: " + public_key.to_string({}) + "\n";
-   out_str += "Proof of Possession: " + pop_str + "\n";
+   out_str += "Proof of Possession: " + pop.to_string({}) + "\n";
    if (opt->print_console) {
       std::cout << out_str;
    } else {
@@ -106,9 +106,9 @@ int bls_actions::create_pop() {
    // create private key object using input private key string
    const bls_private_key private_key = bls_private_key(private_key_str);
    const bls_public_key public_key = private_key.get_public_key();
-   std::string pop_str = private_key.get_pop_str();
+   const bls_signature pop = private_key.pop_proof();
 
-   std::cout << "Proof of Possession: " << pop_str << "\n";
+   std::cout << "Proof of Possession: " << pop.to_string({})<< "\n";
    std::cout << "Public key: " <<  public_key.to_string({}) << "\n";
 
    return 0;

--- a/programs/leap-util/actions/bls.cpp
+++ b/programs/leap-util/actions/bls.cpp
@@ -55,7 +55,7 @@ int bls_actions::create_key() {
    const bls_public_key public_key = private_key.get_public_key();
 
    // generate proof of possession
-   const bls_signature pop = private_key.pop_proof();
+   const bls_signature pop = private_key.proof_of_possession();
 
    // prepare output
    std::string out_str = "Private key: " + private_key.to_string({}) + "\n";
@@ -106,7 +106,7 @@ int bls_actions::create_pop() {
    // create private key object using input private key string
    const bls_private_key private_key = bls_private_key(private_key_str);
    const bls_public_key public_key = private_key.get_public_key();
-   const bls_signature pop = private_key.pop_proof();
+   const bls_signature pop = private_key.proof_of_possession();
 
    std::cout << "Proof of Possession: " << pop.to_string({})<< "\n";
    std::cout << "Public key: " <<  public_key.to_string({}) << "\n";

--- a/programs/leap-util/actions/bls.cpp
+++ b/programs/leap-util/actions/bls.cpp
@@ -55,7 +55,7 @@ int bls_actions::create_key() {
    const bls_public_key public_key = private_key.get_public_key();
 
    // generate pop
-   const std::string pop_str = generate_pop_str(private_key);
+   const std::string pop_str = private_key.get_pop_str();
 
    // prepare output
    std::string out_str = "Private key: " + private_key.to_string({}) + "\n";
@@ -106,20 +106,10 @@ int bls_actions::create_pop() {
    // create private key object using input private key string
    const bls_private_key private_key = bls_private_key(private_key_str);
    const bls_public_key public_key = private_key.get_public_key();
-   std::string pop_str = generate_pop_str(private_key); 
+   std::string pop_str = private_key.get_pop_str();
 
    std::cout << "Proof of Possession: " << pop_str << "\n";
    std::cout << "Public key: " <<  public_key.to_string({}) << "\n";
 
    return 0;
-}
-
-std::string bls_actions::generate_pop_str(const bls_private_key& private_key) {
-   const bls_public_key public_key = private_key.get_public_key();
-
-   const std::array<uint8_t, 96> msg = public_key._pkey.toAffineBytesLE(true); // true means raw
-   const std::vector<uint8_t> msg_vector = std::vector<uint8_t>(msg.begin(), msg.end());
-   const bls_signature pop = private_key.sign(msg_vector);
-
-   return pop.to_string({});
 }

--- a/tests/leap_util_bls_test.py
+++ b/tests/leap_util_bls_test.py
@@ -100,12 +100,13 @@ def check_create_key_results(rslts):
     # check each output has valid value
     assert "PVT_BLS_" in results["Private key"]
     assert "PUB_BLS_" in results["Public key"]
+    assert "SIG_BLS_" in results["Proof of Possession"]
 
 def get_results(rslts):
     # sample output looks like
     # Private key: PVT_BLS_kRhJJ2MsM+/CddO...
     # Public key: PUB_BLS_lbUE8922wUfX0Iy5...
-    # Proof of Possession: 3jwkVUUYahHgsnmnEA...
+    # Proof of Possession: SIG_BLS_3jwkVUUYahHgsnmnEA...
     pattern = r'(\w+[^:]*): ([^\n]+)'
     matched= re.findall(pattern, rslts)
     

--- a/tests/leap_util_bls_test.py
+++ b/tests/leap_util_bls_test.py
@@ -100,13 +100,12 @@ def check_create_key_results(rslts):
     # check each output has valid value
     assert "PVT_BLS_" in results["Private key"]
     assert "PUB_BLS_" in results["Public key"]
-    assert "SIG_BLS_" in results["Proof of Possession"]
 
 def get_results(rslts):
     # sample output looks like
     # Private key: PVT_BLS_kRhJJ2MsM+/CddO...
     # Public key: PUB_BLS_lbUE8922wUfX0Iy5...
-    # Proof of Possession: SIG_BLS_olZfcFw...
+    # Proof of Possession: 3jwkVUUYahHgsnmnEA...
     pattern = r'(\w+[^:]*): ([^\n]+)'
     matched= re.findall(pattern, rslts)
     


### PR DESCRIPTION
Fixed https://github.com/AntelopeIO/leap/issues/1525 to use BLS library `pop_prove` to generate POP.
* Added `get_pop_str` to libfc `bls_private_key` using `pop_prove`;
* Modified leap-util to use `get_pop_str`;
* Updated the test.