### PR TITLE
IF: Fix set_finalizers fthreshold check

### DIFF
--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -196,7 +196,7 @@ namespace eosio { namespace chain { namespace webassembly {
 
       // system contract should perform a duplicate check and fthreshold check before calling
       EOS_ASSERT( finalizers.size() == unique_finalizer_keys.size(), wasm_execution_error, "Duplicate finalizer bls key in finalizer set" );
-      EOS_ASSERT( finset.fthreshold >= f_weight_sum / 2, wasm_execution_error, "Finalizer set threshold cannot be met by finalizer weights" );
+      EOS_ASSERT( finset.fthreshold > f_weight_sum / 2, wasm_execution_error, "Finalizer set threshold cannot be met by finalizer weights" );
 
       context.control.set_proposed_finalizers( finset );
    }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1186,7 +1186,7 @@ namespace eosio { namespace testing {
    }
 
    transaction_trace_ptr base_tester::set_finalizers(const vector<account_name>& finalizer_names) {
-      uint64_t fthreshold = finalizer_names.size() * 2 / 3;
+      uint64_t fthreshold = finalizer_names.size() * 2 / 3 + 1;
 
       fc::variants finalizer_auths;
       for (const auto& n: finalizer_names) {

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -3880,7 +3880,7 @@ BOOST_AUTO_TEST_CASE(set_finalizer_test) { try {
    BOOST_TEST(!!ext);
    BOOST_TEST(std::get<hs_finalizer_set_extension>(*ext).finalizers.size() == finalizers.size());
    BOOST_TEST(std::get<hs_finalizer_set_extension>(*ext).generation == 1);
-   BOOST_TEST(std::get<hs_finalizer_set_extension>(*ext).fthreshold == finalizers.size() / 3 * 2);
+   BOOST_TEST(std::get<hs_finalizer_set_extension>(*ext).fthreshold == finalizers.size() / 3 * 2 + 1);
 
    // old dpos still in affect until block is irreversible
    BOOST_TEST(block->confirmed == 0);


### PR DESCRIPTION
`fthreshold` should be `>` to ensure Byzantine fault tolerance of at least one.

Issue #1916 