### PR TITLE
[PH] Fix issues with processing read-only transactions.

### DIFF
--- a/tests/PerformanceHarness/log_reader.py
+++ b/tests/PerformanceHarness/log_reader.py
@@ -269,11 +269,13 @@ def scrapeTrxGenTrxSentDataLogs(trxSent: dict, trxGenLogDirPath, quiet):
     if not quiet:
         print(f"Transaction Log Files Scraped: {filesScraped}")
 
-def populateTrxSentAndAcked(trxSent: dict, trxDict: dict, notFound):
+def populateTrxSentAndAcked(trxSent: dict, data: chainData, notFound):
+    trxDict = data.trxDict
     for sentTrxId in trxSent.keys():
         if (isinstance(trxSent[sentTrxId], sentTrxExtTrace)):
             trxDict[sentTrxId] = trxData(blockNum=trxSent[sentTrxId].blockNum, cpuUsageUs=trxSent[sentTrxId].cpuUsageUs, netUsageUs=trxSent[sentTrxId].netUsageWords, blockTime=trxSent[sentTrxId].blockTime, acknowledged=trxSent[sentTrxId].acked, ackRespTimeUs=trxSent[sentTrxId].ackResponseTimeUs)
             trxDict[sentTrxId].sentTimestamp = trxSent[sentTrxId].sentTime
+            data.blockDict[str(trxSent[sentTrxId].blockNum)].transactions +=1
         elif sentTrxId in trxDict.keys():
             trxDict[sentTrxId].sentTimestamp = trxSent[sentTrxId].sentTime
             trxDict[sentTrxId].acknowledged = trxSent[sentTrxId].acked
@@ -493,7 +495,7 @@ def analyzeLogResults(data: chainData, tpsTestConfig: TpsTestConfig, artifacts: 
     trxAckStatsApplicable="NOT APPLICABLE" if list(trxSent.values())[0].acked == "NA" else "APPLICABLE"
 
     notFound = []
-    populateTrxSentAndAcked(trxSent, data.trxDict, notFound)
+    populateTrxSentAndAcked(trxSent, data, notFound)
 
     prodDict = {}
     getProductionWindows(prodDict, data)

--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -107,6 +107,10 @@ namespace eosio::testing {
    }
 
    bool http_connection::needs_response_trace_info() {
+      return is_read_only_transaction();
+   }
+
+   bool http_connection::is_read_only_transaction() {
       return _config._api_endpoint == "/v1/chain/send_read_only_transaction";
    }
 
@@ -139,6 +143,7 @@ namespace eosio::testing {
                       const auto& processed      = resp_json["processed"];
                       const auto& block_num      = processed["block_num"].as_uint64();
                       const auto& block_time     = processed["block_time"].as_string();
+                      const auto& elapsed_time     = processed["elapsed"].as_uint64();
                       std::string status         = "failed";
                       uint32_t    net            = 0;
                       uint32_t    cpu            = 0;
@@ -150,7 +155,7 @@ namespace eosio::testing {
                             cpu    = receipt["cpu_usage_us"].as_uint64();
                          }
                          if (status == "executed") {
-                            record_trx_info(trx_id, block_num, cpu, net, block_time);
+                            record_trx_info(trx_id, block_num, this->is_read_only_transaction() ? elapsed_time : cpu, net, block_time);
                          } else {
                             elog("async_http_request Transaction receipt status not executed: ${string}",
                                  ("string", response.body()));

--- a/tests/trx_generator/trx_provider.hpp
+++ b/tests/trx_generator/trx_provider.hpp
@@ -99,6 +99,7 @@ namespace eosio::testing {
       void connect() override final;
       void disconnect() override final;
       bool needs_response_trace_info();
+      bool is_read_only_transaction();
    };
 
    struct p2p_connection : public provider_connection {


### PR DESCRIPTION
Read only transactions are not logged in trace for cpu usage since they are not billed as such, thus use the elapsed time for the transaction processing to get the cpu usage overall.

Because read only transactions don't make it into blocks in the block log, need to add the transactions from the log file into the data block transaction counter for use in tps stats calculations in performance harness.

Relates to: https://github.com/AntelopeIO/leap/issues/1634