### PR TITLE
add a stub `pinned_build.yaml` on main so the pinned build can be performed in CI for 3.x/4.0

### DIFF
--- a/.github/workflows/pinned_build.yaml
+++ b/.github/workflows/pinned_build.yaml
@@ -1,0 +1,11 @@
+name: "Pinned Build"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dummy
+        run: echo This workflow is a stub on main to allow it to be manually run on 3.x/4.0


### PR DESCRIPTION
`pinned_build.yaml` was removed in 5.0 (and thus main) since the pinned builds are performed together with the non-pinned builds that normally occur in `build.yaml`; i.e. this separate workflow is no longer needed. But that means it's no longer possible to manually kick off this workflow for pre-5.0 branches -- something we need for 3.x & 4.0 releases.

Add back a stub workflow that allows the `pinned_build.yaml` to be manually run for 3.x & 4.0, for now.