### PR TITLE
[5.0 -> main] Extra info level logging

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2408,7 +2408,18 @@ struct controller_impl {
             } // end if exception
          } /// end for each block in branch
 
-         ilog("successfully switched fork to new head ${new_head_id}", ("new_head_id", new_head->id));
+         if (fc::logger::get(DEFAULT_LOGGER).is_enabled(fc::log_level::info)) {
+            auto get_ids = [&](auto& container)->std::string {
+               std::string ids;
+               for(auto ritr = container.rbegin(), e = container.rend(); ritr != e; ++ritr) {
+                  ids += std::to_string((*ritr)->block_num) + ":" + (*ritr)->id.str() + ",";
+               }
+               if (!ids.empty()) ids.resize(ids.size()-1);
+               return ids;
+            };
+            ilog("successfully switched fork to new head ${new_head_id}, removed {${rm_ids}}, applied {${new_ids}}",
+                ("new_head_id", new_head->id)("rm_ids", get_ids(branches.second))("new_ids", get_ids(branches.first)));
+         }
       } else {
          head_changed = false;
       }

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -541,9 +541,10 @@ private:
          fc_ilog(plugin.get_logger(),
                  "pushing result "
                  "{\"head\":{\"block_num\":${head}},\"last_irreversible\":{\"block_num\":${last_irr}},\"this_block\":{"
-                 "\"block_num\":${this_block}}} to send queue",
-                 ("head", result.head.block_num)("last_irr", result.last_irreversible.block_num)(
-                     "this_block", result.this_block ? result.this_block->block_num : fc::variant()));
+                 "\"block_num\":${this_block}, \"block_id\":${this_id}}} to send queue",
+                 ("head", result.head.block_num)("last_irr", result.last_irreversible.block_num)
+                 ("this_block", result.this_block ? result.this_block->block_num : fc::variant())
+                 ("this_id", result.this_block ? fc::variant{result.this_block->block_id} : fc::variant{}));
       }
 
       --current_request->max_messages_in_flight;


### PR DESCRIPTION
- SHiP - Added block id to `this_block` output of `pushing result` log message.
```
info  2023-12-12T14:55:21.213 ship-0    session.hpp:547               send_update          ] pushing result {"head":{"block_num":397},"last_irreversible":{"block_num":57},"this_block":{"block_num":397, "block_id":0000018d5fb988342f29ac31a55ada90d20cb993f344fc4ee3f9963451b69a7b}} to send queue
```

