### PR TITLE
[5.0 -> main] P2P: Fix: Throttling of last block of request caused lost block

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1732,10 +1732,6 @@ namespace eosio {
          peer_dlog( this, "enqueue sync block ${num}", ("num", peer_requested->last + 1) );
       }
       uint32_t num = peer_requested->last + 1;
-      if(num == peer_requested->end_block) {
-         peer_requested.reset();
-         peer_dlog( this, "completing enqueue_sync_block ${num}", ("num", num) );
-      }
 
       controller& cc = my_impl->chain_plug->chain();
       signed_block_ptr sb;
@@ -1756,6 +1752,10 @@ namespace eosio {
          block_sync_throttling = false;
          block_sync_bytes_sent += enqueue_block( sb, true );
          ++peer_requested->last;
+         if(num == peer_requested->end_block) {
+            peer_requested.reset();
+            peer_dlog( this, "completing enqueue_sync_block ${num}", ("num", num) );
+         }
       } else {
          peer_ilog( this, "enqueue sync, unable to fetch block ${num}, sending benign_other go away", ("num", num) );
          peer_requested.reset(); // unable to provide requested blocks


### PR DESCRIPTION
When throttling was enabled on a connection, the `net_plugin` would assume the last block of a `peer_requested` was sent and reset the `peer_requested` indicating no other sync blocks need to be sent to the peer.  This caused the block to not be sent or rescheduled to be sent later resulting in the peer not receiving the block. The peer would have to wait for a full timeout before requesting the required block from a different peer.

Merges `release/5.0` into `main` including #1791 

Resolves #1776 