### PR TITLE
[5.0 -> main] Improve cleos error messages

### DIFF
--- a/programs/cleos/help_text.cpp.in
+++ b/programs/cleos/help_text.cpp.in
@@ -208,11 +208,18 @@ const char* error_advice_missing_auth_exception =  R"=====(Ensure that you have 
 If you are currently using '@CLI_CLIENT_EXECUTABLE_NAME@ push action' command, try to add the relevant authority using -p option.)=====";
 const char* error_advice_irrelevant_auth_exception =  "Please remove the unnecessary authority from your action!";
 
-const char* error_advice_missing_chain_api_plugin_exception =  "Ensure that you have \033[2meosio::chain_api_plugin\033[0m\033[32m added to your node's configuration!";
-const char* error_advice_missing_wallet_api_plugin_exception =  "Ensure that you have \033[2meosio::wallet_api_plugin\033[0m\033[32m added to your node's configuration!\n"\
-                                    "Otherwise specify your wallet location with \033[2m--wallet-url\033[0m\033[32m argument!";
-const char* error_advice_missing_history_api_plugin_exception =  "Ensure that you have \033[2meosio::history_api_plugin\033[0m\033[32m added to your node's configuration!";
-const char* error_advice_missing_net_api_plugin_exception =  "Ensure that you have \033[2meosio::net_api_plugin\033[0m\033[32m added to your node's configuration!";
+const char* error_advice_missing_chain_api_plugin_exception =  "Ensure that you have \033[2meosio::chain_api_plugin\033[0m\033[32m added to your node's configuration and enabled on the specified endpoint.\n"
+                                                               "For example:\n"
+                                                               "http-server-address   = http-category-address\n"
+                                                               "http-category-address = chain_ro,127.0.0.1:8081\n"
+                                                               "http-category-address = chain_rw,[::]:8083";
+const char* error_advice_missing_wallet_api_plugin_exception =  "Ensure that you have keosd enabled on the \033[2m--wallet-url\033[0m\033[32m specified endpoint.";
+const char* error_advice_missing_history_api_plugin_exception =  "The \033[2meosio::history_api_plugin\033[0m\033[32m has been removed. Verify endpoint simulates removed history_api_plugin or use a different option.";
+const char* error_advice_missing_net_api_plugin_exception =  "Ensure that you have \033[2meosio::net_api_plugin\033[0m\033[32m added to your node's configuration and enabled on the specified endpoint.\n"
+                                                             "For example:\n"
+                                                             "http-server-address   = http-category-address\n"
+                                                             "http-category-address = net_ro,127.0.0.1:8081\n"
+                                                             "http-category-address = net_rw,[::]:8083";
 
 const char* error_advice_wallet_exist_exception =  "Try to use different wallet name.";
 const char* error_advice_wallet_nonexistent_exception =  "Are you sure you typed the wallet name correctly?";

--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -63,13 +63,13 @@ fc::variant do_http_call(const config_t& config, const std::string& base_uri, co
       } else if( status_code == 404 ) {
          // Unknown endpoint
          if (path.compare(0, chain_func_base.size(), chain_func_base) == 0) {
-            throw chain::missing_chain_api_plugin_exception(FC_LOG_MESSAGE(error, "Chain API plugin is not enabled"));
+            throw chain::missing_chain_api_plugin_exception(FC_LOG_MESSAGE(error, "Chain API plugin is not enabled on specified endpoint"));
          } else if (path.compare(0, wallet_func_base.size(), wallet_func_base) == 0) {
-            throw chain::missing_wallet_api_plugin_exception(FC_LOG_MESSAGE(error, "Wallet is not available"));
+            throw chain::missing_wallet_api_plugin_exception(FC_LOG_MESSAGE(error, "Wallet is not available on specified endpoint"));
          } else if (path.compare(0, history_func_base.size(), history_func_base) == 0) {
-            throw chain::missing_history_api_plugin_exception(FC_LOG_MESSAGE(error, "History API plugin is not enabled"));
+            throw chain::missing_history_api_plugin_exception(FC_LOG_MESSAGE(error, "History API support is not enabled on specified endpoint"));
          } else if (path.compare(0, net_func_base.size(), net_func_base) == 0) {
-            throw chain::missing_net_api_plugin_exception(FC_LOG_MESSAGE(error, "Net API plugin is not enabled"));
+            throw chain::missing_net_api_plugin_exception(FC_LOG_MESSAGE(error, "Net API plugin is not enabled on specified endpoint"));
          }
       } else {
          auto &&error_info = response_result.as<eosio::error_results>().error;


### PR DESCRIPTION
With the addition of https://github.com/AntelopeIO/leap/pull/1137 different categories of plugins can be configured to different endpoints. Update `cleos` error message to provide a better suggestion when feature is not available at provided endpoint.

Example output:
```
./cleos -u http://127.0.0.1:8081 net peers
Error 3110004: Missing Net API Plugin
Ensure that you have eosio::net_api_plugin added to your node's configuration and enabled on the specified endpoint.
For example:
http-server-address   = http-category-address
http-category-address = net_ro,127.0.0.1:8081
http-category-address = net_rw,[::]:8083
Error Details:
Net API plugin is not enabled on specified endpoint
```

Also updated history_api_plugin error details:
```
./cleos -u http://127.0.0.1:8081 get transaction 13fccbfb5f484f23ea081c81ba3dc07cd1eb0ed13e084d5d9e26ddc8f9aa94d1
Error 3110003: Missing History API Plugin
The eosio::history_api_plugin has been removed. Verify endpoint simulates removed history_api_plugin or use a different option.
Error Details:
History API plugin is not enabled on specified endpoint
```

Merges `release/5.0` into `main` including #1733 

Resolves #1688