### PR TITLE
upload core dumps from failed tests in CI

### DIFF
--- a/.github/actions/parallel-ctest-containers/action.yml
+++ b/.github/actions/parallel-ctest-containers/action.yml
@@ -12,5 +12,5 @@ inputs:
   test-timeout:
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.mjs'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,7 @@ jobs:
     runs-on: ["self-hosted", "enf-x86-hightier"]
     container:
       image: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.cfg.base].image}}
-      options: --security-opt seccomp=unconfined
+      options: --security-opt seccomp=unconfined --mount type=bind,source=/var/lib/systemd/coredump,target=/cores
     steps:
       - uses: actions/checkout@v4
       - name: Download builddir
@@ -152,6 +152,13 @@ jobs:
           zstdcat build.tar.zst | tar x
           cd build
           ctest --output-on-failure -j $(nproc) -LE "(nonparallelizable_tests|long_running_tests)" --timeout 420
+      - name: Upload core files from failed tests
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: ${{matrix.cfg.name}}-tests-logs
+          if-no-files-found: ignore
+          path: /cores
       - name: Check CPU Features
         run: awk 'BEGIN {err = 1} /bmi2/ && /adx/ {err = 0} END {exit err}' /proc/cpuinfo
 
@@ -181,12 +188,17 @@ jobs:
           log-tarball-prefix: ${{matrix.cfg.name}}
           tests-label: nonparallelizable_tests
           test-timeout: 420
+      - name: Export core dumps
+        run: docker run --mount type=bind,source=/var/lib/systemd/coredump,target=/cores alpine sh -c 'tar -C /cores/ -c .' | tar x
+        if: failure()
       - name: Upload logs from failed tests
         uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ${{matrix.cfg.name}}-np-logs
-          path: '*-logs.tar.gz'
+          path: |
+            *-logs.tar.gz
+            core*.zst
 
   lr-tests:
     name: LR Tests (${{matrix.cfg.name}})
@@ -214,12 +226,17 @@ jobs:
           log-tarball-prefix: ${{matrix.cfg.name}}
           tests-label: long_running_tests
           test-timeout: 1800
+      - name: Export core dumps
+        run: docker run --mount type=bind,source=/var/lib/systemd/coredump,target=/cores alpine sh -c 'tar -C /cores/ -c .' | tar x
+        if: failure()
       - name: Upload logs from failed tests
         uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ${{matrix.cfg.name}}-lr-logs
-          path: '*-logs.tar.gz'
+          path: |
+            *-logs.tar.gz
+            core*.zst
 
   libtester-tests:
     name: libtester tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.platform].image}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Download builddir
@@ -140,7 +140,7 @@ jobs:
       image: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.cfg.base].image}}
       options: --security-opt seccomp=unconfined
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v3
         with:
@@ -168,7 +168,7 @@ jobs:
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-midtier"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v3
         with:
@@ -201,7 +201,7 @@ jobs:
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-lowtier"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v3
         with:
@@ -243,7 +243,7 @@ jobs:
       # LEAP
       - if: ${{ matrix.test != 'deb-install' }}
         name: Clone leap
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - if: ${{ matrix.test != 'deb-install' }}
@@ -296,7 +296,7 @@ jobs:
 
       # Reference Contracts
       - name: checkout eos-system-contracts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: eosnetworkfoundation/eos-system-contracts
           path: eos-system-contracts

--- a/.github/workflows/build_base.yaml
+++ b/.github/workflows/build_base.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ["self-hosted", "enf-x86-beefy"]
     container: ${{fromJSON(inputs.platforms)[matrix.platform].image}}
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
             submodules: recursive
         - name: Build

--- a/.github/workflows/ph_backward_compatibility.yaml
+++ b/.github/workflows/ph_backward_compatibility.yaml
@@ -46,7 +46,7 @@ jobs:
       image: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.platform].image}}
       options: --security-opt seccomp=unconfined
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Core dumps will now be uploaded from crashing tests in CI. Resolves #640. Example of failure and uploaded files can be found here,
https://github.com/AntelopeIO/leap/actions/runs/6724910321
(I trimmed the run down to just Tests & NP Tests on a single platform)

While I didn't change anything on the ENF runners to accomplish this, it's worth noting that this probably only works with ENF runners because of their behavior to put core dumps in to `/var/lib/systemd/coredump`. Something like Github's runners don't do that. While I like to keep the workflows runner-agnostic so that forks could potentially work in the future, afaik this won't break the workflow on other runners; you'll just miss out on the core dumps.

Coming along for the ride in some separate commits were a couple modifications to use node20 instead of node16. In some of our repos starting to notice warnings about using node16, for example: https://github.com/AntelopeIO/bls12-381/actions/runs/6633721660 (I'm not sure why we haven't seen warnings in leap; possibly a slow rollout by Github?). So,
* upgrade to actions/checkout@v4, and
* upgrade parallel-ctest-containers to use node20