### PR TITLE
[5.0] Test: Check for unlinkable blocks while syncing

### DIFF
--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -170,7 +170,10 @@ try:
             waitForBlock(node0, catchupHead+5, timeout=twoRoundsTimeout*2, blockType=BlockType.lib)
 
         Print("Restart catchup node")
-        catchupNode.relaunch()
+        addSwapFlags = None
+        if catchup_num % 3 == 0:
+            addSwapFlags = {"--block-log-retain-blocks": "0", "--delete-all": ""}
+        catchupNode.relaunch(skipGenesis=False, addSwapFlags=addSwapFlags)
         waitForNodeStarted(catchupNode)
         lastCatchupLibNum=lib(catchupNode)
 
@@ -188,6 +191,12 @@ try:
         waitForBlock(catchupNode, lastLibNum, timeout=(numBlocksToCatchup/2 + 60), blockType=BlockType.lib)
         catchupNode.interruptAndVerifyExitStatus(60)
         catchupNode.popenProc=None
+
+        logFile = Utils.getNodeDataDir(catchupNodeNum) + "/stderr.txt"
+        f = open(logFile)
+        contents = f.read()
+        if contents.count("unlinkable_block_exception") > 3: # a few are fine
+            errorExit(f"Node{catchupNodeNum} has unlinkable blocks: {logFile}.")
 
     testSuccessful=True
 


### PR DESCRIPTION
Update `nodeos_startup_catchup.py` test to sync with `--block-log-retain-blocks=0` and verify no `unlinkable` blocks.
Test fails before #2007 fix.

Resolves #2006