### PR TITLE
[5.0] globally (effectively) `--catch_system_errors=no` all boost-test based unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,10 @@ endif()
 # do not attempt to use an external OpenSSL in any manner
 set(CMAKE_DISABLE_FIND_PACKAGE_OpenSSL On)
 
+# many tests require handling of signals themselves and even when they don't we'd like for them to generate a core dump, this
+# is effectively --catch_system_errors=no broadly across all tests
+add_compile_definitions(BOOST_TEST_DEFAULTS_TO_CORE_DUMP)
+
 add_subdirectory( libraries )
 add_subdirectory( plugins )
 add_subdirectory( programs )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ else()
 endif()
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
-add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output --catch_system_errors=no)
+add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
 
 add_test(NAME nodeos_sanity_test COMMAND tests/nodeos_run_test.py -v --sanity-test ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_sanity_test PROPERTY LABELS nonparallelizable_tests)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -85,7 +85,7 @@ target_include_directories( unit_test PUBLIC
                             ${CMAKE_SOURCE_DIR}/plugins/chain_interface/include)
 
 ### MARK TEST SUITES FOR EXECUTION ###
-add_test(NAME protocol_feature_digest_unit_test COMMAND unit_test --run_test=protocol_feature_digest_tests --report_level=detailed --color_output --catch_system_errors=no)
+add_test(NAME protocol_feature_digest_unit_test COMMAND unit_test --run_test=protocol_feature_digest_tests --report_level=detailed --color_output)
 set(ctest_tests "protocol_feature_digest_tests")
 foreach(TEST_SUITE ${UNIT_TESTS}) # create an independent target for each test suite
   execute_process(COMMAND sh -c "grep -E 'BOOST_AUTO_TEST_SUITE\\s*[(]' '${TEST_SUITE}' | grep -vE '//.*BOOST_AUTO_TEST_SUITE\\s*[(]' | cut -d ')' -f 1 | cut -d '(' -f 2" OUTPUT_VARIABLE SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # get the test suite name from the *.cpp file
@@ -93,7 +93,7 @@ foreach(TEST_SUITE ${UNIT_TESTS}) # create an independent target for each test s
     execute_process(COMMAND sh -c "echo ${SUITE_NAME} | sed -e 's/s$//' | sed -e 's/_test$//'" OUTPUT_VARIABLE TRIMMED_SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # trim "_test" or "_tests" from the end of ${SUITE_NAME}
     # to run unit_test with all log from blockchain displayed, put "--verbose" after "--", i.e. "unit_test -- --verbose"
     foreach(RUNTIME ${EOSIO_WASM_RUNTIMES})
-      add_test(NAME ${TRIMMED_SUITE_NAME}_unit_test_${RUNTIME} COMMAND unit_test --run_test=${SUITE_NAME} --report_level=detailed --color_output --catch_system_errors=no -- --${RUNTIME})
+      add_test(NAME ${TRIMMED_SUITE_NAME}_unit_test_${RUNTIME} COMMAND unit_test --run_test=${SUITE_NAME} --report_level=detailed --color_output -- --${RUNTIME})
       # build list of tests to run during coverage testing
       if(ctest_tests)
          string(APPEND ctest_tests "|")

--- a/unittests/wasm-spec-tests/generated-tests/CMakeLists.txt
+++ b/unittests/wasm-spec-tests/generated-tests/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach(TEST_SUITE ${WASM_TESTS}) # create an independent target for each test s
       foreach(RUNTIME ${EOSIO_WASM_RUNTIMES})
           get_test_property(${SN}_unit_test_${RUNTIME} LABELS TEST_LABEL)
           if ("NOTFOUND" STREQUAL "${TEST_LABEL}") # prevent duplicates
-            add_test(NAME ${SN}_unit_test_${RUNTIME} COMMAND wasm_spec_test --run_test=${SN} --report_level=detailed --color_output --catch_system_errors=no -- --${RUNTIME})
+            add_test(NAME ${SN}_unit_test_${RUNTIME} COMMAND wasm_spec_test --run_test=${SN} --report_level=detailed --color_output -- --${RUNTIME})
             set_property(TEST ${SN}_unit_test_${RUNTIME} PROPERTY LABELS wasm_spec_tests)
             # build list of tests to run during coverage testing
             if(ctest_tests)


### PR DESCRIPTION
Some of our tests require `--catch_system_errors=no` to properly operate, but there is another compelling reason to blanket this option on _all_ tests: gathering core dumps. Default behavior (`--catch_system_errors=yes`) will block core dump creation for those tests should they fail. Instead of needing to remember to sprinkle `--catch_system_errors=no` in all the various `add_test()` declarations (prone to missing some), we have some other options,
* set `BOOST_TEST_CATCH_SYSTEM_ERRORS` environment variable in CI. This allows CI to gobble up core dumps from any test, but introduces a difference in CI vs non-CI behavior
* plumb the option in boost test's C++ initialization (but this requires manual plumbing for every test)
* set the `BOOST_TEST_DEFAULTS_TO_CORE_DUMP` preprocessor macro
  * Secondary option: plumb through a new `INTERFACE` library that depends on `Boost::unit_test_framework` to add  `BOOST_TEST_DEFAULTS_TO_CORE_DUMP`; but this still requires remembering in every place we use boost test we need to link to `leap_boost_unit_test` instead of `Boost::unit_test_framework`

As much as I detest "global" cmake compile definitions, the `BOOST_TEST_DEFAULTS_TO_CORE_DUMP` preprocessor macro seems the best option in terms of being a single location with consistent blanket behavior. Certainly open to opinions though.

Work on #640 