### PR TITLE
[5.0] automatically create `experimental-binaries` package on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,13 +13,6 @@ jobs:
       packages: write
       actions: read
     steps:
-      - name: Create Dockerfile
-        run: |
-          cat <<EOF > Dockerfile
-          FROM scratch
-          LABEL org.opencontainers.image.description="A collection of experimental Leap binary packages"
-          COPY *.deb /
-          EOF
       - name: Get ubuntu20 leap-dev.deb
         uses: AntelopeIO/asset-artifact-download-action@v3
         with:
@@ -38,6 +31,13 @@ jobs:
           target: ${{github.sha}}
           artifact-name: leap-dev-ubuntu22-amd64
           wait-for-exact-target-workflow: true
+      - name: Create Dockerfile
+        run: |
+          cat <<EOF > Dockerfile
+          FROM scratch
+          LABEL org.opencontainers.image.description="A collection of experimental Leap binary packages"
+          COPY *.deb /
+          EOF
       - name: Login to ghcr
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,52 @@
+name: Release Actions
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  eb:
+    name: experimental-binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    steps:
+      - name: Create Dockerfile
+        run: |
+          cat <<EOF > Dockerfile
+          FROM scratch
+          LABEL org.opencontainers.image.description="A collection of experimental Leap binary packages"
+          COPY *.deb /
+          EOF
+      - name: Get ubuntu20 leap-dev.deb
+        uses: AntelopeIO/asset-artifact-download-action@v3
+        with:
+          owner: ${{github.repository_owner}}
+          repo: ${{github.event.repository.name}}
+          file: leap-dev.deb
+          target: ${{github.sha}}
+          artifact-name: leap-dev-ubuntu20-amd64
+          wait-for-exact-target-workflow: true
+      - name: Get ubuntu22 leap-dev.deb
+        uses: AntelopeIO/asset-artifact-download-action@v3
+        with:
+          owner: ${{github.repository_owner}}
+          repo: ${{github.event.repository.name}}
+          file: leap-dev.deb
+          target: ${{github.sha}}
+          artifact-name: leap-dev-ubuntu22-amd64
+          wait-for-exact-target-workflow: true
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.repository_owner}}
+          password: ${{github.token}}
+      - name: Build and push experimental-binaries
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ghcr.io/${{github.repository_owner}}/experimental-binaries:${{github.ref_name}}
+          context: .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           owner: ${{github.repository_owner}}
           repo: ${{github.event.repository.name}}
-          file: leap-dev.deb
+          file: 'leap-dev.*(x86_64|amd64).deb'
           target: ${{github.sha}}
           artifact-name: leap-dev-ubuntu20-amd64
           wait-for-exact-target-workflow: true
@@ -34,7 +34,7 @@ jobs:
         with:
           owner: ${{github.repository_owner}}
           repo: ${{github.event.repository.name}}
-          file: leap-dev.deb
+          file: 'leap-dev.*(x86_64|amd64).deb'
           target: ${{github.sha}}
           artifact-name: leap-dev-ubuntu22-amd64
           wait-for-exact-target-workflow: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           owner: ${{github.repository_owner}}
           repo: ${{github.event.repository.name}}
-          file: 'leap-dev.*(x86_64|amd64).deb'
+          file: 'leap-dev.*amd64.deb'
           target: ${{github.sha}}
           artifact-name: leap-dev-ubuntu20-amd64
           wait-for-exact-target-workflow: true
@@ -27,7 +27,7 @@ jobs:
         with:
           owner: ${{github.repository_owner}}
           repo: ${{github.event.repository.name}}
-          file: 'leap-dev.*(x86_64|amd64).deb'
+          file: 'leap-dev.*amd64.deb'
           target: ${{github.sha}}
           artifact-name: leap-dev-ubuntu22-amd64
           wait-for-exact-target-workflow: true


### PR DESCRIPTION
The `experimental-binaries` package is where we stash away some versioned packages that are not fully supported but we want indefinitely (they would eventually expire as a workflow artifact). Historically we've used this for `leap-dev.deb` which is used in CI, and ARM packages for DUNE -- both packages we don't fully support thus don't want them highly visible as a release asset.

Now that we're no longer creating ARM packages for DUNE, we can go ahead and automatically create the `experimental-binaries` package that solely stores `leap-dev.deb`. This is a rather obtuse procedure that has been done manually so automating it is a great improvement.

Clearly one of the problems with reviewing this is.. how to test it?! I don't have a good answer for that. I developed and tested it manually in a private repo. I think we'll just have to iterate on it if it doesn't work for future releases :confused: 

I made some changes to `asset-artifact-download-action` as part of this work -- AntelopeIO/asset-artifact-download-action#4. This got YOLOed merged but we can refine it some more if something comes out of the review. (we want the new `wait-for-exact-target` feature here so if someone releases before CI is complete at that ref, we wait around for CI to complete so we can upload

⚠️ 5.0 is the first version that has both a ubuntu20 & ubuntu22 `leap-dev.deb`; this might confuse existing workflows that just install `leap-dev*.deb` or such -- they might get the package for a different ubuntu version then they're running.

Resolves #1781