### PR TITLE
[5.0] backport: upload core dumps from failed tests in CI

### DIFF
--- a/.github/actions/parallel-ctest-containers/action.yml
+++ b/.github/actions/parallel-ctest-containers/action.yml
@@ -12,5 +12,5 @@ inputs:
   test-timeout:
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.mjs'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,7 @@ jobs:
     runs-on: ["self-hosted", "enf-x86-hightier"]
     container:
       image: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.cfg.base].image}}
-      options: --security-opt seccomp=unconfined
+      options: --security-opt seccomp=unconfined --mount type=bind,source=/var/lib/systemd/coredump,target=/cores
     steps:
       - uses: actions/checkout@v4
       - name: Download builddir
@@ -152,6 +152,13 @@ jobs:
           zstdcat build.tar.zst | tar x
           cd build
           ctest --output-on-failure -j $(nproc) -LE "(nonparallelizable_tests|long_running_tests)" --timeout 420
+      - name: Upload core files from failed tests
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: ${{matrix.cfg.name}}-tests-logs
+          if-no-files-found: ignore
+          path: /cores
       - name: Check CPU Features
         run: awk 'BEGIN {err = 1} /bmi2/ && /adx/ {err = 0} END {exit err}' /proc/cpuinfo
 
@@ -181,12 +188,17 @@ jobs:
           log-tarball-prefix: ${{matrix.cfg.name}}
           tests-label: nonparallelizable_tests
           test-timeout: 420
+      - name: Export core dumps
+        run: docker run --mount type=bind,source=/var/lib/systemd/coredump,target=/cores alpine sh -c 'tar -C /cores/ -c .' | tar x
+        if: failure()
       - name: Upload logs from failed tests
         uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ${{matrix.cfg.name}}-np-logs
-          path: '*-logs.tar.gz'
+          path: |
+            *-logs.tar.gz
+            core*.zst
 
   lr-tests:
     name: LR Tests (${{matrix.cfg.name}})
@@ -214,12 +226,17 @@ jobs:
           log-tarball-prefix: ${{matrix.cfg.name}}
           tests-label: long_running_tests
           test-timeout: 1800
+      - name: Export core dumps
+        run: docker run --mount type=bind,source=/var/lib/systemd/coredump,target=/cores alpine sh -c 'tar -C /cores/ -c .' | tar x
+        if: failure()
       - name: Upload logs from failed tests
         uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ${{matrix.cfg.name}}-lr-logs
-          path: '*-logs.tar.gz'
+          path: |
+            *-logs.tar.gz
+            core*.zst
 
   libtester-tests:
     name: libtester tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.platform].image}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Download builddir
@@ -140,7 +140,7 @@ jobs:
       image: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.cfg.base].image}}
       options: --security-opt seccomp=unconfined
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v3
         with:
@@ -168,7 +168,7 @@ jobs:
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-midtier"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v3
         with:
@@ -201,7 +201,7 @@ jobs:
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-lowtier"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v3
         with:
@@ -243,7 +243,7 @@ jobs:
       # LEAP
       - if: ${{ matrix.test != 'deb-install' }}
         name: Clone leap
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - if: ${{ matrix.test != 'deb-install' }}
@@ -296,7 +296,7 @@ jobs:
 
       # Reference Contracts
       - name: checkout eos-system-contracts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: eosnetworkfoundation/eos-system-contracts
           path: eos-system-contracts

--- a/.github/workflows/build_base.yaml
+++ b/.github/workflows/build_base.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ["self-hosted", "enf-x86-beefy"]
     container: ${{fromJSON(inputs.platforms)[matrix.platform].image}}
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
             submodules: recursive
         - name: Build

--- a/.github/workflows/ph_backward_compatibility.yaml
+++ b/.github/workflows/ph_backward_compatibility.yaml
@@ -46,7 +46,7 @@ jobs:
       image: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.platform].image}}
       options: --security-opt seccomp=unconfined
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,10 @@ endif()
 # do not attempt to use an external OpenSSL in any manner
 set(CMAKE_DISABLE_FIND_PACKAGE_OpenSSL On)
 
