### PR TITLE
PH: Disable p2p trx execution on validation and api nodes

### DIFF
--- a/tests/PerformanceHarness/performance_test_basic.py
+++ b/tests/PerformanceHarness/performance_test_basic.py
@@ -124,6 +124,7 @@ class PerformanceTestBasic:
 
             def configureValidationNodes():
                 validationNodeSpecificNodeosStr = ""
+                validationNodeSpecificNodeosStr += '--p2p-accept-transactions false '
                 if "v2" in self.nodeosVers:
                     validationNodeSpecificNodeosStr += '--plugin eosio::history_api_plugin --filter-on "*" '
                 else:
@@ -137,6 +138,7 @@ class PerformanceTestBasic:
 
             def configureApiNodes():
                 apiNodeSpecificNodeosStr = ""
+                apiNodeSpecificNodeosStr += "--p2p-accept-transactions false "
                 apiNodeSpecificNodeosStr += "--plugin eosio::chain_api_plugin "
                 apiNodeSpecificNodeosStr += "--plugin eosio::net_api_plugin "
                 if "v4" in self.nodeosVers:


### PR DESCRIPTION
The performance harness is evaluating performance of BP nodes or API nodes according to what they can individually handle. There is no need for the validation node or the API node to speculatively execute trxs. This removes load from the overall test rig allowing for better results. Also it better represents real-world API configuration.