### PR TITLE
[4.0 -> 5.0] consolidated security fixes for 5.0.0-rc3

### DIFF
--- a/libraries/chain/include/eosio/chain/contract_table_objects.hpp
+++ b/libraries/chain/include/eosio/chain/contract_table_objects.hpp
@@ -3,6 +3,8 @@
 #include <eosio/chain/database_utils.hpp>
 #include <eosio/chain/contract_types.hpp>
 #include <eosio/chain/multi_index_includes.hpp>
+#include <eosio/chain/snapshot.hpp>
+#include <eosio/chain/database_utils.hpp>
 
 #include <array>
 #include <type_traits>
@@ -281,6 +283,35 @@ namespace config {
    };
 
 } // namespace config
+
+namespace detail {
+   template<>
+   struct snapshot_row_traits<key_value_object> {
+      using value_type = key_value_object;
+      using snapshot_type = snapshot_key_value_object;
+
+      static snapshot_key_value_object to_snapshot_row(const key_value_object& value, const chainbase::database&) {
+         snapshot_key_value_object ret;
+
+         ret.primary_key = value.primary_key;
+         ret.payer = value.payer;
+         if(value.value.size()) {
+            ret.value.resize(value.value.size());
+            memcpy(ret.value.data(), value.value.data(), value.value.size());
+         }
+         return ret;
+      };
+
+      static void from_snapshot_row(snapshot_key_value_object&& row, key_value_object& value, chainbase::database&) {
+         value.primary_key = row.primary_key;
+         value.payer = row.payer;
+         if(row.value.size())
+            value.value.resize_and_fill(row.value.size(), [&](char* data, std::size_t size) {
+               memcpy(data, row.value.data(), size);
+            });
+      }
+   };
+}
 
 } }  // namespace eosio::chain
 

--- a/libraries/chain/include/eosio/chain/database_utils.hpp
+++ b/libraries/chain/include/eosio/chain/database_utils.hpp
@@ -91,6 +91,42 @@ namespace eosio { namespace chain {
       fc::raw::unpack(ds, static_cast<shared_string &>(b));
       return ds;
    }
+
+namespace detail {
+   struct snapshot_key_value_object {
+      template<typename Stream>
+      friend Stream& operator>>(Stream& ds, snapshot_key_value_object& o) {
+         fc::raw::unpack(ds, o.primary_key);
+         fc::raw::unpack(ds, o.payer);
+
+         fc::unsigned_int sz;
+         fc::raw::unpack(ds, sz);
+         if(sz) {
+            o.value.resize(sz);
+            ds.read(o.value.data(), sz);
+         }
+
+         return ds;
+      }
+
+      template<typename Stream>
+      friend Stream& operator<<(Stream& ds, const snapshot_key_value_object& o) {
+         fc::raw::pack(ds, o.primary_key);
+         fc::raw::pack(ds, o.payer);
+
+         fc::raw::pack(ds, fc::unsigned_int(o.value.size()));
+         if(o.value.size())
+            ds.write(o.value.data(), o.value.size());
+
+         return ds;
+      }
+
+      uint64_t          primary_key;
+      account_name      payer;
+      std::vector<char> value;
+   };
+}
+
 } }
 
 namespace fc {
@@ -196,6 +232,20 @@ namespace fc {
       std::vector<T> _v;
       from_variant(v, _v);
       sv = eosio::chain::shared_vector<T>(_v.begin(), _v.end(), sv.get_allocator());
+   }
+
+   inline
+   void to_variant(const eosio::chain::detail::snapshot_key_value_object& a, fc::variant& v) {
+      v = fc::mutable_variant_object("primary_key", a.primary_key)
+                                    ("payer", a.payer)
+                                    ("value", base64_encode(a.value.data(), a.value.size()));
+   }
+
+   inline
+   void from_variant(const fc::variant& v, eosio::chain::detail::snapshot_key_value_object& a) {
+      from_variant(v["primary_key"], a.primary_key);
+      from_variant(v["payer"], a.payer);
+      a.value = base64_decode(v["value"].as_string());
    }
 }
 

--- a/libraries/state_history/include/eosio/state_history/serialization.hpp
+++ b/libraries/state_history/include/eosio/state_history/serialization.hpp
@@ -120,6 +120,13 @@ datastream<ST>& operator<<(datastream<ST>& ds, const eosio::state_history::big_v
 }
 
 template <typename ST>
+datastream<ST>& operator<<(datastream<ST>& ds, const eosio::state_history::row_pair& rp) {
+   fc::raw::pack(ds, rp.first);
+   history_pack_big_bytes(ds, rp.second);
+   return ds;
+}
+
+template <typename ST>
 inline void history_pack_varuint64(datastream<ST>& ds, uint64_t val) {
    do {
       uint8_t b = uint8_t(val) & 0x7f;
@@ -134,6 +141,12 @@ void history_pack_big_bytes(datastream<ST>& ds, const eosio::chain::bytes& v) {
    history_pack_varuint64(ds, v.size());
    if (v.size())
       ds.write(&v.front(), v.size());
+}
+
+template <typename ST>
+void history_pack_big_bytes(datastream<ST>& ds, const eosio::chain::shared_blob& b) {
+   fc::raw::pack(ds, unsigned_int((uint32_t)b.size()));
+   ds.write(b.data(), b.size());
 }
 
 template <typename ST>
@@ -223,7 +236,7 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_context_wrapper_sta
    fc::raw::pack(ds, as_type<uint64_t>(obj.context.table.to_uint64_t()));
    fc::raw::pack(ds, as_type<uint64_t>(obj.obj.primary_key));
    fc::raw::pack(ds, as_type<uint64_t>(obj.obj.payer.to_uint64_t()));
-   fc::raw::pack(ds, as_type<eosio::chain::shared_string>(obj.obj.value));
+   history_pack_big_bytes(ds, obj.obj.value);
    return ds;
 }
 

--- a/libraries/state_history/include/eosio/state_history/types.hpp
+++ b/libraries/state_history/include/eosio/state_history/types.hpp
@@ -17,6 +17,13 @@ struct big_vector_wrapper {
    T obj;
 };
 
+struct row_pair {
+   row_pair() {}
+   row_pair(const bool f, const bytes& s) : first(f), second(s){}
+   bool first = false;
+   bytes second;
+};
+
 struct partial_transaction {
    fc::time_point_sec          expiration             = {};
    uint16_t                    ref_block_num          = {};
@@ -66,7 +73,7 @@ struct augmented_transaction_trace {
 struct table_delta {
    fc::unsigned_int                                                       struct_version = 0;
    std::string                                                            name{};
-   state_history::big_vector_wrapper<std::vector<std::pair<bool, bytes>>> rows{};
+   state_history::big_vector_wrapper<std::vector<row_pair>>               rows{};
 };
 
 struct block_position {

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -29,6 +29,18 @@ bool operator==(const eosio::checksum256& lhs, const transaction_id_type& rhs) {
 
 namespace eosio::state_history {
 
+template <typename ST>
+datastream<ST>& operator>>(datastream<ST>& ds, row_pair& rp) {
+   fc::raw::unpack(ds, rp.first);
+   fc::unsigned_int sz;
+   fc::raw::unpack(ds, sz);
+   if(sz) {
+      rp.second.resize(sz);
+      ds.read(rp.second.data(), sz);
+   }
+   return ds;
+}
+
 template <typename ST, typename T>
 datastream<ST>& operator>>(datastream<ST>& ds, eosio::state_history::big_vector_wrapper<T>& obj) {
    fc::unsigned_int sz;


### PR DESCRIPTION
Merges up #1964 from 4.0; originally #1961 from 3.2