### PR TITLE
Improve trx_generator http client

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -297,7 +297,7 @@ public:
       if(ec) {
          // See on_read comment below
          if(ec == http::error::end_of_stream || ec == asio::error::connection_reset)
-            return; // socket destructor will be called
+            return do_eof();
 
          return fail(ec, "read_header", plugin_state_.get_logger(), "closing connection");
       }
@@ -337,7 +337,7 @@ public:
          // on another read. If the client disconnects, we may get
          // http::error::end_of_stream or asio::error::connection_reset.
          if(ec == http::error::end_of_stream || ec == asio::error::connection_reset)
-            return; // socket destructor will be called
+            return do_eof();
 
          return fail(ec, "read", plugin_state_.get_logger(), "closing connection");
       }
@@ -367,7 +367,7 @@ public:
       if(close) {
          // This means we should close the connection, usually because
          // the response indicated the "Connection: close" semantic.
-         return; // socket destructor will be called
+         return do_eof();
       }
 
       // create a new response object
@@ -383,7 +383,7 @@ public:
       case continue_state_t::reject:
          // request body too large. After issuing 401 response, close connection
          continue_state_ = continue_state_t::none;
-         // socket destructor will be called
+         do_eof();
          break;
          
       default:
@@ -450,7 +450,7 @@ public:
          res_->set(http::field::server, BOOST_BEAST_VERSION_STRING);
 
          send_response(std::move(err_str), static_cast<unsigned int>(http::status::internal_server_error));
-         // socket destructor will be called
+         do_eof();
       }
    }
 
@@ -492,11 +492,25 @@ public:
    void run_session() {
       if(auto error_str = verify_max_requests_in_flight(); !error_str.empty()) {
          send_busy_response(std::move(error_str));
-         return; // socket destructor will be called
+         return do_eof();
       }
 
       do_read_header();
    }
+
+   void do_eof() {
+      is_send_exception_response_ = false;
+      try {
+         // Send a shutdown signal
+         beast::error_code ec;
+         socket_.shutdown(Socket::shutdown_both, ec);
+         socket_.close(ec);
+         // At this point the connection is closed gracefully
+      } catch(...) {
+         handle_exception();
+      }
+   }
+
 
    bool allow_host(const http::request<http::string_body>& req) {
       if constexpr(std::is_same_v<Socket, tcp::socket>) {

--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -503,7 +503,8 @@ public:
       try {
          // Send a shutdown signal
          beast::error_code ec;
-         socket_.shutdown(Socket::shutdown_send, ec);
+         socket_.shutdown(Socket::shutdown_both, ec);
+         socket_.close(ec);
          // At this point the connection is closed gracefully
       } catch(...) {
          handle_exception();

--- a/tests/trx_generator/http_client_async.hpp
+++ b/tests/trx_generator/http_client_async.hpp
@@ -73,8 +73,9 @@ class session : public std::enable_shared_from_this<session> {
       req_.set(http::field::host, host);
       req_.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
       req_.set(http::field::content_type, content_type);
-      req_.set(http::field::connection, "close");
       req_.body() = std::move(request_body);
+      // current implementation does not reuse socket, disable keep_alive
+      req_.set(http::field::connection, "close");
       req_.keep_alive(false);
       req_.prepare_payload();
 

--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -133,6 +133,10 @@ namespace eosio::testing {
           [this, trx_id = trx.id()](boost::beast::error_code                                      ec,
                                     boost::beast::http::response<boost::beast::http::string_body> response) {
              trx_acknowledged(trx_id, fc::time_point::now());
+             if (ec) {
+                elog("http error: ${c}: ${m}", ("c", ec.value())("m", ec.message()));
+                throw std::runtime_error(ec.message());
+             }
 
              if (this->needs_response_trace_info() && response.result() == boost::beast::http::status::ok) {
                 try {


### PR DESCRIPTION
When error conditions (eof) have the `http_plugin` `shutdown_both` on socket. Also call `close()` for good measure. I actually tried this explicit shutdown in the destructor but it seemed to make no difference.

Modify the `trx_generator` to better handle errors from client and also specify no keep alive.

This improved performance as can be seen by comparing:
This branch: https://github.com/AntelopeIO/leap/actions/runs/6356928532  15001 TPS
With main: https://github.com/AntelopeIO/leap/actions/runs/6356929999  14001 TPS
