### PR TITLE
Fix a couple perf issues in `fc::raw::pack` and add tuple support.

### DIFF
--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -449,7 +449,12 @@ namespace fc {
 
     template<typename Stream, typename... Ts >
     inline void pack( Stream& s, const std::tuple<Ts...>& tup ) {
-       auto l = [&s](const auto& v) { fc::raw::pack( s, v ); };
+       auto l = [&s](const auto&... v) { fc::raw::pack( s, v... ); };
+       std::apply(l, tup);
+    }
+    template<typename Stream, typename... Ts >
+    inline void unpack( Stream& s, std::tuple<Ts...>& tup ) {
+       auto l = [&s](auto&... v) { (fc::raw::unpack( s, v ), ...); };
        std::apply(l, tup);
     }
 

--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -40,6 +40,11 @@ namespace fc {
        pack( s, a0 );
        pack( s, args... );
     }
+    template<typename Stream, typename Arg0, typename... Args>
+    inline void unpack( Stream& s, Arg0& a0, Args&... args ) {
+       unpack( s, a0 );
+       unpack( s, args... );
+    }
 
     template<typename Stream>
     inline void pack( Stream& s, const fc::exception& e )
@@ -454,7 +459,7 @@ namespace fc {
     }
     template<typename Stream, typename... Ts >
     inline void unpack( Stream& s, std::tuple<Ts...>& tup ) {
-       auto l = [&s](auto&... v) { (fc::raw::unpack( s, v ), ...); };
+       auto l = [&s](auto&... v) { fc::raw::unpack( s, v... ); };
        std::apply(l, tup);
     }
 

--- a/libraries/libfc/test/network/test_message_buffer.cpp
+++ b/libraries/libfc/test/network/test_message_buffer.cpp
@@ -373,6 +373,28 @@ BOOST_AUTO_TEST_CASE(message_buffer_datastream_tuple) {
    }
 }
 
+BOOST_AUTO_TEST_CASE(message_buffer_datastream_variadic_pack_unpack) {
+   using my_message_buffer_t = fc::message_buffer<1024>;
+   my_message_buffer_t mbuff;
+
+   char buf[1024];
+   fc::datastream<char*> ds( buf, 1024 );
+
+   using my_tuple = std::tuple<int, int, std::string>;
+   my_tuple t(13, 42, "hello");
+   fc::raw::pack( ds, std::get<0>(t), std::get<1>(t),  std::get<2>(t) );
+
+   memcpy(mbuff.write_ptr(), buf, 1024);
+   mbuff.advance_write_ptr(1024);
+
+   for( int i = 0; i < 3; ++i ) {
+      auto ds2 = mbuff.create_peek_datastream();
+      my_tuple t2;
+      fc::raw::unpack( ds2, std::get<0>(t2), std::get<1>(t2),  std::get<2>(t2) );
+      BOOST_CHECK( t == t2 );
+   }
+}
+
 // Make sure that the memory allocation is thread-safe.
 // A previous version used boost::object_pool without synchronization.
 BOOST_AUTO_TEST_CASE(test_message_buffer) {

--- a/libraries/libfc/test/network/test_message_buffer.cpp
+++ b/libraries/libfc/test/network/test_message_buffer.cpp
@@ -344,6 +344,35 @@ BOOST_AUTO_TEST_CASE(message_buffer_datastream) {
    }
 }
 
+BOOST_AUTO_TEST_CASE(message_buffer_datastream_tuple) {
+   using my_message_buffer_t = fc::message_buffer<1024>;
+   my_message_buffer_t mbuff;
+
+   char buf[1024];
+   fc::datastream<char*> ds( buf, 1024 );
+
+   using my_tuple = std::tuple<int, int, std::string>;
+   my_tuple t(13, 42, "hello");
+   fc::raw::pack( ds, t );
+
+   memcpy(mbuff.write_ptr(), buf, 1024);
+   mbuff.advance_write_ptr(1024);
+
+   for( int i = 0; i < 3; ++i ) {
+      auto ds2 = mbuff.create_peek_datastream();
+      my_tuple t2;
+      fc::raw::unpack( ds2, t2 );
+      BOOST_CHECK( t == t2 );
+   }
+
+   {
+      auto ds2 = mbuff.create_datastream();
+      my_tuple t2;
+      fc::raw::unpack( ds2, t2 );
+      BOOST_CHECK( t == t2 );
+   }
+}
+
 // Make sure that the memory allocation is thread-safe.
 // A previous version used boost::object_pool without synchronization.
 BOOST_AUTO_TEST_CASE(test_message_buffer) {


### PR DESCRIPTION
- pack parameters were passed by value causing unneeded copies.
- packing a `char*` was unnecessarily allocating a temp `std::string`.
- added `std::tuple` support for `pack`, so that we can provide lists longer than pairs, so we don't have to do [this](https://github.com/AntelopeIO/leap/blob/4b34cf572886dda4641c650d36a142bd2aeea3bc/libraries/chain/include/eosio/chain/hotstuff.hpp#L17-L18).