### PR TITLE
[5.0] Test: read-only trxs should only be posted to read_exclusive queue

### DIFF
--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -132,7 +132,7 @@ void test_trxs_common(std::vector<const char*>& specific_args, bool test_disable
                chain_plug->get_read_only_api(fc::seconds(90)).get_account(chain_apis::read_only::get_account_params{.account_name=config::system_account_name}, fc::time_point::now()+fc::seconds(90));
                ++num_get_account_calls;
             });
-            app->executor().post( priority::low, exec_queue::read_only, [ptrx, &next_calls, &num_posts, &trace_with_except, &trx_match, &app]() {
+            app->executor().post( priority::low, exec_queue::read_exclusive, [ptrx, &next_calls, &num_posts, &trace_with_except, &trx_match, &app]() {
                ++num_posts;
                bool return_failure_traces = true;
                app->get_method<plugin_interface::incoming::methods::transaction_async>()(ptrx,


### PR DESCRIPTION
As of #1702 read only trxs should only be posted to `read_exclusive` queue. The `test_read_only_trx` test was posting them to the `read_only` queue which caused them to sometimes run during the write window. They were run in the write window because read only transactions are allowed to run on the main thread. It is not clear if this is why test failed but seems we can assume that is the problem unless it fails again. I ran the `test_read_only_trx` many times locally without failure with this fix.

Resolves #1736 