### PR TITLE
used `signed char` for `char`s compared against `EOF`

### DIFF
--- a/libraries/libfc/include/fc/io/json_relaxed.hpp
+++ b/libraries/libfc/include/fc/io/json_relaxed.hpp
@@ -27,7 +27,7 @@ namespace fc { namespace json_relaxed
       std::stringstream token;
       try
       {
-         char c = in.peek();
+         signed char c = in.peek();
 
          while( true )
          {
@@ -152,7 +152,7 @@ namespace fc { namespace json_relaxed
 
            while( true )
            {
-               char c = in.peek();
+               signed char c = in.peek();
 
                if (c == EOF) {
                   FC_THROW_EXCEPTION( eof_exception, "unexpected end of file" );
@@ -187,7 +187,7 @@ namespace fc { namespace json_relaxed
    {
       try
       {
-         char c = in.peek(), c2;
+         signed char c = in.peek(), c2;
 
          switch( c )
          {


### PR DESCRIPTION
On ARM, unlike x86, `char` is unsigned by default. So on ARM, a comparison of a `char` against `EOF` causes a warning since an `unsigned char` cannot possibly ever match `-1` (the value of `EOF`). The proper way of dealing with this is by `int c = in.peek()` (`peek()` return an `int`), but I'm worried doing that may slightly alter behavior for some pathological case a 0xff byte is in JSON somewhere. So maybe just make ARM & x86 consistent here via an explicit `signed char`. There is precedent in this file already,
https://github.com/AntelopeIO/leap/blob/017eb43346972549e20d9be06ef783e89e425003/libraries/libfc/include/fc/io/json_relaxed.hpp#L699