### PR TITLE
generate `.tar.zst` out of `cpack` instead of `.tar.gz`

### DIFF
--- a/package.cmake
+++ b/package.cmake
@@ -1,4 +1,4 @@
-set(CPACK_GENERATOR "TGZ")
+set(CPACK_GENERATOR "TZST")
 find_program(DPKG_FOUND "dpkg")
 find_program(RPMBUILD_FOUND "rpmbuild")
 if(DPKG_FOUND)


### PR DESCRIPTION
No reason to keep using .tar.gz over .tar.zst. The `TZST` option was added in cmake 3.16, which is now our minimum version having dumped Ubuntu 18 support.