### PR TITLE
[5.0] Recover keys in chain thread pool

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -802,7 +802,7 @@ public:
       fc::microseconds   max_trx_cpu_usage = max_trx_time_ms < 0 ? fc::microseconds::maximum() : fc::milliseconds(max_trx_time_ms);
 
       auto future = transaction_metadata::start_recover_keys(trx,
-                                                             _thread_pool.get_executor(),
+                                                             chain.get_thread_pool(),
                                                              chain.get_chain_id(),
                                                              fc::microseconds(max_trx_cpu_usage),
                                                              trx_type,


### PR DESCRIPTION
Using the chain thread pool improves TPS (eosio.token transfer per second) significantly. From ~25K to ~31K. Since this is a rather simple change targeting it for 5.0. With this PR the sequence is net-thread => chain-thread => producer-thread => main-thread.

An improved version of this code that avoids a thread hop will target 6.0; net-thread => chain-thread => main-thread.

Removing 2 thread hops is also possible by recovering the keys on the net thread, however that overwhelms the main thread; net-thread => main-thread. That improvement would require throttling the net threads so they do not overwhelm the main thread. The current mechanism of a limit on the number of active trxs works as a protection but is not ideal for performance measurement as it drops trxs instead of just delaying them.

Issue #1690