### PR TITLE
IF: Use `set_finalizer` type names that match `eosio.bios` and CDT

### DIFF
--- a/libraries/chain/hotstuff/test/test_hotstuff.cpp
+++ b/libraries/chain/hotstuff/test/test_hotstuff.cpp
@@ -192,7 +192,7 @@ static finalizer_policy create_fs(std::vector<std::string> keys){
       f_auths.push_back(eosio::chain::finalizer_authority{"" , 1 , pk});
    }
    eosio::chain::finalizer_policy fset;
-   fset.fthreshold = 15;
+   fset.threshold = 15;
    fset.finalizers = f_auths;
    return fset;
 }

--- a/libraries/chain/include/eosio/chain/hotstuff/finalizer_authority.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff/finalizer_authority.hpp
@@ -8,7 +8,7 @@ namespace eosio::chain {
    struct finalizer_authority {
 
       std::string  description;
-      uint64_t     fweight = 0; // weight that this finalizer's vote has for meeting fthreshold
+      uint64_t     weight = 0; // weight that this finalizer's vote has for meeting fthreshold
       fc::crypto::blslib::bls_public_key  public_key;
 
       auto operator<=>(const finalizer_authority&) const = default;
@@ -16,4 +16,4 @@ namespace eosio::chain {
 
 } /// eosio::chain
 
-FC_REFLECT( eosio::chain::finalizer_authority, (description)(fweight)(public_key) )
+FC_REFLECT( eosio::chain::finalizer_authority, (description)(weight)(public_key) )

--- a/libraries/chain/include/eosio/chain/hotstuff/finalizer_policy.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff/finalizer_policy.hpp
@@ -17,7 +17,7 @@ namespace eosio::chain {
       finalizer_policy& operator=(finalizer_policy&&) noexcept;
 
       uint32_t                         generation = 0; ///< sequentially incrementing version number
-      uint64_t                         fthreshold = 0;  ///< vote fweight threshold to finalize blocks
+      uint64_t                         threshold = 0;  ///< vote weight threshold to finalize blocks
       std::vector<finalizer_authority> finalizers; ///< Instant Finality voter set
    };
 
@@ -33,5 +33,5 @@ namespace eosio::chain {
 
 } /// eosio::chain
 
-FC_REFLECT( eosio::chain::finalizer_policy, (generation)(fthreshold)(finalizers) )
+FC_REFLECT( eosio::chain::finalizer_policy, (generation)(threshold)(finalizers) )
 FC_REFLECT_DERIVED( eosio::chain::finalizer_policy_extension, (eosio::chain::finalizer_policy), )

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -3882,7 +3882,7 @@ BOOST_AUTO_TEST_CASE(set_finalizer_test) { try {
    BOOST_TEST(!!ext);
    BOOST_TEST(std::get<finalizer_policy_extension>(*ext).finalizers.size() == finalizers.size());
    BOOST_TEST(std::get<finalizer_policy_extension>(*ext).generation == 1);
-   BOOST_TEST(std::get<finalizer_policy_extension>(*ext).fthreshold == finalizers.size() / 3 * 2 + 1);
+   BOOST_TEST(std::get<finalizer_policy_extension>(*ext).threshold == finalizers.size() / 3 * 2 + 1);
 
    // old dpos still in affect until block is irreversible
    BOOST_TEST(block->confirmed == 0);


### PR DESCRIPTION
No change in functionality, just renaming.

Resolves #1992 