### PR TITLE
P2P: Advance read pointer when dropping trx

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3025,7 +3025,8 @@ namespace eosio {
          return true;
       }
       if (my_impl->sync_master->syncing_from_peer()) {
-         peer_wlog(this, "syncing, dropping trx");
+         peer_dlog(this, "syncing, dropping trx");
+         pending_message_buffer.advance_read_ptr( message_length );
          return true;
       }
 


### PR DESCRIPTION
Fix issue introduced by #1215 where read buffer not updated when dropping a trx while syncing. Also change log to `debug` level as there is nothing wrong here, just a peer sent you a trx.

Resolves #1705 