### PR TITLE
randomize secp256k1 context used for signing

### DIFF
--- a/libraries/libfc/src/crypto/_elliptic_impl_priv.hpp
+++ b/libraries/libfc/src/crypto/_elliptic_impl_priv.hpp
@@ -9,7 +9,6 @@ namespace fc { namespace ecc { namespace detail {
 
 
 const secp256k1_context* _get_context();
-void _init_lib();
 
 class private_key_impl
 {

--- a/libraries/libfc/src/crypto/_elliptic_impl_pub.hpp
+++ b/libraries/libfc/src/crypto/_elliptic_impl_pub.hpp
@@ -8,8 +8,6 @@
 
 namespace fc { namespace ecc { namespace detail {
 
-void _init_lib();
-
 class public_key_impl
 {
     public:

--- a/libraries/libfc/src/crypto/elliptic_impl_priv.cpp
+++ b/libraries/libfc/src/crypto/elliptic_impl_priv.cpp
@@ -10,14 +10,10 @@
 namespace fc { namespace ecc {
     namespace detail {
 
-        private_key_impl::private_key_impl() BOOST_NOEXCEPT
-        {
-            _init_lib();
-        }
+        private_key_impl::private_key_impl() BOOST_NOEXCEPT {}
 
         private_key_impl::private_key_impl( const private_key_impl& cpy ) BOOST_NOEXCEPT
         {
-            _init_lib();
             this->_key = cpy._key;
         }
 


### PR DESCRIPTION
secp256k1's documentation states,
```c
/*  If the context is intended to be used for API functions that perform computations
 *  involving secret keys, e.g., signing and public key generation, then it is highly
 *  recommended to call secp256k1_context_randomize on the context before calling
 *  those API functions. This will provide enhanced protection against side-channel
 *  leakage, see secp256k1_context_randomize for details. */
```

It seems like it would be wise to perform this defense.