### PR TITLE
PH: Include full version in performance harness reports

### DIFF
--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -612,4 +612,4 @@ class Utils:
 
     @staticmethod
     def getNodeosVersion():
-        return os.popen(f"{Utils.EosServerPath} --version").read().replace("\n", "")
+        return os.popen(f"{Utils.EosServerPath} --full-version").read().replace("\n", "")


### PR DESCRIPTION
For performance harness and other tests report the full `nodeos` version which includes the commit hash. Recently I was looking at some old reports and it would be very helpful to know the exact commit hash that was run.