### PR TITLE
only run libtester tests on ubuntu22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -244,10 +244,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu20, ubuntu22]
+        platform: [ubuntu22]
         test: [build-tree, make-dev-install, deb-install]
     runs-on:  ["self-hosted", "enf-x86-midtier"]
-    container: ${{ matrix.test != 'deb-install' && fromJSON(needs.platform-cache.outputs.platforms)[matrix.platform].image || matrix.platform == 'ubuntu20' && 'ubuntu:focal' || 'ubuntu:jammy' }}
+    container: ${{ matrix.test != 'deb-install' && fromJSON(needs.platform-cache.outputs.platforms)[matrix.platform].image || 'ubuntu:jammy' }}
     env:
       DEBIAN_FRONTEND: noninteractive
       TZ: Etc/UTC


### PR DESCRIPTION
By far the primary purpose of the libtester tests are to ensure we didn't goof proper referencing or installation of a libtester dependency since they aren't handled automatically. It's easy to break in one of the three ways we support.

Testing libtester on all the supported Ubuntu versions is a distant second purpose. But I am not sure I can think of cases where this has gone awry recently, and there is nothing in libtester's cmake complexity that is different for different Linux distros.

Due to #1936 let's just remove libtester testing on ubuntu20 for now. While I'm sure it's possible (even easy) to fix the underlying issue of needing to use a newer compiler for these tests on ubuntu20, it's nice not to add more complexity for this case imo. Resolves #1936 indirectly.