### PR TITLE
Remove thread hop to producer thread for trx signature recovery

### DIFF
--- a/docs/01_nodeos/03_plugins/producer_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/producer_plugin/index.md
@@ -111,8 +111,6 @@ Config Options for eosio::producer_plugin:
   --disable-subjective-api-billing arg (=1)
                                         Disable subjective CPU billing for API
                                         transactions
-  --producer-threads arg (=2)           Number of worker threads in producer
-                                        thread pool
   --snapshots-dir arg (="snapshots")    the location of the snapshots directory
                                         (absolute path or relative to
                                         application data dir)

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -83,6 +83,12 @@ class transaction_metadata {
       start_recover_keys( packed_transaction_ptr trx, boost::asio::io_context& thread_pool,
                           const chain_id_type& chain_id, fc::microseconds time_limit,
                           trx_type t, uint32_t max_variable_sig_size = UINT32_MAX );
+      /// Thread safe.
+      /// @returns transaction_metadata_ptr or throws
+      static transaction_metadata_ptr
+      recover_keys( packed_transaction_ptr trx,
+                    const chain_id_type& chain_id, fc::microseconds time_limit,
+                    trx_type t, uint32_t max_variable_sig_size = UINT32_MAX );
 
       /// @returns constructed transaction_metadata with no key recovery (sig_cpu_usage=0, recovered_pub_keys=empty)
       static transaction_metadata_ptr

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -12,15 +12,23 @@ recover_keys_future transaction_metadata::start_recover_keys( packed_transaction
                                                               uint32_t max_variable_sig_size )
 {
    return post_async_task( thread_pool, [trx{std::move(trx)}, chain_id, time_limit, t, max_variable_sig_size]() mutable {
-         fc::time_point deadline = time_limit == fc::microseconds::maximum() ?
-                                   fc::time_point::maximum() : fc::time_point::now() + time_limit;
-         check_variable_sig_size( trx, max_variable_sig_size );
-         const signed_transaction& trn = trx->get_signed_transaction();
-         flat_set<public_key_type> recovered_pub_keys;
-         fc::microseconds cpu_usage = trn.get_signature_keys( chain_id, deadline, recovered_pub_keys );
-         return std::make_shared<transaction_metadata>( private_type(), std::move( trx ), cpu_usage, std::move( recovered_pub_keys ), t );
-      }
-   );
+      return recover_keys( std::move(trx), chain_id, time_limit, t, max_variable_sig_size );
+   });
+}
+
+transaction_metadata_ptr transaction_metadata::recover_keys( packed_transaction_ptr trx,
+                                                              const chain_id_type& chain_id,
+                                                              fc::microseconds time_limit,
+                                                              trx_type t,
+                                                              uint32_t max_variable_sig_size )
+{
+   fc::time_point deadline = time_limit == fc::microseconds::maximum() ?
+                             fc::time_point::maximum() : fc::time_point::now() + time_limit;
+   check_variable_sig_size( trx, max_variable_sig_size );
+   const signed_transaction& trn = trx->get_signed_transaction();
+   flat_set<public_key_type> recovered_pub_keys;
+   fc::microseconds cpu_usage = trn.get_signature_keys( chain_id, deadline, recovered_pub_keys );
+   return std::make_shared<transaction_metadata>( private_type(), std::move( trx ), cpu_usage, std::move( recovered_pub_keys ), t );
 }
 
 size_t transaction_metadata::get_estimated_size() const {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -827,12 +827,12 @@ public:
                                app().executor().post(priority::low, exec_queue::read_write,
                                                      [ex_ptr = std::current_exception(), this, trx{std::move(trx)}, is_transient, next{std::move(next)}]() {
                                                         auto start       = fc::time_point::now();
-                                                        auto idle_time   = this->_time_tracker.add_idle_time(start);
-                                                        auto trx_tracker = this->_time_tracker.start_trx(is_transient, start);
+                                                        auto idle_time   = _time_tracker.add_idle_time(start);
+                                                        auto trx_tracker = _time_tracker.start_trx(is_transient, start);
                                                         fc_tlog(_log, "Time since last trx: ${t}us", ("t", idle_time));
                                                         auto ex_handler =
                                                                 [this, is_transient, &next, &trx](fc::exception_ptr ex) {
-                                                                   this->log_trx_results(trx, nullptr, ex, 0, is_transient);
+                                                                   log_trx_results(trx, nullptr, ex, 0, is_transient);
                                                                    next(std::move(ex));
                                                                 };
                                                         try {
@@ -845,21 +845,21 @@ public:
                             app().executor().post(priority::low, exec_queue::read_write,
                                                   [this, trx_meta{std::move(trx_meta)}, api_trx, is_transient, next{std::move(next)}, return_failure_traces]() mutable {
                                                      auto start       = fc::time_point::now();
-                                                     auto idle_time   = this->_time_tracker.add_idle_time(start);
-                                                     auto trx_tracker = this->_time_tracker.start_trx(is_transient, start);
+                                                     auto idle_time   = _time_tracker.add_idle_time(start);
+                                                     auto trx_tracker = _time_tracker.start_trx(is_transient, start);
                                                      fc_tlog(_log, "Time since last trx: ${t}us", ("t", idle_time));
 
                                                      auto exception_handler =
                                                              [this, is_transient, &next, &trx_meta](fc::exception_ptr ex) {
-                                                                this->log_trx_results(trx_meta->packed_trx(), nullptr, ex, 0, is_transient);
+                                                                log_trx_results(trx_meta->packed_trx(), nullptr, ex, 0, is_transient);
                                                                 next(std::move(ex));
                                                              };
                                                      try {
-                                                        if (!this->process_incoming_transaction_async(trx_meta, api_trx, return_failure_traces, trx_tracker, next)) {
-                                                           if (this->in_producing_mode()) {
-                                                              this->schedule_maybe_produce_block(true);
+                                                        if (!process_incoming_transaction_async(trx_meta, api_trx, return_failure_traces, trx_tracker, next)) {
+                                                           if (in_producing_mode()) {
+                                                              schedule_maybe_produce_block(true);
                                                            } else {
-                                                              this->restart_speculative_block();
+                                                              restart_speculative_block();
                                                            }
                                                         }
                                                      }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -850,8 +850,8 @@ public:
                                                      fc_tlog(_log, "Time since last trx: ${t}us", ("t", idle_time));
 
                                                      auto exception_handler =
-                                                             [this, is_transient, &next, &trx{trx_meta->packed_trx()}](fc::exception_ptr ex) {
-                                                                this->log_trx_results(trx, nullptr, ex, 0, is_transient);
+                                                             [this, is_transient, &next, &trx_meta](fc::exception_ptr ex) {
+                                                                this->log_trx_results(trx_meta->packed_trx(), nullptr, ex, 0, is_transient);
                                                                 next(std::move(ex));
                                                              };
                                                      try {

--- a/tests/PerformanceHarness/README.md
+++ b/tests/PerformanceHarness/README.md
@@ -371,7 +371,6 @@ Operational Modes:
 
 ```
 usage: PerformanceHarnessScenarioRunner.py findMax testBpOpMode [--skip-tps-test]
-                                                                [--calc-producer-threads {none,lmax,full}]
                                                                 [--calc-chain-threads {none,lmax,full}]
                                                                 [--calc-net-threads {none,lmax,full}]
                                                                 [--del-test-report]
@@ -398,22 +397,6 @@ Performance Harness:
 
   --skip-tps-test       Determines whether to skip the max TPS measurement
                         tests
-  --calc-producer-threads {none,lmax,full}
-                        Determines whether to calculate number of worker
-                        threads to use in producer thread pool ("none",
-                        "lmax", or "full"). In "none" mode, the default, no
-                        calculation will be attempted and the configured
-                        --producer-threads value will be used. In "lmax" mode,
-                        producer threads will incrementally be tested,
-                        starting at plugin default, until the performance rate
-                        ceases to increase with the addition of additional
-                        threads. In "full" mode producer threads will
-                        incrementally be tested from plugin default..num
-                        logical processors, recording each performance and
-                        choosing the local max performance (same value as
-                        would be discovered in "lmax" mode). Useful for
-                        graphing the full performance impact of each available
-                        thread.
   --calc-chain-threads {none,lmax,full}
                         Determines whether to calculate number of worker
                         threads to use in chain thread pool ("none", "lmax",
@@ -505,7 +488,6 @@ usage: PerformanceHarnessScenarioRunner.py findMax testBpOpMode overrideBasicTes
        [--net-threads NET_THREADS]
        [--disable-subjective-billing DISABLE_SUBJECTIVE_BILLING]
        [--produce-block-offset-ms PRODUCE_BLOCK_OFFSET_MS]
-       [--producer-threads PRODUCER_THREADS]
        [--read-only-write-window-time-us READ_ONLY_WRITE_WINDOW_TIME_US]
        [--read-only-read-window-time-us READ_ONLY_READ_WINDOW_TIME_US]
        [--http-max-in-flight-requests HTTP_MAX_IN_FLIGHT_REQUESTS]
@@ -582,8 +564,6 @@ Performance Test Basic Base:
   --produce-block-offset-ms PRODUCE_BLOCK_OFFSET_MS
                         The number of milliseconds early the last block of a production round should
                         be produced.
-  --producer-threads PRODUCER_THREADS
-                        Number of worker threads in producer thread pool
   --read-only-write-window-time-us READ_ONLY_WRITE_WINDOW_TIME_US
                         Time in microseconds the write window lasts.
   --read-only-read-window-time-us READ_ONLY_READ_WINDOW_TIME_US
@@ -665,7 +645,6 @@ The following classes and scripts are typically used by the Performance Harness 
                                   [--net-threads NET_THREADS]
                                   [--disable-subjective-billing DISABLE_SUBJECTIVE_BILLING]
                                   [--produce-block-offset-ms PRODUCE_BLOCK_OFFSET_MS]
-                                  [--producer-threads PRODUCER_THREADS]
                                   [--http-max-in-flight-requests HTTP_MAX_IN_FLIGHT_REQUESTS]
                                   [--http-max-response-time-ms HTTP_MAX_RESPONSE_TIME_MS]
                                   [--http-max-bytes-in-flight-mb HTTP_MAX_BYTES_IN_FLIGHT_MB]
@@ -746,8 +725,6 @@ Performance Test Basic Base:
   --produce-block-offset-ms PRODUCE_BLOCK_OFFSET_MS
                         The number of milliseconds early the last block of a production round should
                         be produced.
-  --producer-threads PRODUCER_THREADS
-                        Number of worker threads in producer thread pool (default: 2)
   --http-max-in-flight-requests HTTP_MAX_IN_FLIGHT_REQUESTS
                         Maximum number of requests http_plugin should use for processing http requests. 429 error response when exceeded. -1 for unlimited (default: -1)
   --http-max-response-time-ms HTTP_MAX_RESPONSE_TIME_MS
@@ -879,7 +856,7 @@ The Performance Harness Scenario Runner, through the `PerformanceTest` and `Perf
 Command used to run test and generate report:
 
 ``` bash
-./tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-producer-threads lmax --calc-chain-threads lmax --calc-net-threads lmax
+./tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-chain-threads lmax --calc-net-threads lmax
 ```
 
 ### Report Breakdown
@@ -1255,7 +1232,7 @@ Finally, the full detail test report for each of the determined max TPS throughp
     "analysisFinish": "2023-08-18T17:39:08.002767"
   },
   "args": {
-    "rawCmdLine ": "tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-producer-threads lmax --calc-chain-threads lmax --calc-net-threads lmax",
+    "rawCmdLine ": "tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-chain-threads lmax --calc-net-threads lmax",
     "dumpErrorDetails": false,
     "delay": 1,
     "nodesFile": null,
@@ -1621,9 +1598,6 @@ Finally, the full detail test report for each of the determined max TPS throughp
         "disableSubjectiveApiBilling": true,
         "_disableSubjectiveApiBillingNodeosDefault": 1,
         "_disableSubjectiveApiBillingNodeosArg": "--disable-subjective-api-billing",
-        "producerThreads": 2,
-        "_producerThreadsNodeosDefault": 2,
-        "_producerThreadsNodeosArg": "--producer-threads",
         "snapshotsDir": null,
         "_snapshotsDirNodeosDefault": "\"snapshots\"",
         "_snapshotsDirNodeosArg": "--snapshots-dir",
@@ -1771,7 +1745,6 @@ Finally, the full detail test report for each of the determined max TPS throughp
     "quiet": false,
     "logDirRoot": ".",
     "skipTpsTests": false,
-    "calcProducerThreads": "lmax",
     "calcChainThreads": "lmax",
     "calcNetThreads": "lmax",
     "userTrxDataFile": null,
@@ -1915,7 +1888,7 @@ The Performance Test Basic generates, by default, a report that details results 
     }
   },
   "args": {
-    "rawCmdLine ": "tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-producer-threads lmax --calc-chain-threads lmax --calc-net-threads lmax",
+    "rawCmdLine ": "tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-chain-threads lmax --calc-net-threads lmax",
     "dumpErrorDetails": false,
     "delay": 1,
     "nodesFile": null,
@@ -2281,9 +2254,6 @@ The Performance Test Basic generates, by default, a report that details results 
         "disableSubjectiveApiBilling": true,
         "_disableSubjectiveApiBillingNodeosDefault": 1,
         "_disableSubjectiveApiBillingNodeosArg": "--disable-subjective-api-billing",
-        "producerThreads": 2,
-        "_producerThreadsNodeosDefault": 2,
-        "_producerThreadsNodeosArg": "--producer-threads",
         "snapshotsDir": null,
         "_snapshotsDirNodeosDefault": "\"snapshots\"",
         "_snapshotsDirNodeosArg": "--snapshots-dir",

--- a/tests/PerformanceHarness/performance_test_basic.py
+++ b/tests/PerformanceHarness/performance_test_basic.py
@@ -664,7 +664,7 @@ class PerformanceTestBasic:
         producerPluginArgs = ProducerPluginArgs(disableSubjectiveApiBilling=args.disable_subjective_billing,
                                                 disableSubjectiveP2pBilling=args.disable_subjective_billing,
                                                 produceBlockOffsetMs=args.produce_block_offset_ms,
-                                                producerThreads=args.producer_threads, maxTransactionTime=-1,
+                                                maxTransactionTime=-1,
                                                 readOnlyWriteWindowTimeUs=args.read_only_write_window_time_us,
                                                 readOnlyReadWindowTimeUs=args.read_only_read_window_time_us)
         httpPluginArgs = HttpPluginArgs(httpMaxBytesInFlightMb=args.http_max_bytes_in_flight_mb, httpMaxInFlightRequests=args.http_max_in_flight_requests,
@@ -721,7 +721,6 @@ class PtbArgumentsHandler(object):
         ptbBaseParserGroup.add_argument("--net-threads", type=int, help=argparse.SUPPRESS if suppressHelp else "Number of worker threads in net_plugin thread pool", default=4)
         ptbBaseParserGroup.add_argument("--disable-subjective-billing", type=bool, help=argparse.SUPPRESS if suppressHelp else "Disable subjective CPU billing for API/P2P transactions", default=True)
         ptbBaseParserGroup.add_argument("--produce-block-offset-ms", type=int, help=argparse.SUPPRESS if suppressHelp else "The minimum time to reserve at the end of a production round for blocks to propagate to the next block producer.", default=0)
-        ptbBaseParserGroup.add_argument("--producer-threads", type=int, help=argparse.SUPPRESS if suppressHelp else "Number of worker threads in producer thread pool", default=2)
         ptbBaseParserGroup.add_argument("--read-only-write-window-time-us", type=int, help=argparse.SUPPRESS if suppressHelp else "Time in microseconds the write window lasts.", default=200000)
         ptbBaseParserGroup.add_argument("--read-only-read-window-time-us", type=int, help=argparse.SUPPRESS if suppressHelp else "Time in microseconds the read window lasts.", default=60000)
         ptbBaseParserGroup.add_argument("--http-max-in-flight-requests", type=int, help=argparse.SUPPRESS if suppressHelp else "Maximum number of requests http_plugin should use for processing http requests. 429 error response when exceeded. -1 for unlimited", default=-1)

--- a/tests/PerformanceHarnessScenarioRunner.py
+++ b/tests/PerformanceHarnessScenarioRunner.py
@@ -82,7 +82,6 @@ def main():
                                             quiet=args.quiet,
                                             logDirRoot=Path("."),
                                             skipTpsTests=args.skip_tps_test,
-                                            calcProducerThreads=args.calc_producer_threads,
                                             calcChainThreads=args.calc_chain_threads,
                                             calcNetThreads=args.calc_net_threads,
                                             userTrxDataFile=Path(args.user_trx_data_file) if args.user_trx_data_file is not None else None,

--- a/tests/p2p_high_latency_test.py
+++ b/tests/p2p_high_latency_test.py
@@ -68,7 +68,7 @@ specificExtraNodeosArgs[syncingNodeId]="--p2p-peer-address 0.0.0.0:{}".format(98
 
 try:
     TestHelper.printSystemInfo("BEGIN")
-    traceNodeosArgs=" --plugin eosio::producer_plugin --produce-block-offset-ms 0 --producer-threads 1 --plugin eosio::net_plugin --net-threads 1"
+    traceNodeosArgs=" --plugin eosio::producer_plugin --produce-block-offset-ms 0 --plugin eosio::net_plugin --net-threads 1"
     if cluster.launch(pnodes=1, totalNodes=totalNodes, totalProducers=1, specificExtraNodeosArgs=specificExtraNodeosArgs, extraNodeosArgs=traceNodeosArgs) is False:
         Utils.cmdError("launcher")
         Utils.errorExit("Failed to stand up eos cluster.")


### PR DESCRIPTION
Remove the use of a `std::future` and `wait` in producer thread pool. Now after signature recovery is complete the chain thread posts directly to the main application thread. This improves the eosio token transfer per second (TPS) tests from ~31K TPS to ~36K TPS.

Transaction now transitions from net-thread => chain-thread => main-thread.

Removing the thread hop to chain-thread and performing key recovery on the net thread is possible (net-thread => main-thread), but testing shows it easily overwhelms the main-thread. Instead I think we need to create a memory pool of trxs that the main thread can pull from instead of pushing low priority tasks for trx execution to the main thread. That would greatly reduce the contention on the app post call and on the main thread priority queue. See https://github.com/AntelopeIO/leap/issues/1860

This builds off the improvement of #1846.

Removes `--producer-threads` option as there is now no use for the producer thread pool.

Issue #1690