### PR TITLE
[5.0 -> main] Recover keys in chain thread pool

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -803,7 +803,7 @@ public:
       fc::microseconds   max_trx_cpu_usage = max_trx_time_ms < 0 ? fc::microseconds::maximum() : fc::milliseconds(max_trx_time_ms);
 
       auto future = transaction_metadata::start_recover_keys(trx,
-                                                             _thread_pool.get_executor(),
+                                                             chain.get_thread_pool(),
                                                              chain.get_chain_id(),
                                                              fc::microseconds(max_trx_cpu_usage),
                                                              trx_type,


### PR DESCRIPTION
Using the chain thread pool improves TPS (eosio.token transfer per second) significantly. From ~25K to ~31K. Since this is a rather simple change targeting it for 5.0. With this PR the sequence is net-thread => chain-thread => producer-thread => main-thread.

An improved version of this code that avoids a thread hop will target 6.0; net-thread => chain-thread => main-thread. See #1859

Merges `release/5.0` into `main` including #1846 

Issue #1690