### PR TITLE
[3.2 -> 4.0] Fix non-working cleos set code and set abi commands

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3473,12 +3473,18 @@ int main( int argc, char** argv ) {
       bytes code_bytes;
       if(!contract_clear){
         std::string wasm;
-        fc::path cpath = fc::canonical(fc::path(contractPath));
 
-        if( wasmPath.empty() ) {
-           wasmPath = (cpath / fc::path(cpath.filename().generic_string()+".wasm")).generic_string();
-        } else if ( boost::filesystem::path(wasmPath).is_relative() ) {
-           wasmPath = (cpath / fc::path(wasmPath)).generic_string();
+        // contractPath (set by contract-dir argument) is only applicable
+        // to "set contract" command. It is empty for "set code" and can be
+        // empty for "set contract.
+        if(!contractPath.empty()) {
+           fc::path cpath = fc::canonical(fc::path(contractPath));
+
+           if( wasmPath.empty() ) {
+              wasmPath = (cpath / (cpath.filename().generic_string()+".wasm")).generic_string();
+           } else if ( boost::filesystem::path(wasmPath).is_relative() ) {
+              wasmPath = (cpath / wasmPath).generic_string();
+           }
         }
 
         std::cerr << localized(("Reading WASM from " + wasmPath + "...").c_str()) << std::endl;
@@ -3529,12 +3535,17 @@ int main( int argc, char** argv ) {
 
       bytes abi_bytes;
       if(!contract_clear){
-        fc::path cpath = fc::canonical(fc::path(contractPath));
+        // contractPath (set by contract-dir argument) is only applicable
+        // to "set contract" command. It is empty for "set abi" and can be
+        // empty for "set contract.
+        if(!contractPath.empty()) {
+           fc::path cpath = fc::canonical(fc::path(contractPath));
 
-        if( abiPath.empty() ) {
-           abiPath = (cpath / fc::path(cpath.filename().generic_string()+".abi")).generic_string();
-        } else if ( boost::filesystem::path(abiPath).is_relative() ) {
-           abiPath = (cpath / fc::path(abiPath)).generic_string();
+           if( abiPath.empty() ) {
+              abiPath = (cpath / (cpath.filename().generic_string()+".abi")).generic_string();
+           } else if ( boost::filesystem::path(abiPath).is_relative() ) {
+              abiPath = (cpath / abiPath).generic_string();
+           }
         }
 
         EOS_ASSERT( fc::exists( abiPath ), abi_file_not_found, "no abi file found ${f}", ("f", abiPath)  );


### PR DESCRIPTION
Cleos `set code` and `set abi` have not worked since `release/3.2`. The root cause is the common code `set_code_callback` for `set contract` and `set code` assumes `contract-dir` argument which is only applicable to `set contract`; and the common code `set_code_callback` for `set abi` and `set code` assumes `contract-dir` argument too.

This PR fixes the problem.

The fix has been tested manually. CI tests will be added to `release/5.0` to minimize changes to 4.0.

Merges release/3.2 into release/4.0 including [#1897](https://github.com/AntelopeIO/leap/pull/1897)

Resolves https://github.com/AntelopeIO/leap/issues/1868.