### PR TITLE
[5.0 -> main] fix new signedness warnings to have a clean build for rc3

### DIFF
--- a/plugins/net_plugin/tests/rate_limit_parse_unittest.cpp
+++ b/plugins/net_plugin/tests/rate_limit_parse_unittest.cpp
@@ -20,25 +20,25 @@ BOOST_AUTO_TEST_CASE(test_parse_rate_limit) {
    size_t which = 0;
    auto [listen_addr, block_sync_rate_limit] = plugin_impl.parse_listen_address(p2p_addresses[which++]);
    BOOST_CHECK_EQUAL(listen_addr, "0.0.0.0:9876");
-   BOOST_CHECK_EQUAL(block_sync_rate_limit, 0);
+   BOOST_CHECK_EQUAL(block_sync_rate_limit, 0u);
    std::tie(listen_addr, block_sync_rate_limit) = plugin_impl.parse_listen_address(p2p_addresses[which++]);
    BOOST_CHECK_EQUAL(listen_addr, "0.0.0.0:9776");
-   BOOST_CHECK_EQUAL(block_sync_rate_limit, 0);
+   BOOST_CHECK_EQUAL(block_sync_rate_limit, 0u);
    std::tie(listen_addr, block_sync_rate_limit) = plugin_impl.parse_listen_address(p2p_addresses[which++]);
    BOOST_CHECK_EQUAL(listen_addr, "0.0.0.0:9877");
-   BOOST_CHECK_EQUAL(block_sync_rate_limit, 640000);
+   BOOST_CHECK_EQUAL(block_sync_rate_limit, 640000u);
    std::tie(listen_addr, block_sync_rate_limit) = plugin_impl.parse_listen_address(p2p_addresses[which++]);
    BOOST_CHECK_EQUAL(listen_addr, "192.168.0.1:9878");
-   BOOST_CHECK_EQUAL(block_sync_rate_limit, 20971520);
+   BOOST_CHECK_EQUAL(block_sync_rate_limit, 20971520u);
    std::tie(listen_addr, block_sync_rate_limit) = plugin_impl.parse_listen_address(p2p_addresses[which++]);
    BOOST_CHECK_EQUAL(listen_addr, "localhost:9879");
-   BOOST_CHECK_EQUAL(block_sync_rate_limit, 500);
+   BOOST_CHECK_EQUAL(block_sync_rate_limit, 500u);
    std::tie(listen_addr, block_sync_rate_limit) = plugin_impl.parse_listen_address(p2p_addresses[which++]);
    BOOST_CHECK_EQUAL(listen_addr, "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:9876");
-   BOOST_CHECK_EQUAL(block_sync_rate_limit, 250000);
+   BOOST_CHECK_EQUAL(block_sync_rate_limit, 250000u);
    std::tie(listen_addr, block_sync_rate_limit) = plugin_impl.parse_listen_address(p2p_addresses[which++]);
    BOOST_CHECK_EQUAL(listen_addr, "[::1]:9876");
-   BOOST_CHECK_EQUAL(block_sync_rate_limit, 250000);
+   BOOST_CHECK_EQUAL(block_sync_rate_limit, 250000u);
    BOOST_CHECK_EXCEPTION(plugin_impl.parse_listen_address(p2p_addresses[which++]), eosio::chain::plugin_config_exception,
                          [](const eosio::chain::plugin_config_exception& e)
                          {return std::strstr(e.top_message().c_str(), "IPv6 addresses must be enclosed in square brackets");});

--- a/plugins/state_history_plugin/tests/session_test.cpp
+++ b/plugins/state_history_plugin/tests/session_test.cpp
@@ -485,7 +485,7 @@ BOOST_FIXTURE_TEST_CASE(test_split_log, state_history_test_fixture) {
       eosio::state_history::state_result result;
       // we should get 1023 consecutive block result
       eosio::chain::block_id_type prev_id;
-      for (int i = 0; i < head; ++i) {
+      for (uint32_t i = 0; i < head; ++i) {
          receive_result(result);
          BOOST_REQUIRE(std::holds_alternative<eosio::state_history::get_blocks_result_v0>(result));
          auto r = std::get<eosio::state_history::get_blocks_result_v0>(result);


### PR DESCRIPTION
Replace https://github.com/AntelopeIO/leap/pull/1838 as base branch was wrong.

Fix new warnings so we have a clean rc3 build

```
plugins/net_plugin/tests/rate_limit_parse_unittest.cpp:23:4:   required from here
libraries/boost/libs/test/include/boost/test/tools/old/impl.hpp:107:17: warning: comparison of integer expressions of different signedness: ‘const long unsigned int’ and ‘const int’ [-Wsign-compare]

...

plugins/state_history_plugin/tests/session_test.cpp:488:25: warning: comparison of integer expressions of different signedness: ‘int’ and ‘const uint32_t’ {aka ‘const unsigned int’} [-Wsign-compare]
  488 |       for (int i = 0; i < head; ++i) {
      |                       ~~^~~~~~
```
Merges release/5.0 into main including https://github.com/AntelopeIO/leap/pull/1836

Resolves #1835