### PR TITLE
IF: remove event-driven mode 

### DIFF
--- a/libraries/chain/include/eosio/chain/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff.hpp
@@ -87,7 +87,6 @@ namespace eosio::chain {
    };
 
    struct finalizer_state {
-      bool chained_mode = false;
       fc::sha256 b_leaf;
       fc::sha256 b_lock;
       fc::sha256 b_exec;
@@ -117,4 +116,4 @@ FC_REFLECT(eosio::chain::extended_schedule, (producer_schedule)(bls_pub_keys));
 FC_REFLECT(eosio::chain::hs_vote_message, (proposal_id)(finalizer_key)(sig));
 FC_REFLECT(eosio::chain::hs_proposal_message, (proposal_id)(block_id)(parent_id)(final_on_qc)(justify)(phase_counter));
 FC_REFLECT(eosio::chain::hs_new_view_message, (high_qc));
-FC_REFLECT(eosio::chain::finalizer_state, (chained_mode)(b_leaf)(b_lock)(b_exec)(b_finality_violation)(block_exec)(pending_proposal_block)(v_height)(high_qc)(current_qc)(schedule)(proposals));
+FC_REFLECT(eosio::chain::finalizer_state, (b_leaf)(b_lock)(b_exec)(b_finality_violation)(block_exec)(pending_proposal_block)(v_height)(high_qc)(current_qc)(schedule)(proposals));

--- a/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
+++ b/libraries/hotstuff/include/eosio/hotstuff/qc_chain.hpp
@@ -234,8 +234,6 @@ namespace eosio::hotstuff {
 
       void gc_proposals(uint64_t cutoff);
 
-      bool _chained_mode = false;
-
       block_id_type _block_exec;
       block_id_type _pending_proposal_block;
       safety_state _safety_state;

--- a/libraries/hotstuff/qc_chain.cpp
+++ b/libraries/hotstuff/qc_chain.cpp
@@ -27,7 +27,6 @@ namespace eosio::hotstuff {
    }
 
    void qc_chain::get_state(finalizer_state& fs) const {
-      fs.chained_mode           = _chained_mode;
       fs.b_leaf                 = _b_leaf;
       fs.b_lock                 = _safety_state.get_b_lock();
       fs.b_exec                 = _b_exec;
@@ -428,30 +427,6 @@ namespace eosio::hotstuff {
 
             //check for leader change
             leader_rotation_check();
-
-            //if we're operating in event-driven mode and the proposal hasn't reached the decide phase yet
-            if (_chained_mode == false && p->phase_counter < 3) {
-               fc_tlog(_logger, " === ${id} phase increment on proposal ${proposal_id}", ("proposal_id", vote.proposal_id)("id", _id));
-               hs_proposal_message proposal_candidate;
-
-               if (_pending_proposal_block.empty())
-                  proposal_candidate = new_proposal_candidate( p->block_id, p->phase_counter + 1 );
-               else
-                  proposal_candidate = new_proposal_candidate( _pending_proposal_block, 0 );
-
-               reset_qc(proposal_candidate.proposal_id);
-               fc_tlog(_logger, " === ${id} setting _pending_proposal_block to null (process_vote)", ("id", _id));
-
-               _pending_proposal_block = {};
-               _b_leaf = proposal_candidate.proposal_id;
-
-               //todo : asynchronous?
-               //write_state(_liveness_state_file , _liveness_state);
-
-               send_hs_proposal_msg( std::nullopt, proposal_candidate );
-
-               fc_tlog(_logger, " === ${id} _b_leaf updated (process_vote): ${proposal_id}", ("proposal_id", proposal_candidate.proposal_id)("id", _id));
-            }
          }
       }
 

--- a/libraries/hotstuff/test/test_hotstuff.cpp
+++ b/libraries/hotstuff/test/test_hotstuff.cpp
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_1) try {
    tpm.dispatch(""); //send proposal to replicas (precommit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
@@ -243,19 +243,19 @@ BOOST_AUTO_TEST_CASE(hotstuff_1) try {
    tpm.dispatch(""); //send proposal to replicas (commit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on first block)
    tpm.dispatch(""); //send proposal to replicas (decide on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (decide on first block)
 
@@ -266,51 +266,51 @@ BOOST_AUTO_TEST_CASE(hotstuff_1) try {
    tpm.dispatch(""); //send proposal to replicas (prepare on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
    tpm.dispatch(""); //send proposal to replicas (precommit on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on second block)
    tpm.dispatch(""); //send proposal to replicas (commit on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on second block)
    tpm.dispatch(""); //send proposal to replicas (decide on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send proposal to replicas (decide on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpb as well
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));/**/
 
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
    tpm.dispatch(""); //send proposal to replicas (precommit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
@@ -364,44 +364,44 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
    tpm.dispatch(""); //send proposal to replicas (prepare on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
    tpm.dispatch(""); //send proposal to replicas (precommit on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.set_current_block_id(ids[2]); //second block
    tpm.beat(); //produce third block and associated proposal
    tpm.dispatch(""); //propagating votes on new proposal (prepare on third block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("e297a3ea4cbacde037f796dfef36bfbeabc38e3c22cf35fab663e13e59ad9534"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on third block)
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on third block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("0d77972a81cefce394736f23f8b4d97de3af5bd160376626bdd6a77de89ee324"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("e297a3ea4cbacde037f796dfef36bfbeabc38e3c22cf35fab663e13e59ad9534"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("e297a3ea4cbacde037f796dfef36bfbeabc38e3c22cf35fab663e13e59ad9534"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpb as well
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
    tpm.dispatch(""); //send proposal to replicas (precommit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
@@ -456,9 +456,9 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
    tpm.dispatch(""); //send proposal to replicas (commit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.set_next_leader("bpb"_n); //leader is set to rotate on next block
@@ -467,10 +467,10 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
    tpm.dispatch(""); //send proposal to replicas (decide on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (decide on first block)
    tpm.set_proposer("bpb"_n); //leader has rotated
@@ -480,49 +480,49 @@ BOOST_AUTO_TEST_CASE(hotstuff_2) try {
    tpm.dispatch(""); //send proposal to replicas (prepare on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
    tpm.dispatch(""); //send proposal to replicas (precommit on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on second block)
    tpm.dispatch(""); //send proposal to replicas (commit on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on second block)
    tpm.dispatch(""); //send proposal to replicas (decide on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("89f468a127dbadd81b59076067238e3e9c313782d7d83141b16d9da4f2c2b078"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpa as well
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpc as well
    qcc_bpc->second->get_state(fs_bpc);
-   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
    tpm.dispatch(""); //send proposal to replicas (precommit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
@@ -584,18 +584,18 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
    tpm.dispatch(""); //send proposal to replicas (commit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.set_next_leader("bpi"_n); //leader is set to rotate on next block
    tpm.dispatch(""); //propagating votes on new proposal (insufficient to reach quorum)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.activate("bpb"_n);
@@ -613,9 +613,9 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
    tpm.dispatch(""); //send proposal to replicas (prepare on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
@@ -623,20 +623,20 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
 
 //ht.print_bp_state("bpa"_n, "");
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on second block)
    tpm.dispatch(""); //send proposal to replicas (commit on second block)
 
 //ht.print_bp_state("bpa"_n, "");
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on second block)
    tpm.dispatch(""); //send proposal to replicas (decide on second block)
@@ -644,23 +644,23 @@ BOOST_AUTO_TEST_CASE(hotstuff_4) try {
 //ht.print_bp_state("bpa"_n, "");
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
 //ht.print_bp_state("bpb"_n, "");
    //check bpa as well
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
 //ht.print_bp_state("bpi"_n, "");
    qcc_bpi->second->get_state(fs_bpi);
-   BOOST_CHECK_EQUAL(fs_bpi.high_qc.proposal_id.str(), std::string("747676c95a4c866c915ab2d2171dbcaf126a4f0aeef62bf9720c138f8e03add9"));
-   BOOST_CHECK_EQUAL(fs_bpi.b_lock.str(), std::string("f1cc5d8add3db0c0f13271815c4e08eec5e8730b0e3ba24ab7b7990981b9b338"));
-   BOOST_CHECK_EQUAL(fs_bpi.b_exec.str(), std::string("a56ae5316e731168f5cfea5a85ffa3467b29094c2e5071019a1b89cd7fa49d98"));
+   BOOST_CHECK_EQUAL(fs_bpi.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpi.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpi.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
@@ -801,7 +801,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    tpm2.dispatch("");
 
    qcc_bpe->second->get_state(fs_bpe);
-   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
@@ -812,9 +812,9 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    tpm2.dispatch("");
 
    qcc_bpe->second->get_state(fs_bpe);
-   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm1.dispatch("");
@@ -823,10 +823,10 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    tpm2.dispatch("");
 
    qcc_bpe->second->get_state(fs_bpe);
-   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm1.dispatch("");
    tpm1.dispatch("");
@@ -834,10 +834,10 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    tpm2.dispatch("");
 
    qcc_bpe->second->get_state(fs_bpe);
-   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm1.set_current_block_id(ids[1]); //first block
    tpm2.set_current_block_id(alternate_ids[1]); //first block
@@ -852,10 +852,10 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    tpm1.dispatch("");
 
    qcc_bpe->second->get_state(fs_bpe);
-   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm1.pipe(tpm2.dispatch(""));
    tpm1.dispatch("");
@@ -864,10 +864,10 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    tpm1.dispatch("");
 
    qcc_bpe->second->get_state(fs_bpe);
-   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm1.pipe(tpm2.dispatch(""));
    tpm1.dispatch("");
@@ -876,10 +876,10 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    tpm1.dispatch("");
 
    qcc_bpe->second->get_state(fs_bpe);
-   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm1.pipe(tpm2.dispatch(""));
    tpm1.dispatch("");
@@ -888,12 +888,12 @@ BOOST_AUTO_TEST_CASE(hotstuff_5) try {
    tpm1.dispatch("");
 
    qcc_bpe->second->get_state(fs_bpe);
-   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpe.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
-   BOOST_CHECK_EQUAL(fs_bpe.b_finality_violation.str(), std::string("5585accc44c753636d1381067c7f915d7fff2d33846aae04820abc055d952860"));
+   BOOST_CHECK_EQUAL(fs_bpe.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
 } FC_LOG_AND_RETHROW();
 
@@ -944,7 +944,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_7) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (precommit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
@@ -954,9 +954,9 @@ BOOST_AUTO_TEST_CASE(hotstuff_7) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (commit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.set_next_leader("bpb"_n); //leader is set to rotate on next block
@@ -966,10 +966,10 @@ BOOST_AUTO_TEST_CASE(hotstuff_7) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (decide on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_vote); //propagating votes on new proposal (decide on first block)
 
@@ -983,52 +983,52 @@ BOOST_AUTO_TEST_CASE(hotstuff_7) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (prepare on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_vote); //send votes on proposal (prepareQC on second block)
 
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (precommit on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_vote); //propagating votes on new proposal (precommitQC on second block)
 
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (commit on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_vote); //propagating votes on new proposal (commitQC on second block)
 
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (decide on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("89f468a127dbadd81b59076067238e3e9c313782d7d83141b16d9da4f2c2b078"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpa as well
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpc as well
    qcc_bpc->second->get_state(fs_bpc);
-   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
@@ -1087,7 +1087,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_8) try {
    tpm.dispatch(""); //send proposal to replicas (precommit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
@@ -1097,9 +1097,9 @@ BOOST_AUTO_TEST_CASE(hotstuff_8) try {
    tpm.dispatch(""); //send proposal to replicas (commit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on first block)
@@ -1107,10 +1107,10 @@ BOOST_AUTO_TEST_CASE(hotstuff_8) try {
    tpm.dispatch(""); //send proposal to replicas (decide on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (decide on first block)
 
@@ -1121,54 +1121,54 @@ BOOST_AUTO_TEST_CASE(hotstuff_8) try {
    tpm.dispatch(""); //send proposal to replicas (prepare on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send votes on proposal (prepareQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (precommit on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (precommitQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (commit on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //propagating votes on new proposal (commitQC on second block)
 
    tpm.dispatch(""); //send proposal to replicas (decide on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.dispatch(""); //send proposal to replicas (decide on second block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("9eeffb58a16133517d8d2f6f90b8a3420269de3356362677055b225a44a7c151"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpb as well
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("ab04f499892ad5ebd209d54372fd5c0bda0288410a084b55c70eda40514044f3"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("4af7c22e5220a61ac96c35533539e65d398e9f44de4c6e11b5b0279e7a79912f"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a8c84b7f9613aebf2ae34f457189d58de95a6b0a50d103a4c9e6405180d6fffb"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
@@ -1220,7 +1220,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_9) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (precommit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
@@ -1230,9 +1230,9 @@ BOOST_AUTO_TEST_CASE(hotstuff_9) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (commit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09")); //4b4
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));//a250
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));//00
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8")); //4b4
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));//a250
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));//00
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.set_next_leader("bpb"_n); //leader is set to rotate on next block
@@ -1243,10 +1243,10 @@ BOOST_AUTO_TEST_CASE(hotstuff_9) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (decide on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_new_view);
    ht.dispatch(tpm, test_pacemaker::hs_vote); //propagating votes on new proposal (decide on first block)
@@ -1261,52 +1261,52 @@ BOOST_AUTO_TEST_CASE(hotstuff_9) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (prepare on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_vote); //send votes on proposal (prepareQC on second block)
 
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (precommit on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_vote); //propagating votes on new proposal (precommitQC on second block)
 
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (commit on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_vote); //propagating votes on new proposal (commitQC on second block)
 
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (decide on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("89f468a127dbadd81b59076067238e3e9c313782d7d83141b16d9da4f2c2b078"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpa as well
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpc as well
    qcc_bpc->second->get_state(fs_bpc);
-   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
@@ -1381,7 +1381,7 @@ BOOST_AUTO_TEST_CASE(hotstuff_10) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (precommit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
    BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
@@ -1391,9 +1391,9 @@ BOOST_AUTO_TEST_CASE(hotstuff_10) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (commit on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
    BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    tpm.set_next_leader("bpb"_n); //leader is set to rotate on next block
@@ -1404,10 +1404,10 @@ BOOST_AUTO_TEST_CASE(hotstuff_10) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (decide on first block)
 
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("487e5fcbf2c515618941291ae3b6dcebb68942983d8ac3f61c4bdd9901dadbe7"));
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_leaf.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_new_view);
    ht.dispatch(tpm, test_pacemaker::hs_vote); //propagating votes on new proposal (decide on first block)
@@ -1422,52 +1422,52 @@ BOOST_AUTO_TEST_CASE(hotstuff_10) try {
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (prepare on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_vote); //send votes on proposal (prepareQC on second block)
 
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (precommit on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("4b43fb144a8b5e874777f61f3b37d7a8b06c33fbc48db464ce0e8788ff4edb4f"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_vote); //propagating votes on new proposal (precommitQC on second block)
 
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (commit on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("aedf8bb1ee70bd6e743268f7fe0f8171418aa43a68bb9c6e7329ffa856896c09"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    ht.dispatch(tpm, test_pacemaker::hs_vote); //propagating votes on new proposal (commitQC on second block)
 
    ht.dispatch(tpm, test_pacemaker::hs_proposal); //send proposal to replicas (decide on second block)
 
    qcc_bpb->second->get_state(fs_bpb);
-   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("89f468a127dbadd81b59076067238e3e9c313782d7d83141b16d9da4f2c2b078"));
-   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_leaf.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.high_qc.proposal_id.str(), std::string("848b788b0140cec9c40893b4d1ba1eef238e8e6986212d9d7e7daaba844a2097"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpb.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpa as well
    qcc_bpa->second->get_state(fs_bpa);
-   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpa.high_qc.proposal_id.str(), std::string("a252070cd26d3b231ab2443b9ba97f57fc72e50cca04a020952e45bc7e2d27a8"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpa.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    //check bpc as well
    qcc_bpc->second->get_state(fs_bpc);
-   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("fd77164bf3898a6a8f27ccff440d17ef6870e75c368fcc93b969066cec70939c"));
-   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("6462add7d157da87931c859cb689f722003a20f30c0f1408d11b872020903b85"));
-   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("1511035fdcbabdc5e272a3ac19356536252884ed77077cf871ae5029a7502279"));
+   BOOST_CHECK_EQUAL(fs_bpc.high_qc.proposal_id.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_lock.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
+   BOOST_CHECK_EQUAL(fs_bpc.b_exec.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 
    BOOST_CHECK_EQUAL(fs_bpa.b_finality_violation.str(), std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2665,7 +2665,6 @@ read_only::get_finalizer_state(const get_finalizer_state_params&, const fc::time
    if ( chain_pacemaker ) {  // is null when called from chain_plugin_tests.cpp and get_table_tests.cpp
       finalizer_state fs;
       chain_pacemaker->get_state( fs );
-      results.chained_mode           = fs.chained_mode;
       results.b_leaf                 = fs.b_leaf;
       results.b_lock                 = fs.b_lock;
       results.b_exec                 = fs.b_exec;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -858,7 +858,6 @@ public:
 
    using get_finalizer_state_params = empty;
    struct get_finalizer_state_results {
-      bool chained_mode = false;
       fc::sha256 b_leaf;
       fc::sha256 b_lock;
       fc::sha256 b_exec;
@@ -1132,4 +1131,4 @@ FC_REFLECT( eosio::chain_apis::read_only::send_read_only_transaction_params, (tr
 FC_REFLECT( eosio::chain_apis::read_only::send_read_only_transaction_results, (transaction_id)(processed) )
 FC_REFLECT( eosio::chain_apis::read_only::get_consensus_parameters_results, (chain_config)(wasm_config))
 FC_REFLECT( eosio::chain_apis::read_only::hs_complete_proposal_message, (proposal_id)(block_id)(parent_id)(final_on_qc)(justify)(phase_counter)(block_height)(view_number))
-FC_REFLECT( eosio::chain_apis::read_only::get_finalizer_state_results, (chained_mode)(b_leaf)(b_lock)(b_exec)(b_finality_violation)(block_exec)(pending_proposal_block)(v_height)(high_qc)(current_qc)(schedule)(proposals))
+FC_REFLECT( eosio::chain_apis::read_only::get_finalizer_state_results, (b_leaf)(b_lock)(b_exec)(b_finality_violation)(block_exec)(pending_proposal_block)(v_height)(high_qc)(current_qc)(schedule)(proposals))


### PR DESCRIPTION
- chained_mode variable removed
- removed (chained_mode == false) code path in qc_chain::process_vote()
- fixed asserts in test_hotstuff.cpp to reflect chained mode outcome, without modifying test logic (this reduces test coverage, which will be restored later)

This is part of the work for #1910 . It's not a blocker for solving the whole issue, but I wanted this to be a discrete PR.