### PR TITLE
Clean up controller signals to improve abstraction

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1950,7 +1950,7 @@ struct controller_impl {
          if( s == controller::block_status::incomplete ) {
             fork_db.add( bsp );
             fork_db.mark_valid( bsp );
-            emit( self.accepted_block_header, bsp );
+            emit( self.accepted_block_header, std::tie(bsp->block, bsp->id, bsp->header.producer) );
             EOS_ASSERT( bsp == fork_db.head(), fork_database_exception, "committed block did not become the new head in fork database");
          } else if (s != controller::block_status::irreversible) {
             fork_db.mark_valid( bsp );
@@ -2266,7 +2266,7 @@ struct controller_impl {
             trusted_producer_light_validation = true;
          };
 
-         emit( self.accepted_block_header, bsp );
+         emit( self.accepted_block_header, std::tie(bsp->block, bsp->id, bsp->header.producer) );
 
          if( read_mode != db_read_mode::IRREVERSIBLE ) {
             maybe_switch_forks( br, fork_db.pending_head(), s, forked_branch_cb, trx_lookup );
@@ -2311,7 +2311,7 @@ struct controller_impl {
             fork_db.add( bsp, true );
          }
 
-         emit( self.accepted_block_header, bsp );
+         emit( self.accepted_block_header, std::tie(bsp->block, bsp->id, bsp->header.producer) );
 
          controller::block_report br;
          if( s == controller::block_status::irreversible ) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -369,7 +369,7 @@ struct controller_impl {
    }
 
    /**
-    *  Plugins / observers listening to signals emited (such as accepted_transaction) might trigger
+    *  Plugins / observers listening to signals emited might trigger
     *  errors and throw exceptions. Unless those exceptions are caught it could impact consensus and/or
     *  cause a node to fork.
     *
@@ -1337,7 +1337,6 @@ struct controller_impl {
          pending->_block_report.total_cpu_usage_us += billed_cpu_time_us;
          pending->_block_report.total_elapsed_time += trace->elapsed;
          pending->_block_report.total_time += trace->elapsed;
-         emit( self.accepted_transaction, trx );
          dmlog_applied_transaction(trace);
          emit( self.applied_transaction, std::tie(trace, trx->packed_trx()) );
          undo_session.squash();
@@ -1403,7 +1402,6 @@ struct controller_impl {
 
          trace->account_ram_delta = account_delta( gtrx.payer, trx_removal_ram_delta );
 
-         emit( self.accepted_transaction, trx );
          dmlog_applied_transaction(trace);
          emit( self.applied_transaction, std::tie(trace, trx->packed_trx()) );
 
@@ -1448,7 +1446,6 @@ struct controller_impl {
          if( !trace->except_ptr ) {
             trace->account_ram_delta = account_delta( gtrx.payer, trx_removal_ram_delta );
             trace->elapsed = fc::time_point::now() - start;
-            emit( self.accepted_transaction, trx );
             dmlog_applied_transaction(trace);
             emit( self.applied_transaction, std::tie(trace, trx->packed_trx()) );
             undo_session.squash();
@@ -1494,13 +1491,11 @@ struct controller_impl {
          trace->receipt = push_receipt(gtrx.trx_id, transaction_receipt::hard_fail, cpu_time_to_bill_us, 0);
          trace->account_ram_delta = account_delta( gtrx.payer, trx_removal_ram_delta );
 
-         emit( self.accepted_transaction, trx );
          dmlog_applied_transaction(trace);
          emit( self.applied_transaction, std::tie(trace, trx->packed_trx()) );
 
          undo_session.squash();
       } else {
-         emit( self.accepted_transaction, trx );
          dmlog_applied_transaction(trace);
          emit( self.applied_transaction, std::tie(trace, trx->packed_trx()) );
       }
@@ -1634,7 +1629,6 @@ struct controller_impl {
                    // call the accept signal but only once for this transaction
                    if (!trx->accepted) {
                        trx->accepted = true;
-                       emit(self.accepted_transaction, trx);
                    }
 
                    dmlog_applied_transaction(trace, &trn);
@@ -1681,7 +1675,6 @@ struct controller_impl {
          }
 
          if (!trx->is_transient()) {
-            emit(self.accepted_transaction, trx);
             dmlog_applied_transaction(trace);
             emit(self.applied_transaction, std::tie(trace, trx->packed_trx()));
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -342,8 +342,8 @@ struct controller_impl {
       set_activation_handler<builtin_protocol_feature_t::bls_primitives>();
       set_activation_handler<builtin_protocol_feature_t::disable_deferred_trxs_stage_2>();
 
-      self.irreversible_block.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-         const auto& [ block, id, header, block_num ] = t;
+      self.irreversible_block.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, uint32_t> t) {
+         const auto& [ block, id, block_num ] = t;
          wasmif.current_lib(block_num);
       });
 
@@ -449,7 +449,7 @@ struct controller_impl {
                apply_block( br, *bitr, controller::block_status::complete, trx_meta_cache_lookup{} );
             }
 
-            emit( self.irreversible_block, std::tie((*bitr)->block, (*bitr)->id, (*bitr)->header, (*bitr)->block_num) );
+            emit( self.irreversible_block, std::tie((*bitr)->block, (*bitr)->id, (*bitr)->block_num) );
 
             // blog.append could fail due to failures like running out of space.
             // Do it before commit so that in case it throws, DB can be rolled back.
@@ -2317,7 +2317,7 @@ struct controller_impl {
 
             // On replay, log_irreversible is not called and so no irreversible_block signal is emitted.
             // So emit it explicitly here.
-            emit( self.irreversible_block, std::tie(bsp->block, bsp->id, bsp->header, bsp->block_num) );
+            emit( self.irreversible_block, std::tie(bsp->block, bsp->id, bsp->block_num) );
 
             if (!self.skip_db_sessions(s)) {
                db.commit(bsp->block_num);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1951,7 +1951,7 @@ struct controller_impl {
          if( s == controller::block_status::incomplete ) {
             fork_db.add( bsp );
             fork_db.mark_valid( bsp );
-            emit( self.accepted_block_header, std::tie(bsp->block, bsp->id, bsp->header.producer) );
+            emit( self.accepted_block_header, std::tie(bsp->block, bsp->id, bsp->header, bsp->block_num) );
             EOS_ASSERT( bsp == fork_db.head(), fork_database_exception, "committed block did not become the new head in fork database");
          } else if (s != controller::block_status::irreversible) {
             fork_db.mark_valid( bsp );
@@ -2265,7 +2265,7 @@ struct controller_impl {
             trusted_producer_light_validation = true;
          };
 
-         emit( self.accepted_block_header, std::tie(bsp->block, bsp->id, bsp->header.producer) );
+         emit( self.accepted_block_header, std::tie(bsp->block, bsp->id, bsp->header, bsp->block_num) );
 
          if( read_mode != db_read_mode::IRREVERSIBLE ) {
             maybe_switch_forks( br, fork_db.pending_head(), s, forked_branch_cb, trx_lookup );
@@ -2309,7 +2309,7 @@ struct controller_impl {
             fork_db.add( bsp, true );
          }
 
-         emit( self.accepted_block_header, std::tie(bsp->block, bsp->id, bsp->header.producer) );
+         emit( self.accepted_block_header, std::tie(bsp->block, bsp->id, bsp->header, bsp->block_num) );
 
          controller::block_report br;
          if( s == controller::block_status::irreversible ) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1962,7 +1962,7 @@ struct controller_impl {
             dm_logger->on_accepted_block(bsp);
          }
 
-         emit( self.accepted_block, bsp );
+         emit( self.accepted_block, std::tie(bsp->block, bsp->id, bsp->header, bsp->block_num) );
 
          if( s == controller::block_status::incomplete ) {
             log_irreversible();

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -342,7 +342,7 @@ struct controller_impl {
       set_activation_handler<builtin_protocol_feature_t::bls_primitives>();
       set_activation_handler<builtin_protocol_feature_t::disable_deferred_trxs_stage_2>();
 
-      self.irreversible_block.connect([this](block_signal_params t) {
+      self.irreversible_block.connect([this](const block_signal_params& t) {
          const auto& [ block, id] = t;
          wasmif.current_lib(block->block_num());
       });

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2258,8 +2258,6 @@ struct controller_impl {
             return;
          }
 
-         emit( self.pre_accepted_block, b );
-
          fork_db.add( bsp );
 
          if (self.is_trusted_producer(b->producer)) {
@@ -2293,7 +2291,6 @@ struct controller_impl {
             return;
          }
 
-         emit( self.pre_accepted_block, b );
          const bool skip_validate_signee = !conf.force_all_checks;
 
          auto bsp = std::make_shared<block_state_legacy>(

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -44,6 +44,8 @@ namespace eosio { namespace chain {
    // lookup transaction_metadata via supplied function to avoid re-creation
    using trx_meta_cache_lookup = std::function<transaction_metadata_ptr( const transaction_id_type&)>;
 
+   using block_signal_params = std::tuple<const signed_block_ptr&, const block_id_type&>;
+
    class fork_database;
 
    enum class db_read_mode {
@@ -326,10 +328,10 @@ namespace eosio { namespace chain {
 
          static std::optional<uint64_t> convert_exception_to_error_code( const fc::exception& e );
 
-         signal<void(uint32_t)>                        block_start;
-         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)> accepted_block_header;
-         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)> accepted_block;
-         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, uint32_t>)> irreversible_block;
+         signal<void(uint32_t)>             block_start;
+         signal<void(block_signal_params)>  accepted_block_header;
+         signal<void(block_signal_params)>  accepted_block;
+         signal<void(block_signal_params)>  irreversible_block;
          signal<void(const transaction_metadata_ptr&)> accepted_transaction;
          signal<void(std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&>)> applied_transaction;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -327,7 +327,7 @@ namespace eosio { namespace chain {
          static std::optional<uint64_t> convert_exception_to_error_code( const fc::exception& e );
 
          signal<void(uint32_t)>                        block_start;
-         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const account_name&>)> accepted_block_header;
+         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)> accepted_block_header;
          signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)> accepted_block;
          signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)> irreversible_block;
          signal<void(const transaction_metadata_ptr&)> accepted_transaction;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -328,7 +328,7 @@ namespace eosio { namespace chain {
 
          signal<void(uint32_t)>                        block_start;
          signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const account_name&>)> accepted_block_header;
-         signal<void(const block_state_legacy_ptr&)>   accepted_block;
+         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)>   accepted_block;
          signal<void(const block_state_legacy_ptr&)>   irreversible_block;
          signal<void(const transaction_metadata_ptr&)> accepted_transaction;
          signal<void(std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&>)> applied_transaction;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -326,24 +326,12 @@ namespace eosio { namespace chain {
 
          static std::optional<uint64_t> convert_exception_to_error_code( const fc::exception& e );
 
-         signal<void(uint32_t)>                        block_start; // block_num
-         signal<void(const signed_block_ptr&)>         pre_accepted_block;
+         signal<void(uint32_t)>                        block_start;
          signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const account_name&>)> accepted_block_header;
          signal<void(const block_state_legacy_ptr&)>   accepted_block;
          signal<void(const block_state_legacy_ptr&)>   irreversible_block;
          signal<void(const transaction_metadata_ptr&)> accepted_transaction;
          signal<void(std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&>)> applied_transaction;
-         signal<void(const int&)>                      bad_alloc;
-
-         /*
-         signal<void()>                                  pre_apply_block;
-         signal<void()>                                  post_apply_block;
-         signal<void()>                                  abort_apply_block;
-         signal<void(const transaction_metadata_ptr&)>   pre_apply_transaction;
-         signal<void(const transaction_trace_ptr&)>      post_apply_transaction;
-         signal<void(const transaction_trace_ptr&)>  pre_apply_action;
-         signal<void(const transaction_trace_ptr&)>  post_apply_action;
-         */
 
          const apply_handler* find_apply_handler( account_name contract, scope_name scope, action_name act )const;
          wasm_interface& get_wasm_interface();

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -332,7 +332,6 @@ namespace eosio { namespace chain {
          signal<void(block_signal_params)>  accepted_block_header;
          signal<void(block_signal_params)>  accepted_block;
          signal<void(block_signal_params)>  irreversible_block;
-         signal<void(const transaction_metadata_ptr&)> accepted_transaction;
          signal<void(std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&>)> applied_transaction;
 
          const apply_handler* find_apply_handler( account_name contract, scope_name scope, action_name act )const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -329,7 +329,7 @@ namespace eosio { namespace chain {
          signal<void(uint32_t)>                        block_start;
          signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)> accepted_block_header;
          signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)> accepted_block;
-         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)> irreversible_block;
+         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, uint32_t>)> irreversible_block;
          signal<void(const transaction_metadata_ptr&)> accepted_transaction;
          signal<void(std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&>)> applied_transaction;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -328,8 +328,8 @@ namespace eosio { namespace chain {
 
          signal<void(uint32_t)>                        block_start;
          signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const account_name&>)> accepted_block_header;
-         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)>   accepted_block;
-         signal<void(const block_state_legacy_ptr&)>   irreversible_block;
+         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)> accepted_block;
+         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t>)> irreversible_block;
          signal<void(const transaction_metadata_ptr&)> accepted_transaction;
          signal<void(std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&>)> applied_transaction;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -328,7 +328,7 @@ namespace eosio { namespace chain {
 
          signal<void(uint32_t)>                        block_start; // block_num
          signal<void(const signed_block_ptr&)>         pre_accepted_block;
-         signal<void(const block_state_legacy_ptr&)>   accepted_block_header;
+         signal<void(std::tuple<const signed_block_ptr&, const block_id_type&, const account_name&>)> accepted_block_header;
          signal<void(const block_state_legacy_ptr&)>   accepted_block;
          signal<void(const block_state_legacy_ptr&)>   irreversible_block;
          signal<void(const transaction_metadata_ptr&)> accepted_transaction;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -329,9 +329,9 @@ namespace eosio { namespace chain {
          static std::optional<uint64_t> convert_exception_to_error_code( const fc::exception& e );
 
          signal<void(uint32_t)>             block_start;
-         signal<void(block_signal_params)>  accepted_block_header;
-         signal<void(block_signal_params)>  accepted_block;
-         signal<void(block_signal_params)>  irreversible_block;
+         signal<void(const block_signal_params&)>  accepted_block_header;
+         signal<void(const block_signal_params&)>  accepted_block;
+         signal<void(const block_signal_params&)>  irreversible_block;
          signal<void(std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&>)> applied_transaction;
 
          const apply_handler* find_apply_handler( account_name contract, scope_name scope, action_name act )const;

--- a/libraries/chain/include/eosio/chain/subjective_billing.hpp
+++ b/libraries/chain/include/eosio/chain/subjective_billing.hpp
@@ -2,7 +2,6 @@
 
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/exceptions.hpp>
-#include <eosio/chain/block_state_legacy.hpp>
 #include <eosio/chain/transaction.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/resource_limits_private.hpp>
@@ -81,9 +80,9 @@ private:
       }
    }
 
-   void remove_subjective_billing( const chain::block_state_legacy_ptr& bsp, uint32_t time_ordinal ) {
+   void remove_subjective_billing( const chain::signed_block_ptr& block, uint32_t time_ordinal ) {
       if( !_trx_cache_index.empty() ) {
-         for( const auto& receipt : bsp->block->transactions ) {
+         for( const auto& receipt : block->transactions ) {
             if( std::holds_alternative<chain::packed_transaction>(receipt.trx) ) {
                const auto& pt = std::get<chain::packed_transaction>(receipt.trx);
                remove_subjective_billing( pt.id(), time_ordinal );
@@ -151,11 +150,11 @@ public:
       }
    }
 
-   void on_block( fc::logger& log, const chain::block_state_legacy_ptr& bsp, const fc::time_point& now ) {
-      if( bsp == nullptr || _disabled ) return;
+   void on_block( fc::logger& log, const chain::signed_block_ptr& block, const fc::time_point& now ) {
+      if( block == nullptr || _disabled ) return;
       const auto time_ordinal = time_ordinal_for(now);
       const auto orig_count = _account_subjective_bill_cache.size();
-      remove_subjective_billing( bsp, time_ordinal );
+      remove_subjective_billing( block, time_ordinal );
       if (orig_count > 0) {
          fc_dlog( log, "Subjective billed accounts ${n} removed ${r}",
                   ("n", orig_count)("r", orig_count - _account_subjective_bill_cache.size()) );

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -114,10 +114,10 @@ public:
       return true;
    }
 
-   void clear_applied( const block_state_legacy_ptr& bs ) {
+   void clear_applied( const signed_block_ptr& block ) {
       if( empty() ) return;
       auto& idx = queue.get<by_trx_id>();
-      for( const auto& receipt : bs->block->transactions ) {
+      for( const auto& receipt : block->transactions ) {
          if( std::holds_alternative<packed_transaction>(receipt.trx) ) {
             const auto& pt = std::get<packed_transaction>(receipt.trx);
             auto itr = idx.find( pt.id() );

--- a/libraries/state_history/include/eosio/state_history/trace_converter.hpp
+++ b/libraries/state_history/include/eosio/state_history/trace_converter.hpp
@@ -6,7 +6,6 @@
 namespace eosio {
 namespace state_history {
 
-using chain::block_state_legacy_ptr;
 using chain::transaction_id_type;
 
 struct trace_converter {

--- a/libraries/state_history/include/eosio/state_history/trace_converter.hpp
+++ b/libraries/state_history/include/eosio/state_history/trace_converter.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <eosio/chain/block_state_legacy.hpp>
 #include <eosio/state_history/types.hpp>
 #include <boost/iostreams/filtering_streambuf.hpp>
 
@@ -15,7 +14,7 @@ struct trace_converter {
    std::optional<augmented_transaction_trace>                 onblock_trace;
 
    void add_transaction(const transaction_trace_ptr& trace, const chain::packed_transaction_ptr& transaction);
-   void pack(boost::iostreams::filtering_ostreambuf& ds, bool trace_debug_mode, const block_state_legacy_ptr& block_state_legacy);
+   void pack(boost::iostreams::filtering_ostreambuf& ds, bool trace_debug_mode, const chain::signed_block_ptr& block);
 };
 
 } // namespace state_history

--- a/libraries/state_history/trace_converter.cpp
+++ b/libraries/state_history/trace_converter.cpp
@@ -15,11 +15,11 @@ void trace_converter::add_transaction(const transaction_trace_ptr& trace, const 
    }
 }
 
-void trace_converter::pack(boost::iostreams::filtering_ostreambuf& obuf, bool trace_debug_mode, const block_state_legacy_ptr& block_state) {
+void trace_converter::pack(boost::iostreams::filtering_ostreambuf& obuf, bool trace_debug_mode, const chain::signed_block_ptr& block) {
    std::vector<augmented_transaction_trace> traces;
    if (onblock_trace)
       traces.push_back(*onblock_trace);
-   for (auto& r : block_state->block->transactions) {
+   for (auto& r : block->transactions) {
       transaction_id_type id;
       if (std::holds_alternative<transaction_id_type>(r.trx))
          id = std::get<transaction_id_type>(r.trx);

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -321,9 +321,10 @@ namespace eosio { namespace testing {
       control->add_indices();
       if (lambda) lambda();
       chain_transactions.clear();
-      control->accepted_block.connect([this]( const block_state_legacy_ptr& block_state ){
-        FC_ASSERT( block_state->block );
-          for( auto receipt : block_state->block->transactions ) {
+      control->accepted_block.connect([this]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ){
+        const auto& [ block, id, header, block_num ] = t;
+        FC_ASSERT( block );
+          for( auto receipt : block->transactions ) {
               if( std::holds_alternative<packed_transaction>(receipt.trx) ) {
                   auto &pt = std::get<packed_transaction>(receipt.trx);
                   chain_transactions[pt.get_transaction().id()] = std::move(receipt);

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -321,8 +321,8 @@ namespace eosio { namespace testing {
       control->add_indices();
       if (lambda) lambda();
       chain_transactions.clear();
-      control->accepted_block.connect([this]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ){
-        const auto& [ block, id, header, block_num ] = t;
+      control->accepted_block.connect([this]( block_signal_params t ){
+        const auto& [ block, id ] = t;
         FC_ASSERT( block );
           for( auto receipt : block->transactions ) {
               if( std::holds_alternative<packed_transaction>(receipt.trx) ) {

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -17,7 +17,7 @@ namespace eosio::chain::plugin_interface {
       using rejected_block         = channel_decl<struct rejected_block_tag,        signed_block_ptr>;
       using accepted_block_header  = channel_decl<struct accepted_block_header_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
       using accepted_block         = channel_decl<struct accepted_block_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
-      using irreversible_block     = channel_decl<struct irreversible_block_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
+      using irreversible_block     = channel_decl<struct irreversible_block_tag, std::tuple<signed_block_ptr, block_id_type, uint32_t>>;
       using applied_transaction    = channel_decl<struct applied_transaction_tag,   transaction_trace_ptr>;
    }
 

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -16,7 +16,7 @@ namespace eosio::chain::plugin_interface {
    namespace channels {
       using pre_accepted_block     = channel_decl<struct pre_accepted_block_tag,    signed_block_ptr>;
       using rejected_block         = channel_decl<struct rejected_block_tag,        signed_block_ptr>;
-      using accepted_block_header  = channel_decl<struct accepted_block_header_tag, block_state_legacy_ptr>;
+      using accepted_block_header  = channel_decl<struct accepted_block_header_tag, std::tuple<signed_block_ptr, block_id_type, account_name>>;
       using accepted_block         = channel_decl<struct accepted_block_tag,        block_state_legacy_ptr>;
       using irreversible_block     = channel_decl<struct irreversible_block_tag,    block_state_legacy_ptr>;
       using accepted_transaction   = channel_decl<struct accepted_transaction_tag,  transaction_metadata_ptr>;

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -14,12 +14,10 @@ namespace eosio::chain::plugin_interface {
    struct chain_plugin_interface;
 
    namespace channels {
-      using pre_accepted_block     = channel_decl<struct pre_accepted_block_tag,    signed_block_ptr>;
       using rejected_block         = channel_decl<struct rejected_block_tag,        signed_block_ptr>;
       using accepted_block_header  = channel_decl<struct accepted_block_header_tag, std::tuple<signed_block_ptr, block_id_type, account_name>>;
       using accepted_block         = channel_decl<struct accepted_block_tag,        block_state_legacy_ptr>;
       using irreversible_block     = channel_decl<struct irreversible_block_tag,    block_state_legacy_ptr>;
-      using accepted_transaction   = channel_decl<struct accepted_transaction_tag,  transaction_metadata_ptr>;
       using applied_transaction    = channel_decl<struct applied_transaction_tag,   transaction_trace_ptr>;
    }
 

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -15,9 +15,9 @@ namespace eosio::chain::plugin_interface {
 
    namespace channels {
       using rejected_block         = channel_decl<struct rejected_block_tag,        signed_block_ptr>;
-      using accepted_block_header  = channel_decl<struct accepted_block_header_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
-      using accepted_block         = channel_decl<struct accepted_block_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
-      using irreversible_block     = channel_decl<struct irreversible_block_tag, std::tuple<signed_block_ptr, block_id_type, uint32_t>>;
+      using accepted_block_header  = channel_decl<struct accepted_block_header_tag, block_signal_params>;
+      using accepted_block         = channel_decl<struct accepted_block_tag, block_signal_params>;
+      using irreversible_block     = channel_decl<struct irreversible_block_tag,block_signal_params>;
       using applied_transaction    = channel_decl<struct applied_transaction_tag,   transaction_trace_ptr>;
    }
 

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -15,7 +15,7 @@ namespace eosio::chain::plugin_interface {
 
    namespace channels {
       using rejected_block         = channel_decl<struct rejected_block_tag,        signed_block_ptr>;
-      using accepted_block_header  = channel_decl<struct accepted_block_header_tag, std::tuple<signed_block_ptr, block_id_type, account_name>>;
+      using accepted_block_header  = channel_decl<struct accepted_block_header_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
       using accepted_block         = channel_decl<struct accepted_block_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
       using irreversible_block     = channel_decl<struct irreversible_block_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
       using applied_transaction    = channel_decl<struct applied_transaction_tag,   transaction_trace_ptr>;

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -16,7 +16,7 @@ namespace eosio::chain::plugin_interface {
    namespace channels {
       using rejected_block         = channel_decl<struct rejected_block_tag,        signed_block_ptr>;
       using accepted_block_header  = channel_decl<struct accepted_block_header_tag, std::tuple<signed_block_ptr, block_id_type, account_name>>;
-      using accepted_block         = channel_decl<struct accepted_block_tag,        block_state_legacy_ptr>;
+      using accepted_block         = channel_decl<struct accepted_block_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
       using irreversible_block     = channel_decl<struct irreversible_block_tag,    block_state_legacy_ptr>;
       using applied_transaction    = channel_decl<struct applied_transaction_tag,   transaction_trace_ptr>;
    }

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -17,7 +17,7 @@ namespace eosio::chain::plugin_interface {
       using rejected_block         = channel_decl<struct rejected_block_tag,        signed_block_ptr>;
       using accepted_block_header  = channel_decl<struct accepted_block_header_tag, std::tuple<signed_block_ptr, block_id_type, account_name>>;
       using accepted_block         = channel_decl<struct accepted_block_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
-      using irreversible_block     = channel_decl<struct irreversible_block_tag,    block_state_legacy_ptr>;
+      using irreversible_block     = channel_decl<struct irreversible_block_tag, std::tuple<signed_block_ptr, block_id_type, signed_block_header, uint32_t>>;
       using applied_transaction    = channel_decl<struct applied_transaction_tag,   transaction_trace_ptr>;
    }
 

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -265,7 +265,7 @@ namespace eosio::chain_apis {
             } else {
                const auto& po = *itr;
 
-               uint32_t last_updated_height = chain::block_timestamp_type(po.last_updated) == static_cast<chain::signed_block_header>(*block).timestamp ?
+               uint32_t last_updated_height = chain::block_timestamp_type(po.last_updated) == block->timestamp ?
                   bnum : last_updated_time_to_height(po.last_updated);
 
                index.modify(index.iterator_to(pi), [&po, last_updated_height](auto& mutable_pi) {
@@ -375,7 +375,7 @@ namespace eosio::chain_apis {
             rollback_to_before(block);
 
             // insert this blocks time into the time map
-            time_to_block_num.emplace(static_cast<chain::signed_block_header>(*block).timestamp, block_num);
+            time_to_block_num.emplace(block->timestamp, block_num);
 
             const auto bnum = block_num;
             auto& index = permission_info_index.get<by_owner_name>();

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -231,7 +231,9 @@ namespace eosio::chain_apis {
        *
        * For each removed entry, this will create a new entry if there exists an equivalent {owner, name} permission
        * at the HEAD state of the chain.
-       * @param bsp - the block to rollback before
+       * @param block - the block to rollback before
+       * @param header - the block header
+       * @param block_num - the block number
        */
       void rollback_to_before( const chain::signed_block_ptr block, const chain::signed_block_header& header, uint32_t block_num ) {
          const auto bnum = block->block_num();
@@ -303,7 +305,7 @@ namespace eosio::chain_apis {
       /**
        * Pre-Commit step with const qualifier to guarantee it does not mutate
        * the thread-safe data set
-       * @param bsp
+       * @param block
        */
       auto commit_block_prelock( const chain::signed_block_ptr block ) const {
          permission_set_t updated;
@@ -358,7 +360,9 @@ namespace eosio::chain_apis {
       /**
        * Commit a block of transactions to the account query DB
        * transaction traces need to be in the cache prior to this call
-       * @param bsp
+       * @param block
+       * @param header
+       * @param block_num
        */
       void commit_block(const chain::signed_block_ptr& block, const chain::signed_block_header& header, uint32_t block_num ) {
          permission_set_t updated;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1039,7 +1039,7 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
          const auto& [ block, id ] = t;
 
          if (_trx_retry_db) {
-            _trx_retry_db->on_irreversible_block(block, block->block_num());
+            _trx_retry_db->on_irreversible_block(block);
          }
 
          if (_trx_finality_status_processing) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1051,19 +1051,20 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
       
       applied_transaction_connection = chain->applied_transaction.connect(
             [this]( std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> t ) {
+               const auto& [ trace, ptrx ] = t;
                if (_account_query_db) {
-                  _account_query_db->cache_transaction_trace(std::get<0>(t));
+                  _account_query_db->cache_transaction_trace(trace);
                }
 
                if (_trx_retry_db) {
-                  _trx_retry_db->on_applied_transaction(std::get<0>(t), std::get<1>(t));
+                  _trx_retry_db->on_applied_transaction(trace, ptrx);
                }
 
                if (_trx_finality_status_processing) {
-                  _trx_finality_status_processing->signal_applied_transaction(std::get<0>(t), std::get<1>(t));
+                  _trx_finality_status_processing->signal_applied_transaction(trace, ptrx);
                }
 
-               applied_transaction_channel.publish( priority::low, std::get<0>(t) );
+               applied_transaction_channel.publish( priority::low, trace );
             } );
 
       if (_trx_finality_status_processing || _trx_retry_db) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -154,11 +154,9 @@ using boost::signals2::scoped_connection;
 class chain_plugin_impl {
 public:
    chain_plugin_impl()
-   :pre_accepted_block_channel(app().get_channel<channels::pre_accepted_block>())
-   ,accepted_block_header_channel(app().get_channel<channels::accepted_block_header>())
+   :accepted_block_header_channel(app().get_channel<channels::accepted_block_header>())
    ,accepted_block_channel(app().get_channel<channels::accepted_block>())
    ,irreversible_block_channel(app().get_channel<channels::irreversible_block>())
-   ,accepted_transaction_channel(app().get_channel<channels::accepted_transaction>())
    ,applied_transaction_channel(app().get_channel<channels::applied_transaction>())
    ,incoming_block_sync_method(app().get_method<incoming::methods::block_sync>())
    ,incoming_transaction_async_method(app().get_method<incoming::methods::transaction_async>())
@@ -181,11 +179,9 @@ public:
 
 
    // retained references to channels for easy publication
-   channels::pre_accepted_block::channel_type&     pre_accepted_block_channel;
    channels::accepted_block_header::channel_type&  accepted_block_header_channel;
    channels::accepted_block::channel_type&         accepted_block_channel;
    channels::irreversible_block::channel_type&     irreversible_block_channel;
-   channels::accepted_transaction::channel_type&   accepted_transaction_channel;
    channels::applied_transaction::channel_type&    applied_transaction_channel;
 
    // retained references to methods for easy calling
@@ -199,11 +195,9 @@ public:
    methods::get_last_irreversible_block_number::method_type::handle  get_last_irreversible_block_number_provider;
 
    // scoped connections for chain controller
-   std::optional<scoped_connection>                                   pre_accepted_block_connection;
    std::optional<scoped_connection>                                   accepted_block_header_connection;
    std::optional<scoped_connection>                                   accepted_block_connection;
    std::optional<scoped_connection>                                   irreversible_block_connection;
-   std::optional<scoped_connection>                                   accepted_transaction_connection;
    std::optional<scoped_connection>                                   applied_transaction_connection;
    std::optional<scoped_connection>                                   block_start_connection;
 
@@ -1019,19 +1013,6 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
             } );
 
       // relay signals to channels
-      pre_accepted_block_connection = chain->pre_accepted_block.connect([this](const signed_block_ptr& blk) {
-         auto itr = loaded_checkpoints.find( blk->block_num() );
-         if( itr != loaded_checkpoints.end() ) {
-            auto id = blk->calculate_id();
-            EOS_ASSERT( itr->second == id, checkpoint_exception,
-                        "Checkpoint does not match for block number ${num}: expected: ${expected} actual: ${actual}",
-                        ("num", blk->block_num())("expected", itr->second)("actual", id)
-            );
-         }
-
-         pre_accepted_block_channel.publish(priority::medium, blk);
-      });
-
       accepted_block_header_connection = chain->accepted_block_header.connect(
             [this]( std::tuple<const signed_block_ptr&, const block_id_type&, const account_name&> t ) {
                accepted_block_header_channel.publish( priority::medium, t );
@@ -1064,12 +1045,7 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
 
          irreversible_block_channel.publish( priority::low, blk );
       } );
-
-      accepted_transaction_connection = chain->accepted_transaction.connect(
-            [this]( const transaction_metadata_ptr& meta ) {
-               accepted_transaction_channel.publish( priority::low, meta );
-            } );
-
+      
       applied_transaction_connection = chain->applied_transaction.connect(
             [this]( std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> t ) {
                if (_account_query_db) {
@@ -1162,11 +1138,9 @@ void chain_plugin::plugin_startup() {
 }
 
 void chain_plugin_impl::plugin_shutdown() {
-   pre_accepted_block_connection.reset();
    accepted_block_header_connection.reset();
    accepted_block_connection.reset();
    irreversible_block_connection.reset();
-   accepted_transaction_connection.reset();
    applied_transaction_connection.reset();
    block_start_connection.reset();
    chain.reset();

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1014,11 +1014,11 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
 
       // relay signals to channels
       accepted_block_header_connection = chain->accepted_block_header.connect(
-            [this]( block_signal_params t ) {
+            [this]( const block_signal_params& t ) {
                accepted_block_header_channel.publish( priority::medium, t );
             } );
 
-      accepted_block_connection = chain->accepted_block.connect( [this]( block_signal_params t ) {
+      accepted_block_connection = chain->accepted_block.connect( [this]( const block_signal_params& t ) {
          const auto& [ block, id ] = t;
          if (_account_query_db) {
             _account_query_db->commit_block(block, static_cast<signed_block_header>(*block), block->block_num());
@@ -1035,7 +1035,7 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
          accepted_block_channel.publish( priority::high, t );
       } );
 
-      irreversible_block_connection = chain->irreversible_block.connect( [this]( block_signal_params t ) {
+      irreversible_block_connection = chain->irreversible_block.connect( [this]( const block_signal_params& t ) {
          const auto& [ block, id ] = t;
 
          if (_trx_retry_db) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1035,8 +1035,8 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
          accepted_block_channel.publish( priority::high, t );
       } );
 
-      irreversible_block_connection = chain->irreversible_block.connect( [this]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
-         const auto& [ block, id, header, block_num ] = t;
+      irreversible_block_connection = chain->irreversible_block.connect( [this]( std::tuple<const signed_block_ptr&, const block_id_type&, uint32_t> t ) {
+         const auto& [ block, id, block_num ] = t;
 
          if (_trx_retry_db) {
             _trx_retry_db->on_irreversible_block(block, block_num);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1035,16 +1035,18 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
          accepted_block_channel.publish( priority::high, t );
       } );
 
-      irreversible_block_connection = chain->irreversible_block.connect( [this]( const block_state_legacy_ptr& blk ) {
+      irreversible_block_connection = chain->irreversible_block.connect( [this]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
+         const auto& [ block, id, header, block_num ] = t;
+
          if (_trx_retry_db) {
-            _trx_retry_db->on_irreversible_block(blk);
+            _trx_retry_db->on_irreversible_block(block, block_num);
          }
 
          if (_trx_finality_status_processing) {
-            _trx_finality_status_processing->signal_irreversible_block(blk);
+            _trx_finality_status_processing->signal_irreversible_block(block, id);
          }
 
-         irreversible_block_channel.publish( priority::low, blk );
+         irreversible_block_channel.publish( priority::low, t );
       } );
       
       applied_transaction_connection = chain->applied_transaction.connect(

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1033,8 +1033,8 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
       });
 
       accepted_block_header_connection = chain->accepted_block_header.connect(
-            [this]( const block_state_legacy_ptr& blk ) {
-               accepted_block_header_channel.publish( priority::medium, blk );
+            [this]( std::tuple<const signed_block_ptr&, const block_id_type&, const account_name&> t ) {
+               accepted_block_header_channel.publish( priority::medium, t );
             } );
 
       accepted_block_connection = chain->accepted_block.connect( [this]( const block_state_legacy_ptr& blk ) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1014,7 +1014,7 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
 
       // relay signals to channels
       accepted_block_header_connection = chain->accepted_block_header.connect(
-            [this]( std::tuple<const signed_block_ptr&, const block_id_type&, const account_name&> t ) {
+            [this]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
                accepted_block_header_channel.publish( priority::medium, t );
             } );
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1021,7 +1021,7 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
       accepted_block_connection = chain->accepted_block.connect( [this]( const block_signal_params& t ) {
          const auto& [ block, id ] = t;
          if (_account_query_db) {
-            _account_query_db->commit_block(block, static_cast<signed_block_header>(*block), block->block_num());
+            _account_query_db->commit_block(block);
          }
 
          if (_trx_retry_db) {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <eosio/chain/types.hpp>
-#include <eosio/chain/block_state_legacy.hpp>
 #include <eosio/chain/trace.hpp>
 
 namespace eosio::chain_apis {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
@@ -40,7 +40,7 @@ namespace eosio::chain_apis {
        * uncommitted traces.
        * @param block
        */
-      void commit_block(const chain::block_state_legacy_ptr& block );
+      void commit_block( const chain::signed_block_ptr& block, const chain::signed_block_header& header, uint32_t block_num );
 
       /**
        * parameters for the get_accounts_by_authorizers RPC

--- a/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
@@ -39,7 +39,7 @@ namespace eosio::chain_apis {
        * uncommitted traces.
        * @param block
        */
-      void commit_block( const chain::signed_block_ptr& block, const chain::signed_block_header& header, uint32_t block_num );
+      void commit_block( const chain::signed_block_ptr& block );
 
       /**
        * parameters for the get_accounts_by_authorizers RPC

--- a/plugins/chain_plugin/include/eosio/chain_plugin/trx_finality_status_processing.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/trx_finality_status_processing.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <eosio/chain/types.hpp>
-#include <eosio/chain/block_state_legacy.hpp>
 #include <eosio/chain/trace.hpp>
 
 #include <fc/container/tracked_storage.hpp>
@@ -44,7 +43,7 @@ namespace eosio::chain_apis {
 
       void signal_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id );
 
-      void signal_irreversible_block( const chain::block_state_legacy_ptr& bsp );
+      void signal_irreversible_block( const chain::signed_block_ptr& block, const chain::block_id_type& id );
 
       void signal_block_start( uint32_t block_num );
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/trx_finality_status_processing.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/trx_finality_status_processing.hpp
@@ -42,7 +42,7 @@ namespace eosio::chain_apis {
 
       void signal_applied_transaction( const chain::transaction_trace_ptr& trace, const chain::packed_transaction_ptr& ptrx );
 
-      void signal_accepted_block( const chain::block_state_legacy_ptr& bsp );
+      void signal_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id );
 
       void signal_irreversible_block( const chain::block_state_legacy_ptr& bsp );
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/trx_retry_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/trx_retry_db.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <eosio/chain/types.hpp>
-#include <eosio/chain/block_state_legacy.hpp>
 #include <eosio/chain/trace.hpp>
 
 namespace eosio::chain_apis {
@@ -69,7 +68,7 @@ public:
    /**
     * Attach to chain irreversible_block signal
     */
-   void on_irreversible_block(const chain::block_state_legacy_ptr& block );
+   void on_irreversible_block( const chain::signed_block_ptr& block, uint32_t block_num );
 
 private:
    std::unique_ptr<struct trx_retry_db_impl> _impl;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/trx_retry_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/trx_retry_db.hpp
@@ -64,7 +64,7 @@ public:
    /**
     * Attach to chain accepted_block signal
     */
-   void on_accepted_block(const chain::block_state_legacy_ptr& block );
+   void on_accepted_block( uint32_t block_num );
 
    /**
     * Attach to chain irreversible_block signal

--- a/plugins/chain_plugin/include/eosio/chain_plugin/trx_retry_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/trx_retry_db.hpp
@@ -68,7 +68,7 @@ public:
    /**
     * Attach to chain irreversible_block signal
     */
-   void on_irreversible_block( const chain::signed_block_ptr& block, uint32_t block_num );
+   void on_irreversible_block( const chain::signed_block_ptr& block );
 
 private:
    std::unique_ptr<struct trx_retry_db_impl> _impl;

--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -37,9 +37,9 @@ BOOST_FIXTURE_TEST_CASE(newaccount_test, validating_tester) { try {
    auto aq_db = account_query_db(*control);
 
     //link aq_db to the `accepted_block` signal on the controller
-   auto c2 = control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-        const auto& [ block, id, header, block_num ] = t;
-        aq_db.commit_block( block, header, block_num );
+   auto c2 = control->accepted_block.connect([&](block_signal_params t) {
+        const auto& [ block, id ] = t;
+        aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
    });
 
    produce_blocks(10);
@@ -63,9 +63,9 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test, validating_tester) { try {
     auto aq_db = account_query_db(*control);
 
     //link aq_db to the `accepted_block` signal on the controller
-    auto c = control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-        const auto& [ block, id, header, block_num ] = t;
-        aq_db.commit_block( block, header, block_num );
+    auto c = control->accepted_block.connect([&](block_signal_params t) {
+        const auto& [ block, id ] = t;
+        aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
     });
 
     produce_blocks(10);
@@ -98,9 +98,9 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test_multi_threaded, validating_tester) { try
    auto aq_db = account_query_db(*control);
 
    //link aq_db to the `accepted_block` signal on the controller
-   auto c = control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-      const auto& [ block, id, header, block_num ] = t;
-      aq_db.commit_block( block, header, block_num );
+   auto c = control->accepted_block.connect([&](block_signal_params t) {
+      const auto& [ block, id ] = t;
+      aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
    });
 
    produce_blocks(10);
@@ -151,9 +151,9 @@ BOOST_AUTO_TEST_CASE(future_fork_test) { try {
    auto aq_db = account_query_db(*node_a.control);
 
    //link aq_db to the `accepted_block` signal on the controller
-   auto c = node_a.control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-      const auto& [ block, id, header, block_num ] = t;
-      aq_db.commit_block( block, header, block_num );
+   auto c = node_a.control->accepted_block.connect([&](block_signal_params t) {
+      const auto& [ block, id ] = t;
+      aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
    });
 
    // create 10 blocks synced
@@ -199,9 +199,9 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
       auto aq_db = account_query_db(*node_a.control);
 
       //link aq_db to the `accepted_block` signal on the controller
-      auto c = node_a.control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-         const auto& [ block, id, header, block_num ] = t;
-         aq_db.commit_block( block, header, block_num );
+      auto c = node_a.control->accepted_block.connect([&](block_signal_params t) {
+         const auto& [ block, id ] = t;
+         aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
       });
 
       // create 10 blocks synced

--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -37,7 +37,7 @@ BOOST_FIXTURE_TEST_CASE(newaccount_test, validating_tester) { try {
    auto aq_db = account_query_db(*control);
 
     //link aq_db to the `accepted_block` signal on the controller
-   auto c2 = control->accepted_block.connect([&](block_signal_params t) {
+   auto c2 = control->accepted_block.connect([&](const block_signal_params& t) {
         const auto& [ block, id ] = t;
         aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
    });
@@ -63,7 +63,7 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test, validating_tester) { try {
     auto aq_db = account_query_db(*control);
 
     //link aq_db to the `accepted_block` signal on the controller
-    auto c = control->accepted_block.connect([&](block_signal_params t) {
+    auto c = control->accepted_block.connect([&](const block_signal_params& t) {
         const auto& [ block, id ] = t;
         aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
     });
@@ -98,7 +98,7 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test_multi_threaded, validating_tester) { try
    auto aq_db = account_query_db(*control);
 
    //link aq_db to the `accepted_block` signal on the controller
-   auto c = control->accepted_block.connect([&](block_signal_params t) {
+   auto c = control->accepted_block.connect([&](const block_signal_params& t) {
       const auto& [ block, id ] = t;
       aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
    });
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(future_fork_test) { try {
    auto aq_db = account_query_db(*node_a.control);
 
    //link aq_db to the `accepted_block` signal on the controller
-   auto c = node_a.control->accepted_block.connect([&](block_signal_params t) {
+   auto c = node_a.control->accepted_block.connect([&](const block_signal_params& t) {
       const auto& [ block, id ] = t;
       aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
    });
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
       auto aq_db = account_query_db(*node_a.control);
 
       //link aq_db to the `accepted_block` signal on the controller
-      auto c = node_a.control->accepted_block.connect([&](block_signal_params t) {
+      auto c = node_a.control->accepted_block.connect([&](const block_signal_params& t) {
          const auto& [ block, id ] = t;
          aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
       });

--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -2,7 +2,6 @@
 #include <eosio/chain/permission_object.hpp>
 #include <eosio/testing/tester.hpp>
 #include <eosio/chain/types.hpp>
-#include <eosio/chain/block_state_legacy.hpp>
 #include <eosio/chain_plugin/account_query_db.hpp>
 #include <eosio/chain/thread_utils.hpp>
 
@@ -38,8 +37,9 @@ BOOST_FIXTURE_TEST_CASE(newaccount_test, validating_tester) { try {
    auto aq_db = account_query_db(*control);
 
     //link aq_db to the `accepted_block` signal on the controller
-   auto c2 = control->accepted_block.connect([&](const block_state_legacy_ptr& blk) {
-        aq_db.commit_block( blk);
+   auto c2 = control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+        const auto& [ block, id, header, block_num ] = t;
+        aq_db.commit_block( block, header, block_num );
    });
 
    produce_blocks(10);
@@ -63,8 +63,9 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test, validating_tester) { try {
     auto aq_db = account_query_db(*control);
 
     //link aq_db to the `accepted_block` signal on the controller
-    auto c = control->accepted_block.connect([&](const block_state_legacy_ptr& blk) {
-        aq_db.commit_block( blk);
+    auto c = control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+        const auto& [ block, id, header, block_num ] = t;
+        aq_db.commit_block( block, header, block_num );
     });
 
     produce_blocks(10);
@@ -97,8 +98,9 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test_multi_threaded, validating_tester) { try
    auto aq_db = account_query_db(*control);
 
    //link aq_db to the `accepted_block` signal on the controller
-   auto c = control->accepted_block.connect([&](const block_state_legacy_ptr& blk) {
-      aq_db.commit_block( blk);
+   auto c = control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+      const auto& [ block, id, header, block_num ] = t;
+      aq_db.commit_block( block, header, block_num );
    });
 
    produce_blocks(10);
@@ -149,8 +151,9 @@ BOOST_AUTO_TEST_CASE(future_fork_test) { try {
    auto aq_db = account_query_db(*node_a.control);
 
    //link aq_db to the `accepted_block` signal on the controller
-   auto c = node_a.control->accepted_block.connect([&](const block_state_legacy_ptr& blk) {
-      aq_db.commit_block( blk);
+   auto c = node_a.control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+      const auto& [ block, id, header, block_num ] = t;
+      aq_db.commit_block( block, header, block_num );
    });
 
    // create 10 blocks synced
@@ -196,8 +199,9 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
       auto aq_db = account_query_db(*node_a.control);
 
       //link aq_db to the `accepted_block` signal on the controller
-      auto c = node_a.control->accepted_block.connect([&](const block_state_legacy_ptr& blk) {
-         aq_db.commit_block( blk);
+      auto c = node_a.control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+         const auto& [ block, id, header, block_num ] = t;
+         aq_db.commit_block( block, header, block_num );
       });
 
       // create 10 blocks synced

--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -39,7 +39,7 @@ BOOST_FIXTURE_TEST_CASE(newaccount_test, validating_tester) { try {
     //link aq_db to the `accepted_block` signal on the controller
    auto c2 = control->accepted_block.connect([&](const block_signal_params& t) {
         const auto& [ block, id ] = t;
-        aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
+        aq_db.commit_block( block );
    });
 
    produce_blocks(10);
@@ -65,7 +65,7 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test, validating_tester) { try {
     //link aq_db to the `accepted_block` signal on the controller
     auto c = control->accepted_block.connect([&](const block_signal_params& t) {
         const auto& [ block, id ] = t;
-        aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
+        aq_db.commit_block( block );
     });
 
     produce_blocks(10);
@@ -100,7 +100,7 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test_multi_threaded, validating_tester) { try
    //link aq_db to the `accepted_block` signal on the controller
    auto c = control->accepted_block.connect([&](const block_signal_params& t) {
       const auto& [ block, id ] = t;
-      aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
+      aq_db.commit_block( block );
    });
 
    produce_blocks(10);
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(future_fork_test) { try {
    //link aq_db to the `accepted_block` signal on the controller
    auto c = node_a.control->accepted_block.connect([&](const block_signal_params& t) {
       const auto& [ block, id ] = t;
-      aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
+      aq_db.commit_block( block );
    });
 
    // create 10 blocks synced
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
       //link aq_db to the `accepted_block` signal on the controller
       auto c = node_a.control->accepted_block.connect([&](const block_signal_params& t) {
          const auto& [ block, id ] = t;
-         aq_db.commit_block( block, static_cast<signed_block_header>(*block), block->block_num() );
+         aq_db.commit_block( block );
       });
 
       // create 10 blocks synced

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -750,7 +750,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(!ts);
 
    // irreversible
-   status.signal_irreversible_block(bs_19_alt);
+   status.signal_irreversible_block(bs_19_alt->block, bs_19_alt->id);
 
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_19_alt->id);

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    const auto block_20_time = set_now("2022-04-04", "04:44:44.500");
    add(trx_pairs_20, bs_20);
    add(trx_pairs_20, bs_20);
-   status.signal_accepted_block(bs_20);
+   status.signal_accepted_block(bs_20->block, bs_20->id);
 
 
    cs = status.get_chain_state();
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
 
    add(trx_pairs_21, bs_21);
-   status.signal_accepted_block(bs_21);
+   status.signal_accepted_block(bs_21->block, bs_21->id);
 
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_21->id);
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    status.signal_block_start(bn);
 
    add(trx_pairs_22, bs_22);
-   status.signal_accepted_block(bs_22);
+   status.signal_accepted_block(bs_22->block, bs_22->id);
 
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_22->id);
@@ -468,7 +468,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    status.signal_block_start(bn);
 
    add(trx_pairs_22_alt, bs_22_alt);
-   status.signal_accepted_block(bs_22_alt);
+   status.signal_accepted_block(bs_22_alt->block, bs_22_alt->id);
 
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_22_alt->id);
@@ -553,7 +553,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    status.signal_block_start(bn);
 
    add(trx_pairs_19, bs_19);
-   status.signal_accepted_block(bs_19);
+   status.signal_accepted_block(bs_19->block, bs_19->id);
 
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_19->id);
@@ -661,7 +661,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
       status.signal_applied_transaction(trace, txn);
    }
 
-   status.signal_accepted_block(bs_19_alt);
+   status.signal_accepted_block(bs_19_alt->block, bs_19_alt->id);
 
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_19_alt->id);
@@ -898,7 +898,7 @@ namespace {
             status.signal_applied_transaction(trace, txn);
          }
 
-         status.signal_accepted_block(bs);
+         status.signal_accepted_block(bs->block, bs->id);
       }
 
       void send_spec_block() {

--- a/plugins/chain_plugin/test/test_trx_retry_db.cpp
+++ b/plugins/chain_plugin/test/test_trx_retry_db.cpp
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       auto bsp1 = make_block_state(1, {});
       trx_retry.on_block_start(1);
       trx_retry.on_accepted_block(bsp1->block_num);
-      trx_retry.on_irreversible_block(bsp1->block, bsp1->block_num);
+      trx_retry.on_irreversible_block(bsp1->block);
       BOOST_CHECK(!trx_1_expired);
       BOOST_CHECK(!trx_2_expired);
       // increase time by 3 seconds to expire first
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       auto bsp2 = make_block_state(2, {});
       trx_retry.on_block_start(2);
       trx_retry.on_accepted_block(bsp2->block_num);
-      trx_retry.on_irreversible_block(bsp2->block, bsp2->block_num);
+      trx_retry.on_irreversible_block(bsp2->block);
       BOOST_CHECK(trx_1_expired);
       BOOST_CHECK(!trx_2_expired);
       // increase time by 2 seconds to expire second
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       auto bsp3 = make_block_state(3, {});
       trx_retry.on_block_start(3);
       trx_retry.on_accepted_block(bsp3->block_num);
-      trx_retry.on_irreversible_block(bsp3->block, bsp3->block_num);
+      trx_retry.on_irreversible_block(bsp3->block);
       BOOST_CHECK(trx_1_expired);
       BOOST_CHECK(trx_2_expired);
       BOOST_CHECK_EQUAL(0u, trx_retry.size());
@@ -348,9 +348,9 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       auto bsp6 = make_block_state(6, {});
       trx_retry.on_block_start(6);
       trx_retry.on_accepted_block(bsp6->block_num);
-      trx_retry.on_irreversible_block(bsp4->block, bsp4->block_num);
-      trx_retry.on_irreversible_block(bsp5->block, bsp5->block_num);
-      trx_retry.on_irreversible_block(bsp6->block, bsp6->block_num);
+      trx_retry.on_irreversible_block(bsp4->block);
+      trx_retry.on_irreversible_block(bsp5->block);
+      trx_retry.on_irreversible_block(bsp6->block);
       BOOST_CHECK(trx_3_expired);
       BOOST_CHECK(trx_4_expired);
       BOOST_CHECK_EQUAL(0u, trx_retry.size());
@@ -416,10 +416,10 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       trx_retry.on_accepted_block(bsp11->block_num);
       BOOST_CHECK(!trx_5_variant);
       BOOST_CHECK(trx_6_variant);
-      trx_retry.on_irreversible_block(bsp7->block, bsp7->block_num);
+      trx_retry.on_irreversible_block(bsp7->block);
       BOOST_CHECK(!trx_5_variant);
       BOOST_CHECK(trx_6_variant);
-      trx_retry.on_irreversible_block(bsp8->block, bsp8->block_num);
+      trx_retry.on_irreversible_block(bsp8->block);
       BOOST_CHECK(trx_5_variant);
       BOOST_CHECK(trx_6_variant);
       BOOST_CHECK_EQUAL(0u, trx_retry.size());
@@ -541,16 +541,16 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
-      trx_retry.on_irreversible_block(bsp9->block, bsp9->block_num);
-      trx_retry.on_irreversible_block(bsp10->block, bsp10->block_num);
-      trx_retry.on_irreversible_block(bsp11->block, bsp11->block_num);
-      trx_retry.on_irreversible_block(bsp12->block, bsp12->block_num);
-      trx_retry.on_irreversible_block(bsp13b->block, bsp13b->block_num);
-      trx_retry.on_irreversible_block(bsp14b->block, bsp14b->block_num);
+      trx_retry.on_irreversible_block(bsp9->block);
+      trx_retry.on_irreversible_block(bsp10->block);
+      trx_retry.on_irreversible_block(bsp11->block);
+      trx_retry.on_irreversible_block(bsp12->block);
+      trx_retry.on_irreversible_block(bsp13b->block);
+      trx_retry.on_irreversible_block(bsp14b->block);
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
-      trx_retry.on_irreversible_block(bsp15b->block, bsp15b->block_num);
+      trx_retry.on_irreversible_block(bsp15b->block);
       BOOST_CHECK(trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -560,11 +560,11 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       auto bsp19 = make_block_state(19, {});
       trx_retry.on_block_start(19);
       trx_retry.on_accepted_block(bsp19->block_num);
-      trx_retry.on_irreversible_block(bsp15->block, bsp15->block_num);
-      trx_retry.on_irreversible_block(bsp16->block, bsp16->block_num);
-      trx_retry.on_irreversible_block(bsp17->block, bsp17->block_num);
-      trx_retry.on_irreversible_block(bsp18->block, bsp18->block_num);
-      trx_retry.on_irreversible_block(bsp19->block, bsp19->block_num);
+      trx_retry.on_irreversible_block(bsp15->block);
+      trx_retry.on_irreversible_block(bsp16->block);
+      trx_retry.on_irreversible_block(bsp17->block);
+      trx_retry.on_irreversible_block(bsp18->block);
+      trx_retry.on_irreversible_block(bsp19->block);
       BOOST_CHECK(trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       BOOST_CHECK(trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
-      trx_retry.on_irreversible_block(bsp20->block, bsp20->block_num);
+      trx_retry.on_irreversible_block(bsp20->block);
       BOOST_CHECK(trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(trx_9_expired);

--- a/plugins/chain_plugin/test/test_trx_retry_db.cpp
+++ b/plugins/chain_plugin/test/test_trx_retry_db.cpp
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       // signal block, nothing should be expired as now has not changed
       auto bsp1 = make_block_state(1, {});
       trx_retry.on_block_start(1);
-      trx_retry.on_accepted_block(bsp1);
+      trx_retry.on_accepted_block(bsp1->block_num);
       trx_retry.on_irreversible_block(bsp1);
       BOOST_CHECK(!trx_1_expired);
       BOOST_CHECK(!trx_2_expired);
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       // signal block, first transaction should expire
       auto bsp2 = make_block_state(2, {});
       trx_retry.on_block_start(2);
-      trx_retry.on_accepted_block(bsp2);
+      trx_retry.on_accepted_block(bsp2->block_num);
       trx_retry.on_irreversible_block(bsp2);
       BOOST_CHECK(trx_1_expired);
       BOOST_CHECK(!trx_2_expired);
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       // signal block, second transaction should expire
       auto bsp3 = make_block_state(3, {});
       trx_retry.on_block_start(3);
-      trx_retry.on_accepted_block(bsp3);
+      trx_retry.on_accepted_block(bsp3->block_num);
       trx_retry.on_irreversible_block(bsp3);
       BOOST_CHECK(trx_1_expired);
       BOOST_CHECK(trx_2_expired);
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       // signal block, transaction 3 should be sent
       auto bsp4 = make_block_state(4, {});
       trx_retry.on_block_start(4);
-      trx_retry.on_accepted_block(bsp4);
+      trx_retry.on_accepted_block(bsp4->block_num);
       BOOST_CHECK( get_id(transactions_acked.pop().second) == 3 );
       BOOST_CHECK_EQUAL( 0u, transactions_acked.size() );
       // increase time by 1 seconds, so trx_4 is sent
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       // signal block, transaction 4 should be sent
       auto bsp5 = make_block_state(5, {});
       trx_retry.on_block_start(5);
-      trx_retry.on_accepted_block(bsp5);
+      trx_retry.on_accepted_block(bsp5->block_num);
       BOOST_CHECK( get_id(transactions_acked.pop().second) == 4 );
       BOOST_CHECK_EQUAL( 0u, transactions_acked.size() );
       BOOST_CHECK(!trx_3_expired);
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       fc::mock_time_traits::set_now(pnow);
       auto bsp6 = make_block_state(6, {});
       trx_retry.on_block_start(6);
-      trx_retry.on_accepted_block(bsp6);
+      trx_retry.on_accepted_block(bsp6->block_num);
       trx_retry.on_irreversible_block(bsp4);
       trx_retry.on_irreversible_block(bsp5);
       trx_retry.on_irreversible_block(bsp6);
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       // not in block 7, so not returned to user
       auto bsp7 = make_block_state(7, {});
       trx_retry.on_block_start(7);
-      trx_retry.on_accepted_block(bsp7);
+      trx_retry.on_accepted_block(bsp7->block_num);
       BOOST_CHECK(!trx_5_variant);
       BOOST_CHECK(!trx_6_variant);
       // 5,6 in block 8
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       trx_retry.on_applied_transaction(trace_5, trx_5);
       trx_retry.on_applied_transaction(trace_6, trx_6);
       auto bsp8 = make_block_state(8, {trx_5, trx_6});
-      trx_retry.on_accepted_block(bsp8);
+      trx_retry.on_accepted_block(bsp8->block_num);
       BOOST_CHECK(!trx_5_variant);
       BOOST_CHECK(!trx_6_variant);
       // need 2 blocks before 6 returned to user
@@ -398,14 +398,14 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       fc::mock_time_traits::set_now(pnow);
       auto bsp9 = make_block_state(9, {});
       trx_retry.on_block_start(9);
-      trx_retry.on_accepted_block(bsp9);
+      trx_retry.on_accepted_block(bsp9->block_num);
       BOOST_CHECK(!trx_5_variant);
       BOOST_CHECK(!trx_6_variant);
       pnow += boost::posix_time::seconds(1); // new block, new time
       fc::mock_time_traits::set_now(pnow);
       auto bsp10 = make_block_state(10, {});
       trx_retry.on_block_start(10);
-      trx_retry.on_accepted_block(bsp10);
+      trx_retry.on_accepted_block(bsp10->block_num);
       BOOST_CHECK(!trx_5_variant);
       BOOST_CHECK(trx_6_variant);
       // now signal lib for trx_6
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       fc::mock_time_traits::set_now(pnow);
       auto bsp11 = make_block_state(11, {});
       trx_retry.on_block_start(11);
-      trx_retry.on_accepted_block(bsp11);
+      trx_retry.on_accepted_block(bsp11->block_num);
       BOOST_CHECK(!trx_5_variant);
       BOOST_CHECK(trx_6_variant);
       trx_retry.on_irreversible_block(bsp7);
@@ -456,7 +456,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       // not in block 12
       auto bsp12 = make_block_state(12, {});
       trx_retry.on_block_start(12);
-      trx_retry.on_accepted_block(bsp12);
+      trx_retry.on_accepted_block(bsp12->block_num);
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(!trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -471,7 +471,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       trx_retry.on_applied_transaction(trace_8, trx_8);
       trx_retry.on_applied_transaction(trace_9, trx_9);
       auto bsp13 = make_block_state(13, {trx_7, trx_8, trx_9});
-      trx_retry.on_accepted_block(bsp13);
+      trx_retry.on_accepted_block(bsp13->block_num);
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(!trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -480,7 +480,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       fc::mock_time_traits::set_now(pnow);
       auto bsp14 = make_block_state(14, {});
       trx_retry.on_block_start(14);
-      trx_retry.on_accepted_block(bsp14);
+      trx_retry.on_accepted_block(bsp14->block_num);
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(!trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       fc::mock_time_traits::set_now(pnow);
       auto bsp15 = make_block_state(15, {});
       trx_retry.on_block_start(15);
-      trx_retry.on_accepted_block(bsp15);
+      trx_retry.on_accepted_block(bsp15->block_num);
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(!trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -500,14 +500,14 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       BOOST_CHECK_EQUAL(3u, trx_retry.size());
       // now produce an empty 13
       auto bsp13b = make_block_state(13, {}); // now 13 has no traces
-      trx_retry.on_accepted_block(bsp13b);
+      trx_retry.on_accepted_block(bsp13b->block_num);
       // produced another empty block
       pnow += boost::posix_time::seconds(1); // new block, new time
       fc::mock_time_traits::set_now(pnow);
       trx_retry.on_block_start(14);
       // now produce an empty 14
       auto bsp14b = make_block_state(14, {}); // empty
-      trx_retry.on_accepted_block(bsp14b);
+      trx_retry.on_accepted_block(bsp14b->block_num);
       // produce block with 7,8
       trx_retry.on_block_start(15);
       auto trace_7b = make_transaction_trace( trx_7, 15);
@@ -515,13 +515,13 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       trx_retry.on_applied_transaction(trace_7b, trx_7);
       trx_retry.on_applied_transaction(trace_8b, trx_8);
       auto bsp15b = make_block_state(15, {trx_7, trx_8});
-      trx_retry.on_accepted_block(bsp15b);
+      trx_retry.on_accepted_block(bsp15b->block_num);
       // need 3 blocks before 8 returned to user
       pnow += boost::posix_time::seconds(1); // new block, new time
       fc::mock_time_traits::set_now(pnow);
       auto bsp16 = make_block_state(16, {});
       trx_retry.on_block_start(16);
-      trx_retry.on_accepted_block(bsp16);
+      trx_retry.on_accepted_block(bsp16->block_num);
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(!trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       fc::mock_time_traits::set_now(pnow);
       auto bsp17 = make_block_state(17, {});
       trx_retry.on_block_start(17);
-      trx_retry.on_accepted_block(bsp17);
+      trx_retry.on_accepted_block(bsp17->block_num);
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(!trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       fc::mock_time_traits::set_now(pnow);
       auto bsp18 = make_block_state(18, {});
       trx_retry.on_block_start(18);
-      trx_retry.on_accepted_block(bsp18);
+      trx_retry.on_accepted_block(bsp18->block_num);
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -559,7 +559,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       fc::mock_time_traits::set_now(pnow);
       auto bsp19 = make_block_state(19, {});
       trx_retry.on_block_start(19);
-      trx_retry.on_accepted_block(bsp19);
+      trx_retry.on_accepted_block(bsp19->block_num);
       trx_retry.on_irreversible_block(bsp15);
       trx_retry.on_irreversible_block(bsp16);
       trx_retry.on_irreversible_block(bsp17);
@@ -572,7 +572,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       fc::mock_time_traits::set_now(pnow);
       auto bsp20 = make_block_state(20, {});
       trx_retry.on_block_start(20);
-      trx_retry.on_accepted_block(bsp20);
+      trx_retry.on_accepted_block(bsp20->block_num);
       // waits for LIB
       BOOST_CHECK(trx_7_variant);
       BOOST_CHECK(trx_8_variant);
@@ -607,14 +607,14 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       trx_retry.on_applied_transaction(trace_10, trx_10);
       trx_retry.on_applied_transaction(trace_11, trx_11);
       auto bsp21 = make_block_state(21, {trx_10, trx_11});
-      trx_retry.on_accepted_block(bsp21);
+      trx_retry.on_accepted_block(bsp21->block_num);
       BOOST_CHECK(trx_10_variant);
       BOOST_CHECK(!trx_11_variant);
       pnow += boost::posix_time::seconds(1); // new block, new time
       fc::mock_time_traits::set_now(pnow);
       auto bsp22 = make_block_state(22, {});
       trx_retry.on_block_start(22);
-      trx_retry.on_accepted_block(bsp22);
+      trx_retry.on_accepted_block(bsp22->block_num);
       BOOST_CHECK(trx_10_variant);
       BOOST_CHECK(trx_11_variant);
       BOOST_CHECK_EQUAL(0u, trx_retry.size());

--- a/plugins/chain_plugin/test/test_trx_retry_db.cpp
+++ b/plugins/chain_plugin/test/test_trx_retry_db.cpp
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       auto bsp1 = make_block_state(1, {});
       trx_retry.on_block_start(1);
       trx_retry.on_accepted_block(bsp1->block_num);
-      trx_retry.on_irreversible_block(bsp1);
+      trx_retry.on_irreversible_block(bsp1->block, bsp1->block_num);
       BOOST_CHECK(!trx_1_expired);
       BOOST_CHECK(!trx_2_expired);
       // increase time by 3 seconds to expire first
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       auto bsp2 = make_block_state(2, {});
       trx_retry.on_block_start(2);
       trx_retry.on_accepted_block(bsp2->block_num);
-      trx_retry.on_irreversible_block(bsp2);
+      trx_retry.on_irreversible_block(bsp2->block, bsp2->block_num);
       BOOST_CHECK(trx_1_expired);
       BOOST_CHECK(!trx_2_expired);
       // increase time by 2 seconds to expire second
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       auto bsp3 = make_block_state(3, {});
       trx_retry.on_block_start(3);
       trx_retry.on_accepted_block(bsp3->block_num);
-      trx_retry.on_irreversible_block(bsp3);
+      trx_retry.on_irreversible_block(bsp3->block, bsp3->block_num);
       BOOST_CHECK(trx_1_expired);
       BOOST_CHECK(trx_2_expired);
       BOOST_CHECK_EQUAL(0u, trx_retry.size());
@@ -348,9 +348,9 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       auto bsp6 = make_block_state(6, {});
       trx_retry.on_block_start(6);
       trx_retry.on_accepted_block(bsp6->block_num);
-      trx_retry.on_irreversible_block(bsp4);
-      trx_retry.on_irreversible_block(bsp5);
-      trx_retry.on_irreversible_block(bsp6);
+      trx_retry.on_irreversible_block(bsp4->block, bsp4->block_num);
+      trx_retry.on_irreversible_block(bsp5->block, bsp5->block_num);
+      trx_retry.on_irreversible_block(bsp6->block, bsp6->block_num);
       BOOST_CHECK(trx_3_expired);
       BOOST_CHECK(trx_4_expired);
       BOOST_CHECK_EQUAL(0u, trx_retry.size());
@@ -416,10 +416,10 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       trx_retry.on_accepted_block(bsp11->block_num);
       BOOST_CHECK(!trx_5_variant);
       BOOST_CHECK(trx_6_variant);
-      trx_retry.on_irreversible_block(bsp7);
+      trx_retry.on_irreversible_block(bsp7->block, bsp7->block_num);
       BOOST_CHECK(!trx_5_variant);
       BOOST_CHECK(trx_6_variant);
-      trx_retry.on_irreversible_block(bsp8);
+      trx_retry.on_irreversible_block(bsp8->block, bsp8->block_num);
       BOOST_CHECK(trx_5_variant);
       BOOST_CHECK(trx_6_variant);
       BOOST_CHECK_EQUAL(0u, trx_retry.size());
@@ -541,16 +541,16 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
-      trx_retry.on_irreversible_block(bsp9);
-      trx_retry.on_irreversible_block(bsp10);
-      trx_retry.on_irreversible_block(bsp11);
-      trx_retry.on_irreversible_block(bsp12);
-      trx_retry.on_irreversible_block(bsp13b);
-      trx_retry.on_irreversible_block(bsp14b);
+      trx_retry.on_irreversible_block(bsp9->block, bsp9->block_num);
+      trx_retry.on_irreversible_block(bsp10->block, bsp10->block_num);
+      trx_retry.on_irreversible_block(bsp11->block, bsp11->block_num);
+      trx_retry.on_irreversible_block(bsp12->block, bsp12->block_num);
+      trx_retry.on_irreversible_block(bsp13b->block, bsp13b->block_num);
+      trx_retry.on_irreversible_block(bsp14b->block, bsp14b->block_num);
       BOOST_CHECK(!trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
-      trx_retry.on_irreversible_block(bsp15b);
+      trx_retry.on_irreversible_block(bsp15b->block, bsp15b->block_num);
       BOOST_CHECK(trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -560,11 +560,11 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       auto bsp19 = make_block_state(19, {});
       trx_retry.on_block_start(19);
       trx_retry.on_accepted_block(bsp19->block_num);
-      trx_retry.on_irreversible_block(bsp15);
-      trx_retry.on_irreversible_block(bsp16);
-      trx_retry.on_irreversible_block(bsp17);
-      trx_retry.on_irreversible_block(bsp18);
-      trx_retry.on_irreversible_block(bsp19);
+      trx_retry.on_irreversible_block(bsp15->block, bsp15->block_num);
+      trx_retry.on_irreversible_block(bsp16->block, bsp16->block_num);
+      trx_retry.on_irreversible_block(bsp17->block, bsp17->block_num);
+      trx_retry.on_irreversible_block(bsp18->block, bsp18->block_num);
+      trx_retry.on_irreversible_block(bsp19->block, bsp19->block_num);
       BOOST_CHECK(trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
       BOOST_CHECK(trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(!trx_9_expired);
-      trx_retry.on_irreversible_block(bsp20);
+      trx_retry.on_irreversible_block(bsp20->block, bsp20->block_num);
       BOOST_CHECK(trx_7_variant);
       BOOST_CHECK(trx_8_variant);
       BOOST_CHECK(trx_9_expired);

--- a/plugins/chain_plugin/trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/trx_finality_status_processing.cpp
@@ -15,7 +15,7 @@ namespace eosio::chain_apis {
 
       void signal_applied_transaction( const chain::transaction_trace_ptr& trace, const chain::packed_transaction_ptr& ptrx );
 
-      void signal_accepted_block( const chain::block_state_legacy_ptr& bsp );
+      void signal_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id );
 
       void handle_rollback();
 
@@ -67,9 +67,9 @@ namespace eosio::chain_apis {
       } FC_LOG_AND_DROP(("Failed to signal applied transaction for finality status"));
    }
 
-   void trx_finality_status_processing::signal_accepted_block( const chain::block_state_legacy_ptr& bsp ) {
+   void trx_finality_status_processing::signal_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id ) {
       try {
-         _my->signal_accepted_block(bsp);
+         _my->signal_accepted_block(block, id);
       } FC_LOG_AND_DROP(("Failed to signal accepted block for finality status"));
    }
 
@@ -139,14 +139,14 @@ namespace eosio::chain_apis {
       }
    }
 
-   void trx_finality_status_processing_impl::signal_accepted_block( const chain::block_state_legacy_ptr& bsp ) {
+   void trx_finality_status_processing_impl::signal_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id ) {
       // if this block had any transactions, then we have processed everything we need to already
-      if (bsp->id == _head_block_id) {
+      if (id == _head_block_id) {
          return;
       }
 
-      _head_block_id = bsp->id;
-      _head_block_timestamp = bsp->block->timestamp;
+      _head_block_id = id;
+      _head_block_timestamp = block->timestamp;
 
       const auto head_block_num = chain::block_header::num_from_id(_head_block_id);
       if (head_block_num <= _last_proc_block_num) {

--- a/plugins/chain_plugin/trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/trx_finality_status_processing.cpp
@@ -47,10 +47,10 @@ namespace eosio::chain_apis {
 
    trx_finality_status_processing::~trx_finality_status_processing() = default;
 
-   void trx_finality_status_processing::signal_irreversible_block( const chain::block_state_legacy_ptr& bsp ) {
+   void trx_finality_status_processing::signal_irreversible_block( const chain::signed_block_ptr& block, const chain::block_id_type& id ) {
       try {
-         _my->_irr_block_id = bsp->id;
-         _my->_irr_block_timestamp = bsp->block->timestamp;
+         _my->_irr_block_id = id;
+         _my->_irr_block_timestamp = block->timestamp;
       } FC_LOG_AND_DROP(("Failed to signal irreversible block for finality status"));
    }
 

--- a/plugins/chain_plugin/trx_retry_db.cpp
+++ b/plugins/chain_plugin/trx_retry_db.cpp
@@ -161,13 +161,13 @@ struct trx_retry_db_impl {
       rollback_to( block_num );
    }
 
-   void on_accepted_block(const chain::block_state_legacy_ptr& bsp ) {
+   void on_accepted_block( uint32_t block_num ) {
       // good time to perform processing
-      ack_ready_trxs_by_block_num( bsp->block_num );
+      ack_ready_trxs_by_block_num( block_num );
       retry_trxs();
    }
 
-   void on_irreversible_block(const chain::block_state_legacy_ptr& bsp ) {
+   void on_irreversible_block( const chain::block_state_legacy_ptr& bsp ) {
       ack_ready_trxs_by_lib( bsp->block_num );
       clear_expired( bsp->block->timestamp );
    }
@@ -321,9 +321,9 @@ void trx_retry_db::on_block_start( uint32_t block_num ) {
    } FC_LOG_AND_DROP(("trx retry block_start ERROR"));
 }
 
-void trx_retry_db::on_accepted_block(const chain::block_state_legacy_ptr& block ) {
+void trx_retry_db::on_accepted_block( uint32_t block_num ) {
    try {
-      _impl->on_accepted_block(block);
+      _impl->on_accepted_block(block_num);
    } FC_LOG_AND_DROP(("trx retry accepted_block ERROR"));
 }
 

--- a/plugins/chain_plugin/trx_retry_db.cpp
+++ b/plugins/chain_plugin/trx_retry_db.cpp
@@ -167,8 +167,8 @@ struct trx_retry_db_impl {
       retry_trxs();
    }
 
-   void on_irreversible_block( const chain::signed_block_ptr& block, uint32_t block_num ) {
-      ack_ready_trxs_by_lib( block_num );
+   void on_irreversible_block( const chain::signed_block_ptr& block ) {
+      ack_ready_trxs_by_lib( block->block_num() );
       clear_expired( block->timestamp );
    }
 
@@ -327,9 +327,9 @@ void trx_retry_db::on_accepted_block( uint32_t block_num ) {
    } FC_LOG_AND_DROP(("trx retry accepted_block ERROR"));
 }
 
-void trx_retry_db::on_irreversible_block(const chain::signed_block_ptr& block, uint32_t block_num ) {
+void trx_retry_db::on_irreversible_block(const chain::signed_block_ptr& block) {
    try {
-      _impl->on_irreversible_block(block, block_num);
+      _impl->on_irreversible_block(block);
    } FC_LOG_AND_DROP(("trx retry irreversible_block ERROR"));
 }
 

--- a/plugins/chain_plugin/trx_retry_db.cpp
+++ b/plugins/chain_plugin/trx_retry_db.cpp
@@ -167,9 +167,9 @@ struct trx_retry_db_impl {
       retry_trxs();
    }
 
-   void on_irreversible_block( const chain::block_state_legacy_ptr& bsp ) {
-      ack_ready_trxs_by_lib( bsp->block_num );
-      clear_expired( bsp->block->timestamp );
+   void on_irreversible_block( const chain::signed_block_ptr& block, uint32_t block_num ) {
+      ack_ready_trxs_by_lib( block_num );
+      clear_expired( block->timestamp );
    }
 
 private:
@@ -327,9 +327,9 @@ void trx_retry_db::on_accepted_block( uint32_t block_num ) {
    } FC_LOG_AND_DROP(("trx retry accepted_block ERROR"));
 }
 
-void trx_retry_db::on_irreversible_block(const chain::block_state_legacy_ptr& block ) {
+void trx_retry_db::on_irreversible_block(const chain::signed_block_ptr& block, uint32_t block_num ) {
    try {
-      _impl->on_irreversible_block(block);
+      _impl->on_irreversible_block(block, block_num);
    } FC_LOG_AND_DROP(("trx retry irreversible_block ERROR"));
 }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4292,8 +4292,8 @@ namespace eosio {
          cc.accepted_block.connect( [my = shared_from_this()]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
             my->on_accepted_block();
          } );
-         cc.irreversible_block.connect( [my = shared_from_this()]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
-            const auto& [ block, id, header, block_num ] = t;
+         cc.irreversible_block.connect( [my = shared_from_this()]( std::tuple<const signed_block_ptr&, const block_id_type&, uint32_t> t ) {
+            const auto& [ block, id, block_num ] = t;
             my->on_irreversible_block( id, block_num );
          } );
       }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -529,7 +529,7 @@ namespace eosio {
       uint32_t get_chain_head_num() const;
 
       void on_accepted_block_header( const signed_block_ptr& block, const block_id_type& id );
-      void on_accepted_block( const block_state_legacy_ptr& bs );
+      void on_accepted_block();
 
       void transaction_ack(const std::pair<fc::exception_ptr, packed_transaction_ptr>&);
       void on_irreversible_block( const block_state_legacy_ptr& block );
@@ -3891,7 +3891,7 @@ namespace eosio {
       });
    }
 
-   void net_plugin_impl::on_accepted_block(const block_state_legacy_ptr& ) {
+   void net_plugin_impl::on_accepted_block() {
       on_pending_schedule(chain_plug->chain().pending_producers());
       on_active_schedule(chain_plug->chain().active_producers());
    }
@@ -4288,8 +4288,8 @@ namespace eosio {
             my->on_accepted_block_header( std::get<0>(t), std::get<1>(t) );
          } );
 
-         cc.accepted_block.connect( [my = shared_from_this()]( const block_state_legacy_ptr& s ) {
-            my->on_accepted_block( s );
+         cc.accepted_block.connect( [my = shared_from_this()]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
+            my->on_accepted_block();
          } );
          cc.irreversible_block.connect( [my = shared_from_this()]( const block_state_legacy_ptr& s ) {
             my->on_irreversible_block( s );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -528,7 +528,7 @@ namespace eosio {
       uint32_t get_chain_lib_num() const;
       uint32_t get_chain_head_num() const;
 
-      void on_accepted_block_header( const signed_block_ptr& block, const block_id_type& id, uint32_t block_num );
+      void on_accepted_block_header( const signed_block_ptr& block, const block_id_type& id );
       void on_accepted_block();
 
       void transaction_ack(const std::pair<fc::exception_ptr, packed_transaction_ptr>&);
@@ -3882,11 +3882,11 @@ namespace eosio {
    }
 
    // called from application thread
-   void net_plugin_impl::on_accepted_block_header(const signed_block_ptr& block, const block_id_type& id, uint32_t block_num) {
+   void net_plugin_impl::on_accepted_block_header(const signed_block_ptr& block, const block_id_type& id) {
       update_chain_info();
 
-      dispatcher->strand.post([block, id, block_num]() {
-         fc_dlog(logger, "signaled accepted_block_header, blk num = ${num}, id = ${id}", ("num", block_num)("id", id));
+      dispatcher->strand.post([block, id]() {
+         fc_dlog(logger, "signaled accepted_block_header, blk num = ${num}, id = ${id}", ("num", block->block_num())("id", id));
          my_impl->dispatcher->bcast_block(block, id);
       });
    }
@@ -4286,7 +4286,7 @@ namespace eosio {
          chain::controller& cc = chain_plug->chain();
          cc.accepted_block_header.connect( [my = shared_from_this()]( const block_signal_params& t ) {
             const auto& [ block, id ] = t;
-            my->on_accepted_block_header( block, id, block->block_num() );
+            my->on_accepted_block_header( block, id );
          } );
 
          cc.accepted_block.connect( [my = shared_from_this()]( const block_signal_params& t ) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4284,15 +4284,15 @@ namespace eosio {
 
       {
          chain::controller& cc = chain_plug->chain();
-         cc.accepted_block_header.connect( [my = shared_from_this()]( block_signal_params t ) {
+         cc.accepted_block_header.connect( [my = shared_from_this()]( const block_signal_params& t ) {
             const auto& [ block, id ] = t;
             my->on_accepted_block_header( block, id, block->block_num() );
          } );
 
-         cc.accepted_block.connect( [my = shared_from_this()]( block_signal_params t ) {
+         cc.accepted_block.connect( [my = shared_from_this()]( const block_signal_params& t ) {
             my->on_accepted_block();
          } );
-         cc.irreversible_block.connect( [my = shared_from_this()]( block_signal_params t ) {
+         cc.irreversible_block.connect( [my = shared_from_this()]( const block_signal_params& t ) {
             const auto& [ block, id ] = t;
             my->on_irreversible_block( id, block->block_num() );
          } );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -532,7 +532,7 @@ namespace eosio {
       void on_accepted_block();
 
       void transaction_ack(const std::pair<fc::exception_ptr, packed_transaction_ptr>&);
-      void on_irreversible_block( const block_state_legacy_ptr& block );
+      void on_irreversible_block( const block_id_type& id, uint32_t block_num );
 
       void start_expire_timer();
       void start_monitors();
@@ -3897,8 +3897,8 @@ namespace eosio {
    }
 
    // called from application thread
-   void net_plugin_impl::on_irreversible_block( const block_state_legacy_ptr& block) {
-      fc_dlog( logger, "on_irreversible_block, blk num = ${num}, id = ${id}", ("num", block->block_num)("id", block->id) );
+   void net_plugin_impl::on_irreversible_block( const block_id_type& id, uint32_t block_num) {
+      fc_dlog( logger, "on_irreversible_block, blk num = ${num}, id = ${id}", ("num", block_num)("id", id) );
       update_chain_info();
    }
 
@@ -4291,8 +4291,9 @@ namespace eosio {
          cc.accepted_block.connect( [my = shared_from_this()]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
             my->on_accepted_block();
          } );
-         cc.irreversible_block.connect( [my = shared_from_this()]( const block_state_legacy_ptr& s ) {
-            my->on_irreversible_block( s );
+         cc.irreversible_block.connect( [my = shared_from_this()]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
+            const auto& [ block, id, header, block_num ] = t;
+            my->on_irreversible_block( id, block_num );
          } );
       }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4284,17 +4284,17 @@ namespace eosio {
 
       {
          chain::controller& cc = chain_plug->chain();
-         cc.accepted_block_header.connect( [my = shared_from_this()]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
-            const auto& [ block, id, header, block_num ] = t;
-            my->on_accepted_block_header( block, id, block_num );
+         cc.accepted_block_header.connect( [my = shared_from_this()]( block_signal_params t ) {
+            const auto& [ block, id ] = t;
+            my->on_accepted_block_header( block, id, block->block_num() );
          } );
 
-         cc.accepted_block.connect( [my = shared_from_this()]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
+         cc.accepted_block.connect( [my = shared_from_this()]( block_signal_params t ) {
             my->on_accepted_block();
          } );
-         cc.irreversible_block.connect( [my = shared_from_this()]( std::tuple<const signed_block_ptr&, const block_id_type&, uint32_t> t ) {
-            const auto& [ block, id, block_num ] = t;
-            my->on_irreversible_block( id, block_num );
+         cc.irreversible_block.connect( [my = shared_from_this()]( block_signal_params t ) {
+            const auto& [ block, id ] = t;
+            my->on_irreversible_block( id, block->block_num() );
          } );
       }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -528,7 +528,7 @@ namespace eosio {
       uint32_t get_chain_lib_num() const;
       uint32_t get_chain_head_num() const;
 
-      void on_accepted_block_header( const block_state_legacy_ptr& bs );
+      void on_accepted_block_header( const signed_block_ptr& block, const block_id_type& id );
       void on_accepted_block( const block_state_legacy_ptr& bs );
 
       void transaction_ack(const std::pair<fc::exception_ptr, packed_transaction_ptr>&);
@@ -3882,12 +3882,12 @@ namespace eosio {
    }
 
    // called from application thread
-   void net_plugin_impl::on_accepted_block_header(const block_state_legacy_ptr& bs) {
+   void net_plugin_impl::on_accepted_block_header(const signed_block_ptr& block, const block_id_type& id) {
       update_chain_info();
 
-      dispatcher->strand.post([bs]() {
-         fc_dlog(logger, "signaled accepted_block_header, blk num = ${num}, id = ${id}", ("num", bs->block_num)("id", bs->id));
-         my_impl->dispatcher->bcast_block(bs->block, bs->id);
+      dispatcher->strand.post([block, id]() {
+         fc_dlog(logger, "signaled accepted_block_header, blk num = ${num}, id = ${id}", ("num", block_header::num_from_id(id))("id", id));
+         my_impl->dispatcher->bcast_block(block, id);
       });
    }
 
@@ -4284,8 +4284,8 @@ namespace eosio {
 
       {
          chain::controller& cc = chain_plug->chain();
-         cc.accepted_block_header.connect( [my = shared_from_this()]( const block_state_legacy_ptr& s ) {
-            my->on_accepted_block_header( s );
+         cc.accepted_block_header.connect( [my = shared_from_this()]( std::tuple<const signed_block_ptr&, const block_id_type&, const chain::account_name&> t ) {
+            my->on_accepted_block_header( std::get<0>(t), std::get<1>(t) );
          } );
 
          cc.accepted_block.connect( [my = shared_from_this()]( const block_state_legacy_ptr& s ) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1337,8 +1337,8 @@ void producer_plugin_impl::plugin_startup() {
             const auto& [ block, id, header, block_num ] = t;
             on_block_header(header.producer, block_num, block->timestamp);
          }));
-         _irreversible_block_connection.emplace(chain.irreversible_block.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-            const auto& [ block, id, header, block_num ] = t;
+         _irreversible_block_connection.emplace(chain.irreversible_block.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, uint32_t> t) {
+            const auto& [ block, id, block_num ] = t;
             on_irreversible_block(block);
          }));
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1329,16 +1329,16 @@ void producer_plugin_impl::plugin_startup() {
          EOS_ASSERT(_producers.empty() || chain_plug->accept_transactions(), plugin_config_exception,
                     "node cannot have any producer-name configured because no block production is possible with no [api|p2p]-accepted-transactions");
 
-         _accepted_block_connection.emplace(chain.accepted_block.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) { 
-            const auto& [ block, id, header, block_num ] = t;
+         _accepted_block_connection.emplace(chain.accepted_block.connect([this](block_signal_params t) { 
+            const auto& [ block, id ] = t;
             on_block(block);
           }));
-         _accepted_block_header_connection.emplace(chain.accepted_block_header.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-            const auto& [ block, id, header, block_num ] = t;
-            on_block_header(header.producer, block_num, block->timestamp);
+         _accepted_block_header_connection.emplace(chain.accepted_block_header.connect([this](block_signal_params t) {
+            const auto& [ block, id ] = t;
+            on_block_header(static_cast<signed_block_header>(*block).producer, block->block_num(), block->timestamp);
          }));
-         _irreversible_block_connection.emplace(chain.irreversible_block.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, uint32_t> t) {
-            const auto& [ block, id, block_num ] = t;
+         _irreversible_block_connection.emplace(chain.irreversible_block.connect([this](block_signal_params t) {
+            const auto& [ block, id ] = t;
             on_irreversible_block(block);
          }));
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1333,11 +1333,9 @@ void producer_plugin_impl::plugin_startup() {
             const auto& [ block, id, header, block_num ] = t;
             on_block(block);
           }));
-         _accepted_block_header_connection.emplace(chain.accepted_block_header.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, const account_name&> t) {
-            const auto& block = std::get<0>(t);
-            const auto& id = std::get<1>(t);
-            const auto& producer = std::get<2>(t);
-            on_block_header(producer, block_header::num_from_id(id), block->timestamp);
+         _accepted_block_header_connection.emplace(chain.accepted_block_header.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+            const auto& [ block, id, header, block_num ] = t;
+            on_block_header(header.producer, block_num, block->timestamp);
          }));
          _irreversible_block_connection.emplace(chain.irreversible_block.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
             const auto& [ block, id, header, block_num ] = t;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1329,15 +1329,15 @@ void producer_plugin_impl::plugin_startup() {
          EOS_ASSERT(_producers.empty() || chain_plug->accept_transactions(), plugin_config_exception,
                     "node cannot have any producer-name configured because no block production is possible with no [api|p2p]-accepted-transactions");
 
-         _accepted_block_connection.emplace(chain.accepted_block.connect([this](block_signal_params t) { 
+         _accepted_block_connection.emplace(chain.accepted_block.connect([this](const block_signal_params& t) {
             const auto& [ block, id ] = t;
             on_block(block);
           }));
-         _accepted_block_header_connection.emplace(chain.accepted_block_header.connect([this](block_signal_params t) {
+         _accepted_block_header_connection.emplace(chain.accepted_block_header.connect([this](const block_signal_params& t) {
             const auto& [ block, id ] = t;
             on_block_header(static_cast<signed_block_header>(*block).producer, block->block_num(), block->timestamp);
          }));
-         _irreversible_block_connection.emplace(chain.irreversible_block.connect([this](block_signal_params t) {
+         _irreversible_block_connection.emplace(chain.irreversible_block.connect([this](const block_signal_params& t) {
             const auto& [ block, id ] = t;
             on_irreversible_block(block);
          }));

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1332,15 +1332,17 @@ void producer_plugin_impl::plugin_startup() {
          _accepted_block_connection.emplace(chain.accepted_block.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) { 
             const auto& [ block, id, header, block_num ] = t;
             on_block(block);
-           }));
+          }));
          _accepted_block_header_connection.emplace(chain.accepted_block_header.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, const account_name&> t) {
             const auto& block = std::get<0>(t);
             const auto& id = std::get<1>(t);
             const auto& producer = std::get<2>(t);
             on_block_header(producer, block_header::num_from_id(id), block->timestamp);
          }));
-         _irreversible_block_connection.emplace(
-            chain.irreversible_block.connect([this](const auto& bsp) { on_irreversible_block(bsp->block); }));
+         _irreversible_block_connection.emplace(chain.irreversible_block.connect([this](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+            const auto& [ block, id, header, block_num ] = t;
+            on_irreversible_block(block);
+         }));
 
          _block_start_connection.emplace(chain.block_start.connect([this, &chain](uint32_t bs) {
             try {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1335,7 +1335,7 @@ void producer_plugin_impl::plugin_startup() {
           }));
          _accepted_block_header_connection.emplace(chain.accepted_block_header.connect([this](const block_signal_params& t) {
             const auto& [ block, id ] = t;
-            on_block_header(static_cast<signed_block_header>(*block).producer, block->block_num(), block->timestamp);
+            on_block_header(block->producer, block->block_num(), block->timestamp);
          }));
          _irreversible_block_connection.emplace(chain.irreversible_block.connect([this](const block_signal_params& t) {
             const auto& [ block, id ] = t;

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -129,8 +129,8 @@ BOOST_AUTO_TEST_CASE(producer) {
       std::deque<signed_block_ptr> all_blocks;
       std::promise<void> empty_blocks_promise;
       std::future<void> empty_blocks_fut = empty_blocks_promise.get_future();
-      auto ab = chain_plug->chain().accepted_block.connect( [&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-         const auto& [ block, id, header, block_num ] = t;
+      auto ab = chain_plug->chain().accepted_block.connect( [&](chain::block_signal_params t) {
+         const auto& [ block, id ] = t;
          static int num_empty = std::numeric_limits<int>::max();
          all_blocks.push_back( block );
          if( block->transactions.empty() ) {

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -68,15 +68,15 @@ auto make_unique_trx( const chain_id_type& chain_id ) {
 }
 
 // verify all trxs are in blocks only once
-bool verify_equal( const std::deque<packed_transaction_ptr>& trxs, const std::deque<block_state_legacy_ptr>& all_blocks) {
+bool verify_equal( const std::deque<packed_transaction_ptr>& trxs, const std::deque<signed_block_ptr>& all_blocks) {
    std::set<transaction_id_type> trxs_ids; // trx can appear more than once if they were aborted
    std::set<transaction_id_type> blk_trxs_ids;
 
    for( const auto& trx : trxs ) {
       trxs_ids.emplace( trx->id() );
    }
-   for( const auto& bs : all_blocks ) {
-      for( const auto& trx_receipt : bs->block->transactions ) {
+   for( const auto& block : all_blocks ) {
+      for( const auto& trx_receipt : block->transactions ) {
          const auto& trx = std::get<packed_transaction>( trx_receipt.trx ).get_transaction();
          blk_trxs_ids.emplace( trx.id() );
       }
@@ -126,13 +126,14 @@ BOOST_AUTO_TEST_CASE(producer) {
       auto[prod_plug, chain_plug] = plugin_fut.get();
       auto chain_id = chain_plug->get_chain_id();
 
-      std::deque<block_state_legacy_ptr> all_blocks;
+      std::deque<signed_block_ptr> all_blocks;
       std::promise<void> empty_blocks_promise;
       std::future<void> empty_blocks_fut = empty_blocks_promise.get_future();
-      auto ab = chain_plug->chain().accepted_block.connect( [&](const block_state_legacy_ptr& bsp) {
+      auto ab = chain_plug->chain().accepted_block.connect( [&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+         const auto& [ block, id, header, block_num ] = t;
          static int num_empty = std::numeric_limits<int>::max();
-         all_blocks.push_back( bsp );
-         if( bsp->block->transactions.empty() ) {
+         all_blocks.push_back( block );
+         if( block->transactions.empty() ) {
             --num_empty;
             if( num_empty == 0 ) empty_blocks_promise.set_value();
          } else { // we want a few empty blocks after we have some non-empty blocks

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(producer) {
       std::deque<signed_block_ptr> all_blocks;
       std::promise<void> empty_blocks_promise;
       std::future<void> empty_blocks_fut = empty_blocks_promise.get_future();
-      auto ab = chain_plug->chain().accepted_block.connect( [&](chain::block_signal_params t) {
+      auto ab = chain_plug->chain().accepted_block.connect( [&](const chain::block_signal_params& t) {
          const auto& [ block, id ] = t;
          static int num_empty = std::numeric_limits<int>::max();
          all_blocks.push_back( block );

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -503,7 +503,7 @@ private:
       // not just an optimization, on accepted_block signal may not be able to find block_num in forkdb as it has not been validated
       // until after the accepted_block signal
       std::optional<chain::block_id_type> block_id =
-          (block->block_num() == to_send_block_num) ? id : plugin.get_block_id(to_send_block_num);
+          (block && block->block_num() == to_send_block_num) ? id : plugin.get_block_id(to_send_block_num);
 
       if (block_id && position_it && (*position_it)->block_num == to_send_block_num) {
          // This branch happens when the head block of nodeos is behind the head block of connecting client.
@@ -527,8 +527,10 @@ private:
          auto prev_block_id = plugin.get_block_id(to_send_block_num - 1);
          if (prev_block_id)
             result.prev_block = state_history::block_position{to_send_block_num - 1, *prev_block_id};
-         if (current_request->fetch_block)
-            plugin.get_block(to_send_block_num, block->block_num(), block, result.block);
+         if (current_request->fetch_block) {
+            uint32_t block_num = block ? block->block_num() : 0; // block can be nullptr in testing
+            plugin.get_block(to_send_block_num, block_num, block, result.block);
+         }
          if (current_request->fetch_traces && plugin.get_trace_log())
             result.traces.emplace();
          if (current_request->fetch_deltas && plugin.get_chain_state_log())

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <eosio/chain/block_state_legacy.hpp>
 #include <eosio/state_history/compression.hpp>
 #include <eosio/state_history/log.hpp>
 #include <eosio/state_history/serialization.hpp>

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -329,9 +329,9 @@ void state_history_plugin_impl::plugin_initialize(const variables_map& options) 
              on_applied_transaction(std::get<0>(t), std::get<1>(t));
           }));
       accepted_block_connection.emplace(
-          chain.accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-             const auto& [ block, id, header, block_num ] = t;
-             on_accepted_block(block, id, header, block_num);
+          chain.accepted_block.connect([&](block_signal_params t) {
+             const auto& [ block, id ] = t;
+             on_accepted_block(block, id, static_cast<signed_block_header>(*block), block->block_num());
           }));
       block_start_connection.emplace(
           chain.block_start.connect([&](uint32_t block_num) { on_block_start(block_num); }));

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -329,7 +329,7 @@ void state_history_plugin_impl::plugin_initialize(const variables_map& options) 
              on_applied_transaction(std::get<0>(t), std::get<1>(t));
           }));
       accepted_block_connection.emplace(
-          chain.accepted_block.connect([&](block_signal_params t) {
+          chain.accepted_block.connect([&](const block_signal_params& t) {
              const auto& [ block, id ] = t;
              on_accepted_block(block, id, static_cast<signed_block_header>(*block), block->block_num());
           }));

--- a/plugins/state_history_plugin/tests/session_test.cpp
+++ b/plugins/state_history_plugin/tests/session_test.cpp
@@ -123,7 +123,7 @@ struct mock_state_history_plugin {
 
    fc::logger& get_logger() { return logger; }
 
-   void get_block(uint32_t block_num, const eosio::chain::block_state_legacy_ptr& block_state,
+   void get_block(uint32_t block_num, uint32_t block_state_block_num, const eosio::chain::signed_block_ptr& block,
                   std::optional<eosio::chain::bytes>& result) const {
       result.emplace().resize(16);
    }

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -32,13 +32,13 @@ private:
 
 void test_control_plugin_impl::connect() {
    _irreversible_block_connection.emplace(
-         _chain.irreversible_block.connect( [&]( std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, uint32_t> t ) {
-            const auto& [ block, id, block_num ] = t;
+         _chain.irreversible_block.connect( [&]( chain::block_signal_params t ) {
+            const auto& [ block, id ] = t;
             applied_irreversible_block( id );
          } ));
    _accepted_block_connection =
-         _chain.accepted_block.connect( [&]( std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, const chain::signed_block_header&, uint32_t> t ) {
-            const auto& [ block, id, header, block_num ] = t;
+         _chain.accepted_block.connect( [&]( chain::block_signal_params t ) {
+            const auto& [ block, id ] = t;
             accepted_block( id );
          } );
 }

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -15,9 +15,9 @@ public:
    void kill_on_head(account_name prod, uint32_t where_in_seq);
 
 private:
-   void accepted_block(const chain::block_state_legacy_ptr& bsp);
+   void accepted_block(const chain::block_id_type& id);
    void applied_irreversible_block(const chain::block_state_legacy_ptr& bsp);
-   void process_next_block_state_legacy(const chain::block_state_legacy_ptr& bsp);
+   void process_next_block_state_legacy(const chain::block_id_type& id);
 
    std::optional<boost::signals2::scoped_connection> _accepted_block_connection;
    std::optional<boost::signals2::scoped_connection> _irreversible_block_connection;
@@ -36,8 +36,9 @@ void test_control_plugin_impl::connect() {
             applied_irreversible_block( bs );
          } ));
    _accepted_block_connection =
-         _chain.accepted_block.connect( [&]( const chain::block_state_legacy_ptr& bs ) {
-            accepted_block( bs );
+         _chain.accepted_block.connect( [&]( std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, const chain::signed_block_header&, uint32_t> t ) {
+            const auto& [ block, id, header, block_num ] = t;
+            accepted_block( id );
          } );
 }
 
@@ -48,17 +49,19 @@ void test_control_plugin_impl::disconnect() {
 
 void test_control_plugin_impl::applied_irreversible_block(const chain::block_state_legacy_ptr& bsp) {
    if (_track_lib)
-      process_next_block_state_legacy(bsp);
+      process_next_block_state_legacy(bsp->id);
 }
 
-void test_control_plugin_impl::accepted_block(const chain::block_state_legacy_ptr& bsp) {
+void test_control_plugin_impl::accepted_block(const chain::block_id_type& id) {
    if (_track_head)
-      process_next_block_state_legacy(bsp);
+      process_next_block_state_legacy(id);
 }
 
-void test_control_plugin_impl::process_next_block_state_legacy(const chain::block_state_legacy_ptr& bsp) {
+void test_control_plugin_impl::process_next_block_state_legacy(const chain::block_id_type& id) {
    // Tests expect the shutdown only after signaling a producer shutdown and seeing a full production cycle
    const auto block_time = _chain.head_block_time() + fc::microseconds(chain::config::block_interval_us);
+   // have to fetch bsp due to get_scheduled_producer call
+   const auto& bsp = _chain.fetch_block_state_by_id(id);
    const auto& producer_authority = bsp->get_scheduled_producer(block_time);
    const auto producer_name = producer_authority.producer_name;
    const auto slot = bsp->block->timestamp.slot % chain::config::producer_repetitions;

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -32,12 +32,12 @@ private:
 
 void test_control_plugin_impl::connect() {
    _irreversible_block_connection.emplace(
-         _chain.irreversible_block.connect( [&]( chain::block_signal_params t ) {
+         _chain.irreversible_block.connect( [&]( const chain::block_signal_params& t ) {
             const auto& [ block, id ] = t;
             applied_irreversible_block( id );
          } ));
    _accepted_block_connection =
-         _chain.accepted_block.connect( [&]( chain::block_signal_params t ) {
+         _chain.accepted_block.connect( [&]( const chain::block_signal_params& t ) {
             const auto& [ block, id ] = t;
             accepted_block( id );
          } );

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -32,8 +32,8 @@ private:
 
 void test_control_plugin_impl::connect() {
    _irreversible_block_connection.emplace(
-         _chain.irreversible_block.connect( [&]( std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, const chain::signed_block_header&, uint32_t> t ) {
-            const auto& [ block, id, header, block_num ] = t;
+         _chain.irreversible_block.connect( [&]( std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, uint32_t> t ) {
+            const auto& [ block, id, block_num ] = t;
             applied_irreversible_block( id );
          } ));
    _accepted_block_connection =

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -17,7 +17,7 @@ public:
 private:
    void accepted_block(const chain::block_id_type& id);
    void applied_irreversible_block(const chain::block_id_type& id);
-   void process_next_block_state_legacy(const chain::block_id_type& id);
+   void process_next_block_state(const chain::block_id_type& id);
 
    std::optional<boost::signals2::scoped_connection> _accepted_block_connection;
    std::optional<boost::signals2::scoped_connection> _irreversible_block_connection;
@@ -50,15 +50,15 @@ void test_control_plugin_impl::disconnect() {
 
 void test_control_plugin_impl::applied_irreversible_block(const chain::block_id_type& id) {
    if (_track_lib)
-      process_next_block_state_legacy(id);
+      process_next_block_state(id);
 }
 
 void test_control_plugin_impl::accepted_block(const chain::block_id_type& id) {
    if (_track_head)
-      process_next_block_state_legacy(id);
+      process_next_block_state(id);
 }
 
-void test_control_plugin_impl::process_next_block_state_legacy(const chain::block_id_type& id) {
+void test_control_plugin_impl::process_next_block_state(const chain::block_id_type& id) {
    // Tests expect the shutdown only after signaling a producer shutdown and seeing a full production cycle
    const auto block_time = _chain.head_block_time() + fc::microseconds(chain::config::block_interval_us);
    // have to fetch bsp due to get_scheduled_producer call

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -31,8 +31,8 @@ public:
    }
 
    /// connect to chain controller accepted_block signal
-   void signal_accepted_block( const chain::block_state_legacy_ptr& bsp ) {
-      on_accepted_block( bsp );
+   void signal_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id, uint32_t block_num ) {
+      on_accepted_block( block, id, block_num );
    }
 
    /// connect to chain controller irreversible_block signal
@@ -63,8 +63,8 @@ private:
       }
    }
 
-   void on_accepted_block(const chain::block_state_legacy_ptr& block_state) {
-      store_block_trace( block_state );
+   void on_accepted_block(const chain::signed_block_ptr& block, const chain::block_id_type& id, uint32_t block_num) {
+      store_block_trace( block, id, block_num );
    }
 
    void on_irreversible_block( const chain::block_state_legacy_ptr& block_state ) {
@@ -80,18 +80,18 @@ private:
       onblock_trace.reset();
    }
 
-   void store_block_trace( const chain::block_state_legacy_ptr& block_state ) {
+   void store_block_trace( const chain::signed_block_ptr& block, const chain::block_id_type& id, uint32_t block_num) {
       try {
          using transaction_trace_t = transaction_trace_v3;
-         auto bt = create_block_trace( block_state );
+         auto bt = create_block_trace( block, id, block_num );
 
          std::vector<transaction_trace_t> traces;
-         traces.reserve( block_state->block->transactions.size() + 1 );
+         traces.reserve( block->transactions.size() + 1 );
          block_trxs_entry tt;
-         tt.ids.reserve(block_state->block->transactions.size() + 1);
+         tt.ids.reserve(block->transactions.size() + 1);
          if( onblock_trace )
             traces.emplace_back( to_transaction_trace<transaction_trace_t>( *onblock_trace ));
-         for( const auto& r : block_state->block->transactions ) {
+         for( const auto& r : block->transactions ) {
             transaction_id_type id;
             if( std::holds_alternative<transaction_id_type>(r.trx)) {
                id = std::get<transaction_id_type>(r.trx);

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -36,8 +36,8 @@ public:
    }
 
    /// connect to chain controller irreversible_block signal
-   void signal_irreversible_block( const chain::block_state_legacy_ptr& bsp ) {
-      on_irreversible_block( bsp );
+   void signal_irreversible_block( uint32_t block_num ) {
+      on_irreversible_block( block_num );
    }
 
    /// connect to chain controller block_start signal
@@ -67,8 +67,8 @@ private:
       store_block_trace( block, id, block_num );
    }
 
-   void on_irreversible_block( const chain::block_state_legacy_ptr& block_state ) {
-      store_lib( block_state );
+   void on_irreversible_block( uint32_t block_num ) {
+      store_lib( block_num );
    }
 
    void on_block_start( uint32_t block_num ) {
@@ -117,9 +117,9 @@ private:
       }
    }
 
-   void store_lib( const chain::block_state_legacy_ptr& bsp ) {
+   void store_lib( uint32_t block_num ) {
       try {
-         store.append_lib( bsp->block_num );
+         store.append_lib( block_num );
       } catch( ... ) {
          except_handler( MAKE_EXCEPTION_WITH_CONTEXT( std::current_exception() ) );
       }

--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -31,8 +31,8 @@ public:
    }
 
    /// connect to chain controller accepted_block signal
-   void signal_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id, uint32_t block_num ) {
-      on_accepted_block( block, id, block_num );
+   void signal_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id ) {
+      on_accepted_block( block, id );
    }
 
    /// connect to chain controller irreversible_block signal
@@ -63,8 +63,8 @@ private:
       }
    }
 
-   void on_accepted_block(const chain::signed_block_ptr& block, const chain::block_id_type& id, uint32_t block_num) {
-      store_block_trace( block, id, block_num );
+   void on_accepted_block(const chain::signed_block_ptr& block, const chain::block_id_type& id ) {
+      store_block_trace( block, id );
    }
 
    void on_irreversible_block( uint32_t block_num ) {
@@ -80,10 +80,10 @@ private:
       onblock_trace.reset();
    }
 
-   void store_block_trace( const chain::signed_block_ptr& block, const chain::block_id_type& id, uint32_t block_num) {
+   void store_block_trace( const chain::signed_block_ptr& block, const chain::block_id_type& id ) {
       try {
          using transaction_trace_t = transaction_trace_v3;
-         auto bt = create_block_trace( block, id, block_num );
+         auto bt = create_block_trace( block, id );
 
          std::vector<transaction_trace_t> traces;
          traces.reserve( block->transactions.size() + 1 );

--- a/plugins/trace_api_plugin/include/eosio/trace_api/extract_util.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/extract_util.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <eosio/trace_api/trace.hpp>
-#include <eosio/chain/block_state_legacy.hpp>
 
 namespace eosio { namespace trace_api {
 

--- a/plugins/trace_api_plugin/include/eosio/trace_api/extract_util.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/extract_util.hpp
@@ -63,16 +63,16 @@ inline TransactionTrace to_transaction_trace( const cache_trace& t ) {
    return r;
 }
 
-inline block_trace_v2 create_block_trace( const chain::block_state_legacy_ptr& bsp ) {
+inline block_trace_v2 create_block_trace( const chain::signed_block_ptr& block, const chain::block_id_type& id, uint32_t block_num ) {
    block_trace_v2 r;
-   r.id = bsp->id;
-   r.number = bsp->block_num;
-   r.previous_id = bsp->block->previous;
-   r.timestamp = bsp->block->timestamp;
-   r.producer = bsp->block->producer;
-   r.schedule_version = bsp->block->schedule_version;
-   r.transaction_mroot = bsp->block->transaction_mroot;
-   r.action_mroot = bsp->block->action_mroot;
+   r.id = id;
+   r.number = block_num;
+   r.previous_id = block->previous;
+   r.timestamp = block->timestamp;
+   r.producer = block->producer;
+   r.schedule_version = block->schedule_version;
+   r.transaction_mroot = block->transaction_mroot;
+   r.action_mroot = block->action_mroot;
    return r;
 }
 

--- a/plugins/trace_api_plugin/include/eosio/trace_api/extract_util.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/extract_util.hpp
@@ -62,10 +62,10 @@ inline TransactionTrace to_transaction_trace( const cache_trace& t ) {
    return r;
 }
 
-inline block_trace_v2 create_block_trace( const chain::signed_block_ptr& block, const chain::block_id_type& id, uint32_t block_num ) {
+inline block_trace_v2 create_block_trace( const chain::signed_block_ptr& block, const chain::block_id_type& id ) {
    block_trace_v2 r;
    r.id = id;
-   r.number = block_num;
+   r.number = block->block_num();
    r.previous_id = block->previous;
    r.timestamp = block->timestamp;
    r.producer = block->producer;

--- a/plugins/trace_api_plugin/test/test_extraction.cpp
+++ b/plugins/trace_api_plugin/test/test_extraction.cpp
@@ -137,7 +137,7 @@ struct extraction_test_fixture {
    }
 
    void signal_accepted_block( const chain::block_state_legacy_ptr& bsp ) {
-      extraction_impl.signal_accepted_block(bsp->block, bsp->id, bsp->block_num);
+      extraction_impl.signal_accepted_block(bsp->block, bsp->id);
    }
 
    // fixture data and methods

--- a/plugins/trace_api_plugin/test/test_extraction.cpp
+++ b/plugins/trace_api_plugin/test/test_extraction.cpp
@@ -137,7 +137,7 @@ struct extraction_test_fixture {
    }
 
    void signal_accepted_block( const chain::block_state_legacy_ptr& bsp ) {
-      extraction_impl.signal_accepted_block(bsp);
+      extraction_impl.signal_accepted_block(bsp->block, bsp->id, bsp->block_num);
    }
 
    // fixture data and methods

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -377,9 +377,10 @@ struct trace_api_plugin_impl {
             }));
 
       accepted_block_connection.emplace(
-         chain.accepted_block.connect([this](const chain::block_state_legacy_ptr& p) {
+         chain.accepted_block.connect([this](std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, const chain::signed_block_header&, uint32_t> t) {
             emit_killer([&](){
-               extraction->signal_accepted_block(p);
+               const auto& [ block, id, header, block_num ] = t;
+               extraction->signal_accepted_block(block, id, block_num);
             });
          }));
 

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -377,7 +377,7 @@ struct trace_api_plugin_impl {
             }));
 
       accepted_block_connection.emplace(
-         chain.accepted_block.connect([this](chain::block_signal_params t) {
+         chain.accepted_block.connect([this](const chain::block_signal_params& t) {
             emit_killer([&](){
                const auto& [ block, id ] = t;
                extraction->signal_accepted_block(block, id, block->block_num());
@@ -385,7 +385,7 @@ struct trace_api_plugin_impl {
          }));
 
       irreversible_block_connection.emplace(
-         chain.irreversible_block.connect([this](chain::block_signal_params t) {
+         chain.irreversible_block.connect([this](const chain::block_signal_params& t) {
             const auto& [ block, id ] = t;
             emit_killer([&](){
                extraction->signal_irreversible_block(block->block_num());

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -385,8 +385,8 @@ struct trace_api_plugin_impl {
          }));
 
       irreversible_block_connection.emplace(
-         chain.irreversible_block.connect([this](std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, const chain::signed_block_header&, uint32_t> t) {
-            const auto& [ block, id, header, block_num ] = t;
+         chain.irreversible_block.connect([this](std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, uint32_t> t) {
+            const auto& [ block, id, block_num ] = t;
             emit_killer([&](){
                extraction->signal_irreversible_block(block_num);
             });

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -377,18 +377,18 @@ struct trace_api_plugin_impl {
             }));
 
       accepted_block_connection.emplace(
-         chain.accepted_block.connect([this](std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, const chain::signed_block_header&, uint32_t> t) {
+         chain.accepted_block.connect([this](chain::block_signal_params t) {
             emit_killer([&](){
-               const auto& [ block, id, header, block_num ] = t;
-               extraction->signal_accepted_block(block, id, block_num);
+               const auto& [ block, id ] = t;
+               extraction->signal_accepted_block(block, id, block->block_num());
             });
          }));
 
       irreversible_block_connection.emplace(
-         chain.irreversible_block.connect([this](std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, uint32_t> t) {
-            const auto& [ block, id, block_num ] = t;
+         chain.irreversible_block.connect([this](chain::block_signal_params t) {
+            const auto& [ block, id ] = t;
             emit_killer([&](){
-               extraction->signal_irreversible_block(block_num);
+               extraction->signal_irreversible_block(block->block_num());
             });
          }));
 

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -380,7 +380,7 @@ struct trace_api_plugin_impl {
          chain.accepted_block.connect([this](const chain::block_signal_params& t) {
             emit_killer([&](){
                const auto& [ block, id ] = t;
-               extraction->signal_accepted_block(block, id, block->block_num());
+               extraction->signal_accepted_block(block, id);
             });
          }));
 

--- a/plugins/trace_api_plugin/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/trace_api_plugin.cpp
@@ -385,9 +385,10 @@ struct trace_api_plugin_impl {
          }));
 
       irreversible_block_connection.emplace(
-         chain.irreversible_block.connect([this](const chain::block_state_legacy_ptr& p) {
+         chain.irreversible_block.connect([this](std::tuple<const chain::signed_block_ptr&, const chain::block_id_type&, const chain::signed_block_header&, uint32_t> t) {
+            const auto& [ block, id, header, block_num ] = t;
             emit_killer([&](){
-               extraction->signal_irreversible_block(p);
+               extraction->signal_irreversible_block(block_num);
             });
          }));
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1471,8 +1471,8 @@ void transaction_tests(T& chain) {
             if (t && t->receipt && t->receipt->status != transaction_receipt::executed) { trace = t; }
          } );
          signed_block_ptr block;
-         auto c2 = chain.control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-            const auto& [ b, id, header, block_num ] = t;
+         auto c2 = chain.control->accepted_block.connect([&](block_signal_params t) {
+            const auto& [ b, id ] = t;
             block = b; });
 
          // test error handling on deferred transaction failure

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1470,8 +1470,10 @@ void transaction_tests(T& chain) {
             auto& t = std::get<0>(x);
             if (t && t->receipt && t->receipt->status != transaction_receipt::executed) { trace = t; }
          } );
-         block_state_legacy_ptr bsp;
-         auto c2 = chain.control->accepted_block.connect([&](const block_state_legacy_ptr& b) { bsp = b; });
+         signed_block_ptr block;
+         auto c2 = chain.control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+            const auto& [ b, id, header, block_num ] = t;
+            block = b; });
 
          // test error handling on deferred transaction failure
          auto test_trace = CALL_TEST_FUNCTION(chain, "test_transaction", "send_transaction_trigger_error_handler", {});
@@ -1480,7 +1482,7 @@ void transaction_tests(T& chain) {
          BOOST_CHECK_EQUAL(trace->receipt->status, transaction_receipt::soft_fail);
 
          std::set<transaction_id_type> block_ids;
-         for( const auto& receipt : bsp->block->transactions ) {
+         for( const auto& receipt : block->transactions ) {
             transaction_id_type id;
             if( std::holds_alternative<packed_transaction>(receipt.trx) ) {
                const auto& pt = std::get<packed_transaction>(receipt.trx);

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -217,11 +217,13 @@ BOOST_AUTO_TEST_CASE(broadcasted_block_test)
   signed_block_ptr bcasted_blk_by_prod_node;
   signed_block_ptr bcasted_blk_by_recv_node;
 
-  producer_node.control->accepted_block.connect( [&](const block_state_legacy_ptr& bs) {
-    bcasted_blk_by_prod_node = bs->block;
+  producer_node.control->accepted_block.connect( [&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+    const auto& [ block, id, header, block_num ] = t;
+    bcasted_blk_by_prod_node = block;
   });
-  receiving_node.control->accepted_block.connect( [&](const block_state_legacy_ptr& bs) {
-    bcasted_blk_by_recv_node = bs->block;
+  receiving_node.control->accepted_block.connect( [&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+    const auto& [ block, id, header, block_num ] = t;
+    bcasted_blk_by_recv_node = block;
   });
 
   auto b = producer_node.produce_block();

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -217,12 +217,12 @@ BOOST_AUTO_TEST_CASE(broadcasted_block_test)
   signed_block_ptr bcasted_blk_by_prod_node;
   signed_block_ptr bcasted_blk_by_recv_node;
 
-  producer_node.control->accepted_block.connect( [&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-    const auto& [ block, id, header, block_num ] = t;
+  producer_node.control->accepted_block.connect( [&](block_signal_params t) {
+    const auto& [ block, id ] = t;
     bcasted_blk_by_prod_node = block;
   });
-  receiving_node.control->accepted_block.connect( [&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-    const auto& [ block, id, header, block_num ] = t;
+  receiving_node.control->accepted_block.connect( [&](block_signal_params t) {
+    const auto& [ block, id ] = t;
     bcasted_blk_by_recv_node = block;
   });
 

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -151,8 +151,9 @@ BOOST_AUTO_TEST_CASE( signal_validated_blocks ) try {
 
    signed_block_ptr accepted_block;
    block_id_type accepted_id;
-   auto c = chain.control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-      const auto& [ block, id, header, block_num ] = t;
+   auto c = chain.control->accepted_block.connect([&](block_signal_params t) {
+      const auto& [ block, id ] = t;
+      auto block_num = block->block_num();
       BOOST_CHECK(block);
       const auto& bsp_by_id = chain.control->fetch_block_state_by_id(id);
       BOOST_CHECK(bsp_by_id->block_num == block_num);
@@ -169,8 +170,9 @@ BOOST_AUTO_TEST_CASE( signal_validated_blocks ) try {
    });
    signed_block_ptr validated_block;
    block_id_type validated_id;
-   auto c2 = validator.control->accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-      const auto& [ block, id, header, block_num ] = t;
+   auto c2 = validator.control->accepted_block.connect([&](block_signal_params t) {
+      const auto& [ block, id ] = t;
+      auto block_num = block->block_num();
       BOOST_CHECK(block);
       const auto& bsp_by_id = validator.control->fetch_block_state_by_id(id);
       BOOST_CHECK(bsp_by_id->block_num == block_num);

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -352,11 +352,13 @@ BOOST_AUTO_TEST_CASE( validator_accepts_valid_blocks ) try {
    auto id = n1.control->head_block_id();
 
    signed_block_ptr first_block;
+   block_id_type first_id;
    signed_block_header first_header;
 
    auto c = n2.control->accepted_block.connect( [&]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
       const auto& [ block, id, header, block_num ] = t;
       first_block = block;
+      first_id = id;
       first_header = header;
    } );
 
@@ -365,7 +367,8 @@ BOOST_AUTO_TEST_CASE( validator_accepts_valid_blocks ) try {
    BOOST_CHECK_EQUAL( n2.control->head_block_id(), id );
 
    BOOST_REQUIRE( first_block );
-   // WARNING first_block->verify_signee();
+   const auto& first_bsp = n2.control->fetch_block_state_by_id(first_id);
+   first_bsp->verify_signee();
    BOOST_CHECK_EQUAL( first_header.calculate_id(), first_block->calculate_id() );
    BOOST_CHECK( first_header.producer_signature == first_block->producer_signature );
 

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -355,11 +355,11 @@ BOOST_AUTO_TEST_CASE( validator_accepts_valid_blocks ) try {
    block_id_type first_id;
    signed_block_header first_header;
 
-   auto c = n2.control->accepted_block.connect( [&]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
-      const auto& [ block, id, header, block_num ] = t;
+   auto c = n2.control->accepted_block.connect( [&]( block_signal_params t ) {
+      const auto& [ block, id ] = t;
       first_block = block;
       first_id = id;
-      first_header = header;
+      first_header = static_cast<signed_block_header>(*block);
    } );
 
    push_blocks( n1, n2 );
@@ -703,8 +703,8 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
 
    // test forked blocks signal accepted_block in order, required by trace_api_plugin
    std::vector<signed_block_ptr> accepted_blocks;
-   auto conn = c.control->accepted_block.connect( [&]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
-      const auto& [ block, id, header, block_num ] = t;
+   auto conn = c.control->accepted_block.connect( [&]( block_signal_params t ) {
+      const auto& [ block, id ] = t;
       accepted_blocks.emplace_back( block );
    } );
 

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -351,10 +351,13 @@ BOOST_AUTO_TEST_CASE( validator_accepts_valid_blocks ) try {
 
    auto id = n1.control->head_block_id();
 
-   block_state_legacy_ptr first_block;
+   signed_block_ptr first_block;
+   signed_block_header first_header;
 
-   auto c = n2.control->accepted_block.connect( [&]( const block_state_legacy_ptr& bsp) {
-      first_block = bsp;
+   auto c = n2.control->accepted_block.connect( [&]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
+      const auto& [ block, id, header, block_num ] = t;
+      first_block = block;
+      first_header = header;
    } );
 
    push_blocks( n1, n2 );
@@ -362,13 +365,13 @@ BOOST_AUTO_TEST_CASE( validator_accepts_valid_blocks ) try {
    BOOST_CHECK_EQUAL( n2.control->head_block_id(), id );
 
    BOOST_REQUIRE( first_block );
-   first_block->verify_signee();
-   BOOST_CHECK_EQUAL( first_block->header.calculate_id(), first_block->block->calculate_id() );
-   BOOST_CHECK( first_block->header.producer_signature == first_block->block->producer_signature );
+   // WARNING first_block->verify_signee();
+   BOOST_CHECK_EQUAL( first_header.calculate_id(), first_block->calculate_id() );
+   BOOST_CHECK( first_header.producer_signature == first_block->producer_signature );
 
    c.disconnect();
 
-   n3.push_block( first_block->block );
+   n3.push_block( first_block );
 
    BOOST_CHECK_EQUAL( n3.control->head_block_id(), id );
 
@@ -697,8 +700,9 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
 
    // test forked blocks signal accepted_block in order, required by trace_api_plugin
    std::vector<signed_block_ptr> accepted_blocks;
-   auto conn = c.control->accepted_block.connect( [&]( const block_state_legacy_ptr& bsp) {
-      accepted_blocks.emplace_back( bsp->block );
+   auto conn = c.control->accepted_block.connect( [&]( std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t ) {
+      const auto& [ block, id, header, block_num ] = t;
+      accepted_blocks.emplace_back( block );
    } );
 
    // dan on chain 1 now gets all of the blocks from chain 2 which should cause fork switch

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -641,7 +641,7 @@ struct state_history_tester : state_history_tester_logs, tester {
             trace_converter.pack(buf, false, block);
          });
 
-         chain_state_log.pack_and_write_entry(header, static_cast<signed_block_header>(*block).previous, [&control](auto&& buf) {
+         chain_state_log.pack_and_write_entry(header, block->previous, [&control](auto&& buf) {
             eosio::state_history::pack_deltas(buf, control.db(), true);
          });
       });

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -631,8 +631,8 @@ struct state_history_tester : state_history_tester_logs, tester {
           trace_converter.add_transaction(std::get<0>(t), std::get<1>(t));
        });
 
-      control.accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
-         const auto& [ block, id, block_header, block_num ] = t;
+      control.accepted_block.connect([&](block_signal_params t) {
+         const auto& [ block, id ] = t;
          eosio::state_history_log_header header{.magic        = eosio::ship_magic(eosio::ship_current_version, 0),
                                       .block_id     = id,
                                       .payload_size = 0};
@@ -641,7 +641,7 @@ struct state_history_tester : state_history_tester_logs, tester {
             trace_converter.pack(buf, false, block);
          });
 
-         chain_state_log.pack_and_write_entry(header, block_header.previous, [&control](auto&& buf) {
+         chain_state_log.pack_and_write_entry(header, static_cast<signed_block_header>(*block).previous, [&control](auto&& buf) {
             eosio::state_history::pack_deltas(buf, control.db(), true);
          });
       });

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -631,16 +631,17 @@ struct state_history_tester : state_history_tester_logs, tester {
           trace_converter.add_transaction(std::get<0>(t), std::get<1>(t));
        });
 
-      control.accepted_block.connect([&](const block_state_legacy_ptr& block_state) {
+      control.accepted_block.connect([&](std::tuple<const signed_block_ptr&, const block_id_type&, const signed_block_header&, uint32_t> t) {
+         const auto& [ block, id, block_header, block_num ] = t;
          eosio::state_history_log_header header{.magic        = eosio::ship_magic(eosio::ship_current_version, 0),
-                                      .block_id     = block_state->id,
+                                      .block_id     = id,
                                       .payload_size = 0};
 
-         traces_log.pack_and_write_entry(header, block_state->block->previous, [this, &block_state](auto&& buf) {
-            trace_converter.pack(buf, false, block_state);
+         traces_log.pack_and_write_entry(header, block->previous, [this, &block](auto&& buf) {
+            trace_converter.pack(buf, false, block);
          });
 
-         chain_state_log.pack_and_write_entry(header, block_state->header.previous, [&control](auto&& buf) {
+         chain_state_log.pack_and_write_entry(header, block_header.previous, [&control](auto&& buf) {
             eosio::state_history::pack_deltas(buf, control.db(), true);
          });
       });

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -124,7 +124,8 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_test ) try {
 
    // clear applied
    q.add_aborted( { trx1, trx2, trx3 } );
-   q.clear_applied( create_test_block_state( { trx1, trx3, trx4 } ) );
+   auto bs0 = create_test_block_state( { trx1, trx3, trx4 } );
+   q.clear_applied( bs0->block );
    BOOST_CHECK( q.size() == 1u );
    BOOST_REQUIRE( next( q ) == trx2 );
    BOOST_CHECK( q.size() == 0u );


### PR DESCRIPTION
Currently `controller` signals an all-purpose `block_state_legacy_ptr` for `accepted_block_header`, `accepted_block`, `and irreversible_block`. `block_state_legacy_ptr` is passed across functions, hiding actual parameters a function needs. Over 40 files depend on `block_state_legacy.hpp`. 

This PR
* Changed to signal types which are only required.
* Changed function interface to use exact parameters instead of one-for-all `block_state_legacy_ptr` and updated implementation
* Updated tests
* Removed unused signals `pre_accepted_block`, `accepted_transaction`, and `bad_alloc`.

Those changes 
* help make Instant Finality coding simpler by removing the need to signal variant types,
* reduce abstraction leakage,
* reduce the overall codebase dependency on to-be-obsolete `block_state_legacy_ptr` by removing the majority uses of it.

Resolved https://github.com/AntelopeIO/leap/issues/1957