### PR TITLE
[5.0 -> main] fix release workflow's artifact download to `wait-for-exact-target` not `wait-for-exact-target-workflow`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
           file: 'leap-dev.*amd64.deb'
           target: ${{github.sha}}
           artifact-name: leap-dev-ubuntu20-amd64
-          wait-for-exact-target-workflow: true
+          wait-for-exact-target: true
       - name: Get ubuntu22 leap-dev.deb
         uses: AntelopeIO/asset-artifact-download-action@v3
         with:
@@ -30,7 +30,7 @@ jobs:
           file: 'leap-dev.*amd64.deb'
           target: ${{github.sha}}
           artifact-name: leap-dev-ubuntu22-amd64
-          wait-for-exact-target-workflow: true
+          wait-for-exact-target: true
       - name: Create Dockerfile
         run: |
           cat <<EOF > Dockerfile


### PR DESCRIPTION
main merge of #1867 fixing the release workflow for experimental-binaries