### PR TITLE
[5.0] Fix unlinked blocks caused by deferred trx removal

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1595,12 +1595,14 @@ struct controller_impl {
                                                trx->packed_trx()->get_prunable_size() );
             }
 
+            trx_context.delay = fc::seconds(trn.delay_sec);
+
             if( check_auth ) {
                authorization.check_authorization(
                        trn.actions,
                        trx->recovered_keys(),
                        {},
-                       fc::seconds(trn.delay_sec),
+                       trx_context.delay,
                        [&trx_context](){ trx_context.checktime(); },
                        false,
                        trx->is_dry_run()
@@ -1613,7 +1615,9 @@ struct controller_impl {
 
             trx->billed_cpu_time_us = trx_context.billed_cpu_time_us;
             if (!trx->implicit() && !trx->is_read_only()) {
-               transaction_receipt::status_enum s = transaction_receipt::executed;
+               transaction_receipt::status_enum s = (trx_context.delay == fc::seconds(0))
+                                                    ? transaction_receipt::executed
+                                                    : transaction_receipt::delayed;
                trace->receipt = push_receipt(*trx->packed_trx(), s, trx_context.billed_cpu_time_us, trace->net_usage);
                std::get<building_block>(pending->_block_stage)._pending_trx_metas.emplace_back(trx);
             } else {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -370,7 +370,6 @@ namespace eosio { namespace chain {
       private:
          friend class apply_context;
          friend class transaction_context;
-         friend void modify_gto_for_canceldelay_test(controller& control, const transaction_id_type& trx_id); // canceldelay_test in delay_tests.cpp need access to mutable_db
 
          chainbase::database& mutable_db()const;
 

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -112,6 +112,7 @@ namespace eosio { namespace chain {
 
          void execute_action( uint32_t action_ordinal, uint32_t recurse_depth );
 
+         void schedule_transaction();
          void record_transaction( const transaction_id_type& id, fc::time_point_sec expire );
 
          void validate_cpu_usage_to_bill( int64_t billed_us, int64_t account_cpu_limit, bool check_minimum, int64_t subjective_billed_us )const;
@@ -142,6 +143,7 @@ namespace eosio { namespace chain {
          /// the maximum number of virtual CPU instructions of the transaction that can be safely billed to the billable accounts
          uint64_t                      initial_max_billable_cpu = 0;
 
+         fc::microseconds              delay;
          bool                          is_input           = false;
          bool                          apply_context_free = true;
          bool                          enforce_whiteblacklist = true;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -247,7 +247,9 @@ namespace eosio { namespace chain {
                                                  uint64_t packed_trx_prunable_size )
    {
       const transaction& trx = packed_trx.get_transaction();
-      EOS_ASSERT( trx.delay_sec.value == 0, transaction_exception, "transaction cannot be delayed" );
+      if ( is_transient() ) {
+         EOS_ASSERT( trx.delay_sec.value == 0, transaction_exception, "transaction cannot be delayed" );
+      }
       if( trx.transaction_extensions.size() > 0 ) {
          disallow_transaction_extensions( "no transaction extensions supported yet for input transactions" );
       }
@@ -265,6 +267,13 @@ namespace eosio { namespace chain {
 
       uint64_t initial_net_usage = static_cast<uint64_t>(cfg.base_per_transaction_net_usage)
                                     + packed_trx_unprunable_size + discounted_size_for_pruned_data;
+
+      if( trx.delay_sec.value > 0 ) {
+          // If delayed, also charge ahead of time for the additional net usage needed to retire the delayed transaction
+          // whether that be by successfully executing, soft failure, hard failure, or expiration.
+         initial_net_usage += static_cast<uint64_t>(cfg.base_per_transaction_net_usage)
+                               + static_cast<uint64_t>(config::transaction_id_net_usage);
+      }
 
       published = control.pending_block_time();
       is_input = true;
@@ -309,14 +318,20 @@ namespace eosio { namespace chain {
          }
       }
 
-      for( const auto& act : trx.actions ) {
-         schedule_action( act, act.account, false, 0, 0 );
+      if( delay == fc::microseconds() ) {
+         for( const auto& act : trx.actions ) {
+            schedule_action( act, act.account, false, 0, 0 );
+         }
       }
 
       auto& action_traces = trace->action_traces;
       uint32_t num_original_actions_to_execute = action_traces.size();
       for( uint32_t i = 1; i <= num_original_actions_to_execute; ++i ) {
          execute_action( i, 0 );
+      }
+
+      if( delay != fc::microseconds() ) {
+         schedule_transaction();
       }
    }
 
@@ -713,6 +728,42 @@ namespace eosio { namespace chain {
       }
 
       acontext.exec();
+   }
+
+   void transaction_context::schedule_transaction() {
+      // Charge ahead of time for the additional net usage needed to retire the delayed transaction
+      // whether that be by successfully executing, soft failure, hard failure, or expiration.
+      const transaction& trx = packed_trx.get_transaction();
+      if( trx.delay_sec.value == 0 ) { // Do not double bill. Only charge if we have not already charged for the delay.
+         const auto& cfg = control.get_global_properties().configuration;
+         add_net_usage( static_cast<uint64_t>(cfg.base_per_transaction_net_usage)
+                         + static_cast<uint64_t>(config::transaction_id_net_usage) ); // Will exit early if net usage cannot be payed.
+      }
+
+      auto first_auth = trx.first_authorizer();
+
+      uint32_t trx_size = 0;
+      const auto& cgto = control.mutable_db().create<generated_transaction_object>( [&]( auto& gto ) {
+        gto.trx_id      = id;
+        gto.payer       = first_auth;
+        gto.sender      = account_name(); /// delayed transactions have no sender
+        gto.sender_id   = transaction_id_to_sender_id( gto.trx_id );
+        gto.published   = control.pending_block_time();
+        gto.delay_until = gto.published + delay;
+        gto.expiration  = gto.delay_until + fc::seconds(control.get_global_properties().configuration.deferred_trx_expiration_window);
+        trx_size = gto.set( trx );
+
+        if (auto dm_logger = control.get_deep_mind_logger(is_transient())) {
+           std::string event_id = RAM_EVENT_ID("${id}", ("id", gto.id));
+
+           dm_logger->on_create_deferred(deep_mind_handler::operation_qualifier::push, gto, packed_trx);
+           dm_logger->on_ram_trace(std::move(event_id), "deferred_trx", "push", "deferred_trx_pushed");
+        }
+      });
+
+      int64_t ram_delta = (config::billable_size_v<generated_transaction_object> + trx_size);
+      add_ram_usage( cgto.payer, ram_delta );
+      trace->account_ram_delta = account_delta( cgto.payer, ram_delta );
    }
 
    void transaction_context::record_transaction( const transaction_id_type& id, fc::time_point_sec expire ) {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -248,9 +248,9 @@ namespace eosio { namespace chain {
    {
       const transaction& trx = packed_trx.get_transaction();
       // delayed transactions are not allowed after protocol feature
-      // DISABLE_DEFERRED_TRXS_STAGE_2 is activated;
+      // DISABLE_DEFERRED_TRXS_STAGE_1 is activated;
       // read-only and dry-run transactions are not allowed to be delayed at any time
-      if( control.is_builtin_activated(builtin_protocol_feature_t::disable_deferred_trxs_stage_2) || is_transient() ) {
+      if( control.is_builtin_activated(builtin_protocol_feature_t::disable_deferred_trxs_stage_1) || is_transient() ) {
          EOS_ASSERT( trx.delay_sec.value == 0, transaction_exception, "transaction cannot be delayed" );
       }
       if( trx.transaction_extensions.size() > 0 ) {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -247,7 +247,10 @@ namespace eosio { namespace chain {
                                                  uint64_t packed_trx_prunable_size )
    {
       const transaction& trx = packed_trx.get_transaction();
-      if ( is_transient() ) {
+      // delayed transactions are not allowed after protocol feature
+      // DISABLE_DEFERRED_TRXS_STAGE_2 is activated;
+      // read-only and dry-run transactions are not allowed to be delayed at any time
+      if( control.is_builtin_activated(builtin_protocol_feature_t::disable_deferred_trxs_stage_2) || is_transient() ) {
          EOS_ASSERT( trx.delay_sec.value == 0, transaction_exception, "transaction cannot be delayed" );
       }
       if( trx.transaction_extensions.size() > 0 ) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -773,6 +773,10 @@ public:
                                       transaction_metadata::trx_type       trx_type,
                                       bool                                 return_failure_traces,
                                       next_function<transaction_trace_ptr> next) {
+
+      const transaction& t = trx->get_transaction();
+      EOS_ASSERT( t.delay_sec.value == 0, transaction_exception, "transaction cannot be delayed" );
+
       if (trx_type == transaction_metadata::trx_type::read_only) {
          assert(_ro_thread_pool_size > 0); // enforced by chain_plugin
          assert(app().executor().get_main_thread_id() != std::this_thread::get_id()); // should only be called from read only threads

--- a/plugins/producer_plugin/test/CMakeLists.txt
+++ b/plugins/producer_plugin/test/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable( test_producer_plugin
         test_trx_full.cpp
         test_options.cpp
         test_block_timing_util.cpp
+        test_disallow_delayed_trx.cpp
         main.cpp
         )
 target_link_libraries( test_producer_plugin producer_plugin eosio_testing eosio_chain_wrap )

--- a/plugins/producer_plugin/test/test_disallow_delayed_trx.cpp
+++ b/plugins/producer_plugin/test/test_disallow_delayed_trx.cpp
@@ -1,0 +1,101 @@
+#include <eosio/producer_plugin/producer_plugin.hpp>
+#include <eosio/testing/tester.hpp>
+#include <boost/test/unit_test.hpp>
+
+namespace eosio::test::detail {
+using namespace eosio::chain::literals;
+struct testit {
+   uint64_t id;
+
+   testit( uint64_t id = 0 ) :id(id){}
+
+   static account_name get_account() {
+      return chain::config::system_account_name;
+   }
+
+   static action_name get_name() {
+      return "testit"_n;
+   }
+};
+}
+FC_REFLECT( eosio::test::detail::testit, (id) )
+
+namespace {
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::test::detail;
+
+auto make_delayed_trx( const chain_id_type& chain_id ) {
+   account_name creator = config::system_account_name;
+
+   signed_transaction trx;
+   trx.actions.emplace_back( vector<permission_level>{{creator, config::active_name}}, testit{0} );
+   trx.delay_sec = 10;
+   auto priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("nathan")));
+   trx.sign( priv_key, chain_id );
+
+   return std::make_shared<packed_transaction>( std::move(trx) );
+}
+}
+
+BOOST_AUTO_TEST_SUITE(disallow_delayed_trx_test)
+
+// Verifies that incoming delayed transactions are blocked.
+BOOST_AUTO_TEST_CASE(delayed_trx) {
+   using namespace std::chrono_literals;
+   fc::temp_directory temp;
+   appbase::scoped_app app;
+   auto temp_dir_str = temp.path().string();
+   
+   std::promise<std::tuple<producer_plugin*, chain_plugin*>> plugin_promise;
+   std::future<std::tuple<producer_plugin*, chain_plugin*>> plugin_fut = plugin_promise.get_future();
+   std::thread app_thread( [&]() {
+      try {
+         fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
+         std::vector<const char*> argv =
+            {"test", "--data-dir", temp_dir_str.c_str(), "--config-dir", temp_dir_str.c_str(),
+               "-p", "eosio", "-e", "--disable-subjective-p2p-billing=true" };
+         app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
+         app->startup();
+         plugin_promise.set_value(
+            {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
+         app->exec();
+         return;
+      } FC_LOG_AND_DROP()
+      BOOST_CHECK(!"app threw exception see logged error");
+   } );
+
+   auto[prod_plug, chain_plug] = plugin_fut.get();
+   auto chain_id = chain_plug->get_chain_id();
+
+   // create a delayed trx
+   auto ptrx = make_delayed_trx( chain_id );
+
+   // send it as incoming trx
+   app->post( priority::low, [ptrx, &app]() {
+      bool return_failure_traces = true;
+
+      // the delayed trx is blocked
+      BOOST_REQUIRE_EXCEPTION(
+         app->get_method<plugin_interface::incoming::methods::transaction_async>()(ptrx,
+            false,
+            transaction_metadata::trx_type::input,
+            return_failure_traces,
+            [ptrx, return_failure_traces] (const next_function_variant<transaction_trace_ptr>& result) {
+               elog( "trace with except ${e}", ("e", fc::json::to_pretty_string( *std::get<chain::transaction_trace_ptr>( result ) )) );
+            }
+         ),
+         fc::exception,
+         eosio::testing::fc_exception_message_starts_with("transaction cannot be delayed")
+      );
+   });
+
+   // leave time for transaction to be executed
+   std::this_thread::sleep_for( 2000ms );
+
+   app->quit();
+   app_thread.join();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/nodeos_chainbase_allocation_test.py
+++ b/tests/nodeos_chainbase_allocation_test.py
@@ -31,7 +31,6 @@ try:
     # The following is the list of chainbase objects that need to be verified:
     # - account_object (bootstrap)
     # - code_object (bootstrap)
-    # - generated_transaction_object
     # - global_property_object
     # - key_value_object (bootstrap)
     # - protocol_state_object (bootstrap)
@@ -54,12 +53,6 @@ try:
     producerNode = cluster.getNode(producerNodeId)
     irrNode = cluster.getNode(irrNodeId)
     nonProdNode = cluster.getNode(nonProdNodeId)
-
-    # Create delayed transaction to create "generated_transaction_object"
-    cmd = "create account -j eosio sample EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV\
-         EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV --delay-sec 600 -p eosio"
-    trans = producerNode.processCleosCmd(cmd, cmd, silentErrors=False)
-    assert trans
 
     # Schedule a new producer to trigger new producer schedule for "global_property_object"
     newProducerAcc = Account("newprod")

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -767,11 +767,11 @@ BOOST_FIXTURE_TEST_CASE(cfa_stateful_api, validating_tester)  try {
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE(deferred_cfa_not_allowed, validating_tester)  try {
+BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, validating_tester)  try {
 
    create_account( "testapi"_n );
-   produce_blocks(1);
-   set_code( "testapi"_n, test_contracts::test_api_wasm() );
+	produce_blocks(1);
+	set_code( "testapi"_n, test_contracts::test_api_wasm() );
 
    account_name a = "testapi2"_n;
    account_name creator = config::system_account_name;
@@ -785,15 +785,58 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_not_allowed, validating_tester)  try {
                                  .owner    = authority( get_public_key( a, "owner" ) ),
                                  .active   = authority( get_public_key( a, "active" ) )
                                  });
-   action act({}, test_api_action<TEST_METHOD("test_transaction", "context_free_api")>{});
+   action act({}, test_api_action<TEST_METHOD("test_transaction", "stateful_api")>{});
    trx.context_free_actions.push_back(act);
-   set_transaction_headers(trx, 10, 2); // set delay_sec to 2
+   set_transaction_headers(trx, 10, 2);
    trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
+
    BOOST_CHECK_EXCEPTION(push_transaction( trx ), fc::exception,
       [&](const fc::exception &e) {
-         // any incoming trx is blocked
-         return expect_assert_message(e, "transaction cannot be delayed");
+         return expect_assert_message(e, "only context free api's can be used in this context");
       });
+
+   produce_blocks(10);
+
+   // CFA failed, testapi2 not created
+   create_account( "testapi2"_n );
+
+   BOOST_REQUIRE_EQUAL( validate(), true );
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, validating_tester_no_disable_deferred_trx)  try {
+
+   create_account( "testapi"_n );
+	produce_blocks(1);
+	set_code( "testapi"_n, test_contracts::test_api_wasm() );
+
+   account_name a = "testapi2"_n;
+   account_name creator = config::system_account_name;
+   signed_transaction trx;
+   trx.actions.emplace_back( vector<permission_level>{{creator,config::active_name}},
+                                 newaccount{
+                                 .creator  = creator,
+                                 .name     = a,
+                                 .owner    = authority( get_public_key( a, "owner" ) ),
+                                 .active   = authority( get_public_key( a, "active" ) )
+                                 });
+   action act({}, test_api_action<TEST_METHOD("test_transaction", "context_free_api")>{});
+   trx.context_free_actions.push_back(act);
+   set_transaction_headers(trx, 10, 2);
+   trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
+   auto trace = push_transaction( trx );
+   BOOST_REQUIRE(trace != nullptr);
+   if (trace) {
+      BOOST_REQUIRE_EQUAL(transaction_receipt_header::status_enum::delayed, trace->receipt->status);
+      BOOST_REQUIRE_EQUAL(1, trace->action_traces.size());
+   }
+   produce_blocks(10);
+
+   // CFA success, testapi2 created
+   BOOST_CHECK_EXCEPTION(create_account( "testapi2"_n ), fc::exception,
+      [&](const fc::exception &e) {
+         return expect_assert_message(e, "Cannot create account named testapi2, as that name is already taken");
+      });
+   BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE(light_validation_skip_cfa) try {

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -767,7 +767,7 @@ BOOST_FIXTURE_TEST_CASE(cfa_stateful_api, validating_tester)  try {
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, validating_tester)  try {
+BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, validating_tester_no_disable_deferred_trx)  try {
 
    create_account( "testapi"_n );
 	produce_blocks(1);

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -16,22 +16,6 @@ using mvo = fc::mutable_variant_object;
 
 const std::string eosio_token = name("eosio.token"_n).to_string();
 
-// Native action hardcodes sender empty and builds sender_id from trx id.
-// This method modifies those two fields for contract generated deferred
-// trxs so canceldelay can be tested by canceldelay_test.
-namespace eosio::chain {
-inline void modify_gto_for_canceldelay_test(controller& control, const transaction_id_type& trx_id) {
-   auto gto = control.mutable_db().find<generated_transaction_object, by_trx_id>(trx_id);
-   if (gto) {
-      control.mutable_db().modify<generated_transaction_object>(*gto, [&]( auto& gtx ) {
-         gtx.sender = account_name();
-
-         fc::uint128 _id(trx_id._hash[3], trx_id._hash[2]);
-         gtx.sender_id = (unsigned __int128)_id;
-      });
-   }
-}} /// namespace eosio::chain
-
 static void create_accounts(validating_tester& chain) {
    chain.produce_blocks();
    chain.create_accounts({"eosio.msig"_n, "eosio.token"_n});
@@ -1370,50 +1354,241 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    validating_tester_no_disable_deferred_trx chain;
    chain.produce_block();
 
-   const auto& contract_account = account_name("defcontract");
-   const auto& test_account = account_name("tester");
+   const auto& tester_account = "tester"_n;
+   std::vector<transaction_id_type> ids;
 
    chain.produce_blocks();
-   chain.create_accounts({contract_account, test_account});
-   chain.produce_blocks();
-   chain.set_code(contract_account, test_contracts::deferred_test_wasm());
-   chain.set_abi(contract_account, test_contracts::deferred_test_abi());
-   chain.produce_blocks();
+   chain.create_account("eosio.token"_n);
+   chain.produce_blocks(10);
 
-   auto gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
-   BOOST_CHECK_EQUAL(0u, gen_size);
+   chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
-   chain.push_action( contract_account, "delayedcall"_n, test_account, fc::mutable_variant_object()
-      ("payer",     test_account)
-      ("sender_id", 1)
-      ("contract",  contract_account)
-      ("payload",   42)
-      ("delay_sec", 1000)
-      ("replace_existing", false)
+   chain.produce_blocks();
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
+   chain.produce_blocks(10);
+
+   chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("auth",  authority(chain.get_public_key(tester_account, "first"), 10))
    );
+   chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", eosio_token)
+           ("type", "transfer")
+           ("requirement", "first"));
+
+   chain.produce_blocks();
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
+           ("issuer", eosio_token)
+           ("maximum_supply", "9000000.0000 CUR")
+   );
+
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
+           ("to",       eosio_token)
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
+
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
+       ("from", eosio_token)
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
+   auto gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_REQUIRE_EQUAL(0u, gen_size);
+
+   chain.produce_blocks();
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "1.0000 CUR")
+       ("memo", "hi" ),
+       30, 10
+   );
+   //wdump((fc::json::to_pretty_string(trace)));
+   ids.push_back(trace->id);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace->receipt->status);
+   gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_CHECK_EQUAL(1u, gen_size);
+   BOOST_CHECK_EQUAL(0u, trace->action_traces.size());
 
    const auto& idx = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>();
-   gen_size = idx.size();
-   BOOST_CHECK_EQUAL(1u, gen_size);
-   auto deferred_id = idx.begin()->trx_id;
+   auto itr = idx.find( trace->id );
+   BOOST_CHECK_EQUAL( (itr != idx.end()), true );
 
-   // canceldelay assumes sender and sender_id to be a specific
-   // format. hardcode them for testing purpose only
-   modify_gto_for_canceldelay_test(*(chain.control.get()), deferred_id);
+   chain.produce_blocks();
 
-   // send canceldelay for the delayed transaction
-   signed_transaction trx;
-   trx.actions.emplace_back(
-      vector<permission_level>{{contract_account, config::active_name}},
-      chain::canceldelay{{contract_account, config::active_name}, deferred_id}
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   BOOST_REQUIRE_EXCEPTION(
+      chain.push_action( config::system_account_name,
+                         updateauth::get_name(),
+                         vector<permission_level>{{tester_account, "first"_n}},
+                         fc::mutable_variant_object()
+            ("account", "tester")
+            ("permission", "first")
+            ("parent", "active")
+            ("auth",  authority(chain.get_public_key(tester_account, "first"))),
+            30, 7
+      ),
+      unsatisfied_authorization,
+      fc_exception_message_starts_with("transaction declares authority")
    );
-   chain.set_transaction_headers(trx);
-   trx.sign(chain.get_private_key(contract_account, "active"), chain.control->get_chain_id());
 
-   chain.push_transaction(trx);
+   // this transaction will be delayed 20 blocks
+   trace = chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("permission", "first")
+           ("parent", "active")
+           ("auth",  authority(chain.get_public_key(tester_account, "first"))),
+           30, 10
+   );
+   //wdump((fc::json::to_pretty_string(trace)));
+   ids.push_back(trace->id);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace->receipt->status);
+   gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_CHECK_EQUAL(2u, gen_size);
+   BOOST_CHECK_EQUAL(0u, trace->action_traces.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   chain.produce_blocks(16);
+
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transaction will be delayed 20 blocks
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "5.0000 CUR")
+       ("memo", "hi" ),
+       30, 10
+   );
+   //wdump((fc::json::to_pretty_string(trace)));
+   ids.push_back(trace->id);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace->receipt->status);
+   gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_CHECK_EQUAL(3u, gen_size);
+   BOOST_CHECK_EQUAL(0u, trace->action_traces.size());
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // send canceldelay for first delayed transaction
+   signed_transaction trx;
+   trx.actions.emplace_back(vector<permission_level>{{"tester"_n, config::active_name}},
+                            chain::canceldelay{{"tester"_n, config::active_name}, ids[0]});
+
+   chain.set_transaction_headers(trx);
+   trx.sign(chain.get_private_key("tester"_n, "active"), chain.control->get_chain_id());
+   // first push as a dry_run trx
+   trace = chain.push_transaction(trx, fc::time_point::maximum(), base_tester::DEFAULT_BILLED_CPU_TIME_US, false, transaction_metadata::trx_type::dry_run);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
+   // now push for real
+   trace = chain.push_transaction(trx);
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
+   gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_CHECK_EQUAL(2u, gen_size);
+
+   const auto& cidx = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>();
+   auto citr = cidx.find( ids[0] );
+   BOOST_CHECK_EQUAL( (citr == cidx.end()), true );
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_CHECK_EQUAL(2u, gen_size);
+
+   chain.produce_blocks();
+
+   gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_CHECK_EQUAL(2u, gen_size);
+
+   chain.produce_blocks();
+   // update auth will finally be performed
+
+   gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_CHECK_EQUAL(1u, gen_size);
+
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+   // this transfer is performed right away since delay is removed
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
+       ("from", "tester")
+       ("to", "tester2")
+       ("quantity", "10.0000 CUR")
+       ("memo", "hi" )
+   );
+   //wdump((fc::json::to_pretty_string(trace)));
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
+
+   gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_CHECK_EQUAL(1u, gen_size);
+
+   chain.produce_blocks();
+
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("90.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("10.0000 CUR"), liquid_balance);
+
+   chain.produce_blocks(15);
+
+   gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_CHECK_EQUAL(1u, gen_size);
+
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("90.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("10.0000 CUR"), liquid_balance);
+
+   // second transfer finally is performed
+   chain.produce_blocks();
 
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_CHECK_EQUAL(0u, gen_size);
+
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("85.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("15.0000 CUR"), liquid_balance);
 } FC_LOG_AND_RETHROW() } /// canceldelay_test
 
 // test canceldelay action under different permission levels
@@ -1421,77 +1596,265 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
    validating_tester_no_disable_deferred_trx chain;
    chain.produce_block();
 
-   const auto& contract_account = account_name("defcontract");
-   const auto& tester_account = account_name("tester");
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_accounts({contract_account, tester_account});
-   chain.produce_blocks();
-   chain.set_code(contract_account, test_contracts::deferred_test_wasm());
-   chain.set_abi(contract_account, test_contracts::deferred_test_abi());
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks();
 
-   chain.push_action(config::system_account_name, updateauth::get_name(), contract_account, fc::mutable_variant_object()
-           ("account", "defcontract")
+   chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
+
+   chain.produce_blocks();
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
+   chain.produce_blocks();
+
+   chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
            ("permission", "first")
            ("parent", "active")
-           ("auth",  authority(chain.get_public_key(contract_account, "first"), 5))
+           ("auth",  authority(chain.get_public_key(tester_account, "first"), 5))
    );
+   chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
+          ("account", "tester")
+          ("permission", "second")
+          ("parent", "first")
+          ("auth",  authority(chain.get_public_key(tester_account, "second")))
+   );
+   chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", eosio_token)
+           ("type", "transfer")
+           ("requirement", "first"));
+
    chain.produce_blocks();
-
-   auto gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
-   BOOST_CHECK_EQUAL(0u, gen_size);
-
-   chain.push_action( contract_account, "delayedcall"_n, tester_account, fc::mutable_variant_object()
-      ("payer",     tester_account)
-      ("sender_id", 1)
-      ("contract",  contract_account)
-      ("payload",   42)
-      ("delay_sec", 1000)
-      ("replace_existing", false)
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
+           ("issuer", eosio_token)
+           ("maximum_supply", "9000000.0000 CUR")
    );
 
-   const auto& idx = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>();
-   gen_size = idx.size();
-   BOOST_CHECK_EQUAL(1u, gen_size);
-   auto deferred_id = idx.begin()->trx_id;
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
+           ("to",       eosio_token)
+           ("quantity", "1000000.0000 CUR")
+           ("memo", "for stuff")
+   );
 
-   // canceldelay assumes sender and sender_id to be a specific
-   // format. hardcode them for testing purpose only
-   modify_gto_for_canceldelay_test(*(chain.control.get()), deferred_id);
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
+       ("from", eosio_token)
+       ("to", "tester")
+       ("quantity", "100.0000 CUR")
+       ("memo", "hi" )
+   );
+   BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
+   auto gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+   BOOST_REQUIRE_EQUAL(0u, gen_size);
 
-   // attempt canceldelay with wrong canceling_auth for delayed trx
+   chain.produce_blocks();
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
+   liquid_balance = get_currency_balance(chain, "tester"_n);
+   BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+
+   ilog("attempting first delayed transfer");
+
    {
+      // this transaction will be delayed 10 blocks
+      trace = chain.push_action("eosio.token"_n, name("transfer"), vector<permission_level>{{"tester"_n, "first"_n}}, fc::mutable_variant_object()
+          ("from", "tester")
+          ("to", "tester2")
+          ("quantity", "1.0000 CUR")
+          ("memo", "hi" ),
+          30, 5
+      );
+      auto trx_id = trace->id;
+      BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace->receipt->status);
+      gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+      BOOST_REQUIRE_EQUAL(1u, gen_size);
+      BOOST_REQUIRE_EQUAL(0u, trace->action_traces.size());
+
+      const auto& idx = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>();
+      auto itr = idx.find( trx_id );
+      BOOST_CHECK_EQUAL( (itr != idx.end()), true );
+
+      chain.produce_blocks();
+
+      liquid_balance = get_currency_balance(chain, "tester"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+      // attempt canceldelay with wrong canceling_auth for delayed transfer of 1.0000 CUR
+      {
+         signed_transaction trx;
+         trx.actions.emplace_back(vector<permission_level>{{"tester"_n, config::active_name}},
+                                  chain::canceldelay{{"tester"_n, config::active_name}, trx_id});
+         chain.set_transaction_headers(trx);
+         trx.sign(chain.get_private_key("tester"_n, "active"), chain.control->get_chain_id());
+         BOOST_REQUIRE_EXCEPTION( chain.push_transaction(trx), action_validate_exception,
+                                  fc_exception_message_is("canceling_auth in canceldelay action was not found as authorization in the original delayed transaction") );
+      }
+
+      // attempt canceldelay with "second" permission for delayed transfer of 1.0000 CUR
+      {
+         signed_transaction trx;
+         trx.actions.emplace_back(vector<permission_level>{{"tester"_n, "second"_n}},
+                                  chain::canceldelay{{"tester"_n, "first"_n}, trx_id});
+         chain.set_transaction_headers(trx);
+         trx.sign(chain.get_private_key("tester"_n, "second"), chain.control->get_chain_id());
+         BOOST_REQUIRE_THROW( chain.push_transaction(trx), irrelevant_auth_exception );
+         BOOST_REQUIRE_EXCEPTION( chain.push_transaction(trx), irrelevant_auth_exception,
+                                  fc_exception_message_starts_with("canceldelay action declares irrelevant authority") );
+      }
+
+      // canceldelay with "active" permission for delayed transfer of 1.0000 CUR
       signed_transaction trx;
       trx.actions.emplace_back(vector<permission_level>{{"tester"_n, config::active_name}},
-                               chain::canceldelay{{"tester"_n, config::active_name}, deferred_id});
+                               chain::canceldelay{{"tester"_n, "first"_n}, trx_id});
       chain.set_transaction_headers(trx);
       trx.sign(chain.get_private_key("tester"_n, "active"), chain.control->get_chain_id());
-      BOOST_REQUIRE_EXCEPTION( chain.push_transaction(trx), action_validate_exception,
-                               fc_exception_message_is("canceling_auth in canceldelay action was not found as authorization in the original delayed transaction") );
+      trace = chain.push_transaction(trx);
+
+      BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
+      gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+      BOOST_REQUIRE_EQUAL(0u, gen_size);
+
+      const auto& cidx = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>();
+      auto citr = cidx.find( trx_id );
+      BOOST_REQUIRE_EQUAL( (citr == cidx.end()), true );
+
+      chain.produce_blocks(10);
+
+      liquid_balance = get_currency_balance(chain, "tester"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
    }
 
-   // attempt canceldelay with wrong permission for delayed trx
+   ilog("reset minimum permission of transfer to second permission");
+
+   chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
+           ("account", "tester")
+           ("code", eosio_token)
+           ("type", "transfer")
+           ("requirement", "second"),
+           30, 5
+   );
+
+   chain.produce_blocks(11);
+
+
+   ilog("attempting second delayed transfer");
    {
+      // this transaction will be delayed 10 blocks
+      trace = chain.push_action("eosio.token"_n, name("transfer"), vector<permission_level>{{"tester"_n, "second"_n}}, fc::mutable_variant_object()
+          ("from", "tester")
+          ("to", "tester2")
+          ("quantity", "5.0000 CUR")
+          ("memo", "hi" ),
+          30, 5
+      );
+      auto trx_id = trace->id;
+      BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace->receipt->status);
+      auto gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+      BOOST_CHECK_EQUAL(1u, gen_size);
+      BOOST_CHECK_EQUAL(0u, trace->action_traces.size());
+
+      const auto& idx = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>();
+      auto itr = idx.find( trx_id );
+      BOOST_CHECK_EQUAL( (itr != idx.end()), true );
+
+      chain.produce_blocks();
+
+      liquid_balance = get_currency_balance(chain, "tester"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+      // canceldelay with "first" permission for delayed transfer of 5.0000 CUR
       signed_transaction trx;
-      trx.actions.emplace_back(vector<permission_level>{{contract_account, "first"_n}},
-                               chain::canceldelay{{contract_account, "first"_n}, deferred_id});
+      trx.actions.emplace_back(vector<permission_level>{{"tester"_n, "first"_n}},
+                               chain::canceldelay{{"tester"_n, "second"_n}, trx_id});
       chain.set_transaction_headers(trx);
-      trx.sign(chain.get_private_key(contract_account, "first"), chain.control->get_chain_id());
-      BOOST_REQUIRE_EXCEPTION( chain.push_transaction(trx), action_validate_exception,
-                               fc_exception_message_is("canceling_auth in canceldelay action was not found as authorization in the original delayed transaction") );
+      trx.sign(chain.get_private_key("tester"_n, "first"), chain.control->get_chain_id());
+      trace = chain.push_transaction(trx);
+
+      BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
+      gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+      BOOST_REQUIRE_EQUAL(0u, gen_size);
+
+      const auto& cidx = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>();
+      auto citr = cidx.find( trx_id );
+      BOOST_REQUIRE_EQUAL( (citr == cidx.end()), true );
+
+      chain.produce_blocks(10);
+
+      liquid_balance = get_currency_balance(chain, "tester"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
    }
 
-   // attempt canceldelay with wrong signature for delayed trx
+   ilog("attempting third delayed transfer");
+
    {
+      // this transaction will be delayed 10 blocks
+      trace = chain.push_action("eosio.token"_n, name("transfer"), vector<permission_level>{{"tester"_n, config::owner_name}}, fc::mutable_variant_object()
+          ("from", "tester")
+          ("to", "tester2")
+          ("quantity", "10.0000 CUR")
+          ("memo", "hi" ),
+          30, 5
+      );
+      auto trx_id = trace->id;
+      BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace->receipt->status);
+      gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+      BOOST_REQUIRE_EQUAL(1u, gen_size);
+      BOOST_REQUIRE_EQUAL(0u, trace->action_traces.size());
+
+      const auto& idx = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>();
+      auto itr = idx.find( trx_id );
+      BOOST_CHECK_EQUAL( (itr != idx.end()), true );
+
+      chain.produce_blocks();
+
+      liquid_balance = get_currency_balance(chain, "tester"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
+
+      // attempt canceldelay with "active" permission for delayed transfer of 10.0000 CUR
+      {
+         signed_transaction trx;
+         trx.actions.emplace_back(vector<permission_level>{{"tester"_n, "active"_n}},
+                                  chain::canceldelay{{"tester"_n, config::owner_name}, trx_id});
+         chain.set_transaction_headers(trx);
+         trx.sign(chain.get_private_key("tester"_n, "active"), chain.control->get_chain_id());
+         BOOST_REQUIRE_THROW( chain.push_transaction(trx), irrelevant_auth_exception );
+      }
+
+      // canceldelay with "owner" permission for delayed transfer of 10.0000 CUR
       signed_transaction trx;
-      trx.actions.emplace_back(vector<permission_level>{{contract_account, config::active_name}},
-                               chain::canceldelay{{contract_account, config::active_name}, deferred_id});
+      trx.actions.emplace_back(vector<permission_level>{{"tester"_n, config::owner_name}},
+                               chain::canceldelay{{"tester"_n, config::owner_name}, trx_id});
       chain.set_transaction_headers(trx);
-      trx.sign(chain.get_private_key(contract_account, "first"), chain.control->get_chain_id());
-      BOOST_REQUIRE_THROW( chain.push_transaction(trx), unsatisfied_authorization );
-      BOOST_REQUIRE_EXCEPTION( chain.push_transaction(trx), unsatisfied_authorization,
-                               fc_exception_message_starts_with("transaction declares authority") );
+      trx.sign(chain.get_private_key("tester"_n, "owner"), chain.control->get_chain_id());
+      trace = chain.push_transaction(trx);
+
+      BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
+      gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
+      BOOST_REQUIRE_EQUAL(0u, gen_size);
+
+      const auto& cidx = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>();
+      auto citr = cidx.find( trx_id );
+      BOOST_REQUIRE_EQUAL( (citr == cidx.end()), true );
+
+      chain.produce_blocks(10);
+
+      liquid_balance = get_currency_balance(chain, "tester"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
+      BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
    }
 } FC_LOG_AND_RETHROW() } /// canceldelay_test2
 


### PR DESCRIPTION
Resolved https://github.com/AntelopeIO/leap/issues/1730.

Unlinked block error was encountered in a replay of mainnet. It was caused by blocking any deferred trxs by https://github.com/AntelopeIO/leap/pull/1643.

This PR
* restored deferred trxs handling in transaction_context
* updated related tests

I have run replay tests from the mainnet and have passed the failed block 320405089 and trx 527bbf9029f604e7021be729c858fb520001c5c5413cbee2fc08dbcf735534bc,
starting from snapshot-2023-07-12-16-eos-v6-0319983883. The previously failed block was at Jul-14-2023, 10:33:36 PM.

I will do more replay tests over the weekend.