### PR TITLE
[5.0] Benchmark BLS host functions

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,7 +1,8 @@
 file(GLOB BENCHMARK "*.cpp")
 add_executable( benchmark ${BENCHMARK} )
 
-target_link_libraries( benchmark fc Boost::program_options bn256)
+target_link_libraries( benchmark eosio_testing fc Boost::program_options bn256)
 target_include_directories( benchmark PUBLIC
                             "${CMAKE_CURRENT_SOURCE_DIR}"
+                            "${CMAKE_CURRENT_BINARY_DIR}/../unittests/include"
                           )

--- a/benchmark/alt_bn_128.cpp
+++ b/benchmark/alt_bn_128.cpp
@@ -4,7 +4,7 @@
 
 #include <benchmark.hpp>
 
-namespace benchmark {
+namespace eosio::benchmark {
 
 using bytes = std::vector<char>;
 using g1g2_pair = std::vector<std::string>;

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -63,10 +63,20 @@ bytes to_bytes(const std::string& source) {
    return output;
 };
 
-void benchmarking(std::string name, const std::function<void()>& func) {
-   uint64_t total {0}, min {std::numeric_limits<uint64_t>::max()}, max {0};
+void benchmarking(const std::string& name,
+      const std::function<void()>& func,
+      uint32_t max_num_runs) {
 
-   for (auto i = 0U; i < num_runs; ++i) {
+   uint64_t total{0};
+   uint64_t min{std::numeric_limits<uint64_t>::max()};
+   uint64_t max{0};
+
+   // some benchmarked functions are expensive and run in a transaction
+   // (like BLS pairing). Limit actual number of runs to the function
+   // specific maximum such that transaction deadline is not exceeded.
+   uint32_t actual_num_runs = (num_runs > max_num_runs) ? max_num_runs : num_runs;
+
+   for (auto i = 0U; i < actual_num_runs; ++i) {
       auto start_time = std::chrono::high_resolution_clock::now();
       func();
       auto end_time = std::chrono::high_resolution_clock::now();
@@ -77,7 +87,7 @@ void benchmarking(std::string name, const std::function<void()>& func) {
       max = std::max(max, duration);
    }
 
-   print_results(name, num_runs, total, min, max);
+   print_results(name, actual_num_runs, total, min, max);
 }
 
 } // benchmark

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -63,20 +63,12 @@ bytes to_bytes(const std::string& source) {
    return output;
 };
 
-void benchmarking(const std::string& name,
-      const std::function<void()>& func,
-      uint32_t max_num_runs) {
-
+void benchmarking(const std::string& name, const std::function<void()>& func) {
    uint64_t total{0};
    uint64_t min{std::numeric_limits<uint64_t>::max()};
    uint64_t max{0};
 
-   // some benchmarked functions are expensive and run in a transaction
-   // (like BLS pairing). Limit actual number of runs to the function
-   // specific maximum such that transaction deadline is not exceeded.
-   uint32_t actual_num_runs = (num_runs > max_num_runs) ? max_num_runs : num_runs;
-
-   for (auto i = 0U; i < actual_num_runs; ++i) {
+   for (auto i = 0U; i < num_runs; ++i) {
       auto start_time = std::chrono::high_resolution_clock::now();
       func();
       auto end_time = std::chrono::high_resolution_clock::now();
@@ -87,7 +79,7 @@ void benchmarking(const std::string& name,
       max = std::max(max, duration);
    }
 
-   print_results(name, actual_num_runs, total, min, max);
+   print_results(name, num_runs, total, min, max);
 }
 
 } // benchmark

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -5,7 +5,7 @@
 
 #include <benchmark.hpp>
 
-namespace benchmark {
+namespace eosio::benchmark {
 
 // update this map when a new feature is supported
 // key is the name and value is the function doing benchmarking

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -15,6 +15,7 @@ std::map<std::string, std::function<void()>> features {
    { "key", key_benchmarking },
    { "hash", hash_benchmarking },
    { "blake2", blake2_benchmarking },
+   { "bls", bls_benchmarking }
 };
 
 // values to control cout format

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -47,10 +47,10 @@ void print_results(std::string name, uint32_t runs, uint64_t total, uint64_t min
    std::cout.imbue(std::locale(""));
    std::cout
       << std::setw(name_width) << std::left << name
-      << std::setw(runs_width)  << runs
       // std::fixed for not printing 1234 in 1.234e3.
       // setprecision(0) for not printing fractions
       << std::right << std::fixed << std::setprecision(0)
+      << std::setw(runs_width)  << runs
       << std::setw(time_width) << total/runs << std::setw(ns_width) << " ns"
       << std::setw(time_width) << min << std::setw(ns_width) << " ns"
       << std::setw(time_width) << max << std::setw(ns_width) << " ns"

--- a/benchmark/benchmark.hpp
+++ b/benchmark/benchmark.hpp
@@ -19,6 +19,7 @@ void modexp_benchmarking();
 void key_benchmarking();
 void hash_benchmarking();
 void blake2_benchmarking();
+void bls_benchmarking();
 
 void benchmarking(std::string name, const std::function<void()>& func);
 

--- a/benchmark/benchmark.hpp
+++ b/benchmark/benchmark.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <map>
 #include <vector>
+#include <limits>
 
 #include <fc/crypto/hex.hpp>
 
@@ -21,6 +22,6 @@ void hash_benchmarking();
 void blake2_benchmarking();
 void bls_benchmarking();
 
-void benchmarking(std::string name, const std::function<void()>& func);
+void benchmarking(const std::string& name, const std::function<void()>& func, uint32_t max_num_runs = std::numeric_limits<uint32_t>::max());
 
 } // benchmark

--- a/benchmark/benchmark.hpp
+++ b/benchmark/benchmark.hpp
@@ -22,6 +22,6 @@ void hash_benchmarking();
 void blake2_benchmarking();
 void bls_benchmarking();
 
-void benchmarking(const std::string& name, const std::function<void()>& func, uint32_t max_num_runs = std::numeric_limits<uint32_t>::max());
+void benchmarking(const std::string& name, const std::function<void()>& func); 
 
 } // benchmark

--- a/benchmark/benchmark.hpp
+++ b/benchmark/benchmark.hpp
@@ -7,7 +7,7 @@
 
 #include <fc/crypto/hex.hpp>
 
-namespace benchmark {
+namespace eosio::benchmark {
 using bytes = std::vector<char>;
 
 void set_num_runs(uint32_t runs);

--- a/benchmark/blake2.cpp
+++ b/benchmark/blake2.cpp
@@ -2,7 +2,7 @@
 
 #include <benchmark.hpp>
 
-namespace benchmark {
+namespace eosio::benchmark {
 
 void blake2_benchmarking() {
    uint32_t _rounds    = 0x0C;

--- a/benchmark/bls.cpp
+++ b/benchmark/bls.cpp
@@ -15,10 +15,7 @@ using namespace bls12_381;
 // to run a benchmarking session, in the build directory, type
 // benchmark/benchmark -f bls
 
-namespace eosio::chain {
-// placed in eosio::chain name space so that interface_in_benchmark
-// can access transaction_context's private member max_transaction_time_subjective.
-// interface_in_benchmark is a friend of transaction_context.
+namespace eosio::benchmark {
 
 // To benchmark host functions directly without CDT wrappers,
 // we need to contruct a eosio::chain::webassembly::interface object,
@@ -96,10 +93,6 @@ struct interface_in_benchmark {
    std::unique_ptr<apply_context>               apply_ctx;
    std::unique_ptr<webassembly::interface>      interface;
 };
-} // namespace eosio::chain
-
-
-namespace benchmark {
 
 // utilility to create a random scalar
 std::array<uint64_t, 4> random_scalar()

--- a/benchmark/bls.cpp
+++ b/benchmark/bls.cpp
@@ -30,9 +30,9 @@ struct interface_in_benchmark {
       auto conf_genesis = tester::default_config( tempdir );
       auto& cfg = conf_genesis.second.initial_configuration;
       // configure large cpu usgaes so expensive BLS functions like pairing
-      // can run a reasonable number of times within a trasaction time
-      cfg.max_block_cpu_usage        = 500'000;
-      cfg.max_transaction_cpu_usage  = 480'000;
+      // can finish within a trasaction time
+      cfg.max_block_cpu_usage        = 999'999'999;
+      cfg.max_transaction_cpu_usage  = 999'999'990;
       cfg.min_transaction_cpu_usage  = 1;
       chain = std::make_unique<tester>(conf_genesis.first, conf_genesis.second);
       chain->execute_setup_policy( setup_policy::full );
@@ -104,10 +104,6 @@ std::array<uint64_t, 4> random_scalar()
       dis(gen) % bls12_381::fp::Q[3]
    };
 }
-
-// some functions like pairing/exp are expensive. set a hard limit to
-// the number of runs such that the transanction does not reach deadline
-constexpr uint32_t num_runs_limit = 200;
 
 // utilility to create a random g1
 bls12_381::g1 random_g1()
@@ -241,7 +237,7 @@ void benchmark_bls_g1_exp(std::string test_name, uint32_t num_points) {
       interface.interface->bls_g1_exp(g1_points, scalars, num_points, result);
    };
 
-   benchmarking(test_name, benchmarked_func, num_runs_limit);
+   benchmarking(test_name, benchmarked_func);
 }
 
 void benchmark_bls_g1_exp_one_point() {
@@ -279,7 +275,7 @@ void benchmark_bls_g2_exp(std::string test_name, uint32_t num_points) {
       interface.interface->bls_g2_exp(g2_points, scalars, num_points, result);
    };
 
-   benchmarking(test_name, benchmarked_func, num_runs_limit);
+   benchmarking(test_name, benchmarked_func);
 }
 
 void benchmark_bls_g2_exp_one_point() {
@@ -318,7 +314,7 @@ void benchmark_bls_pairing(std::string test_name, uint32_t num_pairs) {
       interface.interface->bls_pairing(g1_points, g2_points, num_pairs, result);
    };
 
-   benchmarking(test_name, benchmarked_func, num_runs_limit);
+   benchmarking(test_name, benchmarked_func);
 }
 
 void benchmark_bls_pairing_one_pair() {

--- a/benchmark/bls.cpp
+++ b/benchmark/bls.cpp
@@ -1,0 +1,232 @@
+#include <benchmark.hpp>
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+#include <eosio/chain/platform_timer.hpp>
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/apply_context.hpp>
+#include <eosio/chain/webassembly/interface.hpp>
+#include <fc/variant_object.hpp>
+#include <fc/io/json.hpp>
+#include <test_contracts.hpp>
+#include <fc/log/logger.hpp>
+#include <bls12-381/bls12-381.hpp>
+#include <random>
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::testing;
+using namespace bls12_381;
+
+namespace eosio::chain {
+// placed in eosio::chain name space so that interface_in_benchmark
+// can access transaction_context's private member max_transaction_time_subjective.
+// interface_in_benchmark is a friend of transaction_context.
+
+// To benchmark host functions directly without going through CDT
+// wrappers, we need to contruct a eosio::chain::webassembly::interface
+// object, as host functions are implemented in eosio::chain::webassembly::interface
+struct interface_in_benchmark {
+   interface_in_benchmark() {
+      // prevent logging from messing up benchmark results display
+      fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::off);
+
+      // create a chain
+      fc::temp_directory tempdir;
+      auto conf_genesis = tester::default_config( tempdir );
+      auto& cfg = conf_genesis.second.initial_configuration;
+      // configure large cpu usgaes so expensive BLS functions like pairing
+      // can run a reasonable number of times within a trasaction time
+      cfg.max_block_cpu_usage        = 500'000;
+      cfg.max_transaction_cpu_usage  = 480'000;
+      cfg.min_transaction_cpu_usage  = 1;
+      chain = std::make_unique<tester>(conf_genesis.first, conf_genesis.second);
+      chain->execute_setup_policy( setup_policy::full );
+
+      // get hold controller
+      control = chain->control.get();
+
+      // create account and deploy contract for a temp transaction
+      chain->create_accounts( {"payloadless"_n} );
+      chain->set_code( "payloadless"_n, test_contracts::payloadless_wasm() );
+      chain->set_abi( "payloadless"_n, test_contracts::payloadless_abi() );
+
+      // construct a signed transaction
+      fc::variant pretty_trx = fc::mutable_variant_object()
+         ("actions", fc::variants({
+            fc::mutable_variant_object()
+               ("account", name("payloadless"_n))
+               ("name", "doit")
+               ("authorization", fc::variants({
+                  fc::mutable_variant_object()
+                     ("actor", name("payloadless"_n))
+                     ("permission", name(config::active_name))
+               }))
+               ("data", fc::mutable_variant_object()
+               )
+            })
+        );
+      trx = std::make_unique<signed_transaction>();
+      abi_serializer::from_variant(pretty_trx, *trx, chain->get_resolver(), abi_serializer::create_yield_function( chain->abi_serializer_max_time ));
+      chain->set_transaction_headers(*trx);
+      trx->sign( chain->get_private_key( "payloadless"_n, "active" ), control->get_chain_id() );
+
+      // construct a packed transaction
+      ptrx = std::make_unique<packed_transaction>(*trx, eosio::chain::packed_transaction::compression_type::zlib);
+
+      // build transaction context from the packed transaction
+      timer = std::make_unique<platform_timer>();
+      trx_timer = std::make_unique<transaction_checktime_timer>(*timer);
+      trx_ctx = std::make_unique<transaction_context>(*control, *ptrx, ptrx->id(), std::move(*trx_timer));
+      trx_ctx->max_transaction_time_subjective = fc::microseconds::maximum();
+      trx_ctx->init_for_input_trx( ptrx->get_unprunable_size(), ptrx->get_prunable_size() );
+      trx_ctx->exec();
+
+      // build apply context from the control and transaction context
+      apply_ctx = std::make_unique<apply_context>(*control, *trx_ctx, 1);
+
+      // finally build the interface
+      interface = std::make_unique<webassembly::interface>(*apply_ctx);
+   }
+
+   std::unique_ptr<tester>                      chain;
+   controller*                                  control;
+   std::unique_ptr<signed_transaction>          trx;
+   std::unique_ptr<packed_transaction>          ptrx;
+   std::unique_ptr<platform_timer>              timer;
+   std::unique_ptr<transaction_checktime_timer> trx_timer;
+   std::unique_ptr<transaction_context>         trx_ctx;
+   std::unique_ptr<apply_context>               apply_ctx;
+   std::unique_ptr<webassembly::interface>      interface;
+};
+} // namespace eosio::chain
+
+
+namespace benchmark {
+
+// utilility to create a random scalar
+std::array<uint64_t, 4> random_scalar()
+{
+   std::random_device rd;
+   std::mt19937_64 gen(rd());
+   std::uniform_int_distribution<uint64_t> dis;
+
+   return {
+      dis(gen) % bls12_381::fp::Q[0],
+      dis(gen) % bls12_381::fp::Q[1],
+      dis(gen) % bls12_381::fp::Q[2],
+      dis(gen) % bls12_381::fp::Q[3]
+   };
+}
+
+// utilility to create a random g1
+bls12_381::g1 random_g1()
+{
+   std::array<uint64_t, 4> k = random_scalar();
+   return bls12_381::g1::one().mulScalar(k);
+}
+
+// utilility to create a random g2
+bls12_381::g2 random_g2()
+{
+   std::array<uint64_t, 4> k = random_scalar();
+   return bls12_381::g2::one().mulScalar(k);
+}
+
+void benchmark_bls_g1_add() {
+   // prepare g1 operand in Jacobian LE format
+   g1 p = random_g1();
+   std::vector<char> buf(144);
+   p.toJacobianBytesLE(std::span<uint8_t, 144>((uint8_t*)buf.data(), 144), true);
+   eosio::chain::span<const char> op1(buf.data(), buf.size());
+
+   // prepare result operand
+   std::vector<char> result_buf(144);
+   eosio::chain::span<char> result(result_buf.data(), result_buf.size());
+
+   // set up bls_g1_add to be benchmarked
+   interface_in_benchmark interface;
+   auto g1_add_func = [&]() {
+      interface.interface->bls_g1_add(op1, op1, result);
+   };
+
+   benchmarking("bls_g1_add", g1_add_func);
+}
+
+void benchmark_bls_g2_add() {
+   // prepare g2 operand in Jacobian LE format
+   g2 p = random_g2();
+   std::vector<char> buf(288);
+   p.toJacobianBytesLE(std::span<uint8_t, 288>((uint8_t*)buf.data(), 288), true);
+   eosio::chain::span<const char> op(buf.data(), buf.size());
+
+   // prepare result operand
+   std::vector<char> result_buf(288);
+   eosio::chain::span<char> result(result_buf.data(), result_buf.size());
+
+   // set up bls_g2_add to be benchmarked
+   interface_in_benchmark interface;
+   auto benchmarked_func = [&]() {
+      interface.interface->bls_g2_add(op, op, result);
+   };
+
+   benchmarking("bls_g2_add", benchmarked_func);
+}
+
+void benchmark_bls_g1_mul() {
+   // prepare g1 operand
+   g1 p = random_g1();
+   std::vector<char> buf(144);
+   p.toJacobianBytesLE(std::span<uint8_t, 144>((uint8_t*)buf.data(), 144), true);
+   eosio::chain::span<const char> point(buf.data(), buf.size());
+
+   // prepare scalar operand
+   std::array<uint64_t, 4> s = random_scalar();
+   std::vector<char> scalar_buf(32);
+   scalar::toBytesLE(s, std::span<uint8_t, 32>((uint8_t*)scalar_buf.data(), 32));
+   eosio::chain::span<const char> scalar(scalar_buf.data(), scalar_buf.size());
+
+   // prepare result operand
+   std::vector<char> result_buf(144);
+   eosio::chain::span<char> result(result_buf.data(), result_buf.size());
+
+   // set up bls_g1_mul to be benchmarked
+   interface_in_benchmark interface;
+   auto benchmarked_func = [&]() {
+      interface.interface->bls_g1_mul(point, scalar, result);
+   };
+
+   benchmarking("bls_g1_mul", benchmarked_func);
+}
+
+void benchmark_bls_g2_mul() {
+   g2 p = random_g2();
+   std::vector<char> buf(288);
+   p.toJacobianBytesLE(std::span<uint8_t, 288>((uint8_t*)buf.data(), 288), true);
+   eosio::chain::span<const char> point(buf.data(), buf.size());
+
+   // prepare scalar operand
+   std::array<uint64_t, 4> s = random_scalar();
+   std::vector<char> scalar_buf(32);
+   scalar::toBytesLE(s, std::span<uint8_t, 32>((uint8_t*)scalar_buf.data(), 32));
+   eosio::chain::span<const char> scalar(scalar_buf.data(), scalar_buf.size());
+
+   // prepare result operand
+   std::vector<char> result_buf(288);
+   eosio::chain::span<char> result(result_buf.data(), result_buf.size());
+
+   // set up bls_g2_mul to be benchmarked
+   interface_in_benchmark interface;
+   auto benchmarked_func = [&]() {
+      interface.interface->bls_g2_mul(point, scalar, result);
+   };
+
+   benchmarking("bls_g2_mul", benchmarked_func);
+}
+
+void bls_benchmarking() {
+   benchmark_bls_g1_add();
+   benchmark_bls_g2_add();
+   benchmark_bls_g1_mul();
+   benchmark_bls_g2_mul();
+}
+} // namespace benchmark

--- a/benchmark/hash.cpp
+++ b/benchmark/hash.cpp
@@ -10,7 +10,7 @@
 
 using namespace fc;
 
-namespace benchmark {
+namespace eosio::benchmark {
 
 void hash_benchmarking() {
    std::string small_message = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01";

--- a/benchmark/key.cpp
+++ b/benchmark/key.cpp
@@ -9,7 +9,7 @@ using namespace fc::crypto;
 using namespace fc;
 using namespace std::literals;
 
-namespace benchmark {
+namespace eosio::benchmark {
 
 void k1_sign_benchmarking() {
    auto payload = "Test Cases";

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char* argv[]) {
    uint32_t num_runs = 1;
    std::string feature_name;
 
-   auto features = benchmark::get_features();
+   auto features = eosio::benchmark::get_features();
 
    options_description cli ("benchmark command line options");
    cli.add_options()
@@ -61,8 +61,8 @@ int main(int argc, char* argv[]) {
       std::cerr << "unknown exception" << std::endl;
    }
 
-   benchmark::set_num_runs(num_runs);
-   benchmark::print_header();
+   eosio::benchmark::set_num_runs(num_runs);
+   eosio::benchmark::print_header();
 
    if (feature_name.empty()) {
       for (auto& [name, f]: features) {

--- a/benchmark/modexp.cpp
+++ b/benchmark/modexp.cpp
@@ -5,7 +5,7 @@
 
 #include <benchmark.hpp>
 
-namespace benchmark {
+namespace eosio::benchmark {
 
 void modexp_benchmarking() {
    std::mt19937 r(0x11223344);

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -4,6 +4,10 @@
 #include <eosio/chain/platform_timer.hpp>
 #include <signal.h>
 
+namespace eosio::benchmark {
+   struct interface_in_benchmark; // for benchmark testing
+}
+
 namespace eosio { namespace chain {
 
    struct transaction_checktime_timer {
@@ -92,7 +96,7 @@ namespace eosio { namespace chain {
 
          friend struct controller_impl;
          friend class apply_context;
-         friend struct interface_in_benchmark; // defined in benchmark/bls.cpp
+         friend struct benchmark::interface_in_benchmark; // defined in benchmark/bls.cpp
 
          void add_ram_usage( account_name account, int64_t ram_delta );
 

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -92,6 +92,7 @@ namespace eosio { namespace chain {
 
          friend struct controller_impl;
          friend class apply_context;
+         friend struct interface_in_benchmark; // defined in benchmark/bls.cpp
 
          void add_ram_usage( account_name account, int64_t ram_delta );
 


### PR DESCRIPTION
Add benchmarking of BLS host functions into `Leap` Benchmark suites. Those host functions are directly benchmarked without using CDT wrappers.

Use `benchmark/benchmark -f bls` to benchmark. A sample result looks like

```
function                    runs        average       minimum       maximum

bls:
bls_g1_add                  1,000       2,736 ns       2,607 ns      10,048 ns
bls_g2_add                  1,000       6,766 ns       6,461 ns      13,983 ns
bls_g1_mul                  1,000     193,676 ns     191,533 ns     204,904 ns
bls_g2_mul                  1,000     486,744 ns     480,722 ns     516,755 ns
bls_pairing 1 pair          1,000   1,284,147 ns   1,263,355 ns   1,521,806 ns
bls_pairing 3 pairs         1,000   2,095,239 ns   2,060,983 ns   2,448,659 ns
bls_g1_exp 1 point          1,000     491,239 ns     485,616 ns     626,591 ns
bls_g1_exp 3 points         1,000     698,879 ns     692,786 ns     741,049 ns
bls_g2_exp 1 point          1,000   1,239,919 ns   1,229,475 ns   1,559,680 ns
bls_g2_exp 3 points         1,000   1,841,482 ns   1,821,692 ns   2,167,092 ns
bls_g1_map                  1,000     297,041 ns     291,710 ns     310,379 ns
bls_g2_map                  1,000     380,135 ns     374,088 ns     438,751 ns
bls_fp_mod                  1,000         764 ns         668 ns       7,571 ns
```

Resolves https://github.com/AntelopeIO/leap/issues/1854