### PR TITLE
[5.0] fix release workflow's artifact download to `wait-for-exact-target` not `wait-for-exact-target-workflow`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
           file: 'leap-dev.*amd64.deb'
           target: ${{github.sha}}
           artifact-name: leap-dev-ubuntu20-amd64
-          wait-for-exact-target-workflow: true
+          wait-for-exact-target: true
       - name: Get ubuntu22 leap-dev.deb
         uses: AntelopeIO/asset-artifact-download-action@v3
         with:
@@ -30,7 +30,7 @@ jobs:
           file: 'leap-dev.*amd64.deb'
           target: ${{github.sha}}
           artifact-name: leap-dev-ubuntu22-amd64
-          wait-for-exact-target-workflow: true
+          wait-for-exact-target: true
       - name: Create Dockerfile
         run: |
           cat <<EOF > Dockerfile


### PR DESCRIPTION
I probably renamed asset-artifact-download-action's new input from `wait-for-exact-target-workflow` to `wait-for-exact-target` at the last moment, and neglected to update it here for this new usage of it.

Documentation of asset-artifact-download-action's inputs is here,
https://github.com/AntelopeIO/asset-artifact-download-action#inputs