### PR TITLE
(failed implementation) use boringssl instead of GMP for modexp

### DIFF
--- a/.cicd/platforms/ubuntu20.Dockerfile
+++ b/.cicd/platforms/ubuntu20.Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get upgrade -y && \
                        git                  \
                        jq                   \
                        libcurl4-openssl-dev \
-                       libgmp-dev           \
                        llvm-11-dev          \
                        ninja-build          \
                        python3-numpy        \

--- a/.cicd/platforms/ubuntu22.Dockerfile
+++ b/.cicd/platforms/ubuntu22.Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get upgrade -y && \
                        git                  \
                        jq                   \
                        libcurl4-openssl-dev \
-                       libgmp-dev           \
                        llvm-11-dev          \
                        ninja-build          \
                        python3-numpy        \

--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -85,7 +85,6 @@ target_link_libraries(EosioChain INTERFACE
    ${libsecp256k1}
    ${libbn256}
    ${libbls12-381}
-   @GMP_LIBRARY@
 
    Boost::date_time
    Boost::filesystem

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -82,7 +82,6 @@ target_link_libraries(EosioChain INTERFACE
    ${libsecp256k1}
    ${libbn256}
    ${libbls12-381}
-   @GMP_LIBRARY@
 
    Boost::date_time
    Boost::filesystem

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Requirements to build:
   - newer versions do not work
 - libcurl 7.40.0+
 - git
-- GMP
 - Python 3
 - python3-numpy
 - zlib
@@ -131,7 +130,6 @@ sudo apt-get install -y \
         cmake \
         git \
         libcurl4-openssl-dev \
-        libgmp-dev \
         llvm-11-dev \
         python3-numpy \
         file \

--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -66,22 +66,6 @@ file( GLOB_RECURSE fc_headers ${CMAKE_CURRENT_SOURCE_DIR} *.hpp *.h )
 
 add_library(fc ${fc_sources} ${fc_headers})
 
-find_path(GMP_INCLUDE_DIR NAMES gmp.h)
-find_library(GMP_LIBRARY gmp)
-if(NOT GMP_LIBRARY MATCHES ${CMAKE_SHARED_LIBRARY_SUFFIX})
-  message( FATAL_ERROR "GMP shared library not found" )
-endif()
-set(gmp_library_type SHARED)
-message(STATUS "GMP: ${GMP_LIBRARY}, ${GMP_INCLUDE_DIR}")
-add_library(GMP::gmp ${gmp_library_type} IMPORTED)
-set_target_properties(
-  GMP::gmp PROPERTIES
-  IMPORTED_LOCATION ${GMP_LIBRARY}
-  INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR}
-)
-
-target_link_libraries(fc PUBLIC GMP::gmp)
-
 # fc picks up a dependency on zlib via Boost::iostreams, however in some versions of cmake/boost (depending on if CMake config
 #  files are used) the Boost::iostreams target does not have a dependency on zlib itself so add it explicitly
 find_package(ZLIB REQUIRED)

--- a/libraries/libfc/include/fc/crypto/bigint.hpp
+++ b/libraries/libfc/include/fc/crypto/bigint.hpp
@@ -28,6 +28,7 @@ namespace fc {
 
       int64_t log2()const;
       bigint  exp( const bigint& c )const;
+      bigint  modexp( const bigint& c, const bigint& m )const;
 
       static bigint random( uint32_t bits, int t, int  );
 
@@ -59,6 +60,9 @@ namespace fc {
 
       // returns bignum as bigendian bytes
       operator std::vector<char>()const;
+
+      // returns bignum as bigendian bytes padded to total_bytes number of bytes. throws if total_bytes too small
+      std::vector<char> padded_be_bytes(const size_t total_bytes) const;
 
       BIGNUM* dup()const;
 

--- a/libraries/libfc/src/crypto/bigint.cpp
+++ b/libraries/libfc/src/crypto/bigint.cpp
@@ -185,7 +185,16 @@ namespace fc {
         BN_CTX_free(ctx);
         return tmp;
       }
-
+      bigint bigint::modexp( const bigint& a, const bigint& m )const
+      {
+        FC_ASSERT(!m.is_negative());
+        BN_CTX* ctx = BN_CTX_new();
+        bigint tmp;
+        int ret = BN_mod_exp(tmp.n, n, a.n, m.n, ctx);
+        BN_CTX_free(ctx);
+        FC_ASSERT(ret);
+        return tmp;
+      }
 
       bigint& bigint::operator = ( bigint&& a ) {
         fc_swap( a.n, n );
@@ -204,6 +213,12 @@ namespace fc {
       bigint::operator std::vector<char>()const {
         std::vector<char> to(BN_num_bytes(n)); 
         BN_bn2bin(n,(unsigned char*)to.data());
+        return to;
+      }
+
+      std::vector<char> bigint::padded_be_bytes(const size_t total_bytes) const {
+        std::vector<char> to(total_bytes);
+        FC_ASSERT(BN_bn2bin_padded((uint8_t*)to.data(), to.size(), n));
         return to;
       }
 

--- a/libraries/libfc/src/crypto/modular_arithmetic.cpp
+++ b/libraries/libfc/src/crypto/modular_arithmetic.cpp
@@ -1,47 +1,19 @@
-#include <gmp.h>
+#include <fc/crypto/bigint.hpp>
 #include <fc/crypto/modular_arithmetic.hpp>
-#include <algorithm>
 
 namespace fc {
 
-    std::variant<modular_arithmetic_error, bytes> modexp(const bytes& _base, const bytes& _exponent, const bytes& _modulus)
-    {
-        if (_modulus.size() == 0) {
-            return modular_arithmetic_error::modulus_len_zero;
-        }
+   std::variant<modular_arithmetic_error, bytes> modexp(const bytes& _base, const bytes& _exponent, const bytes& _modulus) {
+      if(_modulus.empty())
+         return modular_arithmetic_error::modulus_len_zero;
 
-        auto output = bytes(_modulus.size(), '\0');
+      bigint base(_base);
+      bigint exponent(_exponent);
+      bigint modulus(_modulus);
 
-        mpz_t base, exponent, modulus;
-        mpz_inits(base, exponent, modulus, nullptr);
+      if(!modulus)
+         return bytes(_modulus.size());
 
-        if (_base.size()) {
-            mpz_import(base, _base.size(), 1, 1, 0, 0, _base.data());
-        }
-
-        if (_exponent.size()) {
-            mpz_import(exponent, _exponent.size(), 1, 1, 0, 0, _exponent.data());
-        }
-
-        mpz_import(modulus, _modulus.size(), 1, 1, 0, 0, _modulus.data());
-
-        if (mpz_sgn(modulus) == 0) {
-            mpz_clears(base, exponent, modulus, nullptr);
-            return output;
-        }
-
-        mpz_t result;
-        mpz_init(result);
-
-        mpz_powm(result, base, exponent, modulus);
-        // export as little-endian
-        mpz_export(output.data(), nullptr, -1, 1, 0, 0, result);
-        // and convert to big-endian
-        std::reverse(output.begin(), output.end());
-
-        mpz_clears(base, exponent, modulus, result, nullptr);
-
-        return output;
-    }
-
+      return base.modexp(exponent, modulus).padded_be_bytes(_modulus.size());
+   }
 }

--- a/package.cmake
+++ b/package.cmake
@@ -65,7 +65,7 @@ set(CPACK_DEBIAN_BASE_FILE_NAME "${CPACK_DEBIAN_FILE_NAME}.deb")
 string(REGEX REPLACE "^(${CMAKE_PROJECT_NAME})" "\\1-dev" CPACK_DEBIAN_DEV_FILE_NAME "${CPACK_DEBIAN_BASE_FILE_NAME}")
 
 #deb package tooling will be unable to detect deps for the dev package. llvm is tricky since we don't know what package could have been used; try to figure it out
-set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS "libgmp-dev, python3-distutils, python3-numpy, zlib1g-dev")
+set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS "python3-distutils, python3-numpy, zlib1g-dev")
 find_program(DPKG_QUERY "dpkg-query")
 if(DPKG_QUERY AND OS_RELEASE MATCHES "\n?ID=\"?ubuntu" AND LLVM_CMAKE_DIR)
    execute_process(COMMAND "${DPKG_QUERY}" -S "${LLVM_CMAKE_DIR}" COMMAND cut -d: -f1 RESULT_VARIABLE LLVM_PKG_FIND_RESULT OUTPUT_VARIABLE LLVM_PKG_FIND_OUTPUT)

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -12,7 +12,6 @@ apt-get install -y \
     git \
     libbz2-dev \
     libcurl4-openssl-dev \
-    libgmp-dev \
     libncurses5 \
     libtinfo-dev \
     libzstd-dev \


### PR DESCRIPTION
This was an implementation of #1277 however it did not go to plan: BoringSSL's modexp is _significantly_ slower than GMP in many cases (although it is faster in some too). I am pushing it up mainly for historical context, and plan to close the PR in due time. There is potentially some interesting commentary around slightly different aspects of BoringSSL vs GMP when it comes to memory allocation failures, etc... but maybe some other time....

Here are some numbers from one CPU I ran the benchmark on,


| Benchmark Test | GMP | BoringSSL |
| :---         |     ---:      |          ---: |
|64 bit even M, B<M   | 814 ns    |     7,133 ns |
|64 bit odd M, B<M     |    418 ns     |   3,096 ns  |
|64 bit even M, B>M     |       809 ns    |     7,327 ns     |
|64 bit odd M, B>M      |          424 ns    |     3,184 ns        |
|128 bit even M, B<M   |         1,925 ns    |   15,467 ns      |
|128 bit odd M, B<M     |          1,951 ns     |   3,142 ns     |
|128 bit even M, B>M    |        1,943 ns  |      15,702 ns     |
|128 bit odd M, B>M     |        2,054 ns   |    3,060 ns     |
|256 bit even M, B<M   |        9,923 ns    |   39,820 ns      |
|256 bit odd M, B<M      |          9,937 ns   |    11,311 ns      |
|256 bit even M, B>M    |          9,807 ns    |   39,089 ns      |
|256 bit odd M, B>M     |         10,110 ns   |    11,339 ns      |
|512 bit even M, B<M    |      48,411 ns   |   124,348 ns     |
|512 bit odd M, B<M      |         47,341 ns   |   33,734 ns     |
|512 bit even M, B>M    |           48,399 ns   |   123,910 ns      |
|512 bit odd M, B>M     |          47,145 ns     | 33,876 ns      |
|1024 bit even M, B<M  |         297,853 ns  |   990,387 ns    |
|1024 bit odd M, B<M    |          295,101 ns  |   200,485 ns     |
|1024 bit even M, B>M   |         296,145 ns  |   992,803 ns     |
|1024 bit odd M, B>M     |     295,101 ns  |   200,074 ns     |
|2048 bit even M, B<M   |       1,930,018 ns  | 3,972,004 ns  |
|2048 bit odd M, B<M      |     1,934,951 ns  | 1,375,708 ns  |
|2048 bit even M, B>M      |     1,932,147 ns  | 3,981,029 ns   |
|2048 bit odd M, B>M      |    1,939,732 ns |  1,374,647 ns   |