### PR TITLE
Support arbitrary labels on p2p peers.

### DIFF
--- a/plugins/net_api_plugin/net_api_plugin.cpp
+++ b/plugins/net_api_plugin/net_api_plugin.cpp
@@ -57,6 +57,8 @@ void net_api_plugin::plugin_startup() {
    app().get_plugin<http_plugin>().add_async_api({
        CALL_WITH_400(net, net_rw, net_mgr, connect,
             INVOKE_R_R(net_mgr, connect, std::string), 201),
+       CALL_WITH_400(net, net_rw, net_mgr, label,
+            INVOKE_R_R(net_mgr, label, std::string), 201),
        CALL_WITH_400(net, net_rw, net_mgr, disconnect,
             INVOKE_R_R(net_mgr, disconnect, std::string), 201),
        CALL_WITH_400(net, net_ro, net_mgr, status,

--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -9,6 +9,7 @@ namespace eosio {
 
    struct connection_status {
       string            peer;
+      string            label;
       string            remote_ip;
       string            remote_port;
       bool              connecting           = false;
@@ -35,9 +36,10 @@ namespace eosio {
         void plugin_shutdown();
 
         string                            connect( const string& endpoint );
+        string                            label( const string& endpoint );
         string                            disconnect( const string& endpoint );
-        std::optional<connection_status>  status( const string& endpoint )const;
-        vector<connection_status>         connections()const;
+        std::optional<connection_status>  status( const string& endpoint ) const;
+        vector<connection_status>         connections() const;
 
         struct p2p_per_connection_metrics {
             struct connection_metric {
@@ -60,6 +62,7 @@ namespace eosio {
                std::chrono::nanoseconds connection_start_time{0};
                std::string p2p_address;
                std::string unique_conn_node_id;
+               std::string label;
             };
             explicit p2p_per_connection_metrics(size_t count) {
                peers.reserve(count);
@@ -98,4 +101,4 @@ namespace eosio {
 
 }
 
-FC_REFLECT( eosio::connection_status, (peer)(remote_ip)(remote_port)(connecting)(syncing)(is_bp_peer)(is_socket_open)(is_blocks_only)(is_transactions_only)(last_handshake) )
+FC_REFLECT( eosio::connection_status, (peer)(label)(remote_ip)(remote_port)(connecting)(syncing)(is_bp_peer)(is_socket_open)(is_blocks_only)(is_transactions_only)(last_handshake) )

--- a/plugins/prometheus_plugin/metrics.hpp
+++ b/plugins/prometheus_plugin/metrics.hpp
@@ -208,7 +208,7 @@ struct catalog_type {
          const auto& conn_id = peer.unique_conn_node_id;
 
          const auto addr = boost::asio::ip::make_address_v6(peer.address).to_string();
-         p2p_metrics.addr.Add({{"connid", conn_id},{"ipv6", addr},{"address", peer.p2p_address}});
+         p2p_metrics.addr.Add({{"connid", conn_id},{"ipv6", addr},{"address", peer.p2p_address},{"label", peer.label}});
 
          auto add_and_set_gauge = [&](auto& fam, const auto& value) {
             auto& gauge = fam.Add({{"connid", conn_id}});

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -61,9 +61,10 @@ try:
 
         abs_path = os.path.abspath(os.getcwd() + '/unittests/contracts/eosio.token/eosio.token.abi')
         traceNodeosArgs=" --http-max-response-time-ms 990000 --trace-rpc-abi eosio.token=" + abs_path
-        extraNodeosArgs=traceNodeosArgs + " --plugin eosio::prometheus_plugin --database-map-mode mapped_private "
+        extraNodeosArgs=traceNodeosArgs + " --plugin eosio::prometheus_plugin --database-map-mode mapped_private --plugin eosio::net_api_plugin "
         specificNodeosInstances={0: "bin/nodeos"}
-        if cluster.launch(totalNodes=2, prodCount=prodCount, onlyBios=onlyBios, dontBootstrap=dontBootstrap, extraNodeosArgs=extraNodeosArgs, specificNodeosInstances=specificNodeosInstances) is False:
+        specificExtraNodeosArgs={0: " --p2p-peer-label localhost:9776:bios_node "}
+        if cluster.launch(totalNodes=2, prodCount=prodCount, onlyBios=onlyBios, dontBootstrap=dontBootstrap, extraNodeosArgs=extraNodeosArgs, specificNodeosInstances=specificNodeosInstances, specificExtraNodeosArgs=specificExtraNodeosArgs) is False:
             cmdError("launcher")
             errorExit("Failed to stand up eos cluster.")
     else:
@@ -295,6 +296,8 @@ try:
     Print("verify no contract in place")
     Print("Get code hash for account %s" % (currencyAccount.name))
     node=cluster.getNode(0)
+    connections = node.processUrllibRequest('net', 'connections')
+    assert connections['payload'][0]['label'] == 'bios_node', "Failed to find expected peer label"
     codeHash=node.getAccountCodeHash(currencyAccount.name)
     if codeHash is None:
         cmdError("%s get code currency1111" % (ClientName))

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -296,8 +296,13 @@ try:
     Print("verify no contract in place")
     Print("Get code hash for account %s" % (currencyAccount.name))
     node=cluster.getNode(0)
+
     connections = node.processUrllibRequest('net', 'connections')
-    assert connections['payload'][0]['label'] == 'bios_node', "Failed to find expected peer label"
+    for record in connections['payload']:
+        if record['peer'] == 'localhost:9776':
+            assert record['label'] == 'bios_node', "Failed to find expected peer label"
+            break
+
     codeHash=node.getAccountCodeHash(currencyAccount.name)
     if codeHash is None:
         cmdError("%s get code currency1111" % (ClientName))


### PR DESCRIPTION
This PR creates a new configuration file and command line option and a new net API endpoint for labeling peers.  For the configuration file and command line options, a `p2p-peer-address` option must exist first.  It can then be labeled using `p2p-peer-label`.

```
p2p-peer-address=p2p.eos.io:9876
p2p-peer-label=p2p.eos.io:9876:Favorite peer
```
The new API endpoint is available at
`/v1/net/label`
and accepts the same format as the configuration option.

Peer labels are available as a new field with key `"label"` in the JSON output of  the `/v1/net/connections` API endpoint and in the Prometheus metrics for each peer.  Peer labels can accept an arbitrary string of arbitrary length.  They are not transmitted over the network to other peers.

For peer addresses which are restricted to only transactions or only blocks, the full address must be specified to match:
```
p2p-peer-address=p2p.trx.eos.io:9876:trx
p2p-peer-label=p2p.trx.eos.io:9876:trx:transaction only peer
```
The label text will include the restriction as prefix, e.g. `trx:transaction only peer`.