### PR TITLE
[4.0] Fix possible segfault switching between read/write windows

### DIFF
--- a/libraries/custom_appbase/include/eosio/chain/application.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/application.hpp
@@ -83,7 +83,6 @@ public:
    void stop() {
       read_only_queue_.stop();
       read_write_queue_.stop();
-      read_exclusive_queue_.stop();
    }
      
    void clear() {

--- a/libraries/custom_appbase/include/eosio/chain/application.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/application.hpp
@@ -79,6 +79,12 @@ public:
       else
          return read_only_queue_.wrap( priority, --order_, std::forward<Function>( func));
    }
+
+   void stop() {
+      read_only_queue_.stop();
+      read_write_queue_.stop();
+      read_exclusive_queue_.stop();
+   }
      
    void clear() {
       read_only_queue_.clear();

--- a/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
@@ -13,6 +13,12 @@ class exec_pri_queue : public boost::asio::execution_context
 {
 public:
 
+   void stop() {
+      std::lock_guard g( mtx_ );
+      exiting_blocking_ = true;
+      cond_.notify_all();
+   }
+
    void enable_locking(uint32_t num_threads, std::function<bool()> should_exit) {
       assert(num_threads > 0 && num_waiting_ == 0);
       lock_enabled_ = true;

--- a/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
@@ -53,17 +53,6 @@ public:
       handlers_ = prio_queue();
    }
 
-   // only call when no lock required
-   bool execute_highest()
-   {
-      if( !handlers_.empty() ) {
-         handlers_.top()->execute();
-         handlers_.pop();
-      }
-
-      return !handlers_.empty();
-   }
-
 private:
    // has to be defined before use, auto return type
    auto pop() {
@@ -73,6 +62,19 @@ private:
    }
 
 public:
+
+   // only call when no lock required
+   bool execute_highest()
+   {
+      if( !handlers_.empty() ) {
+         auto t = pop();
+         bool empty = handlers_.empty();
+         t->execute();
+         return !empty;
+      }
+
+      return false;
+   }
 
    bool execute_highest_locked(bool should_block) {
       std::unique_lock g(mtx_);

--- a/libraries/custom_appbase/tests/custom_appbase_tests.cpp
+++ b/libraries/custom_appbase/tests/custom_appbase_tests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE( default_exec_window ) {
    app->executor().post( priority::lowest, exec_queue::read_only, [&]() {
       // read_only_queue should only contain the current lambda function,
       // and read_write_queue should have executed all its functions
-      BOOST_REQUIRE_EQUAL( app->executor().read_only_queue().size(), 1); // pop()s after execute
+      BOOST_REQUIRE_EQUAL( app->executor().read_only_queue().size(), 0); // pop()s before execute
       BOOST_REQUIRE_EQUAL( app->executor().read_write_queue().size(), 0 );
       app->quit();
       } );
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE( execute_from_both_queues ) {
    // stop application. Use lowest at the end to make sure this executes the last
    app->executor().post( priority::lowest, exec_queue::read_only, [&]() {
       // read_queue should have current function and write_queue's functions are all executed 
-      BOOST_REQUIRE_EQUAL( app->executor().read_only_queue().size(), 1); // pop()s after execute
+      BOOST_REQUIRE_EQUAL( app->executor().read_only_queue().size(), 0); // pop()s before execute
       BOOST_REQUIRE_EQUAL( app->executor().read_write_queue().size(), 0 );
       app->quit();
       } );

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1391,8 +1391,7 @@ void producer_plugin::plugin_startup()
 void producer_plugin::plugin_shutdown() {
    boost::system::error_code ec;
    my->_timer.cancel(ec);
-   boost::system::error_code ro_ec;
-   my->_ro_timer.cancel(ro_ec);
+   my->_ro_timer.cancel(ec);
    app().executor().stop();
    my->_ro_thread_pool.stop();
    my->_thread_pool.stop();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1389,20 +1389,13 @@ void producer_plugin::plugin_startup()
 } FC_CAPTURE_AND_RETHROW() }
 
 void producer_plugin::plugin_shutdown() {
-   try {
-      my->_timer.cancel();
-   } catch ( const std::bad_alloc& ) {
-     chain_plugin::handle_bad_alloc();
-   } catch ( const boost::interprocess::bad_alloc& ) {
-     chain_plugin::handle_bad_alloc();
-   } catch(const fc::exception& e) {
-      edump((e.to_detail_string()));
-   } catch(const std::exception& e) {
-      edump((fc::std_exception_wrapper::from_current_exception(e).to_detail_string()));
-   }
-
+   boost::system::error_code ec;
+   my->_timer.cancel(ec);
+   boost::system::error_code ro_ec;
+   my->_ro_timer.cancel(ro_ec);
+   app().executor().stop();
+   my->_ro_thread_pool.stop();
    my->_thread_pool.stop();
-
    my->_unapplied_transactions.clear();
 
    app().executor().post( 0, [me = my](){} ); // keep my pointer alive until queue is drained


### PR DESCRIPTION
* Always execute the lambda after pop()ing it from the queue. This is needed as the read_write queue is used to post the lambda that switches to the read window. The read window can then start and begin pushing future tasks to the read_write queue. This allows multiple threads to access the read_write at one time as the original call to switch to the read window is running unlocked, once it finishes it pops from the queue while other threads can access it. Backport of #1718 
* Fix for producer shutdown to prevent segfault and deadlock on shutdown. Backport of 1368ecd0b72f1387f0545c6deef9bd494b1aa7fe

Backport of #1718

Resolves #1490
