### PR TITLE
[5.0 -> main] Prometheus: Ensure valid unique_conn_node_id

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4765,9 +4765,18 @@ namespace eosio {
             ++num_peers;
          }
          fc::unique_lock g_conn(c->conn_mtx);
+         if (c->unique_conn_node_id.empty()) { // still connecting, use temp id so that non-connected peers are reported
+            if (!c->p2p_address.empty()) {
+               c->unique_conn_node_id = fc::sha256::hash(c->p2p_address).str().substr(0, 7);
+            } else if (!c->remote_endpoint_ip.empty()) {
+               c->unique_conn_node_id = fc::sha256::hash(c->remote_endpoint_ip).str().substr(0, 7);
+            } else {
+               c->unique_conn_node_id = fc::sha256::hash(std::to_string(c->connection_id)).str().substr(0, 7);
+            }
+         }
+         std::string conn_node_id = c->unique_conn_node_id;
          boost::asio::ip::address_v6::bytes_type addr = c->remote_endpoint_ip_array;
          std::string p2p_addr = c->p2p_address;
-         std::string conn_node_id = c->unique_conn_node_id;
          g_conn.unlock();
          per_connection.peers.emplace_back(
             net_plugin::p2p_per_connection_metrics::connection_metric{

--- a/tests/p2p_sync_throttle_test.py
+++ b/tests/p2p_sync_throttle_test.py
@@ -144,7 +144,7 @@ try:
                 time.sleep(0.5)
                 continue
             Print('Throttling Node Start State')
-            throttlingNodePortMap = {port: id for id, port in connPorts if id != '' and port != '9877'}
+            throttlingNodePortMap = {port: id for id, port in connPorts if port != '0' and port != '9877'}
             throttlingNodeConnId = next(iter(throttlingNodePortMap.values())) # 9879
             startSyncThrottlingBytesSent = extractPrometheusMetric(throttlingNodeConnId,
                                                                     'block_sync_bytes_sent',
@@ -181,7 +181,7 @@ try:
                 errorLimit -= 1
                 continue
             Print('Throttled Node Start State')
-            throttledNodePortMap = {port: id for id, port in connPorts if id != ''}
+            throttledNodePortMap = {port: id for id, port in connPorts if port != '0'}
             throttledNodeConnId = next(iter(throttledNodePortMap.values())) # 9878
             Print(throttledNodeConnId)
             startSyncThrottledBytesReceived = extractPrometheusMetric(throttledNodeConnId,


### PR DESCRIPTION
Make sure a valid and unique connection id is provided to prometheus. If not connected, then use a temporary id until the connection is established and a handshake is received.

Merges `release/5.0` into `main` including #1879 

Resolves #1871 