### PR TITLE
IF: Remove the Hotstuff "new block" message

### DIFF
--- a/libraries/chain/include/eosio/chain/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff.hpp
@@ -73,16 +73,11 @@ namespace eosio::chain {
       view_number get_view_number() const { return view_number(block_header::num_from_id(block_id), phase_counter); };
    };
 
-   struct hs_new_block_message {
-      block_id_type                block_id; //new proposal
-      quorum_certificate_message   justify; //justification
-   };
-
    struct hs_new_view_message {
       quorum_certificate_message   high_qc; //justification
    };
 
-   using hs_message = std::variant<hs_vote_message, hs_proposal_message, hs_new_block_message, hs_new_view_message>;
+   using hs_message = std::variant<hs_vote_message, hs_proposal_message, hs_new_view_message>;
 
    enum class hs_message_warning {
       discarded,               // default code for dropped messages (irrelevant, redundant, ...)
@@ -121,6 +116,5 @@ FC_REFLECT(eosio::chain::quorum_certificate_message, (proposal_id)(active_finali
 FC_REFLECT(eosio::chain::extended_schedule, (producer_schedule)(bls_pub_keys));
 FC_REFLECT(eosio::chain::hs_vote_message, (proposal_id)(finalizer_key)(sig));
 FC_REFLECT(eosio::chain::hs_proposal_message, (proposal_id)(block_id)(parent_id)(final_on_qc)(justify)(phase_counter));
-FC_REFLECT(eosio::chain::hs_new_block_message, (block_id)(justify));
 FC_REFLECT(eosio::chain::hs_new_view_message, (high_qc));
 FC_REFLECT(eosio::chain::finalizer_state, (chained_mode)(b_leaf)(b_lock)(b_exec)(b_finality_violation)(block_exec)(pending_proposal_block)(v_height)(high_qc)(current_qc)(schedule)(proposals));

--- a/libraries/hotstuff/include/eosio/hotstuff/base_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/base_pacemaker.hpp
@@ -33,13 +33,10 @@ namespace eosio::hotstuff {
       virtual chain::name get_next_leader() = 0;
       virtual const eosio::chain::finalizer_set& get_finalizer_set() = 0;
 
-
       //outbound communications; 'id' is the producer name (can be ignored if/when irrelevant to the implementer)
-
       virtual void send_hs_proposal_msg(const chain::hs_proposal_message& msg, const std::string& id, const std::optional<uint32_t>& exclude_peer = std::nullopt) = 0;
       virtual void send_hs_vote_msg(const chain::hs_vote_message& msg, const std::string& id, const std::optional<uint32_t>& exclude_peer = std::nullopt) = 0;
       virtual void send_hs_new_view_msg(const chain::hs_new_view_message& msg, const std::string& id, const std::optional<uint32_t>& exclude_peer = std::nullopt) = 0;
-      virtual void send_hs_new_block_msg(const chain::hs_new_block_message& msg, const std::string& id, const std::optional<uint32_t>& exclude_peer = std::nullopt) = 0;
 
       virtual void send_hs_message_warning(const uint32_t sender_peer, const chain::hs_message_warning code) = 0;
 

--- a/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/chain_pacemaker.hpp
@@ -45,7 +45,6 @@ namespace eosio::hotstuff {
       void send_hs_proposal_msg(const hs_proposal_message& msg, const std::string& id, const std::optional<uint32_t>& exclude_peer);
       void send_hs_vote_msg(const hs_vote_message& msg, const std::string& id, const std::optional<uint32_t>& exclude_peer);
       void send_hs_new_view_msg(const hs_new_view_message& msg, const std::string& id, const std::optional<uint32_t>& exclude_peer);
-      void send_hs_new_block_msg(const hs_new_block_message& msg, const std::string& id, const std::optional<uint32_t>& exclude_peer);
 
       void send_hs_message_warning(const uint32_t sender_peer, const chain::hs_message_warning code);
 
@@ -56,11 +55,7 @@ namespace eosio::hotstuff {
       void on_hs_proposal_msg(const uint32_t connection_id, const hs_proposal_message& msg); //consensus msg event handler
       void on_hs_vote_msg(const uint32_t connection_id, const hs_vote_message& msg); //confirmation msg event handler
       void on_hs_new_view_msg(const uint32_t connection_id, const hs_new_view_message& msg); //new view msg event handler
-      void on_hs_new_block_msg(const uint32_t connection_id, const hs_new_block_message& msg); //new block msg event handler
    private:
-
-      //FIXME/REMOVE: for testing/debugging only
-      name debug_leader_remap(name n);
 
       // This serializes all messages (high-level requests) to the qc_chain core.
       // For maximum safety, the qc_chain core will only process one request at a time.

--- a/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
@@ -27,9 +27,6 @@
 #include <exception>
 #include <stdexcept>
 
-// Enable this to swap the multi-index proposal store with std::map
-//#define QC_CHAIN_SIMPLE_PROPOSAL_STORE
-
 namespace eosio::hotstuff {
 
    template<typename StateObjectType> class state_db_manager {
@@ -175,11 +172,6 @@ namespace eosio::hotstuff {
       void on_hs_proposal_msg(const uint32_t connection_id, const hs_proposal_message& msg);
       void on_hs_new_view_msg(const uint32_t connection_id, const hs_new_view_message& msg);
 
-      // NOTE: The hotstuff New Block message is not ever propagated (multi-hop) by this method.
-      //       Unit tests do not use network topology emulation for this message.
-      //       The live network does not actually dispatch this message to the wire; this is a local callback.
-      void on_hs_new_block_msg(const uint32_t connection_id, const hs_new_block_message& msg);
-
    private:
 
       void write_safety_state_file();
@@ -201,7 +193,6 @@ namespace eosio::hotstuff {
       bool is_quorum_met(const quorum_certificate& qc, const hs_proposal_message& proposal);  //check if quorum has been met over a proposal
 
       hs_proposal_message new_proposal_candidate(const block_id_type& block_id, uint8_t phase_counter);
-      hs_new_block_message new_block_candidate(const block_id_type& block_id);
 
       bool am_i_proposer();
       bool am_i_leader();
@@ -211,7 +202,8 @@ namespace eosio::hotstuff {
       void process_proposal(const std::optional<uint32_t>& connection_id, const hs_proposal_message& msg);
       void process_vote(const std::optional<uint32_t>& connection_id, const hs_vote_message& msg);
       void process_new_view(const std::optional<uint32_t>& connection_id, const hs_new_view_message& msg);
-      void process_new_block(const std::optional<uint32_t>& connection_id, const hs_new_block_message& msg);
+
+      void create_proposal(const block_id_type& block_id);
 
       hs_vote_message sign_proposal(const hs_proposal_message& proposal, const fc::crypto::blslib::bls_public_key& finalizer_pub_key, const fc::crypto::blslib::bls_private_key& finalizer_priv_key);
 
@@ -234,7 +226,6 @@ namespace eosio::hotstuff {
       void send_hs_proposal_msg(const std::optional<uint32_t>& connection_id, const hs_proposal_message& msg);
       void send_hs_vote_msg(const std::optional<uint32_t>& connection_id, const hs_vote_message& msg);
       void send_hs_new_view_msg(const std::optional<uint32_t>& connection_id, const hs_new_view_message& msg);
-      void send_hs_new_block_msg(const std::optional<uint32_t>& connection_id, const hs_new_block_message& msg);
 
       void send_hs_message_warning(const std::optional<uint32_t>& connection_id, const chain::hs_message_warning code);
 
@@ -242,13 +233,6 @@ namespace eosio::hotstuff {
       void commit(const hs_proposal_message& proposal);
 
       void gc_proposals(uint64_t cutoff);
-
-      enum msg_type {
-         new_view = 1,
-         new_block = 2,
-         qc = 3,
-         vote = 4
-      };
 
       bool _chained_mode = false;
 
@@ -272,17 +256,6 @@ namespace eosio::hotstuff {
 
       fc::logger&            _logger;
 
-#ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
-      // keep one proposal store (id -> proposal) by each height (height -> proposal store)
-      typedef map<fc::sha256, hs_proposal_message> proposal_store;
-      typedef map<fc::sha256, hs_proposal_message>::iterator ps_iterator;
-      typedef map<uint64_t, proposal_store>::iterator ps_height_iterator;
-      map<uint64_t, proposal_store> _proposal_stores_by_height;
-
-      // get the height of a given proposal id
-      typedef map<fc::sha256, uint64_t>::iterator ph_iterator;
-      map<fc::sha256, uint64_t> _proposal_height;
-#else
       struct by_proposal_id{};
       struct by_proposal_height{};
 
@@ -301,7 +274,6 @@ namespace eosio::hotstuff {
          > proposal_store_type;
 
       proposal_store_type _proposal_store;  //internal proposals store
-#endif
 
       // Possible optimization: merge _proposal_store and _seen_votes_store.
       // Store a struct { set<name> seen_votes; hs_proposal_message p; } in the (now single) multi-index.

--- a/libraries/hotstuff/include/eosio/hotstuff/test_pacemaker.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/test_pacemaker.hpp
@@ -9,13 +9,12 @@ namespace eosio { namespace hotstuff {
    class test_pacemaker : public base_pacemaker {
    public:
 
-      using hotstuff_message = std::pair<std::string, std::variant<hs_proposal_message, hs_vote_message, hs_new_block_message, hs_new_view_message>>;
+      using hotstuff_message = std::pair<std::string, std::variant<hs_proposal_message, hs_vote_message, hs_new_view_message>>;
 
       enum hotstuff_message_index {
          hs_proposal  = 0,
          hs_vote      = 1,
-         hs_new_block = 2,
-         hs_new_view  = 3,
+         hs_new_view  = 2,
          hs_all_messages
       };
 
@@ -62,7 +61,6 @@ namespace eosio { namespace hotstuff {
       void on_hs_vote_msg(const hs_vote_message & msg, const std::string&  id); //confirmation msg event handler
       void on_hs_proposal_msg(const hs_proposal_message & msg, const std::string&  id); //consensus msg event handler
       void on_hs_new_view_msg(const hs_new_view_message & msg, const std::string&  id); //new view msg event handler
-      void on_hs_new_block_msg(const hs_new_block_message & msg, const std::string&  id); //new block msg event handler
 
       //base_pacemaker interface functions
 
@@ -77,7 +75,6 @@ namespace eosio { namespace hotstuff {
 
       void send_hs_proposal_msg(const hs_proposal_message & msg, const std::string& id, const std::optional<uint32_t>& exclude_peer);
       void send_hs_vote_msg(const hs_vote_message & msg, const std::string& id, const std::optional<uint32_t>& exclude_peer);
-      void send_hs_new_block_msg(const hs_new_block_message & msg, const std::string& id, const std::optional<uint32_t>& exclude_peer);
       void send_hs_new_view_msg(const hs_new_view_message & msg, const std::string& id, const std::optional<uint32_t>& exclude_peer);
 
       void send_hs_message_warning(const uint32_t sender_peer, const chain::hs_message_warning code);

--- a/libraries/hotstuff/qc_chain.cpp
+++ b/libraries/hotstuff/qc_chain.cpp
@@ -13,52 +13,17 @@ namespace eosio::hotstuff {
    }
 
    const hs_proposal_message* qc_chain::get_proposal(const fc::sha256& proposal_id) {
-#ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
-      if (proposal_id == NULL_PROPOSAL_ID)
-         return nullptr;
-      ph_iterator h_it = _proposal_height.find( proposal_id );
-      if (h_it == _proposal_height.end())
-         return nullptr;
-      uint64_t proposal_height = h_it->second;
-      ps_height_iterator psh_it = _proposal_stores_by_height.find( proposal_height );
-      if (psh_it == _proposal_stores_by_height.end())
-         return nullptr;
-      proposal_store & pstore = psh_it->second;
-      ps_iterator ps_it = pstore.find( proposal_id );
-      if (ps_it == pstore.end())
-         return nullptr;
-      const hs_proposal_message & proposal = ps_it->second;
-      return &proposal;
-#else
       proposal_store_type::nth_index<0>::type::iterator itr = _proposal_store.get<by_proposal_id>().find( proposal_id );
       if (itr == _proposal_store.get<by_proposal_id>().end())
          return nullptr;
       return &(*itr);
-#endif
    }
 
    bool qc_chain::insert_proposal(const hs_proposal_message& proposal) {
-#ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
-      uint64_t proposal_height = proposal.get_key();
-      ps_height_iterator psh_it = _proposal_stores_by_height.find( proposal_height );
-      if (psh_it == _proposal_stores_by_height.end()) {
-         _proposal_stores_by_height.emplace( proposal_height, proposal_store() );
-         psh_it = _proposal_stores_by_height.find( proposal_height );
-      }
-      proposal_store & pstore = psh_it->second;
-      const fc::sha256 & proposal_id = proposal.proposal_id;
-      ps_iterator ps_it = pstore.find( proposal_id );
-      if (ps_it != pstore.end())
-         return false; // duplicate proposal insertion, so don't change anything actually
-      _proposal_height.emplace( proposal_id, proposal_height );
-      pstore.emplace( proposal_id, proposal );
-      return true;
-#else
       if (get_proposal( proposal.proposal_id ) != nullptr)
          return false;
       _proposal_store.insert(proposal); //new proposal
       return true;
-#endif
    }
 
    void qc_chain::get_state(finalizer_state& fs) const {
@@ -72,18 +37,6 @@ namespace eosio::hotstuff {
       fs.v_height               = _safety_state.get_v_height();
       fs.high_qc                = _high_qc.to_msg();
       fs.current_qc             = _current_qc.to_msg();
-#ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
-      ps_height_iterator psh_it = _proposal_stores_by_height.begin();
-      while (psh_it != _proposal_stores_by_height.end()) {
-         proposal_store &pstore = psh_it->second;
-         ps_iterator ps_it = pstore.begin();
-         while (ps_it != pstore.end()) {
-            fs.proposals.insert( *ps_it );
-            ++ps_it;
-         }
-         ++psh_it;
-      }
-#else
       auto hgt_itr = _proposal_store.get<by_proposal_height>().begin();
       auto end_itr = _proposal_store.get<by_proposal_height>().end();
       while (hgt_itr != end_itr) {
@@ -91,7 +44,6 @@ namespace eosio::hotstuff {
          fs.proposals.emplace( p.proposal_id, p );
          ++hgt_itr;
       }
-#endif
    }
 
    uint32_t qc_chain::positive_bits_count(const hs_bitset& finalizers) {
@@ -178,13 +130,6 @@ namespace eosio::hotstuff {
       _current_qc.reset(proposal_id, 21); // TODO: use active schedule size
    }
 
-   hs_new_block_message qc_chain::new_block_candidate(const block_id_type& block_id) {
-      hs_new_block_message b;
-      b.block_id = block_id;
-      b.justify = _high_qc.to_msg(); //or null if no _high_qc upon activation or chain launch
-      return b;
-   }
-
    bool qc_chain::evaluate_quorum(const hs_bitset& finalizers, const fc::crypto::blslib::bls_signature& agg_sig, const hs_proposal_message& proposal) {
       if (positive_bits_count(finalizers) < _pacemaker->get_quorum_threshold()){
          return false;
@@ -217,7 +162,7 @@ namespace eosio::hotstuff {
       }
    }
 
-   qc_chain::qc_chain(std::string id, 
+   qc_chain::qc_chain(std::string id,
                       base_pacemaker* pacemaker,
                       std::set<name> my_producers,
                       bls_key_map_t finalizer_keys,
@@ -311,23 +256,12 @@ namespace eosio::hotstuff {
          return; //already aware of proposal, nothing to do
       }
 
-#ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
-      ps_height_iterator psh_it = _proposal_stores_by_height.find( proposal.get_key() );
-      if (psh_it != _proposal_stores_by_height.end())
-      {
-         proposal_store & pstore = psh_it->second;
-         ps_iterator ps_it = pstore.begin();
-         while (ps_it != pstore.end())
-         {
-            hs_proposal_message & existing_proposal = ps_it->second;
-#else
       //height is not necessarily unique, so we iterate over all prior proposals at this height
       auto hgt_itr = _proposal_store.get<by_proposal_height>().lower_bound( proposal.get_key() );
       auto end_itr = _proposal_store.get<by_proposal_height>().upper_bound( proposal.get_key() );
       while (hgt_itr != end_itr)
       {
          const hs_proposal_message & existing_proposal = *hgt_itr;
-#endif
          fc_elog(_logger, " *** ${id} received a different proposal at the same height (${block_num}, ${phase_counter})",
                            ("id",_id)
                            ("block_num", existing_proposal.block_num())
@@ -336,15 +270,8 @@ namespace eosio::hotstuff {
          fc_elog(_logger, " *** Proposal #1 : ${proposal_id_1} Proposal #2 : ${proposal_id_2}",
                            ("proposal_id_1", existing_proposal.proposal_id)
                            ("proposal_id_2", proposal.proposal_id));
-
-#ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
-            ++ps_it;
-         }
-      }
-#else
          hgt_itr++;
       }
-#endif
 
       fc_dlog(_logger, " === ${id} received new proposal : block_num ${block_num} phase ${phase_counter} : proposal_id ${proposal_id} : parent_id ${parent_id} justify ${justify}",
                      ("id", _id)
@@ -545,28 +472,7 @@ namespace eosio::hotstuff {
       }
    }
 
-   void qc_chain::process_new_block(const std::optional<uint32_t>& connection_id, const hs_new_block_message& msg){
-
-      // If I'm not a leader, I probably don't care about hs-new-block messages.
-#warning check for a need to gossip/rebroadcast even if it's not for us (maybe here, maybe somewhere else).
-      // TODO: check for a need to gossip/rebroadcast even if it's not for us (maybe here, maybe somewhere else).
-      if (! am_i_leader()) {
-         fc_tlog(_logger, " === ${id} process_new_block === discarding because I'm not the leader; block_id : ${bid}, justify : ${just}", ("bid", msg.block_id)("just", msg.justify)("id", _id));
-         return;
-      }
-
-      fc_tlog(_logger, " === ${id} process_new_block === am leader; block_id : ${bid}, justify : ${just}", ("bid", msg.block_id)("just", msg.justify)("id", _id));
-
-#warning What to do with the received msg.justify?
-      // ------------------------------------------------------------------
-      //
-      //   FIXME/REVIEW/TODO: What to do with the received msg.justify?
-      //
-      //   We are the leader, and we got a block_id from a proposer, but
-      //     we should probably do something with the justify QC that
-      //     comes with it (which is the _high_qc of the proposer (?))
-      //
-      // ------------------------------------------------------------------
+   void qc_chain::create_proposal(const block_id_type& block_id) {
 
       auto increment_version = fc::make_scoped_exit([this]() { ++_state_version; });
 
@@ -577,8 +483,8 @@ namespace eosio::hotstuff {
                         ("proposal_id", _current_qc.get_proposal_id())
                         ("quorum_met", _current_qc.is_quorum_met()));
 
-         fc_tlog(_logger, " === ${id} setting _pending_proposal_block to ${block_id} (on_beat)", ("id", _id)("block_id", msg.block_id));
-         _pending_proposal_block = msg.block_id;
+         fc_tlog(_logger, " === ${id} setting _pending_proposal_block to ${block_id} (create_proposal)", ("id", _id)("block_id", block_id));
+         _pending_proposal_block = block_id;
 
       } else {
 
@@ -586,11 +492,11 @@ namespace eosio::hotstuff {
                         ("id", _id)
                         ("proposal_id", _current_qc.get_proposal_id())
                         ("quorum_met", _current_qc.is_quorum_met()));
-         hs_proposal_message proposal_candidate = new_proposal_candidate( msg.block_id, 0 );
+         hs_proposal_message proposal_candidate = new_proposal_candidate( block_id, 0 );
 
          reset_qc(proposal_candidate.proposal_id);
 
-         fc_tlog(_logger, " === ${id} setting _pending_proposal_block to null (process_new_block)", ("id", _id));
+         fc_tlog(_logger, " === ${id} setting _pending_proposal_block to null (create_proposal)", ("id", _id));
 
          _pending_proposal_block = {};
          _b_leaf = proposal_candidate.proposal_id;
@@ -600,7 +506,7 @@ namespace eosio::hotstuff {
 
          send_hs_proposal_msg( std::nullopt, proposal_candidate );
 
-         fc_tlog(_logger, " === ${id} _b_leaf updated (on_beat): ${proposal_id}", ("proposal_id", proposal_candidate.proposal_id)("id", _id));
+         fc_tlog(_logger, " === ${id} _b_leaf updated (create_proposal): ${proposal_id}", ("proposal_id", proposal_candidate.proposal_id)("id", _id));
       }
    }
 
@@ -621,11 +527,6 @@ namespace eosio::hotstuff {
    void qc_chain::send_hs_new_view_msg(const std::optional<uint32_t>& connection_id, const hs_new_view_message & msg){
       fc_tlog(_logger, " === broadcast_hs_new_view ===");
       _pacemaker->send_hs_new_view_msg(msg, _id, connection_id);
-   }
-
-   void qc_chain::send_hs_new_block_msg(const std::optional<uint32_t>& connection_id, const hs_new_block_message & msg){
-      fc_tlog(_logger, " === broadcast_hs_new_block ===");
-      _pacemaker->send_hs_new_block_msg(msg, _id, connection_id);
    }
 
    void qc_chain::send_hs_message_warning(const std::optional<uint32_t>& connection_id, const chain::hs_message_warning code) {
@@ -668,40 +569,16 @@ namespace eosio::hotstuff {
    // Invoked when we could perhaps make a proposal to the network (or to ourselves, if we are the leader).
    void qc_chain::on_beat(){
 
-      // Non-proposing leaders do not care about on_beat(), because leaders react to a block proposal
-      //   which comes from processing an incoming new block message from a proposer instead.
-      // on_beat() is called by the pacemaker, which decides when it's time to check whether we are
-      //   proposers that should check whether as proposers we should propose a new hotstuff block to
-      //   the network (or to ourselves, which is faster and doesn't require the bandwidth of an additional
-      //   gossip round for a new proposed block).
-      // The current criteria for a leader selecting a proposal among all proposals it receives is to go
-      //   with the first valid one that it receives. So if a proposer is also a leader, it silently goes
-      //   with its own proposal, which is hopefully valid at the point of generation which is also the
-      //   point of consumption.
-      //
-      if (! am_i_proposer())
+      // only proposer-leaders do on_beat, which is to create a proposal
+      if (!am_i_proposer() || !am_i_leader())
          return;
 
       block_id_type current_block_id = _pacemaker->get_current_block_id();
 
-      hs_new_block_message block_candidate = new_block_candidate( current_block_id );
+      // NOTE: This would be the "justify" of the proposal that is being created
+      // _high_qc.to_msg(); //or null if no _high_qc upon activation or chain launch
 
-      if (am_i_leader()) {
-
-         // I am the proposer; so this assumes that no additional proposal validation is required.
-
-         fc_tlog(_logger, " === I am a leader-proposer that is proposing a block for itself to lead");
-         // Hardwired consumption by self; no networking.
-         process_new_block( std::nullopt, block_candidate );
-
-      } else {
-
-         // I'm only a proposer and not the leader; send a new-block-proposal message out to
-         //   the network, until it reaches the leader.
-
-         fc_tlog(_logger, " === broadcasting new block = #${block_num} ${proposal_id}", ("proposal_id", block_candidate.block_id)("block_num",(block_header::num_from_id(block_candidate.block_id))));
-         send_hs_new_block_msg( std::nullopt, block_candidate );
-      }
+      create_proposal(current_block_id);
    }
 
    // returns true on state change (caller decides update on state version
@@ -900,11 +777,6 @@ namespace eosio::hotstuff {
       process_new_view( std::optional<uint32_t>(connection_id), msg );
    }
 
-   //on new block received, called from network thread
-   void qc_chain::on_hs_new_block_msg(const uint32_t connection_id, const hs_new_block_message& msg) {
-      process_new_block( std::optional<uint32_t>(connection_id), msg );
-   }
-
    void qc_chain::update(const hs_proposal_message& proposal) {
       //fc_tlog(_logger, " === update internal state ===");
       //if proposal has no justification, means we either just activated the feature or launched the chain, or the proposal is invalid
@@ -1030,30 +902,6 @@ namespace eosio::hotstuff {
       auto& seen_votes_index = _seen_votes_store.get<by_seen_votes_proposal_height>();
       seen_votes_index.erase(seen_votes_index.begin(), seen_votes_index.upper_bound(cutoff));
 
-#ifdef QC_CHAIN_SIMPLE_PROPOSAL_STORE
-      ps_height_iterator psh_it = _proposal_stores_by_height.begin();
-      while (psh_it != _proposal_stores_by_height.end()) {
-         uint64_t height = psh_it->first;
-         if (height <= cutoff) {
-            // remove all entries from _proposal_height for this proposal store
-            proposal_store & pstore = psh_it->second;
-            ps_iterator ps_it = pstore.begin();
-            while (ps_it != pstore.end()) {
-               hs_proposal_message & p = ps_it->second;
-               ph_iterator ph_it = _proposal_height.find( p.proposal_id );
-               EOS_ASSERT( ph_it != _proposal_height.end(), chain_exception, "gc_proposals internal error: no proposal height entry");
-               uint64_t proposal_height = ph_it->second;
-               EOS_ASSERT(proposal_height == p.get_key(), chain_exception, "gc_proposals internal error: mismatched proposal height record"); // this check is unnecessary
-               _proposal_height.erase( ph_it );
-               ++ps_it;
-            }
-            // then remove the entire proposal store
-            psh_it = _proposal_stores_by_height.erase( psh_it );
-         } else {
-            ++psh_it;
-         }
-      }
-#else
       auto end_itr = _proposal_store.get<by_proposal_height>().upper_bound(cutoff);
       while (_proposal_store.get<by_proposal_height>().begin() != end_itr){
          auto itr = _proposal_store.get<by_proposal_height>().begin();
@@ -1065,13 +913,12 @@ namespace eosio::hotstuff {
                         ("proposal_id", itr->proposal_id));
          _proposal_store.get<by_proposal_height>().erase(itr);
       }
-#endif
    }
 
 void qc_chain::commit(const hs_proposal_message& initial_proposal) {
    std::vector<const hs_proposal_message*> proposal_chain;
    proposal_chain.reserve(10);
-   
+
    const hs_proposal_message* p = &initial_proposal;
    while (p) {
       fc_tlog(_logger, " === attempting to commit proposal #${block_num}:${phase} ${prop_id} block_id: ${block_id} parent_id: ${parent_id}",

--- a/libraries/hotstuff/test/test_hotstuff.cpp
+++ b/libraries/hotstuff/test/test_hotstuff.cpp
@@ -86,22 +86,19 @@ public:
    void print_msgs(std::vector<test_pacemaker::hotstuff_message> msgs ){
       size_t proposals_count = 0;
       size_t votes_count = 0;
-      size_t new_blocks_count = 0;
       size_t new_views_count = 0;
       auto msg_itr = msgs.begin();
-      while (msg_itr!=msgs.end()){
+      while (msg_itr!=msgs.end()) {
          size_t v_index = msg_itr->second.index();
-         if(v_index==0) proposals_count++;
-         if(v_index==1) votes_count++;
-         if(v_index==2) new_blocks_count++;
-         if(v_index==3) new_views_count++;
+         if (v_index == 0) proposals_count++;
+         else if (v_index == 1) votes_count++;
+         else if (v_index == 2) new_views_count++;
          msg_itr++;
       }
       std::cout << "\n";
       std::cout << "  message queue size : " << msgs.size() << "\n";
       std::cout << "    proposals : " << proposals_count << "\n";
       std::cout << "    votes : " << votes_count << "\n";
-      std::cout << "    new_blocks : " << new_blocks_count << "\n";
       std::cout << "    new_views : " << new_views_count << "\n";
       std::cout << "\n";
    }
@@ -897,128 +894,6 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
 
    BOOST_CHECK_EQUAL(fs_bpe.b_finality_violation.str(), std::string("5585accc44c753636d1381067c7f915d7fff2d33846aae04820abc055d952860"));
-
-} FC_LOG_AND_RETHROW();
-
- BOOST_AUTO_TEST_CASE(hotstuff_6) try {
-
-   //test simple separation between the (single) proposer and the leader; includes one leader rotation
-   test_pacemaker tpm;
-   tpm.connect(unique_replica_keys); // complete connection graph
-
-   hotstuff_test_handler ht;
-   std::vector<fc::crypto::blslib::bls_private_key> sks = map_to_sks(unique_replica_keys);
-   finalizer_set fset = create_fs(unique_replica_keys);
-
-   ht.initialize_qc_chains(tpm, unique_replicas, sks);
-   tpm.set_proposer("bpg"_n);
-   tpm.set_leader("bpa"_n);
-   tpm.set_next_leader("bpa"_n);
-   tpm.set_finalizer_set(fset);
-
-   auto qcc_bpa = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpa"_n; });
-   finalizer_state fs_bpa;
-   qcc_bpa->second->get_state(fs_bpa);
-   auto qcc_bpb = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpb"_n; });
-   finalizer_state fs_bpb;
-   qcc_bpb->second->get_state(fs_bpb);
-   auto qcc_bpc = std::find_if(ht._qc_chains.begin(), ht._qc_chains.end(), [&](const auto& q){ return q.first == "bpc"_n; });
-   finalizer_state fs_bpc;
-   qcc_bpc->second->get_state(fs_bpc);
-
-   tpm.set_current_block_id(ids[0]); //first block
-   tpm.beat(); //produce first block
-   tpm.dispatch(""); //get the first block from the proposer to the leader
-   tpm.dispatch(""); //send proposal to replicas (prepare on first block)
-
-   qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-
-   tpm.dispatch(""); //send votes on proposal (prepareQC on first block)
-   tpm.dispatch(""); //send proposal to replicas (precommit on first block)
-
-   qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-
-   tpm.dispatch(""); //propagating votes on new proposal (precommitQC on first block)
-   tpm.dispatch(""); //send proposal to replicas (commit on first block)
-
-   qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
-
-   tpm.set_next_leader("bpb"_n); //leader is set to rotate on next block
-   tpm.dispatch(""); //propagating votes on new proposal (commitQC on first block)
-   tpm.dispatch(""); //send proposal to replicas (decide on first block)
-
-   qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-
-   tpm.dispatch(""); //propagating votes on new proposal (decide on first block)
-   tpm.set_proposer("bpm"_n); // can be any proposer that's not the leader for this test
-   tpm.set_leader("bpb"_n);   //leader has rotated
-   tpm.set_current_block_id(ids[1]); //second block
-   tpm.beat(); //produce second block
-   tpm.dispatch(""); //get the second block from the proposer to the leader
-   tpm.dispatch(""); //send proposal to replicas (prepare on second block)
-
-   qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
-
-   tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
-   tpm.dispatch(""); //send proposal to replicas (precommit on second block)
-
-   qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-
-   tpm.dispatch(""); //propagating votes on new proposal (precommitQC on second block)
-   tpm.dispatch(""); //send proposal to replicas (commit on second block)
-
-   qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-
-   tpm.dispatch(""); //propagating votes on new proposal (commitQC on second block)
-   tpm.dispatch(""); //send proposal to replicas (decide on second block)
-
-   qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("89f468a127dbadd81b59076067238e3e9c313782d7d83141b16d9da4f2c2b078"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-
-   //check bpa as well
-   qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-
-   //check bpc as well
-   qcc_bpc->second->get_state(fs_bpc);
-   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-
-   BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
 } FC_LOG_AND_RETHROW();
 


### PR DESCRIPTION
This addresses the first part (1 of 2) of #1910 

The "new block" message implements the separation between proposers and leaders, which is not supported in Leap 6, so it is being removed.

Also removed some dead code.