### PR TITLE
[5.0 -> main] Disable EOS VM OC's subjective compilation limits in unit tests

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/code_cache.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/code_cache.hpp
@@ -69,6 +69,7 @@ class code_cache_base {
       code_cache_index _cache_index;
 
       const chainbase::database& _db;
+      eosvmoc::config            _eosvmoc_config;
 
       std::filesystem::path _cache_file_path;
       int                   _cache_fd;

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/config.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/config.hpp
@@ -7,11 +7,24 @@
 
 #include <fc/reflect/reflect.hpp>
 
+#include <sys/resource.h>
+
 namespace eosio { namespace chain { namespace eosvmoc {
 
 struct config {
    uint64_t cache_size = 1024u*1024u*1024u;
    uint64_t threads    = 1u;
+
+   // subjective limits for OC compilation.
+   // nodeos enforces the limits by the default values.
+   // libtester disables the limits in all tests, except enforces the limits
+   // in the tests in unittests/eosvmoc_limits_tests.cpp.
+   std::optional<rlim_t>   cpu_limit {20u};
+   std::optional<rlim_t>   vm_limit  {512u*1024u*1024u};
+   std::optional<uint64_t> stack_size_limit {16u*1024u};
+   std::optional<size_t>   generated_code_size_limit {16u*1024u*1024u};
 };
 
 }}}
+
+FC_REFLECT(eosio::chain::eosvmoc::config, (cache_size)(threads)(cpu_limit)(vm_limit)(stack_size_limit)(generated_code_size_limit))

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/ipc_protocol.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/ipc_protocol.hpp
@@ -22,6 +22,7 @@ struct code_tuple {
 
 struct compile_wasm_message {
    code_tuple code;
+   eosvmoc::config eosvmoc_config;
    //Two sent fd: 1) communication socket for result, 2) the wasm to compile
 };
 
@@ -62,7 +63,7 @@ using eosvmoc_message = std::variant<initialize_message,
 FC_REFLECT(eosio::chain::eosvmoc::initialize_message, )
 FC_REFLECT(eosio::chain::eosvmoc::initalize_response_message, (error_message))
 FC_REFLECT(eosio::chain::eosvmoc::code_tuple, (code_id)(vm_version))
-FC_REFLECT(eosio::chain::eosvmoc::compile_wasm_message, (code))
+FC_REFLECT(eosio::chain::eosvmoc::compile_wasm_message, (code)(eosvmoc_config))
 FC_REFLECT(eosio::chain::eosvmoc::evict_wasms_message, (codes))
 FC_REFLECT(eosio::chain::eosvmoc::code_compilation_result_message, (start)(apply_offset)(starting_memory_pages)(initdata_prologue_size))
 FC_REFLECT(eosio::chain::eosvmoc::compilation_result_unknownfailure, )

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/LLVMJIT.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/LLVMJIT.cpp
@@ -274,7 +274,7 @@ namespace LLVMJIT
 		final_pic_code = std::move(*unitmemorymanager->code);
 	}
 
-	instantiated_code instantiateModule(const IR::Module& module)
+	instantiated_code instantiateModule(const IR::Module& module, uint64_t stack_size_limit, size_t generated_code_size_limit)
 	{
 		static bool inited;
 		if(!inited) {
@@ -315,13 +315,13 @@ namespace LLVMJIT
 				WAVM_ASSERT_THROW(!!c);
 
 				++num_functions_stack_size_found;
-				if(stack_size > 16u*1024u)
+				if(stack_size > stack_size_limit)
 					_exit(1);
 			}
 		}
 		if(num_functions_stack_size_found != module.functions.defs.size())
 			_exit(1);
-		if(jitModule->final_pic_code.size() >= 16u*1024u*1024u)
+		if(jitModule->final_pic_code.size() >= generated_code_size_limit)
 			_exit(1);
 
 		instantiated_code ret;

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/LLVMJIT.h
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/LLVMJIT.h
@@ -15,6 +15,6 @@ struct instantiated_code {
 };
 
 namespace LLVMJIT {
-   instantiated_code instantiateModule(const IR::Module& module);
+   instantiated_code instantiateModule(const IR::Module& module, uint64_t stack_size_limit, size_t generated_code_size_limit);
 }
 }}}

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -406,6 +406,13 @@ namespace eosio { namespace testing {
             cfg.contracts_console = true;
             cfg.eosvmoc_config.cache_size = 1024*1024*8;
 
+            // don't enforce OC compilation subject limits for tests,
+            // particularly EOS EVM tests may run over those limits
+            cfg.eosvmoc_config.cpu_limit.reset();
+            cfg.eosvmoc_config.vm_limit.reset();
+            cfg.eosvmoc_config.stack_size_limit.reset();
+            cfg.eosvmoc_config.generated_code_size_limit.reset();
+
             // don't use auto tier up for tests, since the point is to test diff vms
             cfg.eosvmoc_tierup = chain::wasm_interface::vm_oc_enable::oc_none;
 

--- a/unittests/eosvmoc_limits_tests.cpp
+++ b/unittests/eosvmoc_limits_tests.cpp
@@ -1,0 +1,135 @@
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
+
+#include <eosio/testing/tester.hpp>
+#include <test_contracts.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::testing;
+using mvo = fc::mutable_variant_object;
+
+BOOST_AUTO_TEST_SUITE(eosvmoc_limits_tests)
+
+// common routine to verify wasm_execution_error is raised when a resource
+// limit specified in eosvmoc_config is reached
+void limit_violated_test(const eosvmoc::config& eosvmoc_config) {
+   fc::temp_directory tempdir;
+
+   constexpr bool use_genesis = true;
+   validating_tester chain(
+      tempdir,
+      [&](controller::config& cfg) {
+         cfg.eosvmoc_config = eosvmoc_config;
+      },
+      use_genesis
+   );
+
+   chain.create_accounts({"eosio.token"_n});
+   chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
+
+   if (chain.control->is_eos_vm_oc_enabled()) {
+      BOOST_CHECK_EXCEPTION(
+         chain.push_action( "eosio.token"_n, "create"_n, "eosio.token"_n, mvo()
+            ( "issuer", "eosio.token" )
+            ( "maximum_supply", "1000000.00 TOK" )),
+         eosio::chain::wasm_execution_error,
+         [](const eosio::chain::wasm_execution_error& e) {
+            return expect_assert_message(e, "failed to compile wasm");
+         }
+      );
+   } else {
+      chain.push_action( "eosio.token"_n, "create"_n, "eosio.token"_n, mvo()
+         ( "issuer", "eosio.token" )
+         ( "maximum_supply", "1000000.00 TOK" )
+      );
+   }
+}
+
+// common routine to verify no wasm_execution_error is raised
+// because limits specified in eosvmoc_config are not reached
+void limit_not_violated_test(const eosvmoc::config& eosvmoc_config) {
+   fc::temp_directory tempdir;
+
+   constexpr bool use_genesis = true;
+   validating_tester chain(
+      tempdir,
+      [&](controller::config& cfg) {
+         cfg.eosvmoc_config = eosvmoc_config;
+      },
+      use_genesis
+   );
+
+   chain.create_accounts({"eosio.token"_n});
+   chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
+
+   chain.push_action( "eosio.token"_n, "create"_n, "eosio.token"_n, mvo()
+      ( "issuer", "eosio.token" )
+      ( "maximum_supply", "1000000.00 TOK" )
+   );
+}
+
+// test all limits are not set for tests
+BOOST_AUTO_TEST_CASE( limits_not_set ) { try {
+   validating_tester chain;
+   auto& cfg = chain.get_config();
+
+   BOOST_REQUIRE(cfg.eosvmoc_config.cpu_limit == std::nullopt);
+   BOOST_REQUIRE(cfg.eosvmoc_config.vm_limit == std::nullopt);
+   BOOST_REQUIRE(cfg.eosvmoc_config.stack_size_limit == std::nullopt);
+   BOOST_REQUIRE(cfg.eosvmoc_config.generated_code_size_limit == std::nullopt);
+} FC_LOG_AND_RETHROW() }
+
+// test limits are not enforced unless limits in eosvmoc_config
+// are modified
+BOOST_AUTO_TEST_CASE( limits_not_enforced ) { try {
+   eosvmoc::config eosvmoc_config;
+   limit_not_violated_test(eosvmoc_config);
+} FC_LOG_AND_RETHROW() }
+
+// test VM limit are checked
+BOOST_AUTO_TEST_CASE( vm_limit ) { try {
+   eosvmoc::config eosvmoc_config;
+
+   // set vm_limit to a small value such that it is exceeded
+   eosvmoc_config.vm_limit = 64u*1024u*1024u;
+   limit_violated_test(eosvmoc_config);
+
+   // set vm_limit to a large value such that it is not exceeded
+   eosvmoc_config.vm_limit = 128u*1024u*1024u;
+   limit_not_violated_test(eosvmoc_config);
+} FC_LOG_AND_RETHROW() }
+
+// test stack size limit is checked
+BOOST_AUTO_TEST_CASE( stack_limit ) { try {
+   eosvmoc::config eosvmoc_config;
+
+   // The stack size of the compiled WASM in the test is 104.
+   // Set stack_size_limit one less than the actual needed stack size
+   eosvmoc_config.stack_size_limit = 103;
+   limit_violated_test(eosvmoc_config);
+
+   // set stack_size_limit to the actual needed stack size
+   eosvmoc_config.stack_size_limit = 104;
+   limit_not_violated_test(eosvmoc_config);
+} FC_LOG_AND_RETHROW() }
+
+// test generated code size limit is checked
+BOOST_AUTO_TEST_CASE( generated_code_size_limit ) { try {
+   eosvmoc::config eosvmoc_config;
+
+   // The generated code size of the compiled WASM in the test is 36856.
+   // Set generated_code_size_limit to the actual generated code size
+   eosvmoc_config.generated_code_size_limit = 36856;
+   limit_violated_test(eosvmoc_config);
+
+   // Set generated_code_size_limit to one above the actual generated code size
+   eosvmoc_config.generated_code_size_limit = 36857;
+   limit_not_violated_test(eosvmoc_config);
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+#endif


### PR DESCRIPTION
When EOS VM OC is used in unit tests, contract actions are not dispatched until EOS VM OC has finished compilation. If a unit test violates EOS VM OC's subjective compilation limits, the unit test will fail. This is most notably problematic for EOS EVM because EOS EVM's exhaustive tests run afoul of OC's subjective limits. Another problem with OC's subjective limits  are they prevent ASAN from being used, because ASAN's 16TB of virtual memory usage is flagged by OC's subjective limits.

This PR disables OC subjective limits: `cpu limits`, `vm limits`, `stack size limit`, and `generated code size limit` in unit tests. It also adds unit tests to make sure limits to work properly.

Merges `release/5.0` into main including https://github.com/AntelopeIO/leap/pull/1843

Resolves https://github.com/AntelopeIO/leap/issues/1573