### PR TITLE
avoid unaligned accesses to types casted from byte stream in WAVM's wasm parser

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_eosio_binary_ops.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_binary_ops.hpp
@@ -135,7 +135,7 @@ inline void pack( instruction_stream* stream, branchtabletype field ) {
 template <typename Field>
 struct field_specific_params {
    static constexpr int skip_ahead = sizeof(uint16_t) + sizeof(Field);
-   static auto unpack( char* opcode, Field& f ) { f = *reinterpret_cast<Field*>(opcode); }
+   static auto unpack( char* opcode, Field& f ) { memcpy(&f, opcode, sizeof(f)); }
    static void pack(instruction_stream* stream, Field& f) { return eosio::chain::wasm_ops::pack(stream, f); }
    static auto to_string(Field& f) { return std::string(" ")+
                                        eosio::chain::wasm_ops::to_string(f); }
@@ -664,7 +664,8 @@ struct EOSIO_OperatorDecoderStream
 
    instr* decodeOp() {
       EOS_ASSERT(nextByte + sizeof(IR::Opcode) <= end, wasm_exception, "");
-      IR::Opcode opcode = *(IR::Opcode*)nextByte;  
+      IR::Opcode opcode;
+      memcpy(&opcode, nextByte, sizeof(opcode));
       switch(opcode)
       {
       #define VISIT_OPCODE(opcode,name,nameString,Imm,...) \

--- a/libraries/wasm-jit/Include/IR/Operators.h
+++ b/libraries/wasm-jit/Include/IR/Operators.h
@@ -297,6 +297,7 @@ namespace IR
 	});
 
 	// Specialize for the empty immediate structs so they don't take an extra byte of space.
+	PACKED_STRUCT(
 	template<>
 	struct OpcodeAndImm<NoImm>
 	{
@@ -305,7 +306,8 @@ namespace IR
 			Opcode opcode;
 			NoImm imm;
 		};
-	};
+	});
+	PACKED_STRUCT(
 	template<>
 	struct OpcodeAndImm<MemoryImm>
 	{
@@ -314,7 +316,7 @@ namespace IR
 			Opcode opcode;
 			MemoryImm imm;
 		};
-	};
+	});
 
 	// Decodes an operator from an input stream and dispatches by opcode.
 	struct OperatorDecoderStream
@@ -328,7 +330,8 @@ namespace IR
 		typename Visitor::Result decodeOp(Visitor& visitor)
 		{
 			WAVM_ASSERT_THROW(nextByte + sizeof(Opcode) <= end);
-			Opcode opcode = *(Opcode*)nextByte;
+			Opcode opcode;
+			memcpy(&opcode, nextByte, sizeof(opcode));
 			switch(opcode)
 			{
 			#define VISIT_OPCODE(opcode,name,nameString,Imm,...) \


### PR DESCRIPTION
WAVM's parser casts `Opcode` and `OpcodeAndImm<>` to pointers _at arbitrary bytes_ within the WASM byte stream. For example,
https://github.com/AntelopeIO/leap/blob/6132e3be2225fe1de088ca31625238bc07f65636/libraries/wasm-jit/Include/IR/Operators.h#L327-L341

However, `Opcode`  (including the `Opcode` in the `OpcodeAndImm<>` struct), is a `uint16_t` which gives the compiler leeway to use instructions that require 2-byte alignment on access. On x86 and ARM8 this is not a problem but it's still UB to spec, so prudent to resolve.