### PR TITLE
[3.2 -> 4.0] Do not require trailing `=` for base64 encoded strings

### DIFF
--- a/libraries/libfc/src/variant.cpp
+++ b/libraries/libfc/src/variant.cpp
@@ -525,10 +525,14 @@ blob variant::as_blob()const
       {
          const string& str = get_string();
          if( str.size() == 0 ) return blob();
-         if( str.back() == '=' )
-         {
-            std::string b64 = base64_decode( get_string() );
+         try {
+            // variant adds `=` to end of base64 encoded string (see as_string() above) which produces invalid base64
+            // variant in 5.0 no longer appends the '=' character to conform to valid base64 encoding
+            // fc version of base64_decode allows for extra `=` at the end of the string
+            std::string b64 = base64_decode( str );
             return blob( { std::vector<char>( b64.begin(), b64.end() ) } );
+         } catch(const std::exception&) {
+            // unable to decode, return raw chars
          }
          return blob( { std::vector<char>( str.begin(), str.end() ) } );
       }


### PR DESCRIPTION
All previous versions of nodeos required a trailing `=` for base64 encoded strings. `fc::variant` appends an extra `=` for all of its base64 encoded strings. However, non-fc base64 encoders do not add an extra `=` when one is not needed. This PR modifies `fc::variant` to support non-fc base64 encoded strings that do not have the extra `=`. 

In 5.0, `fc::variant` was updated to not add the extra `=` to base64 encoded strings. See #1888. This PR allows `nodeos` to support the new 5.0 version of base64 encoded strings.

Merges `release/3.2` into `release/4.0` including #1889 

Issue #1461 