### PR TITLE
[5.0 -> main] Fix non-working cleos set code and set abi commands, and add tests

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3471,12 +3471,18 @@ int main( int argc, char** argv ) {
       bytes code_bytes;
       if(!contract_clear){
         std::string wasm;
-        std::filesystem::path cpath = std::filesystem::canonical(std::filesystem::path(contractPath));
 
-        if( wasmPath.empty() ) {
-           wasmPath = (cpath / std::filesystem::path(cpath.filename().generic_string()+".wasm")).generic_string();
-        } else if ( std::filesystem::path(wasmPath).is_relative() ) {
-           wasmPath = (cpath / std::filesystem::path(wasmPath)).generic_string();
+        // contractPath (set by contract-dir argument) is only applicable
+        // to "set contract" command. It is empty for "set code" and can be
+        // empty for "set contract.
+        if(!contractPath.empty()) {
+           std::filesystem::path cpath = std::filesystem::canonical(std::filesystem::path(contractPath));
+
+           if( wasmPath.empty() ) {
+              wasmPath = (cpath / std::filesystem::path(cpath.filename().generic_string()+".wasm")).generic_string();
+           } else if ( std::filesystem::path(wasmPath).is_relative() ) {
+              wasmPath = (cpath / std::filesystem::path(wasmPath)).generic_string();
+           }
         }
 
         std::cerr << localized(("Reading WASM from " + wasmPath + "...").c_str()) << std::endl;
@@ -3527,12 +3533,17 @@ int main( int argc, char** argv ) {
 
       bytes abi_bytes;
       if(!contract_clear){
-        std::filesystem::path cpath = std::filesystem::canonical(std::filesystem::path(contractPath));
+        // contractPath (set by contract-dir argument) is only applicable
+        // to "set contract" command. It is empty for "set abi" and can be
+        // empty for "set contract.
+        if(!contractPath.empty()) {
+           std::filesystem::path cpath = std::filesystem::canonical(std::filesystem::path(contractPath));
 
-        if( abiPath.empty() ) {
-           abiPath = (cpath / std::filesystem::path(cpath.filename().generic_string()+".abi")).generic_string();
-        } else if ( std::filesystem::path(abiPath).is_relative() ) {
-           abiPath = (cpath / std::filesystem::path(abiPath)).generic_string();
+           if( abiPath.empty() ) {
+              abiPath = (cpath / std::filesystem::path(cpath.filename().generic_string()+".abi")).generic_string();
+           } else if ( std::filesystem::path(abiPath).is_relative() ) {
+              abiPath = (cpath / std::filesystem::path(abiPath)).generic_string();
+           }
         }
 
         EOS_ASSERT( std::filesystem::exists( abiPath ), abi_file_not_found, "no abi file found ${f}", ("f", abiPath)  );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -238,7 +238,6 @@ set_property(TEST nodeos_high_transaction_lr_test PROPERTY LABELS long_running_t
 add_test(NAME nodeos_retry_transaction_lr_test COMMAND tests/nodeos_retry_transaction_test.py -v --num-transactions 100 --max-transactions-per-second 10 --total-accounts 5 ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_retry_transaction_lr_test PROPERTY LABELS long_running_tests)
 
-
 add_test(NAME cli_test COMMAND tests/cli_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST cli_test PROPERTY LABELS nonparallelizable_tests)
 

--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -208,6 +208,20 @@ class Transactions(NodeosQueries):
 
         return trans
 
+    # set code or abi and return True for success and False for failure
+    def setCodeOrAbi(self, account, setType, setFile):
+        cmd=f"{Utils.EosClientPath} {self.eosClientArgs()} -v set {setType} -j {account.name} {setFile} "
+        if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
+        try:
+            trans=Utils.runCmdReturnJson(cmd, trace=False)
+            self.trackCmdTransaction(trans)
+        except subprocess.CalledProcessError as ex:
+            msg=ex.stderr.decode("utf-8")
+            Utils.Print("ERROR: Exception during set %s. stderr: %s." % (setType, msg))
+            return False
+
+        return True
+
     # returns tuple with indication if transaction was successfully sent and either the transaction or else the exception output
     def pushTransaction(self, trans, opts="", silentErrors=False, permissions=None):
         assert(isinstance(trans, dict))

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -776,6 +776,17 @@ try:
     currentBlockNum=node.getHeadBlockNum()
     Print("CurrentBlockNum: %d" % (currentBlockNum))
 
+    # Verify "set code" and "set abi" work
+    Print("Verify set code and set abi work")
+    setCodeAbiAccount = Account("setcodeabi")
+    setCodeAbiAccount.ownerPublicKey = cluster.eosioAccount.ownerPublicKey
+    setCodeAbiAccount.activePublicKey = cluster.eosioAccount.ownerPublicKey
+    cluster.createAccountAndVerify(setCodeAbiAccount, cluster.eosioAccount, buyRAM=100000)
+    wasmFile="unittests/test-contracts/payloadless/payloadless.wasm"
+    abiFile="unittests/test-contracts/payloadless/payloadless.abi"
+    assert(node.setCodeOrAbi(setCodeAbiAccount, "code", wasmFile))
+    assert(node.setCodeOrAbi(setCodeAbiAccount, "abi", abiFile))
+
     testSuccessful=True
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful, dumpErrorDetails)


### PR DESCRIPTION
Cleos `set code` and `set abi` have not worked since `release/3.2`. The root cause is the common code `set_code_callback` for `set contract` and `set code` assumes `contract-dir` argument which is only applicable to `set contract`; and the common code `set_code_callback` for `set abi` and `set code` assumes `contract-dir` argument too.

Merges fix from `release/5.0` into `main` including [#1909](https://github.com/AntelopeIO/leap/pull/1909).

In addition to the fix, tests are added in this PR for `release/5.0` and `main`.

Resolves https://github.com/AntelopeIO/leap/issues/1868.