- controller - Added applied and removed block ids to `successfully switched fork` log message. Note that most fork switches are much smaller than this example from a test that purposely creates a large fork.
```
info  2023-12-12T14:47:54.008 nodeos    controller.cpp:2424           maybe_switch_forks   ] successfully switched fork to new head 0000007b225de24730b455eef258f77689976ac8533a0f7482f1ee008e8e7db1, removed {123:0000007beb904ec21fb4f197485305c3665793b65ed0ec55b0de3a5a938ff2f8,124:0000007c3d48fb8cc25b9bf9976104b7d49130667972ff120f52c4a43bf55050,125:0000007def9e2467135fe9a49a882c45579b270d22a5f12b07638cb2e62d5f6c,126:0000007e4d984351b641ff84bc54c571f22dfa1b4a517c5fd16d2a50dd9d09c7,127:0000007f0364287b64dfd68501ca6fd722e1faaa621a3c7c6ec4dc858130c7ef,128:00000080a94d95b5fcbbea4f7a64c46bc16a9f38d03fa9cb504e304c1ed387b6,129:00000081f7a47a6a0d8bcf033c9d942f0175cd9d288c1787d6f9b5890c3e8caf,130:00000082775e0799dcd3aba8af5114a19fd235db7e203e1a9545d7621f37d436,131:000000831cb0d2d11e2831221672000485b649505ce6daddb632d1498badc85a,132:00000084f30f6a2cf6b90af3fefe7b11f2bb16d5f5c94e24ca8bd5bae6a362a8,133:00000085703ac42b8c37916fbf6369beec45fb8706b8628339ef09ed5b032442,134:00000086894371d3ace77769ec9d4c3fa4f60375bc28594be33b2398d178cc97,135:000000879472c9a29f46a46378a6013a33f497783f77c8ece110492adec23afe,136:00000088d888ae324fe23aafb888f5039cb63d0158103665433e2c6fdf529a01,137:00000089254ed52f4492c2676325a22551765fa8233ac21969d9acbd05fb9ba7,138:0000008a60a7c0ab3c37c9e5e683379955ff6c7d3165a5f21bf39736a0fb3b3c,139:0000008b3713e0984a40a212e196886998c280e6ae704fdac50cc8ceccd0fd1d,140:0000008c544c7209c111c60cc472967a35adfcadc89b3c39902c585deabcdcb4,141:0000008d3d00d7d8fc65c0efbec08fe4c95f1307fd3e544ed90c533c0a03f3aa,142:0000008e8ef5d46fff02faad0071f6c0d757f66e1bd84627f5224b599491617a,143:0000008ffc12fb371e7a4abd06d023fe3c417fab03e2942d321fdd72585b000f,144:0000009012601fb7794bedfef05a2e4c0a4c447bc2909b70f9e3d372b0599d96,145:00000091e4bf5bd02712ca5978ae6793f918624d736a74494a67433f2492b8d7,146:0000009271d7cddbb5ece8e79a954927edfdf7e655878428d1102768508410a4,147:00000093a8199ac7365b89361da6572a0b7d0ff9018fdd48e6358be4f365dcd7,148:0000009416f396cce035fdaa9c0040ea9d5563928c4e5836c87ebb64fd430de7,149:0000009543ecb5c5c84650ce3b77a798a6dd04dc3dcf4f18ca5c64696ffc81cd,150:00000096278a831e195aba501e3081247c6314f6b17f06928741169e1805d23d,151:000000976e002ea20d8439ec9846728e1b3ef173539af50f6495665a98ef24f1,152:00000098647b4dfda0fe4c2e390344c8fe82eb961b7c7bb8d9d745ef98942f46,153:000000997805730c4f5efa1794c2269938acfa2cb7c9bd937b026b1ba7009674,154:0000009acd44c4d3c1b7ce80fc720d1dc10748296975aede09b7d5874937a36f,155:0000009ba43afc705d7d37d7a3f68b035b16d2fc95a8a53aef12746e7c46d7b7,156:0000009c92ca250cd32ea5cc13544fa1ac23d123abd3fc3fbab770f69ab09c6a,157:0000009d513ba93fae0590433cd1b2d207d7445d835d25ee888ed7c229e58775,158:0000009e3504fdb6d6abd619bb31d30cef120e893e3159fa18bd3efa48bb57ce,159:0000009f73055574411ea4193ac4885454269cb98dcb2adb61cf75d39c97fa6e,160:000000a08d04cc515ff39ebff76be3796477ea433cdb261015ebfd438ced1203,161:000000a16247cdfd2754627b86ad93631b145a22977e6449946dc736500e2870,162:000000a2d838e6345b4239dd888852fd58920441ce1d55440605dd40370c3c03,163:000000a3af26fc301c65df43c3d4a806f6e0f90df4d1f40afc02b82844384dca,164:000000a43c865d299aaf1ed36b18e9a73b6042ad9302c9ab73470d42b7d71926,165:000000a529853e04952d45e55aa76144c1939b3de42ef94f9af72538cac5b538,166:000000a60b534e1e199f06451b36f6eed7a607bb9bf93bcd3c062ef0c305872c,167:000000a77a8e73600c0cd9b089fea93938da88b796713379664ed1e285fa1065,168:000000a827e0c44fcc2e5b489bc0d6a7d9e8160a981940688269373be43e15f8,169:000000a9e13331d9be3c744747dbc58bff50292bbc0d29cb5926b71fc19fbcd2,170:000000aa6fc488e5f3da9c6804ea6f6582ce116e93c905280ddeca23572bb772,171:000000ab869bca96d8d3a9d6c6398e1bba6eff0a407cc206c1592dda5fba8d94,172:000000ac2a11cf648c0d9428626dc28385ef7416d0756e6f84042ec0653ad83a,173:000000ad0dafb73776b55d545892eeac2e4904ea9d368d2ff2d82ae66cc10594,174:000000aec02476069fbc61b19c755b92f59dc646907f351b9069f5a55541bf94,175:000000af4cc2fe2408a4fb25aa3f4bedf556a2afdaea0a4dd792a8c30883af8f,176:000000b0934973f585320687782bbd422a5435ece9bd146ca6c1f8f75592a781,177:000000b129beae0465877b11bf1d226e47c7641b3e62b188b5c43ee05e8cc1c7,178:000000b23e2f0c4268bcc2d9d1fdc92ffd78033e92e7fc462f428585e79ae06c,179:000000b3191ab566becf951d354f992657b1e375f3e3f2985f08b09a3946c18d,180:000000b49523c20ce30290e496d88ed37cec228d45b4d38030d0dd99069b1603,181:000000b5f977ec643486ab0e3e2dfff63ad0d0523d0aaed179b2f707f6cfeff8,182:000000b66ed99bfbf36fc7845740e40b9bba3bdb6437dcc41184dbc95d7e00b8,183:000000b7fe3e0efb36748c0ee8d07aae59462580ecd688be3d1c770d09fcff52,184:000000b8f83a9dcb246ea39305371fa7473e681f71371573aa8ad5b044b0f179,185:000000b939ab469ff11f97d2539247c37a66ade5dd33ce3e27346e97f630e28d,186:000000ba3e64d76bb98ff7184a953a3ab7820328add1669e964307131240793a,187:000000bbd63cb694d47b704f160bda6e454060f354dadc34e2ccec93b12b5a85,188:000000bc34cf1dd8ea30d0ebdd1246b4a6460dc1549c0969a17413bb2924d3bb,189:000000bdc4154204b56fa3acb933f55f89bffdc59ddd7a4cdca822a7d43f0270,190:000000be0ac6232e0235dafd04c0952a96d6ae96146d40f9e192300f5af2b212,191:000000bf4a05fb28acb9fd4f79233ff0450d79e6e8c27c01d3128b5d3c9da1b1,192:000000c0b00b967e06b68a6cfbda4aa4b6dc2631c7118b005fed0a470d4fffd5,193:000000c1ba883c3eb47abce1e6837b9c6ff587ed1e426b8d4dba28e7e3f5a462,194:000000c28c9a0b504b77131847b7eba7d5ece1dc82bde54f5c6ca0f10d2730f9,195:000000c3bb9f2e37d4695e08520c52628171efade21b12bfd037841fb4090cb7}, applied {123:0000007b225de24730b455eef258f77689976ac8533a0f7482f1ee008e8e7db1}
```

Merges `release/5.0` into `main` including #1984 