### PR TITLE
[4.0] SHiP: Fixes: Stack overflow, invalid index, split file access

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -900,8 +900,8 @@ class state_history_log {
       fc::path log_file_path = log.get_file_path();
       fc::path index_file_path = index.get_file_path();
 
-      fc::datastream<fc::cfile>  new_log_file;
-      fc::datastream<fc::cfile> new_index_file;
+      fc::cfile new_log_file;
+      fc::cfile new_index_file;
 
       fc::path tmp_log_file_path = log_file_path;
       tmp_log_file_path.replace_extension("log.tmp");
@@ -914,13 +914,14 @@ class state_history_log {
       try {
          new_log_file.open(fc::cfile::truncate_rw_mode);
          new_index_file.open(fc::cfile::truncate_rw_mode);
-
       } catch (...) {
          wlog("Unable to open new state history log or index file for writing during log spliting, "
               "continue writing to existing block log file\n");
          return;
       }
 
+      new_log_file.close();
+      new_index_file.close();
       index.close();
       log.close();
 
@@ -937,6 +938,10 @@ class state_history_log {
 
       log.set_file_path(log_file_path);
       index.set_file_path(index_file_path);
+
+      log.open(fc::cfile::update_rw_mode);
+      log.seek_end(0);
+      index.open(fc::cfile::create_or_update_rw_mode);
    }
 }; // state_history_log
 

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -74,9 +74,10 @@ struct state_history_log_header {
    chain::block_id_type block_id     = {};
    uint64_t             payload_size = 0;
 };
-static const int state_history_log_header_serial_size = sizeof(state_history_log_header::magic) +
-                                                        sizeof(state_history_log_header::block_id) +
-                                                        sizeof(state_history_log_header::payload_size);
+static constexpr int state_history_log_header_serial_size = sizeof(state_history_log_header::magic) +
+                                                            sizeof(state_history_log_header::block_id) +
+                                                            sizeof(state_history_log_header::payload_size);
+static_assert(sizeof(state_history_log_header) == state_history_log_header_serial_size);
 
 namespace state_history {
    struct prune_config {
@@ -324,7 +325,7 @@ class state_history_log {
             catalog.open(log_dir, conf.retained_dir, conf.archive_dir, name);
             catalog.max_retained_files = conf.max_retained_files;
             if (_end_block == 0) {
-               _begin_block = _end_block = catalog.last_block_num() +1;
+               _index_begin_block = _begin_block = _end_block = catalog.last_block_num() +1;
             }
          }
       }, _config);
@@ -925,7 +926,7 @@ class state_history_log {
 
       catalog.add(_begin_block, _end_block - 1, log.get_file_path().parent_path(), name);
 
-      _begin_block = _end_block;
+      _index_begin_block = _begin_block = _end_block;
 
       using std::swap;
       swap(new_log_file, log);

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -578,10 +578,19 @@ class state_history_log {
          if (block_num >= _begin_block && block_num < _end_block) {
             state_history_log_header header;
             get_entry(block_num, header);
+            if (chain::block_header::num_from_id(header.block_id) != block_num) { // entry does not match requested block num
+               elog("id does not match requested ${a} != ${b}", ("a", chain::block_header::num_from_id(header.block_id))("b", block_num));
+               assert(false);
+            }
             return header.block_id;
          }
          return {};
       }
+      if (chain::block_header::num_from_id(*result) != block_num) { // catalog failed to fetch correct block id
+         elog("id does not match requested ${a} != ${b}", ("a", chain::block_header::num_from_id(*result))("b", block_num));
+         assert(false);
+      }
+
       return result;
    }
 

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -75,7 +75,6 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
    uint16_t                         endpoint_port = 8080;
    string                           unix_path;
    state_history::trace_converter   trace_converter;
-   session_manager                  session_mgr;
 
    mutable std::mutex mtx;
    block_id_type head_id;
@@ -100,6 +99,8 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
    std::set<acceptor_type>          acceptors;
 
    named_thread_pool<struct ship> thread_pool;
+
+   session_manager                  session_mgr{thread_pool.get_executor()};
 
    bool  plugin_started = false;
 

--- a/plugins/state_history_plugin/tests/session_test.cpp
+++ b/plugins/state_history_plugin/tests/session_test.cpp
@@ -100,7 +100,7 @@ struct mock_state_history_plugin {
    fc::temp_directory                      log_dir;
    std::optional<eosio::state_history_log> log;
    std::atomic<bool>                       stopping = false;
-   eosio::session_manager                  session_mgr;
+   eosio::session_manager                  session_mgr{ship_ioc};
 
    constexpr static uint32_t default_frame_size = 1024;
 


### PR DESCRIPTION
Includes three SHiP `state_history_plugin` fixes:
* Fix for stack overflow due to recursive call to `send()`. Fixed by posting to the SHiP thread on new `send()`s.
* Fix for accessing wrong data after log splitting.
* Fix for accessing wrong file after log splitting.

Resolves #1677 