### PR TITLE
[5.0] Test: Fix trx_generator handling of connection lost

### DIFF
--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -35,7 +35,10 @@ namespace eosio::testing {
    }
 
    void provider_connection::init_and_connect() {
-      _connection_thread_pool.start(1, {});
+      _connection_thread_pool.start(1,
+                                    [&](const fc::exception &e) {
+                                       wlog("Exception in connection_thread: ${e}", ("e", e.to_detail_string()));
+                                    });
       connect();
    };
 


### PR DESCRIPTION
Add an `on_except` so `named_thread_pool` does not terminate when connection lost to client. This should fix the core dumps found in ci/cd runs such as https://github.com/AntelopeIO/leap/issues/1865
This is not a fix for #1865, as something caused nodeos to die for the `trx_generator` to lose connection and core dump. This PR however should remove the red herring of the trx_generator core files in ci/cd. 