+# many tests require handling of signals themselves and even when they don't we'd like for them to generate a core dump, this
+# is effectively --catch_system_errors=no broadly across all tests
+add_compile_definitions(BOOST_TEST_DEFAULTS_TO_CORE_DUMP)
+
 add_subdirectory( libraries )
 add_subdirectory( plugins )
 add_subdirectory( programs )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ else()
 endif()
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
-add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output --catch_system_errors=no)
+add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
 
 add_test(NAME nodeos_sanity_test COMMAND tests/nodeos_run_test.py -v --sanity-test ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_sanity_test PROPERTY LABELS nonparallelizable_tests)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -85,7 +85,7 @@ target_include_directories( unit_test PUBLIC
                             ${CMAKE_SOURCE_DIR}/plugins/chain_interface/include)
 
 ### MARK TEST SUITES FOR EXECUTION ###
-add_test(NAME protocol_feature_digest_unit_test COMMAND unit_test --run_test=protocol_feature_digest_tests --report_level=detailed --color_output --catch_system_errors=no)
+add_test(NAME protocol_feature_digest_unit_test COMMAND unit_test --run_test=protocol_feature_digest_tests --report_level=detailed --color_output)
 set(ctest_tests "protocol_feature_digest_tests")
 foreach(TEST_SUITE ${UNIT_TESTS}) # create an independent target for each test suite
   execute_process(COMMAND sh -c "grep -E 'BOOST_AUTO_TEST_SUITE\\s*[(]' '${TEST_SUITE}' | grep -vE '//.*BOOST_AUTO_TEST_SUITE\\s*[(]' | cut -d ')' -f 1 | cut -d '(' -f 2" OUTPUT_VARIABLE SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # get the test suite name from the *.cpp file
@@ -93,7 +93,7 @@ foreach(TEST_SUITE ${UNIT_TESTS}) # create an independent target for each test s
     execute_process(COMMAND sh -c "echo ${SUITE_NAME} | sed -e 's/s$//' | sed -e 's/_test$//'" OUTPUT_VARIABLE TRIMMED_SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # trim "_test" or "_tests" from the end of ${SUITE_NAME}
     # to run unit_test with all log from blockchain displayed, put "--verbose" after "--", i.e. "unit_test -- --verbose"
     foreach(RUNTIME ${EOSIO_WASM_RUNTIMES})
-      add_test(NAME ${TRIMMED_SUITE_NAME}_unit_test_${RUNTIME} COMMAND unit_test --run_test=${SUITE_NAME} --report_level=detailed --color_output --catch_system_errors=no -- --${RUNTIME})
+      add_test(NAME ${TRIMMED_SUITE_NAME}_unit_test_${RUNTIME} COMMAND unit_test --run_test=${SUITE_NAME} --report_level=detailed --color_output -- --${RUNTIME})
       # build list of tests to run during coverage testing
       if(ctest_tests)
          string(APPEND ctest_tests "|")

--- a/unittests/wasm-spec-tests/generated-tests/CMakeLists.txt
+++ b/unittests/wasm-spec-tests/generated-tests/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach(TEST_SUITE ${WASM_TESTS}) # create an independent target for each test s
       foreach(RUNTIME ${EOSIO_WASM_RUNTIMES})
           get_test_property(${SN}_unit_test_${RUNTIME} LABELS TEST_LABEL)
           if ("NOTFOUND" STREQUAL "${TEST_LABEL}") # prevent duplicates
-            add_test(NAME ${SN}_unit_test_${RUNTIME} COMMAND wasm_spec_test --run_test=${SN} --report_level=detailed --color_output --catch_system_errors=no -- --${RUNTIME})
+            add_test(NAME ${SN}_unit_test_${RUNTIME} COMMAND wasm_spec_test --run_test=${SN} --report_level=detailed --color_output -- --${RUNTIME})
             set_property(TEST ${SN}_unit_test_${RUNTIME} PROPERTY LABELS wasm_spec_tests)
             # build list of tests to run during coverage testing
             if(ctest_tests)


### PR DESCRIPTION
#1849 & #1850 were intended to go in 5.0 but.. whoops! This cherry-picks the commits from those two PRs that went in to `main` on to 5.0 since it brings enough utility that we'd like it in the 5.0 branch