### PR TITLE
[5.0] Minimize abort/start block for speculative blocks

### DIFF
--- a/plugins/producer_plugin/include/eosio/producer_plugin/block_timing_util.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/block_timing_util.hpp
@@ -55,16 +55,7 @@ namespace block_timing_util {
    }
 
    inline fc::time_point calculate_producing_block_deadline(fc::microseconds cpu_effort, chain::block_timestamp_type block_time) {
-      auto estimated_deadline = production_round_block_start_time(cpu_effort, block_time) + cpu_effort;
-      auto now                = fc::time_point::now();
-      if (estimated_deadline > now) {
-         return estimated_deadline;
-      } else {
-         // This could only happen when the producer stop producing and then comes back alive in the middle of its own
-         // production round. In this case, we just use the hard deadline.
-         const auto hard_deadline = block_time.to_time_point() - fc::microseconds(chain::config::block_interval_us - cpu_effort.count());
-         return std::min(hard_deadline, now + cpu_effort);
-      }
+      return production_round_block_start_time(cpu_effort, block_time) + cpu_effort;
    }
 
    namespace detail {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -772,6 +772,7 @@ public:
    }
 
    void restart_speculative_block() {
+      // log message is used by Node.py verifyStartingBlockMessages in distributed-transactions-test.py test
       fc_dlog(_log, "Restarting exhausted speculative block #${n}", ("n", chain_plug->chain().head_block_num() + 1));
       // abort the pending block
       abort_block();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1844,7 +1844,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
 
    // create speculative blocks at regular intervals, so we create blocks with "current" block time
    _pending_block_deadline = block_timing_util::calculate_producing_block_deadline(_produce_block_cpu_effort, block_time);
-   if (in_speculating_mode()) { // if we are producing, then produce block even if deadline has pasted
+   if (in_speculating_mode()) { // if we are producing, then produce block even if deadline has passed
       // speculative block, no reason to start a block that will immediately be re-started, set deadline in the future
       // a block should come in during this time, if not then just keep creating the block every produce_block_cpu_effort
       if (now + fc::milliseconds(config::block_interval_ms/10) > _pending_block_deadline) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -772,9 +772,9 @@ public:
    }
 
    void restart_speculative_block() {
+      fc_dlog(_log, "Restarting exhausted speculative block #${n}", ("n", chain_plug->chain().head_block_num() + 1));
       // abort the pending block
       abort_block();
-
       schedule_production_loop();
    }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2498,6 +2498,10 @@ void producer_plugin_impl::schedule_production_loop() {
       auto wake_time = block_timing_util::calculate_producer_wake_up_time(fc::microseconds{config::block_interval_us}, chain.pending_block_num(), chain.pending_block_timestamp(),
                                                                           _producers, chain.head_block_state()->active_schedule.producers,
                                                                           _producer_watermarks);
+      if (wake_time && fc::time_point::now() > *wake_time) {
+         // if wake time has already passed then use the block deadline instead
+         wake_time = _pending_block_deadline;
+      }
       schedule_delayed_production_loop(weak_from_this(), wake_time);
    } else {
       fc_dlog(_log, "Speculative Block Created");

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2495,7 +2495,7 @@ void producer_plugin_impl::schedule_production_loop() {
       chain::controller& chain = chain_plug->chain();
       fc_dlog(_log, "Speculative Block Created; Scheduling Speculative/Production Change");
       EOS_ASSERT(chain.is_building_block(), missing_pending_block_state, "speculating without pending_block_state");
-      auto wake_time = block_timing_util::calculate_producer_wake_up_time(_produce_block_cpu_effort, chain.pending_block_num(), chain.pending_block_timestamp(),
+      auto wake_time = block_timing_util::calculate_producer_wake_up_time(fc::microseconds{config::block_interval_us}, chain.pending_block_num(), chain.pending_block_timestamp(),
                                                                           _producers, chain.head_block_state()->active_schedule.producers,
                                                                           _producer_watermarks);
       schedule_delayed_production_loop(weak_from_this(), wake_time);

--- a/plugins/producer_plugin/test/test_block_timing_util.cpp
+++ b/plugins/producer_plugin/test/test_block_timing_util.cpp
@@ -76,6 +76,7 @@ BOOST_AUTO_TEST_CASE(test_calculate_block_deadline) {
       auto seventh_block_time = eosio::chain::block_timestamp_type(production_round_1st_block_slot + 6);
       fc::mock_time_traits::set_now(seventh_block_time.to_time_point() - fc::milliseconds(500));
 
+      // 7th block where cpu effort is 100ms less per block
       BOOST_CHECK_EQUAL(calculate_producing_block_deadline(cpu_effort, seventh_block_time),
                         seventh_block_time.to_time_point() - fc::milliseconds(700));
 
@@ -83,6 +84,7 @@ BOOST_AUTO_TEST_CASE(test_calculate_block_deadline) {
       fc::mock_time_traits::set_now(seventh_block_time.to_time_point() - fc::milliseconds(100));
       auto eighth_block_time = eosio::chain::block_timestamp_type(production_round_1st_block_slot + 7);
 
+      // 8th block where cpu effort is 100ms less per block
       BOOST_CHECK_EQUAL(calculate_producing_block_deadline(cpu_effort, eighth_block_time),
                         eighth_block_time.to_time_point() - fc::milliseconds(800));
 
@@ -90,6 +92,7 @@ BOOST_AUTO_TEST_CASE(test_calculate_block_deadline) {
       fc::mock_time_traits::set_now(eighth_block_time.to_time_point() - fc::milliseconds(200));
       auto ninth_block_time = eosio::chain::block_timestamp_type(production_round_1st_block_slot + 8);
 
+      // 9th block where cpu effort is 100ms less per block
       BOOST_CHECK_EQUAL(calculate_producing_block_deadline(cpu_effort, ninth_block_time),
                         ninth_block_time.to_time_point() - fc::milliseconds(900));
    }

--- a/plugins/producer_plugin/test/test_block_timing_util.cpp
+++ b/plugins/producer_plugin/test/test_block_timing_util.cpp
@@ -114,6 +114,13 @@ BOOST_AUTO_TEST_CASE(test_calculate_block_deadline) {
       // 29.962500 + (450000/12) = 30.425
       BOOST_CHECK_EQUAL(block_deadline, fc::time_point::from_iso_string("2023-10-29T13:40:30.425"));
    }
+   {
+      // Real scenario that caused multiple start blocks
+      auto default_cpu_effort = fc::microseconds(block_interval.count() - (450000/12)); // 462,500
+      auto block_time = eosio::chain::block_timestamp_type(fc::time_point::from_iso_string("2023-10-31T13:37:35.000"));
+      fc::time_point block_deadline = calculate_producing_block_deadline(default_cpu_effort, block_time);
+      BOOST_CHECK_EQUAL(block_deadline.to_iso_string(), fc::time_point::from_iso_string("2023-10-31T13:37:34.587").to_iso_string());
+   }
 }
 
 BOOST_AUTO_TEST_CASE(test_calculate_producer_wake_up_time) {

--- a/plugins/producer_plugin/test/test_block_timing_util.cpp
+++ b/plugins/producer_plugin/test/test_block_timing_util.cpp
@@ -277,6 +277,24 @@ BOOST_AUTO_TEST_CASE(test_calculate_producer_wake_up_time) {
       expected_block_time = block_timestamp_type(prod_round_1st_block_slot + 2*config::producer_repetitions + 2).to_time_point(); // with watermark, wait until next
       BOOST_CHECK_EQUAL(calculate_producer_wake_up_time(full_cpu_effort, 2, block_timestamp, producers, active_schedule, prod_watermarks), expected_block_time);
    }
+   { // actual example that caused multiple start blocks
+      producer_watermarks prod_watermarks;
+      std::set<account_name> producers = {
+              "inita"_n, "initb"_n, "initc"_n, "initd"_n, "inite"_n, "initf"_n, "initg"_n, "p1"_n,
+              "inith"_n, "initi"_n, "initj"_n, "initk"_n, "initl"_n, "initm"_n, "initn"_n,
+              "inito"_n, "initp"_n, "initq"_n, "initr"_n, "inits"_n, "initt"_n, "initu"_n, "p2"_n
+      };
+      std::vector<chain::producer_authority> active_schedule{
+              {"inita"_n}, {"initb"_n}, {"initc"_n}, {"initd"_n}, {"inite"_n}, {"initf"_n}, {"initg"_n},
+              {"inith"_n}, {"initi"_n}, {"initj"_n}, {"initk"_n}, {"initl"_n}, {"initm"_n}, {"initn"_n},
+              {"inito"_n}, {"initp"_n}, {"initq"_n}, {"initr"_n}, {"inits"_n}, {"initt"_n}, {"initu"_n}
+      };
+      auto default_cpu_effort = fc::microseconds(block_interval.count() - (450000/12)); // 462,500
+      auto wake_time = calculate_producer_wake_up_time(default_cpu_effort, 106022362, eosio::chain::block_timestamp_type(fc::time_point::from_iso_string("2023-10-31T16:06:41.000")),
+                                                       producers, active_schedule, prod_watermarks);
+      BOOST_REQUIRE(!!wake_time);
+      BOOST_CHECK_EQUAL(wake_time->to_iso_string(), fc::time_point::from_iso_string("2023-10-31T16:06:40.587").to_iso_string());
+   }
 
 }
 

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -550,12 +550,13 @@ class Node(Transactions):
                         return True
         return False
 
-    # verify only one 'Starting block' per block number unless block is restarted
-    def verifyOnlyOneStartingBlock(self):
+    # verify only one or two 'Starting block' per block number unless block is restarted
+    def verifyStartingBlockMessages(self):
         dataDir=Utils.getNodeDataDir(self.nodeId)
         files=Node.findStderrFiles(dataDir)
         for f in files:
             blockNumbers = set()
+            duplicateBlockNumbers = set()
             duplicatesFound = False
             lastRestartBlockNum = 0
 
@@ -569,9 +570,11 @@ class Node(Transactions):
                     match = re.match(r".*Starting block #(\d+)", line)
                     if match:
                         blockNumber = match.group(1)
-                        if blockNumber != lastRestartBlockNum and blockNumber in blockNumbers:
+                        if blockNumber != lastRestartBlockNum and blockNumber in duplicateBlockNumbers:
                             print(f"Duplicate Staring block found: {blockNumber} in {f}")
                             duplicatesFound = True
+                        if blockNumber != lastRestartBlockNum and blockNumber in blockNumbers:
+                            duplicateBlockNumbers.add(blockNumber)
                         blockNumbers.add(blockNumber)
 
             if duplicatesFound:

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -557,30 +557,30 @@ class Node(Transactions):
         for f in files:
             blockNumbers = set()
             duplicateBlockNumbers = set()
-            duplicatesFound = False
+            threeStartsFound = False
             lastRestartBlockNum = 0
+            blockNumber = 0
 
             with open(f, 'r') as file:
                 for line in file:
                     match = re.match(r".*Restarting exhausted speculative block #(\d+)", line)
                     if match:
                         lastRestartBlockNum = match.group(1)
+                        continue
                     if re.match(r".*unlinkable_block_exception", line):
                         lastRestartBlockNum = blockNumber
+                        continue
                     match = re.match(r".*Starting block #(\d+)", line)
                     if match:
                         blockNumber = match.group(1)
                         if blockNumber != lastRestartBlockNum and blockNumber in duplicateBlockNumbers:
                             print(f"Duplicate Staring block found: {blockNumber} in {f}")
-                            duplicatesFound = True
+                            threeStartsFound = True
                         if blockNumber != lastRestartBlockNum and blockNumber in blockNumbers:
                             duplicateBlockNumbers.add(blockNumber)
                         blockNumbers.add(blockNumber)
 
-            if duplicatesFound:
-                return False
-
-        return True
+        return not threeStartsFound
 
     def analyzeProduction(self, specificBlockNum=None, thresholdMs=500):
         dataDir=Utils.getNodeDataDir(self.nodeId)

--- a/tests/distributed-transactions-test.py
+++ b/tests/distributed-transactions-test.py
@@ -113,7 +113,7 @@ try:
 
     # verify only one start block per block unless interrupted
     for node in cluster.getAllNodes():
-        if not node.verifyOnlyOneStartingBlock():
+        if not node.verifyStartingBlockMessages():
             errorExit("Found more than one Starting block in logs")
 
     testSuccessful=True

--- a/tests/distributed-transactions-test.py
+++ b/tests/distributed-transactions-test.py
@@ -111,6 +111,11 @@ try:
 
     cluster.compareBlockLogs()
 
+    # verify only one start block per block unless interrupted
+    for node in cluster.getAllNodes():
+        if not node.verifyOnlyOneStartingBlock():
+            errorExit("Found more than one Starting block in logs")
+
     testSuccessful=True
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful, dumpErrorDetails)


### PR DESCRIPTION
Simplify and fix issues with #1481 block deadline calculation. Remove the concept of a hard deadline as producers want to produce a block even if the deadline has passed for the block. This uses a conservative calculation for producer wake up time, but does verify it is in the future.

Resolves #1831 