### PR TITLE
[5.0 -> main] Signal accepted_block after it is marked valid

### DIFF
--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -179,9 +179,11 @@ BOOST_AUTO_TEST_CASE( signal_validated_blocks ) try {
    chain.produce_blocks(1);
    validator.push_block(accepted_bsp->block);
 
-   auto trace_ptr = chain.create_account("hello"_n);
-   chain.produce_block();
+   chain.create_account("hello"_n);
+   auto produced_block = chain.produce_block();
    validator.push_block(accepted_bsp->block);
+   BOOST_CHECK(produced_block->calculate_id() == accepted_bsp->id);
+   BOOST_CHECK(accepted_bsp->id == validated_bsp->id);
 
 } FC_LOG_AND_RETHROW()
 


### PR DESCRIPTION
Backport of #1386 hence the small diff.

As indicated in #1275, produced blocks were signaled to plugins after being marked valid and placed in the forkdb but signaled before being marked valid and placed in the forkdb for validated blocks. This PR makes sure that the block is marked valid before being signaled for both produced blocks and validated blocks. Also refactors location of updating `head` for applied blocks, consolidating it in `commit_block`.

This also fixes #1694 as `head` is updated consistently before `accepted_block` is signaled which is what `state_history_plugin` SHiP is using for reporting `head` in `get_status_result_v0` messages.

Merges `release/5.0` into `main` including #1769 & #1769

Resolves #1275 
Resolves #1694