### PR TITLE
Support serialization of fixed-size arrays in abi_serializer.

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -400,16 +400,15 @@ namespace eosio { namespace chain {
       auto h = ctx.enter_scope();
       auto rtype = resolve_type(type);
       auto ftype = fundamental_type(rtype);
-      auto btype = built_in_types.find(ftype );
-      bool is_var_array = is_szarray(rtype);
-      if( !is_var_array && btype != built_in_types.end() ) {
+      bool var_is_array = is_szarray(rtype);
+      if( auto btype = built_in_types.find(ftype ); !var_is_array && btype != built_in_types.end() ) {
          try {
             return btype->second.first(stream, is_array(rtype), is_optional(rtype), ctx.get_yield_function());
          } EOS_RETHROW_EXCEPTIONS( unpack_exception, "Unable to unpack ${class} type '${type}' while processing '${p}'",
                                    ("class", is_array(rtype) ? "array of built-in" : is_optional(rtype) ? "optional of built-in" : "built-in")
                                    ("type", impl::limit_size(ftype))("p", ctx.get_path_string()) )
       }
-      if ( is_array(rtype) || is_var_array ) {
+      if ( is_array(rtype) || var_is_array ) {
          ctx.hint_array_type_if_in_array();
          fc::unsigned_int size;
          try {
@@ -497,7 +496,7 @@ namespace eosio { namespace chain {
       auto v_itr = variants.end();
       auto s_itr = structs.end();
 
-      bool var_is_array = var.get_type() == fc::variant::array_type;
+      bool var_is_array = is_szarray(rtype);
       
       if( auto btype = built_in_types.find(fundamental_type(rtype)); !var_is_array && btype != built_in_types.end() ) {
          btype->second.second(var, ds, is_array(rtype), is_optional(rtype), ctx.get_yield_function());

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -47,7 +47,7 @@ struct abi_serializer {
    /// @return string_view of `t` or internal string type
    std::string_view resolve_type(const std::string_view& t)const;
    bool      is_array(const std::string_view& type)const;
-   bool      is_szarray(const std::string_view& type)const;
+   std::optional<fc::unsigned_int> is_szarray(const std::string_view& type)const;
    bool      is_optional(const std::string_view& type)const;
    bool      is_type( const std::string_view& type, const yield_function_t& yield )const;
    bool      is_type(const std::string_view& type, const fc::microseconds& max_serialization_time)const;

--- a/libraries/libfc/include/fc/io/varint.hpp
+++ b/libraries/libfc/include/fc/io/varint.hpp
@@ -4,7 +4,8 @@
 namespace fc {
 
 struct unsigned_int {
-    unsigned_int( uint32_t v = 0 ):value(v){}
+    using base_uint = uint32_t;
+    unsigned_int( base_uint v = 0 ):value(v){}
 
     template<typename T>
     unsigned_int( T v ):value(v){}
@@ -14,22 +15,22 @@ struct unsigned_int {
 
     unsigned_int& operator=( int32_t v ) { value = v; return *this; }
     
-    uint32_t value;
+    base_uint value;
 
-    friend bool operator==( const unsigned_int& i, const uint32_t& v )     { return i.value == v; }
-    friend bool operator==( const uint32_t& i, const unsigned_int& v )     { return i       == v.value; }
+    friend bool operator==( const unsigned_int& i, const base_uint& v )    { return i.value == v; }
+    friend bool operator==( const base_uint& i, const unsigned_int& v )    { return i       == v.value; }
     friend bool operator==( const unsigned_int& i, const unsigned_int& v ) { return i.value == v.value; }
 
-    friend bool operator!=( const unsigned_int& i, const uint32_t& v )     { return i.value != v; }
-    friend bool operator!=( const uint32_t& i, const unsigned_int& v )     { return i       != v.value; }
+    friend bool operator!=( const unsigned_int& i, const base_uint& v )    { return i.value != v; }
+    friend bool operator!=( const base_uint& i, const unsigned_int& v )    { return i       != v.value; }
     friend bool operator!=( const unsigned_int& i, const unsigned_int& v ) { return i.value != v.value; }
 
-    friend bool operator<( const unsigned_int& i, const uint32_t& v )      { return i.value < v; }
-    friend bool operator<( const uint32_t& i, const unsigned_int& v )      { return i       < v.value; }
+    friend bool operator<( const unsigned_int& i, const base_uint& v )     { return i.value < v; }
+    friend bool operator<( const base_uint& i, const unsigned_int& v )     { return i       < v.value; }
     friend bool operator<( const unsigned_int& i, const unsigned_int& v )  { return i.value < v.value; }
 
-    friend bool operator>=( const unsigned_int& i, const uint32_t& v )     { return i.value >= v; }
-    friend bool operator>=( const uint32_t& i, const unsigned_int& v )     { return i       >= v.value; }
+    friend bool operator>=( const unsigned_int& i, const base_uint& v )    { return i.value >= v; }
+    friend bool operator>=( const base_uint& i, const unsigned_int& v )    { return i       >= v.value; }
     friend bool operator>=( const unsigned_int& i, const unsigned_int& v ) { return i.value >= v.value; }
 };
 

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -533,7 +533,7 @@ fc::variant verify_type_round_trip_conversion( const abi_serializer& abis, const
 BOOST_AUTO_TEST_CASE(std_array_types)
 { try {
 
-   const char* currency_abi = R"=====(
+   const char* test_abi = R"=====(
    {
        "version": "eosio::abi/1.0",
        "types": [],
@@ -551,7 +551,7 @@ BOOST_AUTO_TEST_CASE(std_array_types)
    }
    )=====";
 
-   auto abi = fc::json::from_string(currency_abi).as<abi_def>();
+   auto abi = fc::json::from_string(test_abi).as<abi_def>();
 
    abi_serializer abis(eosio_contract_abi(abi), abi_serializer::create_yield_function( max_serialization_time ));
 
@@ -571,7 +571,7 @@ BOOST_AUTO_TEST_CASE(std_array_types)
 BOOST_AUTO_TEST_CASE(uint_types)
 { try {
 
-   const char* currency_abi = R"=====(
+   const char* test_abi = R"=====(
    {
        "version": "eosio::abi/1.0",
        "types": [],
@@ -598,7 +598,7 @@ BOOST_AUTO_TEST_CASE(uint_types)
    }
    )=====";
 
-   auto abi = fc::json::from_string(currency_abi).as<abi_def>();
+   auto abi = fc::json::from_string(test_abi).as<abi_def>();
 
    abi_serializer abis(eosio_contract_abi(abi), abi_serializer::create_yield_function( max_serialization_time ));
 

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -530,6 +530,44 @@ fc::variant verify_type_round_trip_conversion( const abi_serializer& abis, const
 }
 )=====";
 
+BOOST_AUTO_TEST_CASE(std_array_types)
+{ try {
+
+   const char* currency_abi = R"=====(
+   {
+       "version": "eosio::abi/1.0",
+       "types": [],
+       "structs": [{
+           "name": "test",
+           "base": "",
+           "fields": [{
+               "name": "a",
+               "type": "uint8[5]"
+           }]
+       }],
+       "actions": [],
+       "tables": [],
+       "ricardian_clauses": []
+   }
+   )=====";
+
+   auto abi = fc::json::from_string(currency_abi).as<abi_def>();
+
+   abi_serializer abis(eosio_contract_abi(abi), abi_serializer::create_yield_function( max_serialization_time ));
+
+   const char* test_data = R"=====(
+   {
+     "a" : [1, 2, 3, 4, 5]
+   }
+   )=====";
+
+
+   auto var = fc::json::from_string(test_data);
+   verify_byte_round_trip_conversion(abi_serializer{std::move(abi), abi_serializer::create_yield_function( max_serialization_time )}, "test", var);
+
+} FC_LOG_AND_RETHROW() }
+
+
 BOOST_AUTO_TEST_CASE(uint_types)
 { try {
 


### PR DESCRIPTION
[partially] resolves #1931.

- add support for serialization of fixed size array types such as `uint8[5]`.
- [perf] add missing `reserve()` when deserializing a vector (or now an array), fix unnecessary copy in `vector<fc::variant> vars = var.get_array();`
- add tests (thanks to Kevin) for serialization of fixed size array types.