### PR TITLE
[5.0] fix "All Required Tests Passed" CI Branch Protection

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -291,6 +291,8 @@ jobs:
   all-passing:
     name: All Required Tests Passed
     needs: [dev-package, tests, np-tests, libtester-tests]
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - if: needs.dev-package.result != 'success' || needs.tests.result != 'success' || needs.np-tests.result != 'success' || needs.libtester-tests.result != 'success'
+        run: false


### PR DESCRIPTION
The leap repo has a branch protection rule that "All Required Tests Passed" is required to pass. At least I think that's what it's suppose to mean. Now I'm not sure because, mind bogglingly, when that test is skipped (because a dependent job failed) it doesn't block the PR! Consider this example where,
* "NP Tests (ubuntu20)" failed
* "All Required Tests Passed" was skipped, and
* Had 2 approvals
![Screenshot 2023-10-04 at 13-00-31 generate ` tar zst` out of `cpack` instead of ` tar gz` by spoonincode · Pull Request #1714 · AntelopeIO_leap](https://github.com/AntelopeIO/leap/assets/32485495/84817d76-c85b-4e22-b504-0a285f58cbe3)
![Screenshot 2023-10-04 at 13-00-42 generate ` tar zst` out of `cpack` instead of ` tar gz` by spoonincode · Pull Request #1714 · AntelopeIO_leap](https://github.com/AntelopeIO/leap/assets/32485495/2467be8e-5ee9-4f61-961d-f6c0ccba3562)

Expected behavior in this case is to not have the "white" merge button (it should be red for admins; and simply not allowed for non-admins).

So... restore this job back to how it was previously via `if: always()` and status checks on the dependent jobs.

Sending to 5.0 because this branch protection rule is important.