### PR TITLE
[5.0] Undo the temporary switch to `mapped` mode when loading a snapshot in `mapped_private` mode.

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -609,8 +609,6 @@ struct controller_impl {
          ilog( "Snapshot loaded, lib: ${lib}", ("lib", head->block_num) );
 
          init(std::move(check_shutdown));
-         if (conf.revert_to_private_mode)
-            db.revert_to_private_mode();
          auto snapshot_load_time = (fc::time_point::now() - snapshot_load_start_time).to_seconds();
          ilog( "Finished initialization from snapshot (snapshot load time was ${t}s)", ("t", snapshot_load_time) );
       } catch (boost::interprocess::bad_alloc& e) {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -79,7 +79,6 @@ namespace eosio { namespace chain {
             bool                     disable_replay_opts    =  false;
             bool                     contracts_console      =  false;
             bool                     allow_ram_billing_in_notify = false;
-            bool                     revert_to_private_mode =  false;
             uint32_t                 maximum_variable_signature_length = chain::config::default_max_variable_signature_length;
             bool                     disable_all_subjective_mitigations = false; //< for developer & testing purposes, can be configured using `disable-all-subjective-mitigations` when `EOSIO_DEVELOPER` build option is provided
             uint32_t                 terminate_at_block     = 0;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -927,13 +927,6 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
 
       chain_config->db_map_mode = options.at("database-map-mode").as<pinnable_mapped_file::map_mode>();
 
-      // when loading a snapshot, all the state will be modified, so temporarily use the `mapped` mode instead
-      // of `mapped_private` to lower memory requirements.
-      if (snapshot_path && chain_config->db_map_mode == pinnable_mapped_file::mapped_private) {
-        chain_config->db_map_mode = pinnable_mapped_file::mapped;
-        chain_config->revert_to_private_mode = true; // revert to `mapped_private` mode after loading snapshot.
-      }
-
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
       if( options.count("eos-vm-oc-cache-size-mb") )
          chain_config->eosvmoc_config.cache_size = options.at( "eos-vm-oc-cache-size-mb" ).as<uint64_t>() * 1024u * 1024u;


### PR DESCRIPTION
Resolves #1764 

The reason I initially added this `revert_to_private_mode()` (so we'd load a snapshot in `mapped` mode, and revert to `mapped_private` mode after the snapshot is loaded), was that I hoped that we would only touch a few pages in normal `mapped_private` functioning.

The snapshot loading seemed a bad case where all state db pages containing data would be touched.

However, even in normal syncing, most of the pages are dirty after a few minutes, so the remap optimization is not worth it I believe.