### PR TITLE
[4.0 -> 5.0] SHiP: Fixes: Stack overflow, invalid index, split file access

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -73,9 +73,10 @@ struct state_history_log_header {
    chain::block_id_type block_id     = {};
    uint64_t             payload_size = 0;
 };
-static const int state_history_log_header_serial_size = sizeof(state_history_log_header::magic) +
-                                                        sizeof(state_history_log_header::block_id) +
-                                                        sizeof(state_history_log_header::payload_size);
+static constexpr int state_history_log_header_serial_size = sizeof(state_history_log_header::magic) +
+                                                            sizeof(state_history_log_header::block_id) +
+                                                            sizeof(state_history_log_header::payload_size);
+static_assert(sizeof(state_history_log_header) == state_history_log_header_serial_size);
 
 namespace state_history {
    struct prune_config {
@@ -323,7 +324,7 @@ class state_history_log {
             catalog.open(log_dir, conf.retained_dir, conf.archive_dir, name);
             catalog.max_retained_files = conf.max_retained_files;
             if (_end_block == 0) {
-               _begin_block = _end_block = catalog.last_block_num() +1;
+               _index_begin_block = _begin_block = _end_block = catalog.last_block_num() +1;
             }
          }
       }, _config);
@@ -576,10 +577,14 @@ class state_history_log {
          if (block_num >= _begin_block && block_num < _end_block) {
             state_history_log_header header;
             get_entry(block_num, header);
+            EOS_ASSERT(chain::block_header::num_from_id(header.block_id) == block_num, chain::plugin_exception,
+                       "header id does not match requested ${a} != ${b}", ("a", chain::block_header::num_from_id(header.block_id))("b", block_num));
             return header.block_id;
          }
          return {};
       }
+      EOS_ASSERT(chain::block_header::num_from_id(*result) == block_num, chain::plugin_exception,
+                 "catalog id does not match requested ${a} != ${b}", ("a", chain::block_header::num_from_id(*result))("b", block_num));
       return result;
    }
 
@@ -894,47 +899,16 @@ class state_history_log {
    }
 
    void split_log() {
-
-      std::filesystem::path log_file_path = log.get_file_path();
-      std::filesystem::path index_file_path = index.get_file_path();
-
-      fc::datastream<fc::cfile>  new_log_file;
-      fc::datastream<fc::cfile> new_index_file;
-
-      std::filesystem::path tmp_log_file_path = log_file_path;
-      tmp_log_file_path.replace_extension("log.tmp");
-      std::filesystem::path tmp_index_file_path = index_file_path;
-      tmp_index_file_path.replace_extension("index.tmp");
-
-      new_log_file.set_file_path(tmp_log_file_path);
-      new_index_file.set_file_path(tmp_index_file_path);
-
-      try {
-         new_log_file.open(fc::cfile::truncate_rw_mode);
-         new_index_file.open(fc::cfile::truncate_rw_mode);
-
-      } catch (...) {
-         wlog("Unable to open new state history log or index file for writing during log spliting, "
-              "continue writing to existing block log file\n");
-         return;
-      }
-
       index.close();
       log.close();
 
       catalog.add(_begin_block, _end_block - 1, log.get_file_path().parent_path(), name);
 
-      _begin_block = _end_block;
+      _index_begin_block = _begin_block = _end_block;
 
-      using std::swap;
-      swap(new_log_file, log);
-      swap(new_index_file, index);
-
-      std::filesystem::rename(tmp_log_file_path, log_file_path);
-      std::filesystem::rename(tmp_index_file_path, index_file_path);
-
-      log.set_file_path(log_file_path);
-      index.set_file_path(index_file_path);
+      log.open(fc::cfile::truncate_rw_mode);
+      log.seek_end(0);
+      index.open(fc::cfile::truncate_rw_mode);
    }
 }; // state_history_log
 

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -540,6 +540,7 @@ class state_history_log {
                     "wrote payload with incorrect size to ${name}.log", ("name", name));
       fc::raw::pack(log, pos);
 
+      index.seek_end(0);
       fc::raw::pack(index, pos);
       if (_begin_block == _end_block)
          _index_begin_block = _begin_block = block_num;

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -62,7 +62,6 @@ private:
    string                           endpoint_address;
    string                           unix_path;
    state_history::trace_converter   trace_converter;
-   session_manager                  session_mgr;
 
    mutable std::mutex mtx;
    block_id_type      head_id;
@@ -70,6 +69,8 @@ private:
    time_point         head_timestamp;
 
    named_thread_pool<struct ship> thread_pool;
+
+   session_manager                  session_mgr{thread_pool.get_executor()};
 
    bool  plugin_started = false;
 

--- a/tests/ship_streamer_test.py
+++ b/tests/ship_streamer_test.py
@@ -70,7 +70,7 @@ try:
 
     shipNodeNum = 1
     specificExtraNodeosArgs={}
-    specificExtraNodeosArgs[shipNodeNum]="--plugin eosio::state_history_plugin --trace-history --chain-state-history --plugin eosio::net_api_plugin --plugin eosio::producer_api_plugin "
+    specificExtraNodeosArgs[shipNodeNum]="--plugin eosio::state_history_plugin --trace-history --chain-state-history --state-history-stride 200 --plugin eosio::net_api_plugin --plugin eosio::producer_api_plugin "
     # producer nodes will be mapped to 0 through totalProducerNodes-1, so the number totalProducerNodes will be the non-producing node
     specificExtraNodeosArgs[totalProducerNodes]="--plugin eosio::test_control_api_plugin  "
 
@@ -206,7 +206,7 @@ try:
         prodNode0.waitForProducer(forkAtProducer)
         prodNode1.waitForProducer(prodNode1Prod)
     if nonProdNode.verifyAlive():
-        Utils.errorExit("Bridge did not shutdown");
+        Utils.errorExit("Bridge did not shutdown")
     Print("Fork started")
 
     forkProgress="defproducer" + chr(ord(forkAtProducer[-1])+3)
@@ -215,7 +215,7 @@ try:
     Print("Restore fork")
     Print("Relaunching the non-producing bridge node to connect the producing nodes again")
     if nonProdNode.verifyAlive():
-        Utils.errorExit("Bridge is already running");
+        Utils.errorExit("Bridge is already running")
     if not nonProdNode.relaunch():
         Utils.errorExit(f"Failure - (non-production) node {nonProdNode.nodeNum} should have restarted")
 


### PR DESCRIPTION
Includes three SHiP `state_history_plugin` fixes:
* Fix for stack overflow due to recursive call to `send()`. Fixed by posting to the SHiP thread on new `send()`s.
* Fix for accessing wrong data after log splitting.
* Fix for accessing wrong file after log splitting.

Merges `release/4.0` into `release/5.0` including #1779 & #1801

Resolves #1677 