### PR TITLE
IF: Merge main 12-05-2023 - affine non-montgomery bls public key and signature

### DIFF
--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -184,7 +184,7 @@ namespace eosio { namespace chain { namespace webassembly {
                      "Finalizer description greater than ${s}", ("s", config::max_finalizer_description_size) );
          f_weight_sum += f.fweight;
          constexpr bool check = false; // system contract does proof of possession check which is a stronger check
-         constexpr bool raw = true;
+         constexpr bool raw = false; // non-montgomery
          EOS_ASSERT(f.public_key_g1_affine_le.size() == 96, wasm_execution_error, "Invalid bls public key length");
          std::optional<bls12_381::g1> pk = bls12_381::g1::fromAffineBytesLE(std::span<const uint8_t,96>(f.public_key_g1_affine_le.data(), 96), check, raw);
          EOS_ASSERT( pk, wasm_execution_error, "Invalid public key for: ${d}", ("d", f.description) );

--- a/libraries/libfc/include/fc/crypto/bls_public_key.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_public_key.hpp
@@ -18,12 +18,15 @@ namespace fc::crypto::blslib {
          bls_public_key( bls_public_key&& ) = default;
          bls_public_key( const bls_public_key& ) = default;
          explicit bls_public_key( const bls12_381::g1& pkey ) {_pkey = pkey;}
+         // affine non-montgomery base64 with bls_public_key_prefix
          explicit bls_public_key(const std::string& base64str);
 
          bls_public_key& operator=(const bls_public_key&) = default;
-         std::string to_string(const yield_function_t& yield = yield_function_t()) const;
-         friend bool operator==(const bls_public_key& p1, const bls_public_key& p2);
 
+         // affine non-montgomery base64 with bls_public_key_prefix
+         std::string to_string(const yield_function_t& yield = yield_function_t()) const;
+
+         friend bool operator==(const bls_public_key& p1, const bls_public_key& p2);
          auto operator<=>(const bls_public_key&) const = default;
 
          bls12_381::g1 _pkey;

--- a/libraries/libfc/include/fc/crypto/bls_signature.hpp
+++ b/libraries/libfc/include/fc/crypto/bls_signature.hpp
@@ -22,10 +22,15 @@ namespace fc::crypto::blslib {
          bls_signature( bls_signature&& ) = default;
          bls_signature( const bls_signature& ) = default;
          explicit bls_signature( const bls12_381::g2& sig ){_sig = sig;}
+
+         // affine non-montgomery base64 with bls_signature_prefix
          explicit bls_signature(const std::string& base64str);
 
          bls_signature& operator= (const bls_signature& ) = default;
+
+         // affine non-montgomery base64 with bls_signature_prefix
          std::string to_string(const yield_function_t& yield = yield_function_t()) const;
+
          friend bool operator == ( const bls_signature& p1, const bls_signature& p2);
 
          bls12_381::g2 _sig;

--- a/libraries/libfc/src/crypto/bls_public_key.cpp
+++ b/libraries/libfc/src/crypto/bls_public_key.cpp
@@ -16,7 +16,7 @@ namespace fc::crypto::blslib {
       std::array<uint8_t, 96> bytes = fc::crypto::blslib::deserialize_base64<std::array<uint8_t, 96>>(data_str);
       
       constexpr bool check = true; // check if base64str is invalid
-      constexpr bool raw = true;
+      constexpr bool raw = false;  // non-montgomery
       std::optional<bls12_381::g1> g1 = bls12_381::g1::fromAffineBytesLE(bytes, check, raw);
       FC_ASSERT(g1);
       return *g1;
@@ -28,7 +28,7 @@ namespace fc::crypto::blslib {
 
    std::string bls_public_key::to_string(const yield_function_t& yield)const {
 
-      constexpr bool raw = true;
+      constexpr bool raw = false; // non-montgomery
       std::array<uint8_t, 96> bytes = _pkey.toAffineBytesLE(raw);
 
       std::string data_str = fc::crypto::blslib::serialize_base64<std::array<uint8_t, 96>>(bytes);

--- a/libraries/libfc/src/crypto/bls_signature.cpp
+++ b/libraries/libfc/src/crypto/bls_signature.cpp
@@ -18,7 +18,7 @@ namespace fc::crypto::blslib {
          std::array<uint8_t, 192> bytes = fc::crypto::blslib::deserialize_base64<std::array<uint8_t, 192>>(data_str);
 
          constexpr bool check = true; // check if base64str is invalid
-         constexpr bool raw = true;
+         constexpr bool raw = false;  // non-montgomery
          std::optional<bls12_381::g2> g2 = bls12_381::g2::fromAffineBytesLE(bytes, check, raw);
          FC_ASSERT(g2);
          return *g2;
@@ -33,7 +33,7 @@ namespace fc::crypto::blslib {
    std::string bls_signature::to_string(const yield_function_t& yield) const
    {
 
-      constexpr bool raw = true;
+      constexpr bool raw = false; // non-montgomery
       std::array<uint8_t, 192> bytes = _sig.toAffineBytesLE(raw);
 
       std::string data_str = fc::crypto::blslib::serialize_base64<std::array<uint8_t, 192>>(bytes);

--- a/libraries/libfc/test/test_bls.cpp
+++ b/libraries/libfc/test/test_bls.cpp
@@ -294,54 +294,54 @@ BOOST_AUTO_TEST_CASE(bls_regenerate_check) try {
 BOOST_AUTO_TEST_CASE(bls_prefix_encoding_check) try {
 
   //test no_throw for correctly encoded keys
-  BOOST_CHECK_NO_THROW(bls_private_key("PVT_BLS_LaNRcYuQxSm/tRrMofQduPa5U2xUfdrCO0Yo5/CRcDeeHO+x"));
-  BOOST_CHECK_NO_THROW(bls_public_key("PUB_BLS_tCPHD1uL85ZWAX8xY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSRg=="));
-  BOOST_CHECK_NO_THROW(bls_signature("SIG_BLS_Syq5e23eMxcXnSGud+ACbKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQwQ=="));
+  BOOST_CHECK_NO_THROW(bls_private_key("PVT_BLS_O+gS5yNxVtSwL0/Uhl1IVqu/Y7Gq4qdrtB66EIb192ENfK8D"));
+  BOOST_CHECK_NO_THROW(bls_public_key("PUB_BLS_dEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX+JRYlFYrO/qKt/x439vUJ2DkZ32Od6AdJZ+S9dWRE9Sy+7Q6bNjpoIOP0cWzkKC1DqmhfE3paW+KThA3noLkV8SsILcfxpQ=="));
+  BOOST_CHECK_NO_THROW(bls_signature("SIG_BLS_prHR3PtNGJQLEhqcuHqj5Ty6FkNFo+ih32+ZHh6LH74+SKlTgq4PWtudoYt8heEZjPyNDRrqfRoYoTlAZ1mpW0QzgyGRXU+lfZ27M9Bg1mNS0MI6wWL4ZG9E8bchiMUVWijpX66sc11t60m/g8/vJIf1tIuFLhKCcX57OVCoXisciI7D21b3tKjb7VAlc2oNEoJx17XOafIWvcH1YKAc2uv9T/ocAlE3VQNprXKuGaZYA9Q5yzaOhVgGYxrjv/wNv0DlzA=="));
 
   //test no pivot delimiter
-  BOOST_CHECK_THROW(bls_private_key("PVTBLSLaNRcYuQxSm/tRrMofQduPa5U2xUfdrCO0Yo5/CRcDeeHO+x"), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_public_key("PUBBLStCPHD1uL85ZWAX8xY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSRg=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_signature("SIGBLSSyq5e23eMxcXnSGud+ACbKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQwQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_private_key("PVTBLSO+gS5yNxVtSwL0/Uhl1IVqu/Y7Gq4qdrtB66EIb192ENfK8D"), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_public_key("PUBBLSdEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX+JRYlFYrO/qKt/x439vUJ2DkZ32Od6AdJZ+S9dWRE9Sy+7Q6bNjpoIOP0cWzkKC1DqmhfE3paW+KThA3noLkV8SsILcfxpQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_signature("SIGBLSprHR3PtNGJQLEhqcuHqj5Ty6FkNFo+ih32+ZHh6LH74+SKlTgq4PWtudoYt8heEZjPyNDRrqfRoYoTlAZ1mpW0QzgyGRXU+lfZ27M9Bg1mNS0MI6wWL4ZG9E8bchiMUVWijpX66sc11t60m/g8/vJIf1tIuFLhKCcX57OVCoXisciI7D21b3tKjb7VAlc2oNEoJx17XOafIWvcH1YKAc2uv9T/ocAlE3VQNprXKuGaZYA9Q5yzaOhVgGYxrjv/wNv0DlzA=="), fc::assert_exception);
 
   //test first prefix validation
-  BOOST_CHECK_THROW(bls_private_key("XYZ_BLS_LaNRcYuQxSm/tRrMofQduPa5U2xUfdrCO0Yo5/CRcDeeHO+x"), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_public_key("XYZ_BLS_tCPHD1uL85ZWAX8xY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSRg=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_signature("XYZ_BLS_Syq5e23eMxcXnSGud+ACbKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQwQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_private_key("XYZ_BLS_O+gS5yNxVtSwL0/Uhl1IVqu/Y7Gq4qdrtB66EIb192ENfK8D"), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_public_key("XYZ_BLS_dEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX+JRYlFYrO/qKt/x439vUJ2DkZ32Od6AdJZ+S9dWRE9Sy+7Q6bNjpoIOP0cWzkKC1DqmhfE3paW+KThA3noLkV8SsILcfxpQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_signature("XYZ_BLS_prHR3PtNGJQLEhqcuHqj5Ty6FkNFo+ih32+ZHh6LH74+SKlTgq4PWtudoYt8heEZjPyNDRrqfRoYoTlAZ1mpW0QzgyGRXU+lfZ27M9Bg1mNS0MI6wWL4ZG9E8bchiMUVWijpX66sc11t60m/g8/vJIf1tIuFLhKCcX57OVCoXisciI7D21b3tKjb7VAlc2oNEoJx17XOafIWvcH1YKAc2uv9T/ocAlE3VQNprXKuGaZYA9Q5yzaOhVgGYxrjv/wNv0DlzA=="), fc::assert_exception);
 
   //test second prefix validation
-  BOOST_CHECK_THROW(bls_private_key("PVT_XYZ_LaNRcYuQxSm/tRrMofQduPa5U2xUfdrCO0Yo5/CRcDeeHO+x"), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_public_key("PUB_XYZ_tCPHD1uL85ZWAX8xY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSRg=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_signature("SIG_XYZ_Syq5e23eMxcXnSGud+ACbKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQwQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_private_key("PVT_XYZ_O+gS5yNxVtSwL0/Uhl1IVqu/Y7Gq4qdrtB66EIb192ENfK8D"), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_public_key("PUB_XYZ_dEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX+JRYlFYrO/qKt/x439vUJ2DkZ32Od6AdJZ+S9dWRE9Sy+7Q6bNjpoIOP0cWzkKC1DqmhfE3paW+KThA3noLkV8SsILcfxpQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_signature("SIG_XYZ_prHR3PtNGJQLEhqcuHqj5Ty6FkNFo+ih32+ZHh6LH74+SKlTgq4PWtudoYt8heEZjPyNDRrqfRoYoTlAZ1mpW0QzgyGRXU+lfZ27M9Bg1mNS0MI6wWL4ZG9E8bchiMUVWijpX66sc11t60m/g8/vJIf1tIuFLhKCcX57OVCoXisciI7D21b3tKjb7VAlc2oNEoJx17XOafIWvcH1YKAc2uv9T/ocAlE3VQNprXKuGaZYA9Q5yzaOhVgGYxrjv/wNv0DlzA=="), fc::assert_exception);
 
   //test missing prefix
-  BOOST_CHECK_THROW(bls_private_key("LaNRcYuQxSm/tRrMofQduPa5U2xUfdrCO0Yo5/CRcDeeHO+x"), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_public_key("tCPHD1uL85ZWAX8xY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSRg=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_signature("Syq5e23eMxcXnSGud+ACbKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQwQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_private_key("O+gS5yNxVtSwL0/Uhl1IVqu/Y7Gq4qdrtB66EIb192ENfK8D"), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_public_key("dEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX+JRYlFYrO/qKt/x439vUJ2DkZ32Od6AdJZ+S9dWRE9Sy+7Q6bNjpoIOP0cWzkKC1DqmhfE3paW+KThA3noLkV8SsILcfxpQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_signature("prHR3PtNGJQLEhqcuHqj5Ty6FkNFo+ih32+ZHh6LH74+SKlTgq4PWtudoYt8heEZjPyNDRrqfRoYoTlAZ1mpW0QzgyGRXU+lfZ27M9Bg1mNS0MI6wWL4ZG9E8bchiMUVWijpX66sc11t60m/g8/vJIf1tIuFLhKCcX57OVCoXisciI7D21b3tKjb7VAlc2oNEoJx17XOafIWvcH1YKAc2uv9T/ocAlE3VQNprXKuGaZYA9Q5yzaOhVgGYxrjv/wNv0DlzA=="), fc::assert_exception);
 
   //test incomplete prefix
-  BOOST_CHECK_THROW(bls_private_key("PVT_LaNRcYuQxSm/tRrMofQduPa5U2xUfdrCO0Yo5/CRcDeeHO+x"), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_public_key("PUB_tCPHD1uL85ZWAX8xY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSRg=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_signature("SIG_Syq5e23eMxcXnSGud+ACbKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQwQ=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_private_key("BLS_LaNRcYuQxSm/tRrMofQduPa5U2xUfdrCO0Yo5/CRcDeeHO+x"), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_public_key("BLS_tCPHD1uL85ZWAX8xY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSRg=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_signature("BLS_Syq5e23eMxcXnSGud+ACbKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQwQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_private_key("PVT_O+gS5yNxVtSwL0/Uhl1IVqu/Y7Gq4qdrtB66EIb192ENfK8D"), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_public_key("PUB_dEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX+JRYlFYrO/qKt/x439vUJ2DkZ32Od6AdJZ+S9dWRE9Sy+7Q6bNjpoIOP0cWzkKC1DqmhfE3paW+KThA3noLkV8SsILcfxpQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_signature("SIG_prHR3PtNGJQLEhqcuHqj5Ty6FkNFo+ih32+ZHh6LH74+SKlTgq4PWtudoYt8heEZjPyNDRrqfRoYoTlAZ1mpW0QzgyGRXU+lfZ27M9Bg1mNS0MI6wWL4ZG9E8bchiMUVWijpX66sc11t60m/g8/vJIf1tIuFLhKCcX57OVCoXisciI7D21b3tKjb7VAlc2oNEoJx17XOafIWvcH1YKAc2uv9T/ocAlE3VQNprXKuGaZYA9Q5yzaOhVgGYxrjv/wNv0DlzA=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_private_key("BLS_O+gS5yNxVtSwL0/Uhl1IVqu/Y7Gq4qdrtB66EIb192ENfK8D"), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_public_key("BLS_dEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX+JRYlFYrO/qKt/x439vUJ2DkZ32Od6AdJZ+S9dWRE9Sy+7Q6bNjpoIOP0cWzkKC1DqmhfE3paW+KThA3noLkV8SsILcfxpQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_signature("BLS_prHR3PtNGJQLEhqcuHqj5Ty6FkNFo+ih32+ZHh6LH74+SKlTgq4PWtudoYt8heEZjPyNDRrqfRoYoTlAZ1mpW0QzgyGRXU+lfZ27M9Bg1mNS0MI6wWL4ZG9E8bchiMUVWijpX66sc11t60m/g8/vJIf1tIuFLhKCcX57OVCoXisciI7D21b3tKjb7VAlc2oNEoJx17XOafIWvcH1YKAc2uv9T/ocAlE3VQNprXKuGaZYA9Q5yzaOhVgGYxrjv/wNv0DlzA=="), fc::assert_exception);
 
-  //test invalid data / invalid checksum 
-  BOOST_CHECK_THROW(bls_private_key("PVT_BLS_LaNRcYuQxSm/tRrMofQduPa5U2xUfdrCO0Yo5/CRcDeeHO+y"), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_public_key("PUB_BLS_tCPHD1uL85ZWAX8xY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSSg=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_signature("SIG_BLS_Syq5e23eMxcXnSGud+ACbKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQxQ=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_private_key("PVT_BLS_LaNRcYuQxSm/tRrMofQduPb5U2xUfdrCO0Yo5/CRcDeeHO+x"), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_public_key("PUB_BLS_tCPHD1uL85ZWAX8yY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSRg=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_signature("SIG_BLS_Syq5e23eMxcXnSGud+ACcKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQwQ=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_private_key("PVT_BLS_MaNRcYuQxSm/tRrMofQduPa5U2xUfdrCO0Yo5/CRcDeeHO+x"), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_public_key("PUB_BLS_uCPHD1uL85ZWAX8xY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSSg=="), fc::assert_exception);
-  BOOST_CHECK_THROW(bls_signature("SIG_BLS_Tyq5e23eMxcXnSGud+ACbKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQwQ=="), fc::assert_exception);
+  //test invalid data / invalid checksum
+  BOOST_CHECK_THROW(bls_private_key("PVT_BLS_O+gS5yNxVtSwL0/Uhl1IVqu/Y7Gq4qdrtB66EIb192ENfK8a"), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_public_key("PUB_BLS_dEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX+JRYlFYrO/qKt/x439vUJ2DkZ32Od6AdJZ+S9dWRE9Sy+7Q6bNjpoIOP0cWzkKC1DqmhfE3paW+KThA3noLkV8SsILcfxaQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_signature("SIG_BLS_prHR3PtNGJQLEhqcuHqj5Ty6FkNFo+ih32+ZHh6LH74+SKlTgq4PWtudoYt8heEZjPyNDRrqfRoYoTlAZ1mpW0QzgyGRXU+lfZ27M9Bg1mNS0MI6wWL4ZG9E8bchiMUVWijpX66sc11t60m/g8/vJIf1tIuFLhKCcX57OVCoXisciI7D21b3tKjb7VAlc2oNEoJx17XOafIWvcH1YKAc2uv9T/ocAlE3VQNprXKuGaZYA9Q5yzaOhVgGYxrjv/wNv0DlyA=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_private_key("PVT_BLS_p+gS5yNxVtSwL0/Uhl1IVqu/Y7Gq4qdrtB66EIb192ENfK8D"), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_public_key("PUB_BLS_cEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX+JRYlFYrO/qKt/x439vUJ2DkZ32Od6AdJZ+S9dWRE9Sy+7Q6bNjpoIOP0cWzkKC1DqmhfE3paW+KThA3noLkV8SsILcfxpQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_signature("SIG_BLS_rrHR3PtNGJQLEhqcuHqj5Ty6FkNFo+ih32+ZHh6LH74+SKlTgq4PWtudoYt8heEZjPyNDRrqfRoYoTlAZ1mpW0QzgyGRXU+lfZ27M9Bg1mNS0MI6wWL4ZG9E8bchiMUVWijpX66sc11t60m/g8/vJIf1tIuFLhKCcX57OVCoXisciI7D21b3tKjb7VAlc2oNEoJx17XOafIWvcH1YKAc2uv9T/ocAlE3VQNprXKuGaZYA9Q5yzaOhVgGYxrjv/wNv0DlzA=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_private_key("PVT_BLS_O+gS5yNxVtSwL0/Uhl1IVqu/Y7Gq4qdrtB66EIb192ENfK8B"), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_public_key("PUB_BLS_dEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX+JRYlFYrO/qKt/x439vUJ2DkZ32Od6AdJZ+S9dWRE9Sy+7Q6bNjpoIOP0cWzkKC1DqmhfE3paW+KThA3noLkV8SsILcfxsQ=="), fc::assert_exception);
+  BOOST_CHECK_THROW(bls_signature("SIG_BLS_prHR3PtNGJQLEhqcuHqj5Ty6FkNFo+ih32+ZHh6LH74+SKlTgq4PWtudoYt8heEZjPyNDRrqfRoYoTlAZ1mpW0QzgyGRXU+lfZ27M9Bg1mNS0MI6wWL4ZG9E8bchiMUVWijpX66sc11t60m/g8/vJIf1tIuFLhKCcX57OVCoXisciI7D21b3tKjb7VAlc2oNEoJx17XOafIWvcH1YKAc2uv9T/ocAlE3VQNprXKuGaZYA9Q5yzaOhVgGYxrjv/wNv0Dlzb=="), fc::assert_exception);
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(bls_variant) try {
-      bls_private_key prk("PVT_BLS_LaNRcYuQxSm/tRrMofQduPa5U2xUfdrCO0Yo5/CRcDeeHO+x");
-      bls_public_key pk("PUB_BLS_tCPHD1uL85ZWAX8xY06U00e72GZR0ux/RcB3DOFF5KV22F9eAVNAFU/enVJwLtQCG8N0v4KkwSSdoJo9ZRR042/xbiR3JgIsQmUqXoR0YyMuPcUGQbbon65ZgfsD3BkBUOPSRg==");
-      bls_signature sig("SIG_BLS_Syq5e23eMxcXnSGud+ACbKp5on4Rn2kOXdrA5sH/VNS/0i8V9RG/Oq1AliFBuJsNm7Y+LT1bqh/23+mVzYs/YVJAmDUHLFjimqyyMI+5wDLUhqFxVplSlezTOc3kj7cSFJRCfpcZUhD0gPffjBkxXctiNubjdtqLUjkLr6jWGNFrxKeSOXS9elB9tn5nZT4SGzygqNLjcWCu4Bza7tC5B7djLtzr/9SEpDb3XPPCUTmm6kMmi2tWwxGRmu06MMMI2sjQwQ==");
+      bls_private_key prk("PVT_BLS_nv6z13d5yfQk4Mq07Fdmpvzsd+hgGAeL4wBQQH1cCAlB7Nka");
+      bls_public_key pk("PUB_BLS_MPPeebAPxt/ibL2XPuZVGpADjGn+YEVPPoYmTZeBD6Ok2E19M8SnmDGSdZBf2qwSuJim+8H83EsTpEn3OiStWBiFeJYfVRLlEsZuSF0SYYwtVteY48n+KeE1IWzlSAkSyBqiGA==");
+      bls_signature sig("SIG_BLS_UVb0SXln6xkg7X+y3ATkxoSOouIxgYLR/tf+UBz2VXeA0ujahQFRTux/e9/eifkJ7TguHKjMxNMv+tVDIn03DFlav468CagmW/if+lJJjT5ZD/Uhj1OvddUOR6gzD7sLuwL3bQ52L8HXaaWM2ksonwhD03JO3GeZj3j43naG0GstBVaCPpE84WBFyqTBFkcMnLO3LGkJXs5l2VZmtYpI8Z/UlerI0+jiYOzA+p9LTfjfng5HHx367WpMYiK2hyoEiILS1A==");
 
       fc::variant v;
       std::string s;


### PR DESCRIPTION
Merge `main` as of 12-05-2023 into `hotstuff_integration` includes bls12-381 update for proof of possession in affine non-montgomery form.
Use affine non-montgomery base64 encoding for `bls_public_key` and `bls_signature`.
Update host function `set_finalizers` to expect `bls_public_key` in affine non-montgomery form.