### PR TITLE
add some additional test cases in modexp benchmark

### DIFF
--- a/benchmark/modexp.cpp
+++ b/benchmark/modexp.cpp
@@ -51,7 +51,7 @@ void modexp_benchmarking() {
       };
 
       //some modexp implementations need to take a minor different path if base is greater than modulus, try both
-      FC_ASSERT(modulus[0] != '\xff');
+      FC_ASSERT(modulus[0] != '\xff' && modulus[0] != 0);
       base.front() = 0;
       even_and_odd("B<M");
       base.front() = '\xff';


### PR DESCRIPTION
This adds a number of new cases in the modexp benchmark:
* more widths (I was curious to see behavior at smaller sizes)
* even vs odd modulus (very, very, critical performance difference for some modexp impls)
* base being greater vs less than modulus (for some impls results in minor difference in code path taken)