### PR TITLE
Remove prometheus-exporter-address option

### DIFF
--- a/plugins/prometheus_plugin/include/eosio/prometheus_plugin/prometheus_plugin.hpp
+++ b/plugins/prometheus_plugin/include/eosio/prometheus_plugin/prometheus_plugin.hpp
@@ -3,6 +3,8 @@
 #include <eosio/chain/application.hpp>
 #include <eosio/http_plugin/http_plugin.hpp>
 #include <eosio/chain_plugin/chain_plugin.hpp>
+#include <eosio/producer_plugin/producer_plugin.hpp>
+#include <eosio/net_plugin/net_plugin.hpp>
 
 namespace eosio {
 
@@ -13,7 +15,7 @@ namespace eosio {
       prometheus_plugin();
       ~prometheus_plugin() override;
 
-      APPBASE_PLUGIN_REQUIRES((http_plugin)(chain_plugin))
+      APPBASE_PLUGIN_REQUIRES((http_plugin)(chain_plugin)(producer_plugin)(net_plugin))
 
       void set_program_options(options_description&, options_description& cfg) override;
 

--- a/plugins/prometheus_plugin/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/prometheus_plugin.cpp
@@ -3,9 +3,7 @@
 #include <eosio/chain/plugin_interface.hpp>
 #include <eosio/chain/thread_utils.hpp>
 #include <eosio/http_plugin/macros.hpp>
-#include <eosio/net_plugin/net_plugin.hpp>
 #include <eosio/http_plugin/http_plugin.hpp>
-#include <eosio/producer_plugin/producer_plugin.hpp>
 
 #include <fc/log/logger.hpp>
 
@@ -36,9 +34,6 @@ namespace eosio {
    prometheus_plugin::~prometheus_plugin() = default;
 
    void prometheus_plugin::set_program_options(options_description&, options_description& cfg) {
-      cfg.add_options()
-         ("prometheus-exporter-address", bpo::value<string>()->default_value("127.0.0.1:9101"),
-            "The local IP and port to listen for incoming prometheus metrics http request.");
    }
 
    struct prometheus_api_handle {


### PR DESCRIPTION
Remove `prometheus-exporter-address` option as the prometheus plugin can now be configured on a different address via https://github.com/AntelopeIO/leap/pull/1137.

For example:
```
http-server-address   = http-category-address
http-category-address = prometheus,127.0.0.1:9101
```

Includes a bit of include dependency cleanup.

Resolves #1681 