### PR TITLE
[4.0] Only return wasm config settings if configurable wasm limits enabled

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2658,7 +2658,9 @@ read_only::get_consensus_parameters(const get_consensus_parameters_params&, cons
    get_consensus_parameters_results results;
 
    results.chain_config = db.get_global_properties().configuration;
-   results.wasm_config = db.get_global_properties().wasm_configuration;
+   if (db.is_builtin_activated(builtin_protocol_feature_t::configurable_wasm_limits)) {
+      results.wasm_config = db.get_global_properties().wasm_configuration;
+   }
 
    return results;
 }

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -711,8 +711,8 @@ public:
 
    using get_consensus_parameters_params = empty;
    struct get_consensus_parameters_results {
-     chain::chain_config        chain_config;
-     chain::wasm_config         wasm_config;
+     chain::chain_config               chain_config;
+     std::optional<chain::wasm_config> wasm_config;
    };
    get_consensus_parameters_results get_consensus_parameters(const get_consensus_parameters_params&, const fc::time_point& deadline) const;
 

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -130,45 +130,55 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
 
 } FC_LOG_AND_RETHROW() /// get_block_with_invalid_abi
 
-BOOST_FIXTURE_TEST_CASE( get_consensus_parameters, TESTER ) try {
-   produce_blocks(1);
+BOOST_AUTO_TEST_CASE( get_consensus_parameters ) try {
+   tester t{setup_policy::old_wasm_parser};
+   t.produce_blocks(1);
 
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr, nullptr);
+   chain_apis::read_only plugin(*(t.control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr, nullptr);
 
    auto parms = plugin.get_consensus_parameters({}, fc::time_point::maximum());
 
    // verifying chain_config
-   BOOST_TEST(parms.chain_config.max_block_cpu_usage == control->get_global_properties().configuration.max_block_cpu_usage);
-   BOOST_TEST(parms.chain_config.target_block_net_usage_pct == control->get_global_properties().configuration.target_block_net_usage_pct);
-   BOOST_TEST(parms.chain_config.max_transaction_net_usage == control->get_global_properties().configuration.max_transaction_net_usage);
-   BOOST_TEST(parms.chain_config.base_per_transaction_net_usage == control->get_global_properties().configuration.base_per_transaction_net_usage);
-   BOOST_TEST(parms.chain_config.net_usage_leeway == control->get_global_properties().configuration.net_usage_leeway);
-   BOOST_TEST(parms.chain_config.context_free_discount_net_usage_num == control->get_global_properties().configuration.context_free_discount_net_usage_num);
-   BOOST_TEST(parms.chain_config.context_free_discount_net_usage_den == control->get_global_properties().configuration.context_free_discount_net_usage_den);
-   BOOST_TEST(parms.chain_config.max_block_cpu_usage == control->get_global_properties().configuration.max_block_cpu_usage);
-   BOOST_TEST(parms.chain_config.target_block_cpu_usage_pct == control->get_global_properties().configuration.target_block_cpu_usage_pct);
-   BOOST_TEST(parms.chain_config.max_transaction_cpu_usage == control->get_global_properties().configuration.max_transaction_cpu_usage);
-   BOOST_TEST(parms.chain_config.min_transaction_cpu_usage == control->get_global_properties().configuration.min_transaction_cpu_usage);
-   BOOST_TEST(parms.chain_config.max_transaction_lifetime == control->get_global_properties().configuration.max_transaction_lifetime);
-   BOOST_TEST(parms.chain_config.deferred_trx_expiration_window == control->get_global_properties().configuration.deferred_trx_expiration_window);
-   BOOST_TEST(parms.chain_config.max_transaction_delay == control->get_global_properties().configuration.max_transaction_delay);
-   BOOST_TEST(parms.chain_config.max_inline_action_size == control->get_global_properties().configuration.max_inline_action_size);
-   BOOST_TEST(parms.chain_config.max_inline_action_depth == control->get_global_properties().configuration.max_inline_action_depth);
-   BOOST_TEST(parms.chain_config.max_authority_depth == control->get_global_properties().configuration.max_authority_depth);
-   BOOST_TEST(parms.chain_config.max_action_return_value_size == control->get_global_properties().configuration.max_action_return_value_size);
+   BOOST_TEST(parms.chain_config.max_block_cpu_usage == t.control->get_global_properties().configuration.max_block_cpu_usage);
+   BOOST_TEST(parms.chain_config.target_block_net_usage_pct == t.control->get_global_properties().configuration.target_block_net_usage_pct);
+   BOOST_TEST(parms.chain_config.max_transaction_net_usage == t.control->get_global_properties().configuration.max_transaction_net_usage);
+   BOOST_TEST(parms.chain_config.base_per_transaction_net_usage == t.control->get_global_properties().configuration.base_per_transaction_net_usage);
+   BOOST_TEST(parms.chain_config.net_usage_leeway == t.control->get_global_properties().configuration.net_usage_leeway);
+   BOOST_TEST(parms.chain_config.context_free_discount_net_usage_num == t.control->get_global_properties().configuration.context_free_discount_net_usage_num);
+   BOOST_TEST(parms.chain_config.context_free_discount_net_usage_den == t.control->get_global_properties().configuration.context_free_discount_net_usage_den);
+   BOOST_TEST(parms.chain_config.max_block_cpu_usage == t.control->get_global_properties().configuration.max_block_cpu_usage);
+   BOOST_TEST(parms.chain_config.target_block_cpu_usage_pct == t.control->get_global_properties().configuration.target_block_cpu_usage_pct);
+   BOOST_TEST(parms.chain_config.max_transaction_cpu_usage == t.control->get_global_properties().configuration.max_transaction_cpu_usage);
+   BOOST_TEST(parms.chain_config.min_transaction_cpu_usage == t.control->get_global_properties().configuration.min_transaction_cpu_usage);
+   BOOST_TEST(parms.chain_config.max_transaction_lifetime == t.control->get_global_properties().configuration.max_transaction_lifetime);
+   BOOST_TEST(parms.chain_config.deferred_trx_expiration_window == t.control->get_global_properties().configuration.deferred_trx_expiration_window);
+   BOOST_TEST(parms.chain_config.max_transaction_delay == t.control->get_global_properties().configuration.max_transaction_delay);
+   BOOST_TEST(parms.chain_config.max_inline_action_size == t.control->get_global_properties().configuration.max_inline_action_size);
+   BOOST_TEST(parms.chain_config.max_inline_action_depth == t.control->get_global_properties().configuration.max_inline_action_depth);
+   BOOST_TEST(parms.chain_config.max_authority_depth == t.control->get_global_properties().configuration.max_authority_depth);
+   BOOST_TEST(parms.chain_config.max_action_return_value_size == t.control->get_global_properties().configuration.max_action_return_value_size);
+
+   BOOST_TEST(!parms.wasm_config);
+
+   t.preactivate_all_builtin_protocol_features();
+   t.produce_block();
+
+   parms = plugin.get_consensus_parameters({}, fc::time_point::maximum());
+
+   BOOST_REQUIRE(!!parms.wasm_config);
 
    // verifying wasm_config
-   BOOST_TEST(parms.wasm_config->max_mutable_global_bytes == control->get_global_properties().wasm_configuration.max_mutable_global_bytes);
-   BOOST_TEST(parms.wasm_config->max_table_elements == control->get_global_properties().wasm_configuration.max_table_elements);
-   BOOST_TEST(parms.wasm_config->max_section_elements == control->get_global_properties().wasm_configuration.max_section_elements);
-   BOOST_TEST(parms.wasm_config->max_linear_memory_init == control->get_global_properties().wasm_configuration.max_linear_memory_init);
-   BOOST_TEST(parms.wasm_config->max_func_local_bytes == control->get_global_properties().wasm_configuration.max_func_local_bytes);
-   BOOST_TEST(parms.wasm_config->max_nested_structures == control->get_global_properties().wasm_configuration.max_nested_structures);
-   BOOST_TEST(parms.wasm_config->max_symbol_bytes == control->get_global_properties().wasm_configuration.max_symbol_bytes);
-   BOOST_TEST(parms.wasm_config->max_module_bytes == control->get_global_properties().wasm_configuration.max_module_bytes);
-   BOOST_TEST(parms.wasm_config->max_code_bytes == control->get_global_properties().wasm_configuration.max_code_bytes);
-   BOOST_TEST(parms.wasm_config->max_pages == control->get_global_properties().wasm_configuration.max_pages);
-   BOOST_TEST(parms.wasm_config->max_call_depth == control->get_global_properties().wasm_configuration.max_call_depth);
+   BOOST_TEST(parms.wasm_config->max_mutable_global_bytes == t.control->get_global_properties().wasm_configuration.max_mutable_global_bytes);
+   BOOST_TEST(parms.wasm_config->max_table_elements == t.control->get_global_properties().wasm_configuration.max_table_elements);
+   BOOST_TEST(parms.wasm_config->max_section_elements == t.control->get_global_properties().wasm_configuration.max_section_elements);
+   BOOST_TEST(parms.wasm_config->max_linear_memory_init == t.control->get_global_properties().wasm_configuration.max_linear_memory_init);
+   BOOST_TEST(parms.wasm_config->max_func_local_bytes == t.control->get_global_properties().wasm_configuration.max_func_local_bytes);
+   BOOST_TEST(parms.wasm_config->max_nested_structures == t.control->get_global_properties().wasm_configuration.max_nested_structures);
+   BOOST_TEST(parms.wasm_config->max_symbol_bytes == t.control->get_global_properties().wasm_configuration.max_symbol_bytes);
+   BOOST_TEST(parms.wasm_config->max_module_bytes == t.control->get_global_properties().wasm_configuration.max_module_bytes);
+   BOOST_TEST(parms.wasm_config->max_code_bytes == t.control->get_global_properties().wasm_configuration.max_code_bytes);
+   BOOST_TEST(parms.wasm_config->max_pages == t.control->get_global_properties().wasm_configuration.max_pages);
+   BOOST_TEST(parms.wasm_config->max_call_depth == t.control->get_global_properties().wasm_configuration.max_call_depth);
 
 } FC_LOG_AND_RETHROW() //get_consensus_parameters
 

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -158,17 +158,17 @@ BOOST_FIXTURE_TEST_CASE( get_consensus_parameters, TESTER ) try {
    BOOST_TEST(parms.chain_config.max_action_return_value_size == control->get_global_properties().configuration.max_action_return_value_size);
 
    // verifying wasm_config
-   BOOST_TEST(parms.wasm_config.max_mutable_global_bytes == control->get_global_properties().wasm_configuration.max_mutable_global_bytes);
-   BOOST_TEST(parms.wasm_config.max_table_elements == control->get_global_properties().wasm_configuration.max_table_elements);
-   BOOST_TEST(parms.wasm_config.max_section_elements == control->get_global_properties().wasm_configuration.max_section_elements);
-   BOOST_TEST(parms.wasm_config.max_linear_memory_init == control->get_global_properties().wasm_configuration.max_linear_memory_init);
-   BOOST_TEST(parms.wasm_config.max_func_local_bytes == control->get_global_properties().wasm_configuration.max_func_local_bytes);
-   BOOST_TEST(parms.wasm_config.max_nested_structures == control->get_global_properties().wasm_configuration.max_nested_structures);
-   BOOST_TEST(parms.wasm_config.max_symbol_bytes == control->get_global_properties().wasm_configuration.max_symbol_bytes);
-   BOOST_TEST(parms.wasm_config.max_module_bytes == control->get_global_properties().wasm_configuration.max_module_bytes);
-   BOOST_TEST(parms.wasm_config.max_code_bytes == control->get_global_properties().wasm_configuration.max_code_bytes);
-   BOOST_TEST(parms.wasm_config.max_pages == control->get_global_properties().wasm_configuration.max_pages);
-   BOOST_TEST(parms.wasm_config.max_call_depth == control->get_global_properties().wasm_configuration.max_call_depth);
+   BOOST_TEST(parms.wasm_config->max_mutable_global_bytes == control->get_global_properties().wasm_configuration.max_mutable_global_bytes);
+   BOOST_TEST(parms.wasm_config->max_table_elements == control->get_global_properties().wasm_configuration.max_table_elements);
+   BOOST_TEST(parms.wasm_config->max_section_elements == control->get_global_properties().wasm_configuration.max_section_elements);
+   BOOST_TEST(parms.wasm_config->max_linear_memory_init == control->get_global_properties().wasm_configuration.max_linear_memory_init);
+   BOOST_TEST(parms.wasm_config->max_func_local_bytes == control->get_global_properties().wasm_configuration.max_func_local_bytes);
+   BOOST_TEST(parms.wasm_config->max_nested_structures == control->get_global_properties().wasm_configuration.max_nested_structures);
+   BOOST_TEST(parms.wasm_config->max_symbol_bytes == control->get_global_properties().wasm_configuration.max_symbol_bytes);
+   BOOST_TEST(parms.wasm_config->max_module_bytes == control->get_global_properties().wasm_configuration.max_module_bytes);
+   BOOST_TEST(parms.wasm_config->max_code_bytes == control->get_global_properties().wasm_configuration.max_code_bytes);
+   BOOST_TEST(parms.wasm_config->max_pages == control->get_global_properties().wasm_configuration.max_pages);
+   BOOST_TEST(parms.wasm_config->max_call_depth == control->get_global_properties().wasm_configuration.max_call_depth);
 
 } FC_LOG_AND_RETHROW() //get_consensus_parameters
 


### PR DESCRIPTION
The wasm config settings returned by `/v1/chain/get_consensus_parameters` are only valid if the protocol feature `CONFIGURABLE_WASM_LIMITS2` is enabled. Only return `"wasm_config"` if protocol feature `CONFIGURABLE_WASM_LIMITS2` is enabled.

With protocol activated:
```
./cleos get consensus_parameters
{
  "chain_config": {
    "max_block_net_usage": 1048576,
    "target_block_net_usage_pct": 1000,
    "max_transaction_net_usage": 524288,
    "base_per_transaction_net_usage": 12,
    "net_usage_leeway": 500,
    "context_free_discount_net_usage_num": 20,
    "context_free_discount_net_usage_den": 100,
    "max_block_cpu_usage": 500000,
    "target_block_cpu_usage_pct": 1000,
    "max_transaction_cpu_usage": 475000,
    "min_transaction_cpu_usage": 100,
    "max_transaction_lifetime": 3600,
    "deferred_trx_expiration_window": 600,
    "max_transaction_delay": 3888000,
    "max_inline_action_size": 524288,
    "max_inline_action_depth": 4,
    "max_authority_depth": 6,
    "max_action_return_value_size": 256
  },
  "wasm_config": {
    "max_mutable_global_bytes": 1024,
    "max_table_elements": 1024,
    "max_section_elements": 8192,
    "max_linear_memory_init": 65536,
    "max_func_local_bytes": 8192,
    "max_nested_structures": 1024,
    "max_symbol_bytes": 8192,
    "max_module_bytes": 20971520,
    "max_code_bytes": 20971520,
    "max_pages": 528,
    "max_call_depth": 251
  }
}
```

Without protocol activated:
```
./cleos get consensus_parameters
{
  "chain_config": {
    "max_block_net_usage": 1048576,
    "target_block_net_usage_pct": 1000,
    "max_transaction_net_usage": 524288,
    "base_per_transaction_net_usage": 12,
    "net_usage_leeway": 500,
    "context_free_discount_net_usage_num": 20,
    "context_free_discount_net_usage_den": 100,
    "max_block_cpu_usage": 200000,
    "target_block_cpu_usage_pct": 2500,
    "max_transaction_cpu_usage": 150000,
    "min_transaction_cpu_usage": 100,
    "max_transaction_lifetime": 3600,
    "deferred_trx_expiration_window": 600,
    "max_transaction_delay": 3888000,
    "max_inline_action_size": 524287,
    "max_inline_action_depth": 10,
    "max_authority_depth": 10,
    "max_action_return_value_size": 256
  }
}
```

Resolves #1660 