### PR TITLE
[5.0 -> main] Fix compiler warning

### DIFF
--- a/plugins/producer_plugin/test/test_disallow_delayed_trx.cpp
+++ b/plugins/producer_plugin/test/test_disallow_delayed_trx.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(delayed_trx) {
             false,
             transaction_metadata::trx_type::input,
             return_failure_traces,
-            [ptrx, return_failure_traces] (const next_function_variant<transaction_trace_ptr>& result) {
+            [ptrx] (const next_function_variant<transaction_trace_ptr>& result) {
                elog( "trace with except ${e}", ("e", fc::json::to_pretty_string( *std::get<chain::transaction_trace_ptr>( result ) )) );
             }
          ),


### PR DESCRIPTION
Fix compiler warning: `lambda capture 'return_failure_traces' is not used`

Merges `release/5.0` into `main` including #1752 