### PR TITLE
IF: Add a incremental merkle tree that does not do left/right bit flip

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1883,14 +1883,14 @@ struct controller_impl {
 
       auto action_merkle_fut = post_async_task( thread_pool.get_executor(),
                                                 [ids{std::move( bb._action_receipt_digests )}]() mutable {
-                                                   return merkle( std::move( ids ) );
+                                                   return canonical_merkle( std::move( ids ) );
                                                 } );
       const bool calc_trx_merkle = !std::holds_alternative<checksum256_type>(bb._trx_mroot_or_receipt_digests);
       std::future<checksum256_type> trx_merkle_fut;
       if( calc_trx_merkle ) {
          trx_merkle_fut = post_async_task( thread_pool.get_executor(),
                                            [ids{std::move( std::get<digests_t>(bb._trx_mroot_or_receipt_digests) )}]() mutable {
-                                              return merkle( std::move( ids ) );
+                                              return canonical_merkle( std::move( ids ) );
                                            } );
       }
 
@@ -2465,7 +2465,7 @@ struct controller_impl {
       for( const auto& a : trxs )
          trx_digests.emplace_back( a.digest() );
 
-      return merkle( std::move(trx_digests) );
+      return canonical_merkle( std::move(trx_digests) );
    }
 
    void update_producers_authority() {

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -30,7 +30,7 @@ namespace legacy {
       uint32_t                             dpos_proposed_irreversible_blocknum = 0;
       uint32_t                             dpos_irreversible_blocknum = 0;
       producer_schedule_type               active_schedule;
-      incremental_merkle                   blockroot_merkle;
+      incremental_canonical_merkle         blockroot_merkle;
       flat_map<account_name,uint32_t>      producer_to_last_produced;
       flat_map<account_name,uint32_t>      producer_to_last_implied_irb;
       public_key_type                      block_signing_key;
@@ -59,7 +59,7 @@ namespace detail {
       uint32_t                          dpos_irreversible_blocknum = 0;
       producer_authority_schedule       active_schedule;
       uint32_t                          last_proposed_finalizer_set_generation = 0; // TODO: Add to snapshot_block_header_state_v3
-      incremental_merkle                blockroot_merkle;
+      incremental_canonical_merkle      blockroot_merkle;
       flat_map<account_name,uint32_t>   producer_to_last_produced;
       flat_map<account_name,uint32_t>   producer_to_last_implied_irb;
       block_signing_authority           valid_block_signing_authority;

--- a/libraries/chain/include/eosio/chain/merkle.hpp
+++ b/libraries/chain/include/eosio/chain/merkle.hpp
@@ -17,6 +17,6 @@ namespace eosio { namespace chain {
    /**
     *  Calculates the merkle root of a set of digests, if ids is odd it will duplicate the last id.
     */
-   digest_type merkle( deque<digest_type> ids );
+   digest_type canonical_merkle( deque<digest_type> ids );
 
 } } /// eosio::chain

--- a/libraries/chain/merkle.cpp
+++ b/libraries/chain/merkle.cpp
@@ -32,7 +32,7 @@ bool is_canonical_right(const digest_type& val) {
 }
 
 
-digest_type merkle(deque<digest_type> ids) {
+digest_type canonical_merkle(deque<digest_type> ids) {
    if( 0 == ids.size() ) { return digest_type(); }
 
    while( ids.size() > 1 ) {

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_test)
    const auto& trxs = copy_b->transactions;
    for( const auto& a : trxs )
       trx_digests.emplace_back( a.digest() );
-   copy_b->transaction_mroot = merkle( std::move(trx_digests) );
+   copy_b->transaction_mroot = canonical_merkle( std::move(trx_digests) );
 
    // Re-sign the block
    auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), main.control->head_block_state()->blockroot_merkle.get_root() ) );
@@ -115,7 +115,7 @@ std::pair<signed_block_ptr, signed_block_ptr> corrupt_trx_in_block(validating_te
    const auto& trxs = copy_b->transactions;
    for( const auto& a : trxs )
       trx_digests.emplace_back( a.digest() );
-   copy_b->transaction_mroot = merkle( std::move(trx_digests) );
+   copy_b->transaction_mroot = canonical_merkle( std::move(trx_digests) );
 
    // Re-sign the block
    auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), main.control->head_block_state()->blockroot_merkle.get_root() ) );

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -30,8 +30,8 @@ BOOST_AUTO_TEST_CASE( irrblock ) try {
 } FC_LOG_AND_RETHROW()
 
 struct fork_tracker {
-   vector<signed_block_ptr> blocks;
-   incremental_merkle       block_merkle;
+   vector<signed_block_ptr>      blocks;
+   incremental_canonical_merkle  block_merkle;
 };
 
 BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {

--- a/unittests/merkle_tree_tests.cpp
+++ b/unittests/merkle_tree_tests.cpp
@@ -1,0 +1,263 @@
+#include <eosio/chain/incremental_merkle.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fc/crypto/sha256.hpp>
+
+using namespace eosio::chain;
+
+BOOST_AUTO_TEST_SUITE(merkle_tree_tests)
+
+BOOST_AUTO_TEST_CASE(basic_append_and_root_check_canonical) {
+   incremental_canonical_merkle tree;
+   BOOST_CHECK_EQUAL(tree.get_root(), fc::sha256());
+
+   auto node1 = fc::sha256::hash("Node1");
+   tree.append(node1);
+   BOOST_CHECK_EQUAL(tree.get_root(), node1);
+}
+
+BOOST_AUTO_TEST_CASE(multiple_appends_canonical) {
+   incremental_canonical_merkle tree;
+   auto node1 = fc::sha256::hash("Node1");
+   auto node2 = fc::sha256::hash("Node2");
+   auto node3 = fc::sha256::hash("Node3");
+   auto node4 = fc::sha256::hash("Node4");
+   auto node5 = fc::sha256::hash("Node5");
+   auto node6 = fc::sha256::hash("Node6");
+   auto node7 = fc::sha256::hash("Node7");
+   auto node8 = fc::sha256::hash("Node8");
+   auto node9 = fc::sha256::hash("Node9");
+
+   tree.append(node1);
+   BOOST_CHECK_EQUAL(tree.get_root(), node1);
+
+   tree.append(node2);
+   BOOST_CHECK_EQUAL(tree.get_root().str(), fc::sha256::hash(make_canonical_pair(node1, node2)).str());
+
+   tree.append(node3);
+   BOOST_CHECK_EQUAL(tree.get_root().str(), fc::sha256::hash(make_canonical_pair(
+                        fc::sha256::hash(make_canonical_pair(node1, node2)),
+                        fc::sha256::hash(make_canonical_pair(node3, node3)))).str());
+
+   tree.append(node4);
+   auto calculated_root = fc::sha256::hash(make_canonical_pair(
+      fc::sha256::hash(make_canonical_pair(node1, node2)),
+      fc::sha256::hash(make_canonical_pair(node3, node4))));
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+
+   tree.append(node5);
+   calculated_root = fc::sha256::hash(
+      make_canonical_pair(
+         fc::sha256::hash(make_canonical_pair(
+            fc::sha256::hash(make_canonical_pair(node1, node2)),
+            fc::sha256::hash(make_canonical_pair(node3, node4))
+         )),
+         fc::sha256::hash(make_canonical_pair(
+            fc::sha256::hash(make_canonical_pair(node5, node5)),
+            fc::sha256::hash(make_canonical_pair(node5, node5))
+         ))
+      )
+   );
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+
+   tree.append(node6);
+   calculated_root = fc::sha256::hash(
+      make_canonical_pair(
+         fc::sha256::hash(make_canonical_pair(
+            fc::sha256::hash(make_canonical_pair(node1, node2)),
+            fc::sha256::hash(make_canonical_pair(node3, node4))
+         )),
+         fc::sha256::hash(make_canonical_pair(
+            fc::sha256::hash(make_canonical_pair(node5, node6)),
+            fc::sha256::hash(make_canonical_pair(node5, node6))
+         ))
+      )
+   );
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+
+   tree.append(node7);
+   calculated_root = fc::sha256::hash(
+      make_canonical_pair(
+         fc::sha256::hash(make_canonical_pair(
+            fc::sha256::hash(make_canonical_pair(node1, node2)),
+            fc::sha256::hash(make_canonical_pair(node3, node4))
+         )),
+         fc::sha256::hash(make_canonical_pair(
+            fc::sha256::hash(make_canonical_pair(node5, node6)),
+            fc::sha256::hash(make_canonical_pair(node7, node7))
+         ))
+      )
+   );
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+
+   tree.append(node8);
+   calculated_root = fc::sha256::hash(
+      make_canonical_pair(
+         fc::sha256::hash(make_canonical_pair(
+            fc::sha256::hash(make_canonical_pair(node1, node2)),
+            fc::sha256::hash(make_canonical_pair(node3, node4))
+         )),
+         fc::sha256::hash(make_canonical_pair(
+            fc::sha256::hash(make_canonical_pair(node5, node6)),
+            fc::sha256::hash(make_canonical_pair(node7, node8))
+         ))
+      )
+   );
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+
+   tree.append(node9);
+   calculated_root = fc::sha256::hash(make_canonical_pair(
+      fc::sha256::hash(
+         make_canonical_pair(
+            fc::sha256::hash(make_canonical_pair(
+               fc::sha256::hash(make_canonical_pair(node1, node2)),
+               fc::sha256::hash(make_canonical_pair(node3, node4))
+            )),
+            fc::sha256::hash(make_canonical_pair(
+               fc::sha256::hash(make_canonical_pair(node5, node6)),
+               fc::sha256::hash(make_canonical_pair(node7, node8))
+            ))
+         )
+      ),
+      fc::sha256::hash(
+         make_canonical_pair(
+            fc::sha256::hash(make_canonical_pair(
+               fc::sha256::hash(make_canonical_pair(node9, node9)),
+               fc::sha256::hash(make_canonical_pair(node9, node9))
+            )),
+            fc::sha256::hash(make_canonical_pair(
+               fc::sha256::hash(make_canonical_pair(node9, node9)),
+               fc::sha256::hash(make_canonical_pair(node9, node9))
+            ))
+         )
+      )   ));
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+}
+
+BOOST_AUTO_TEST_CASE(basic_append_and_root_check) {
+   incremental_merkle_tree tree;
+   BOOST_CHECK_EQUAL(tree.get_root(), fc::sha256());
+
+   auto node1 = fc::sha256::hash("Node1");
+   tree.append(node1);
+   BOOST_CHECK_EQUAL(tree.get_root(), node1);
+}
+
+BOOST_AUTO_TEST_CASE(multiple_appends) {
+   incremental_merkle_tree tree;
+   auto node1 = fc::sha256::hash("Node1");
+   auto node2 = fc::sha256::hash("Node2");
+   auto node3 = fc::sha256::hash("Node3");
+   auto node4 = fc::sha256::hash("Node4");
+   auto node5 = fc::sha256::hash("Node5");
+   auto node6 = fc::sha256::hash("Node6");
+   auto node7 = fc::sha256::hash("Node7");
+   auto node8 = fc::sha256::hash("Node8");
+   auto node9 = fc::sha256::hash("Node9");
+
+   tree.append(node1);
+   BOOST_CHECK_EQUAL(tree.get_root(), node1);
+
+   tree.append(node2);
+   BOOST_CHECK_EQUAL(tree.get_root().str(), fc::sha256::hash(std::make_pair(node1, node2)).str());
+
+   tree.append(node3);
+   BOOST_CHECK_EQUAL(tree.get_root().str(), fc::sha256::hash(std::make_pair(
+                        fc::sha256::hash(std::make_pair(node1, node2)),
+                        fc::sha256::hash(std::make_pair(node3, node3)))).str());
+
+   tree.append(node4);
+   auto calculated_root = fc::sha256::hash(std::make_pair(
+      fc::sha256::hash(std::make_pair(node1, node2)),
+      fc::sha256::hash(std::make_pair(node3, node4))));
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+
+   tree.append(node5);
+   calculated_root = fc::sha256::hash(
+      std::make_pair(
+         fc::sha256::hash(std::make_pair(
+            fc::sha256::hash(std::make_pair(node1, node2)),
+            fc::sha256::hash(std::make_pair(node3, node4))
+         )),
+         fc::sha256::hash(std::make_pair(
+            fc::sha256::hash(std::make_pair(node5, node5)),
+            fc::sha256::hash(std::make_pair(node5, node5))
+         ))
+      )
+   );
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+
+   tree.append(node6);
+   calculated_root = fc::sha256::hash(
+      std::make_pair(
+         fc::sha256::hash(std::make_pair(
+            fc::sha256::hash(std::make_pair(node1, node2)),
+            fc::sha256::hash(std::make_pair(node3, node4))
+         )),
+         fc::sha256::hash(std::make_pair(
+            fc::sha256::hash(std::make_pair(node5, node6)),
+            fc::sha256::hash(std::make_pair(node5, node6))
+         ))
+      )
+   );
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+
+   tree.append(node7);
+   calculated_root = fc::sha256::hash(
+      std::make_pair(
+         fc::sha256::hash(std::make_pair(
+            fc::sha256::hash(std::make_pair(node1, node2)),
+            fc::sha256::hash(std::make_pair(node3, node4))
+         )),
+         fc::sha256::hash(std::make_pair(
+            fc::sha256::hash(std::make_pair(node5, node6)),
+            fc::sha256::hash(std::make_pair(node7, node7))
+         ))
+      )
+   );
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+
+   tree.append(node8);
+   calculated_root = fc::sha256::hash(
+      std::make_pair(
+         fc::sha256::hash(std::make_pair(
+            fc::sha256::hash(std::make_pair(node1, node2)),
+            fc::sha256::hash(std::make_pair(node3, node4))
+         )),
+         fc::sha256::hash(std::make_pair(
+            fc::sha256::hash(std::make_pair(node5, node6)),
+            fc::sha256::hash(std::make_pair(node7, node8))
+         ))
+      )
+   );
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+
+   tree.append(node9);
+   calculated_root = fc::sha256::hash(std::make_pair(
+      fc::sha256::hash(
+         std::make_pair(
+            fc::sha256::hash(std::make_pair(
+               fc::sha256::hash(std::make_pair(node1, node2)),
+               fc::sha256::hash(std::make_pair(node3, node4))
+            )),
+            fc::sha256::hash(std::make_pair(
+               fc::sha256::hash(std::make_pair(node5, node6)),
+               fc::sha256::hash(std::make_pair(node7, node8))
+            ))
+         )
+      ),
+      fc::sha256::hash(
+         std::make_pair(
+            fc::sha256::hash(std::make_pair(
+               fc::sha256::hash(std::make_pair(node9, node9)),
+               fc::sha256::hash(std::make_pair(node9, node9))
+            )),
+            fc::sha256::hash(std::make_pair(
+               fc::sha256::hash(std::make_pair(node9, node9)),
+               fc::sha256::hash(std::make_pair(node9, node9))
+            ))
+         )
+      )   ));
+   BOOST_CHECK_EQUAL(tree.get_root().str(), calculated_root.str());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -2243,7 +2243,7 @@ BOOST_AUTO_TEST_CASE( block_validation_after_stage_1_test ) { try {
    const auto& trxs = copy_b->transactions;
    for( const auto& a : trxs )
       trx_digests.emplace_back( a.digest() );
-   copy_b->transaction_mroot = merkle( std::move(trx_digests) );
+   copy_b->transaction_mroot = canonical_merkle( std::move(trx_digests) );
 
    // Re-sign the block
    auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), tester1.control->head_block_state()->blockroot_merkle.get_root() ) );


### PR DESCRIPTION
- Renamed function `merkle` to `canonical_merkle` to make it clear it uses the bit flip implementation.
- Renamed `incremental_merkle` to `incremental_canonical_merkle` to make it clear it uses the bit flip implementation.
- Added `incremental_merkle_tree` as an incremental merkle tree implementation that does not use left/right bit flip.
- Added tests.

Resolves #1913 