### PR TITLE
[5.0] PH: Post on resolver strand to ensure execution on strand

### DIFF
--- a/tests/trx_generator/http_client_async.hpp
+++ b/tests/trx_generator/http_client_async.hpp
@@ -80,8 +80,10 @@ class session : public std::enable_shared_from_this<session> {
       req_.prepare_payload();
 
       // Look up the domain name
-      resolver_.async_resolve(
-          host, std::to_string(port), [self = this->shared_from_this()](beast::error_code ec, auto res) { self->on_resolve(ec, res); });
+      boost::asio::post( resolver_.get_executor(), [host, port, self=this->shared_from_this()] {
+         self->resolver_.async_resolve(
+                 host, std::to_string(port), [self](beast::error_code ec, auto res) { self->on_resolve(ec, res); });
+      });
    }
 
    void on_resolve(beast::error_code ec, tcp::resolver::results_type results) {


### PR DESCRIPTION
Unable to get anything meaningful from the core dumps of the failed test of #1858. Before this change the `async_resolve` would run on the main thread even though the resolver was given a different thread to execute on. This change makes sure the resolver is only touched by the resolver thread.

Resolves #1858