### PR TITLE
[5.0] Test Fix: Avoid deadlock on app_thread

### DIFF
--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -117,10 +117,6 @@ void test_trxs_common(std::vector<const char*>& specific_args, bool test_disable
             } FC_LOG_AND_DROP()
             BOOST_CHECK(!"app threw exception see logged error");
          } );
-         fc::scoped_exit<std::function<void()>> on_except = [&](){
-            if (app_thread.joinable())
-               app_thread.join();
-         };
 
          auto[prod_plug, chain_plug] = plugin_fut.get();
 
@@ -168,6 +164,7 @@ void test_trxs_common(std::vector<const char*>& specific_args, bool test_disable
          }
 
          app->quit();
+         app_thread.join();
       }
 
       BOOST_CHECK_EQUAL( trace_with_except, 0u ); // should not have any traces with except in it

--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -117,6 +117,11 @@ void test_trxs_common(std::vector<const char*>& specific_args, bool test_disable
             } FC_LOG_AND_DROP()
             BOOST_CHECK(!"app threw exception see logged error");
          } );
+         fc::scoped_exit<std::function<void()>> on_except = [&](){
+            app->quit();
+            if (app_thread.joinable())
+               app_thread.join();
+         };
 
          auto[prod_plug, chain_plug] = plugin_fut.get();
 
@@ -162,9 +167,6 @@ void test_trxs_common(std::vector<const char*>& specific_args, bool test_disable
          while ( (next_calls < num_pushes || num_get_account_calls < num_pushes) && fc::time_point::now() < hard_deadline ){
             std::this_thread::sleep_for( 100ms );
          }
-
-         app->quit();
-         app_thread.join();
       }
 
       BOOST_CHECK_EQUAL( trace_with_except, 0u ); // should not have any traces with except in it


### PR DESCRIPTION
When `activate_protocol_features_set_bios_contract` => `set_code` => `push_input_trx` => `trx_future.get()` would throw it would cause the `app_thread` to deadlock because it would call `app_thread.join()` without first calling `app->quit()`. 

