### PR TITLE
[4.0] SHiP: Make sure we append to index file

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -541,6 +541,7 @@ class state_history_log {
                     "wrote payload with incorrect size to ${name}.log", ("name", name));
       fc::raw::pack(log, pos);
 
+      index.seek_end(0);
       fc::raw::pack(index, pos);
       if (_begin_block == _end_block)
          _index_begin_block = _begin_block = block_num;


### PR DESCRIPTION
#1779 opens the index file in r/w mode. A `seek_end(0)` is need to make sure the index file is appended to.

Fixes issue introduced by #1779.