### PR TITLE
remove now unneeded macOS z/bz2/lzma/zstd boost iostreams workaround

### DIFF
--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -66,19 +66,6 @@ file( GLOB_RECURSE fc_headers ${CMAKE_CURRENT_SOURCE_DIR} *.hpp *.h )
 
 add_library(fc ${fc_sources} ${fc_headers})
 
-# Yuck: newer CMake files from boost iostreams will effectively target_link_libraries(Boost::iostreams z;bz2;lzma;zstd)
-#  without first "finding" those libraries. This resolves to simple -lz -lbz2 etc: it'll look for those libraries in the linker's
-#  library search path. This is most problematic on macOS where something like libzstd isn't in the standard search path. Historically
-#  fc would just "-L/usr/local/lib" as a heavy handed way to make sure something like -lzstd can be found in brew's library path. But
-#  that isn't sufficient for something like ARM homebrew. Let's just "null" these libraries out since we're already linking to zlib
-#  explicitly anyways via a proper find_package(ZLIB) below.
-if(APPLE)
-  add_library(z INTERFACE)
-  add_library(bz2 INTERFACE)
-  add_library(lzma INTERFACE)
-  add_library(zstd INTERFACE)
-endif()
-
 find_path(GMP_INCLUDE_DIR NAMES gmp.h)
 find_library(GMP_LIBRARY gmp)
 if(NOT GMP_LIBRARY MATCHES ${CMAKE_SHARED_LIBRARY_SUFFIX})


### PR DESCRIPTION
When using boost integrated via a submodule + cmake, iostreams' cmake files correctly discover the dependent compression libraries instead of just blindly doing `-llzma`. We no longer need this workaround.