Introduced by https://github.com/AntelopeIO/leap/commit/3b2227ec9dbea7209bf63d7ff2f0a15b7422c1d8 of #1442. The terminate was actually better than dead lock, but with the `app->quit()` it exits with a nice error:
```
debug 2023-10-24T19:46:06.787 plugin_te producer_plugin.cpp:2081      log_trx_results      ] [TRX_TRACE] Block 4 for producer eosio is REJECTING tx: 8d44f8b6804a185d82af492cdd9866377548cc24cfbeda9be8e3ebb896bd46bb, auth: eosio, action: eosio:setcode, transaction 8d44f8b6804a185d82af492cdd9866377548cc24cfbeda9be8e3ebb896bd46bb was executing for too long 3857us reached node configured max-transaction-time 3000us
debug 2023-10-24T19:46:06.789 plugin_te producer_plugin.cpp:2086      log_trx_results      ] [TRX_TRACE] Block 4 for producer eosio is REJECTING tx: {"expiration":"2023-10-24T19:46:36","ref_block_num":3,"ref_block_prefix":2558504252,"max_net_usage_words":0,"max_cpu_usage_ms":0,"delay_sec":0,"context_free_actions":[],"actions":[{"account":"eosio","name":"setcode","authorization":[{"actor":"eosio","permission":"active"}],"code_hash":"241108ec5076fe0df9dbe9e6aab249bc26cef0362f6805ff43118ab74115cabd","data":{"account":"eosio","vmtype":0,"vmversion":0,"code":{"size":19646,"trimmed_hex":"0061736d010000000198011960000060027f7f0060037f7f7f0060047e7e7e7e017f6000017e60047f7e7e7f0060057f7f7f7f7f017f60037f7f7f017f60027f"}},"hex_data":{"size":19659,"trimmed_hex":"0000000000ea30550000be99010061736d010000000198011960000060027f7f0060037f7f7f0060047e7e7e7e017f6000017e60047f7e7e7f0060057f7f7f7f"}}]}
debug 2023-10-24T19:46:06.790 plugin_te producer_plugin.cpp:2090      log_trx_results      ] [TRX_TRACE] Block 4 for producer eosio is REJECTING tx: {"id":"8d44f8b6804a185d82af492cdd9866377548cc24cfbeda9be8e3ebb896bd46bb","block_num":4,"block_time":"2023-10-24T19:46:07.000","producer_block_id":null,"receipt":null,"elapsed":6900,"net_usage":6873,"scheduled":false,"action_traces":[{"action_ordinal":1,"creator_action_ordinal":0,"closest_unnotified_ancestor_action_ordinal":0,"receipt":null,"receiver":"eosio","act":{"account":"eosio","name":"setcode","authorization":[{"actor":"eosio","permission":"active"}],"code_hash":"241108ec5076fe0df9dbe9e6aab249bc26cef0362f6805ff43118ab74115cabd","data":{"account":"eosio","vmtype":0,"vmversion":0,"code":{"size":19646,"trimmed_hex":"0061736d010000000198011960000060027f7f0060037f7f7f0060047e7e7e7e017f6000017e60047f7e7e7f0060057f7f7f7f7f017f60037f7f7f017f60027f"}},"hex_data":{"size":19659,"trimmed_hex":"0000000000ea30550000be99010061736d010000000198011960000060027f7f0060037f7f7f0060047e7e7e7e017f6000017e60047f7e7e7f0060057f7f7f7f"}},"context_free":false,"elapsed":6510,"console":"","trx_id":"8d44f8b6804a185d82af492cdd9866377548cc24cfbeda9be8e3ebb896bd46bb","block_num":4,"block_time":"2023-10-24T19:46:07.000","producer_block_id":null,"account_ram_deltas":[{"account":"eosio","delta":196460}],"except":{"code":3080004,"name":"tx_cpu_usage_exceeded","message":"Transaction exceeded the current CPU usage limit imposed on the transaction","stack":[{"context":{"level":"error","file":"transaction_context.cpp","line":479,"method":"checktime","hostname":"","thread_name":"plugin_test","timestamp":"2023-10-24T19:46:06.787"},"format":"transaction ${id} was executing for too long ${billing_timer}us reached node configured max-transaction-time ${limit}us","data":{"id":"8d44f8b6804a185d82af492cdd9866377548cc24cfbeda9be8e3ebb896bd46bb","billing_timer":3857,"subjective":0,"limit":3000}},{"context":{"level":"warn","file":"apply_context.cpp","line":134,"method":"exec_one","hostname":"","thread_name":"plugin_test","timestamp":"2023-10-24T19:46:06.787"},"format":"pending console output: ${console}","data":{"console":""}}]},"error_code":"10000000000000000000","return_value_hex_data":""}],"account_ram_delta":null,"except":{"code":3080004,"name":"tx_cpu_usage_exceeded","message":"Transaction exceeded the current CPU usage limit imposed on the transaction","stack":[{"context":{"level":"error","file":"transaction_context.cpp","line":479,"method":"checktime","hostname":"","thread_name":"plugin_test","timestamp":"2023-10-24T19:46:06.787"},"format":"transaction ${id} was executing for too long ${billing_timer}us reached node configured max-transaction-time ${limit}us","data":{"id":"8d44f8b6804a185d82af492cdd9866377548cc24cfbeda9be8e3ebb896bd46bb","billing_timer":3857,"subjective":0,"limit":3000}},{"context":{"level":"warn","file":"apply_context.cpp","line":134,"method":"exec_one","hostname":"","thread_name":"plugin_test","timestamp":"2023-10-24T19:46:06.787"},"format":"pending console output: ${console}","data":{"console":""}}]},"error_code":"10000000000000000000"}
info  2023-10-24T19:46:06.791 plugin_te producer_plugin.cpp:1405      plugin_shutdown      ] exit shutdown
warn  2023-10-24T19:46:06.798 plugin_te test_read_only_trx.cpp:177    test_trxs_common     ] 3080004 tx_cpu_usage_exceeded: Transaction exceeded the current CPU usage limit imposed on the transaction
transaction 8d44f8b6804a185d82af492cdd9866377548cc24cfbeda9be8e3ebb896bd46bb was executing for too long 3857us reached node configured max-transaction-time 3000us
    {"id":"8d44f8b6804a185d82af492cdd9866377548cc24cfbeda9be8e3ebb896bd46bb","billing_timer":3857,"subjective":0,"limit":3000}
    plugin_test  transaction_context.cpp:479 checktime
pending console output:
    {"console":""}
    plugin_test  apply_context.cpp:134 exec_one

3080004 tx_cpu_usage_exceeded: Transaction exceeded the current CPU usage limit imposed on the transaction
transaction 8d44f8b6804a185d82af492cdd9866377548cc24cfbeda9be8e3ebb896bd46bb was executing for too long 3857us reached node configured max-transaction-time 3000us
    {"id":"8d44f8b6804a185d82af492cdd9866377548cc24cfbeda9be8e3ebb896bd46bb","billing_timer":3857,"subjective":0,"limit":3000}
    plugin_test  transaction_context.cpp:479 checktime
pending console output:
    {"console":""}
    plugin_test  apply_context.cpp:134 exec_one
rethrow
    {}
    plugin_test  test_read_only_trx.cpp:177 test_trxs_common

/home/heifner/ext/leap/tests/main.cpp(11): fatal error: in "read_only_trxs/with_3_read_only_threads_no_tierup": Caught Unexpected Exception

*** 1 failure is detected in the test module "Master Test Suite"
```

Resolves #1815