### PR TITLE
add a needed `typename` for newer clang compilers

### DIFF
--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -287,7 +287,7 @@ std::unique_ptr<wasm_instantiated_module_interface> eos_vm_profile_runtime::inst
 #endif
 
 template<typename Impl>
-thread_local eos_vm_runtime<Impl>::context_t eos_vm_runtime<Impl>::_exec_ctx;
+thread_local typename eos_vm_runtime<Impl>::context_t eos_vm_runtime<Impl>::_exec_ctx;
 template<typename Impl>
 thread_local eos_vm_backend_t<Impl> eos_vm_runtime<Impl>::_bkend;
 }


### PR DESCRIPTION
This errored out on me on a recent Xcode version