### PR TITLE
[5.0] Test: larger timeout of set contract

### DIFF
--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -203,7 +203,7 @@ class Transactions(NodeosQueries):
             if not waitForTransBlock:
                 return trans
             transId=NodeosQueries.getTransId(trans)
-            if self.waitForTransactionInBlock(transId, timeout=5, exitOnError=False):
+            if self.waitForTransactionInBlock(transId, timeout=30, exitOnError=False):
                 break
 
         return trans


### PR DESCRIPTION
Recent test failure: https://github.com/AntelopeIO/leap/actions/runs/6476622261 shows that the 5s timeout allowed for a successful `set code` but not enough time for python test to observe the transaction in a block. Increase to 30s to allow for plenty of time for python to parse blocks looking for transaction.

Resolves #1501