### PR TITLE
[5.0] PH: Improve error handling and use one strand

### DIFF
--- a/tests/trx_generator/trx_provider.hpp
+++ b/tests/trx_generator/trx_provider.hpp
@@ -88,6 +88,7 @@ namespace eosio::testing {
 
       std::atomic<uint64_t> _acknowledged{0};
       std::atomic<uint64_t> _sent{0};
+      std::atomic<uint64_t> _errors{0};
 
       explicit http_connection(const provider_base_config& provider_config)
           : provider_connection(provider_config) {}


### PR DESCRIPTION
Update async http client to use one strand like the multi-threaded boost example.
Improve error reporting so an un-caught exception is not generated.

The core file of #1858 did not reveal anything useful. Do a bit of cleanup and hope for the best.

Maybe Resolves #1858 