### PR TITLE
[5.0] Test: Pass in exitOnError so that a retry is allowed

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -146,10 +146,10 @@ class Node(Transactions):
                 Utils.Print("account validation failed. account: %s" % (account.name))
                 raise
 
-    def waitForTransactionInBlock(self, transId, timeout=None):
+    def waitForTransactionInBlock(self, transId, timeout=None, exitOnError=True):
         """Wait for trans id to appear in a block."""
         assert(isinstance(transId, str))
-        lam = lambda: self.isTransInAnyBlock(transId)
+        lam = lambda: self.isTransInAnyBlock(transId, exitOnError=exitOnError)
         ret=Utils.waitForBool(lam, timeout)
         return ret
 
@@ -226,7 +226,7 @@ class Node(Transactions):
         if not waitForTransBlock:
             return trans
         transId=NodeosQueries.getTransId(trans)
-        if not self.waitForTransactionInBlock(transId):
+        if not self.waitForTransactionInBlock(transId, exitOnError=exitOnError):
             if exitOnError:
                 Utils.cmdError("transaction with id %s never made it into a block" % (transId))
                 Utils.errorExit("Failed to find transaction with id %s in a block before timeout" % (transId))

--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -319,11 +319,11 @@ class NodeosQueries:
 
         return None
 
-    def isTransInAnyBlock(self, transId: str):
+    def isTransInAnyBlock(self, transId: str, exitOnError=True):
         """Check if transaction (transId) is in a block."""
         assert(transId)
         assert(isinstance(transId, str))
-        blockId=self.getBlockNumByTransId(transId)
+        blockId=self.getBlockNumByTransId(transId, exitOnError=exitOnError)
         return True if blockId else False
 
     def isTransFinalized(self, transId):

--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -203,7 +203,7 @@ class Transactions(NodeosQueries):
             if not waitForTransBlock:
                 return trans
             transId=NodeosQueries.getTransId(trans)
-            if self.waitForTransactionInBlock(transId, timeout=5):
+            if self.waitForTransactionInBlock(transId, timeout=5, exitOnError=False):
                 break
 
         return trans


### PR DESCRIPTION
#1728 added a retry for `publishContract` (`set contract`), however, the retry never executed because the `waitForTransactionInBlock` would exit on error. Wired in passing `exitOnError` so that a retry could actually run.

Resolves #1501 