### PR TITLE
[5.0] only use `--eos-vm-oc-enable` option in tests when OC is available, and tweak/fix location of its usage

### DIFF
--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -204,6 +204,9 @@ BOOST_AUTO_TEST_CASE(with_3_read_only_threads) {
 BOOST_AUTO_TEST_CASE(with_3_read_only_threads_no_tierup) {
    std::vector<const char*> specific_args = { "-p", "eosio", "-e",
                                              "--read-only-threads=3",
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+                                             "--eos-vm-oc-enable=none",
+#endif
                                              "--max-transaction-time=10",
                                              "--abi-serializer-max-time-ms=999",
                                              "--read-only-write-window-time-us=100000",
@@ -215,7 +218,6 @@ BOOST_AUTO_TEST_CASE(with_3_read_only_threads_no_tierup) {
 BOOST_AUTO_TEST_CASE(with_8_read_only_threads) {
    std::vector<const char*> specific_args = { "-p", "eosio", "-e",
                                               "--read-only-threads=8",
-                                              "--eos-vm-oc-enable=none",
                                               "--max-transaction-time=10",
                                               "--abi-serializer-max-time-ms=999",
                                               "--read-only-write-window-time-us=10000",
@@ -227,7 +229,9 @@ BOOST_AUTO_TEST_CASE(with_8_read_only_threads) {
 BOOST_AUTO_TEST_CASE(with_8_read_only_threads_no_tierup) {
    std::vector<const char*> specific_args = { "-p", "eosio", "-e",
                                              "--read-only-threads=8",
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
                                              "--eos-vm-oc-enable=none",
+#endif
                                              "--max-transaction-time=10",
                                              "--abi-serializer-max-time-ms=999",
                                              "--read-only-write-window-time-us=10000",


### PR DESCRIPTION
`--eos-vm-oc-enable` option is only available when EOS VM OC is supported. Using the option when OC is not supported results in this test getting wedged due to an unknown option being used.

This fixes the test getting wedged on ARM, but maybe is not ideal since ultimately it results in the same test being run twice in such a case (since `--eos-vm-oc-enable=none` is always implied). Oh well.

But while in here I noticed something else sus: there is a `with_3_read_only_threads` & `with_3_read_only_threads_no_tierup`, and then a `with_8_read_only_threads` & `with_8_read_only_threads_no_tierup`. But `--eos-vm-oc-enable=none` is passed for _both_ "8" cases! I think the intention was `--eos-vm-oc-enable=none` should be passed for `3_no_tierup` and `8_no_tierup`, so I've tweaked it to be that way now.