### PR TITLE
[4.0] HTTP: Check for connection_reset

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -319,7 +319,8 @@ public:
 
    void on_read_header(beast::error_code ec, std::size_t /* bytes_transferred */) {
       if(ec) {
-         if(ec == http::error::end_of_stream) // other side closed the connection
+         // See on_read comment below
+         if(ec == http::error::end_of_stream || ec == asio::error::connection_reset)
             return derived().do_eof();
          
          return fail(ec, "read_header", plugin_state_->logger, "closing connection");


### PR DESCRIPTION
When running performance tests on read-only transaction execution, the node generated many errors of `read_header: Connection reset by peer` and didn't make additional progress.

Boost beast http session checks for `http::error::end_of_stream || asio::error::connection_reset` in `on_read` and executes `do_eof()` to shutdown the connection. `on_read_header` was checking for `http::error::end_of_stream` but not `asio::error::connection_reset`. This PR changes `on_read_header` to also check for `asio::error::connection_reset`.

Resolves #1661 