### PR TITLE
[5.0 -> main] PH: Reliability improvements

### DIFF
--- a/tests/PerformanceHarness/log_reader.py
+++ b/tests/PerformanceHarness/log_reader.py
@@ -39,7 +39,7 @@ class TpsTestConfig:
     numTrxGensUsed: int = 0
     targetTpsPerGenList: List[int] = field(default_factory=list)
     quiet: bool = False
-    printMissingTransactions: bool=False
+    printMissingTransactions: bool=True
 
 @dataclass
 class stats():

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -461,6 +461,11 @@ class Cluster(object):
                 if "--plugin eosio::history_api_plugin" in args:
                     argsArr.append("--is-nodeos-v2")
                     break
+
+        # Handle common case of specifying no block offset for older versions
+        if "v2" in self.nodeosVers or "v3" in self.nodeosVers or "v4" in self.nodeosVers:
+            argsArr = list(map(lambda st: str.replace(st, "--produce-block-offset-ms 0", "--last-block-time-offset-us 0 --last-block-cpu-effort-percent 100"), argsArr))
+
         Cluster.__LauncherCmdArr = argsArr.copy()
 
         launcher = cluster_generator(argsArr)

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -161,19 +161,18 @@ class Node(Transactions):
                     transIds.pop(self.fetchTransactionFromTrace(trx))
         return transIds
 
-    def waitForTransactionsInBlockRange(self, transIds, startBlock=2, maxFutureBlocks=0):
+    def waitForTransactionsInBlockRange(self, transIds, startBlock, endBlock):
         nextBlockToProcess = startBlock
-        overallEndBlock = startBlock + maxFutureBlocks
         while len(transIds) > 0:
             currentLoopEndBlock = self.getHeadBlockNum()
-            if currentLoopEndBlock >  overallEndBlock:
-                currentLoopEndBlock = overallEndBlock
+            if currentLoopEndBlock > endBlock:
+                currentLoopEndBlock = endBlock
             for blockNum in range(nextBlockToProcess, currentLoopEndBlock + 1):
                 transIds = self.checkBlockForTransactions(transIds, blockNum)
                 if len(transIds) == 0:
                     return transIds
             nextBlockToProcess = currentLoopEndBlock + 1
-            if currentLoopEndBlock == overallEndBlock:
+            if currentLoopEndBlock == endBlock:
                 Utils.Print("ERROR: Transactions were missing upon expiration of waitOnblockTransactions")
                 break
             self.waitForHeadToAdvance()

--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -73,15 +73,31 @@ namespace eosio::testing {
    }
 
    void p2p_connection::disconnect() {
-      ilog("Closing socket.");
-      _p2p_socket.close();
-      ilog("Socket closed.");
+      int max    = 30;
+      int waited = 0;
+      for (uint64_t sent = _sent.load(), sent_callback_num = _sent_callback_num.load();
+           sent != sent_callback_num && waited < max;
+           sent = _sent.load(), sent_callback_num = _sent_callback_num.load()) {
+         ilog("disconnect waiting on ack - sent ${s} | acked ${a} | waited ${w}",
+              ("s", sent)("a", sent_callback_num)("w", waited));
+         sleep(1);
+         ++waited;
+      }
+      if (waited == max) {
+         elog("disconnect failed to receive all acks in time - sent ${s} | acked ${a} | waited ${w}",
+              ("s", _sent.load())("a", _sent_callback_num.load())("w", waited));
+      }
    }
 
    void p2p_connection::send_transaction(const chain::packed_transaction& trx) {
       send_buffer_type msg = create_send_buffer(trx);
-      _p2p_socket.send(boost::asio::buffer(*msg));
-      trx_acknowledged(trx.id(), fc::time_point::min()); //using min to identify ack time as not applicable for p2p
+
+      ++_sent;
+      _strand.post( [this, msg{std::move(msg)}, id{trx.id()}]() {
+         boost::asio::write(_p2p_socket, boost::asio::buffer(*msg));
+         trx_acknowledged(id, fc::time_point::min()); //using min to identify ack time as not applicable for p2p
+         ++_sent_callback_num;
+      } );
    }
 
    acked_trx_trace_info p2p_connection::get_acked_trx_trace_info(const eosio::chain::transaction_id_type& trx_id) {

--- a/tests/trx_generator/trx_provider.hpp
+++ b/tests/trx_generator/trx_provider.hpp
@@ -2,9 +2,11 @@
 
 #include<eosio/chain/transaction.hpp>
 #include<eosio/chain/block.hpp>
-#include<boost/asio/ip/tcp.hpp>
-#include<fc/network/message_buffer.hpp>
 #include<eosio/chain/thread_utils.hpp>
+
+#include<boost/asio/ip/tcp.hpp>
+#include<boost/asio/strand.hpp>
+
 #include<chrono>
 #include<thread>
 #include<variant>
@@ -104,10 +106,15 @@ namespace eosio::testing {
 
    struct p2p_connection : public provider_connection {
       boost::asio::ip::tcp::socket _p2p_socket;
+      boost::asio::io_context::strand _strand;
+      std::atomic<uint64_t> _sent_callback_num{0};
+      std::atomic<uint64_t> _sent{0};
+
 
       explicit p2p_connection(const provider_base_config& provider_config)
           : provider_connection(provider_config)
-          , _p2p_socket(_connection_thread_pool.get_executor()) {}
+          , _p2p_socket(_connection_thread_pool.get_executor())
+          , _strand(_connection_thread_pool.get_executor()){}
 
       void send_transaction(const chain::packed_transaction& trx) final;
 


### PR DESCRIPTION
- Performance harness tests were failing because the last few trxs from the `trx_generator` were being dropped. Modified the `trx_generator` to wait for all writes to finish before terminating.
- Modify the performance harness to wait for the complete test time for the trxs in blocks.
- Update the performance harness to `--print-missing-transactions` by default as this is very useful for debugging why the test failed.
- Updated Cluster.py to support `--produce-block-offset-ms 0` for older versions of `nodeos`.

Still need to run a complete test run on a quiescent machine.

Merges `release/5.0` into `main` including #1814 

Issue #1690
