### PR TITLE
avoid possible memcpy with nullptr when action data size is 0

### DIFF
--- a/libraries/chain/webassembly/action.cpp
+++ b/libraries/chain/webassembly/action.cpp
@@ -5,10 +5,8 @@
 namespace eosio { namespace chain { namespace webassembly {
    int32_t interface::read_action_data(legacy_span<char> memory) const {
       auto s = context.get_action().data.size();
-      if( s == 0 ) return s;
-      if( memory.size() == 0 ) return s;
-
       auto copy_size = std::min( static_cast<size_t>(memory.size()), s );
+      if( copy_size == 0 ) return s;
       std::memcpy( memory.data(), context.get_action().data.data(), copy_size );
 
       return copy_size;

--- a/libraries/chain/webassembly/action.cpp
+++ b/libraries/chain/webassembly/action.cpp
@@ -5,6 +5,7 @@
 namespace eosio { namespace chain { namespace webassembly {
    int32_t interface::read_action_data(legacy_span<char> memory) const {
       auto s = context.get_action().data.size();
+      if( s == 0 ) return s;
       if( memory.size() == 0 ) return s;
 
       auto copy_size = std::min( static_cast<size_t>(memory.size()), s );


### PR DESCRIPTION
When action data size is 0, it was possible for a `memcpy` call to contain a source pointer of `nullptr` and length of `0`. This is not defined behavior, but a careful analysis of leap's supported platforms and prior builds shows no evidence this could be a source of indeterminism so this change is not being treated as a security fix.