### PR TITLE
[PH] Trx Generator - Use default exception handler.

### DIFF
--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -35,8 +35,7 @@ namespace eosio::testing {
    }
 
    void provider_connection::init_and_connect() {
-      _connection_thread_pool.start(
-          1, [](const fc::exception& e) { elog("provider_connection exception ${e}", ("e", e)); });
+      _connection_thread_pool.start(1, {});
       connect();
    };
 


### PR DESCRIPTION
The non-default exception handler was masking the issue and not terminating the process which was causing misleading errors downstream. With default exception handler there is a better exception message as well as termination of the process. This provides better handling upstream in the performance harness.

This was being caused by an http response of `ok` with an empty string response body.

Using the default exception handler, the exception now looks like:

```error 2023-09-28T18:39:00.747 provider_ thread_utils.hpp:127          run_thread           ] Exiting thread provider_connection-0 on exception: 3100010 json_parse_exception: JSON parse exception
Fail to parse JSON from string:
    {"string":""}
    provider_connection-0  trx_provider.cpp:172 operator()
unexpected end of file
    {}
    provider_connection-0  json.cpp:435 variant_from_stream

    {"str":""}
    provider_connection-0  json.cpp:461 from_string

terminate called after throwing an instance of 'eosio::chain::json_parse_exception'
  what():  JSON parse exception
```


Which terminates the `trx_generator` process and proper exit return code is passed back to the `PerformanceHarness`.

Relates to ongoing work in #1662 