### PR TITLE
IF: Remove block_state_legacy access

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3536,8 +3536,12 @@ account_name  controller::head_block_producer()const {
 const block_header& controller::head_block_header()const {
    return my->head->header;
 }
-block_state_legacy_ptr controller::head_block_state()const {
+block_state_legacy_ptr controller::head_block_state_legacy()const {
+   // TODO: return null after instant finality activated
    return my->head;
+}
+const signed_block_ptr& controller::head_block()const {
+   return my->head->block;
 }
 
 block_state_legacy_ptr controller_impl::fork_db_head() const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3524,6 +3524,9 @@ void controller::set_disable_replay_opts( bool v ) {
 uint32_t controller::head_block_num()const {
    return my->head->block_num();
 }
+block_timestamp_type controller::head_block_timestamp()const {
+   return my->head->header.timestamp;
+}
 time_point controller::head_block_time()const {
    return my->head->header.timestamp;
 }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3636,7 +3636,7 @@ std::optional<signed_block_header> controller::fetch_block_header_by_id( const b
 }
 
 signed_block_ptr controller::fetch_block_by_number( uint32_t block_num )const  { try {
-   auto blk_state = fetch_block_state_by_number( block_num );
+   auto blk_state = my->fork_db.search_on_branch( fork_db_head_block_id(), block_num );
    if( blk_state ) {
       return blk_state->block;
    }
@@ -3645,7 +3645,7 @@ signed_block_ptr controller::fetch_block_by_number( uint32_t block_num )const  {
 } FC_CAPTURE_AND_RETHROW( (block_num) ) }
 
 std::optional<signed_block_header> controller::fetch_block_header_by_number( uint32_t block_num )const  { try {
-   auto blk_state = fetch_block_state_by_number( block_num );
+   auto blk_state = my->fork_db.search_on_branch( fork_db_head_block_id(), block_num );
    if( blk_state ) {
       return blk_state->header;
    }
@@ -3658,17 +3658,13 @@ block_state_legacy_ptr controller::fetch_block_state_by_id( block_id_type id )co
    return state;
 }
 
-block_state_legacy_ptr controller::fetch_block_state_by_number( uint32_t block_num )const  { try {
-   return my->fork_db.search_on_branch( fork_db_head_block_id(), block_num );
-} FC_CAPTURE_AND_RETHROW( (block_num) ) }
-
 block_id_type controller::get_block_id_for_num( uint32_t block_num )const { try {
    const auto& blog_head = my->blog.head();
 
    bool find_in_blog = (blog_head && block_num <= blog_head->block_num());
 
    if( !find_in_blog ) {
-      auto bsp = fetch_block_state_by_number( block_num );
+      auto bsp = my->fork_db.search_on_branch( fork_db_head_block_id(), block_num );
       if( bsp ) return bsp->id();
    }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3656,11 +3656,6 @@ std::optional<signed_block_header> controller::fetch_block_header_by_number( uin
    return my->blog.read_block_header_by_num(block_num);
 } FC_CAPTURE_AND_RETHROW( (block_num) ) }
 
-block_state_legacy_ptr controller::fetch_block_state_by_id( block_id_type id )const {
-   auto state = my->fork_db.get_block(id);
-   return state;
-}
-
 block_id_type controller::get_block_id_for_num( uint32_t block_num )const { try {
    const auto& blog_head = my->blog.head();
 

--- a/libraries/chain/hotstuff/chain_pacemaker.cpp
+++ b/libraries/chain/hotstuff/chain_pacemaker.cpp
@@ -118,7 +118,8 @@ namespace eosio::chain {
          const auto& [ block, id ] = t;
          on_irreversible_block( block );
       } );
-      _head_block_state = chain->head_block_state();
+      // TODO: assuming this will be going away
+      _head_block_state = chain->head_block_state_legacy();
    }
 
    void chain_pacemaker::register_bcast_function(std::function<void(const std::optional<uint32_t>&, const hs_message&)> broadcast_hs_message) {

--- a/libraries/chain/hotstuff/chain_pacemaker.cpp
+++ b/libraries/chain/hotstuff/chain_pacemaker.cpp
@@ -162,7 +162,8 @@ namespace eosio::chain {
    // called from main thread
    void chain_pacemaker::on_accepted_block( const signed_block_ptr& block ) {
       std::scoped_lock g( _chain_state_mutex );
-      _head_block_state = _chain->fetch_block_state_by_number(block->block_num());
+      // TODO: assume this is going away
+      _head_block_state = _chain->head_block_state_legacy();
    }
 
    // called from main thread

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -268,8 +268,6 @@ namespace eosio::chain {
          // thread-safe
          std::optional<signed_block_header> fetch_block_header_by_id( const block_id_type& id )const;
          // return block_state_legacy from forkdb, thread-safe
-         block_state_legacy_ptr fetch_block_state_by_number( uint32_t block_num )const;
-         // return block_state_legacy from forkdb, thread-safe
          block_state_legacy_ptr fetch_block_state_by_id( block_id_type id )const;
          // thread-safe
          block_id_type get_block_id_for_num( uint32_t block_num )const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -230,6 +230,7 @@ namespace eosio::chain {
 
          uint32_t             head_block_num()const;
          time_point           head_block_time()const;
+         block_timestamp_type head_block_timestamp()const;
          block_id_type        head_block_id()const;
          account_name         head_block_producer()const;
          const block_header&  head_block_header()const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -268,8 +268,6 @@ namespace eosio::chain {
          std::optional<signed_block_header> fetch_block_header_by_number( uint32_t block_num )const;
          // thread-safe
          std::optional<signed_block_header> fetch_block_header_by_id( const block_id_type& id )const;
-         // return block_state_legacy from forkdb, thread-safe
-         block_state_legacy_ptr fetch_block_state_by_id( block_id_type id )const;
          // thread-safe
          block_id_type get_block_id_for_num( uint32_t block_num )const;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -233,7 +233,9 @@ namespace eosio::chain {
          block_id_type        head_block_id()const;
          account_name         head_block_producer()const;
          const block_header&  head_block_header()const;
-         block_state_legacy_ptr head_block_state()const;
+         const signed_block_ptr& head_block()const;
+         // returns nullptr after instant finality enabled
+         block_state_legacy_ptr head_block_state_legacy()const;
 
          uint32_t             fork_db_head_block_num()const;
          block_id_type        fork_db_head_block_id()const;

--- a/libraries/chain/include/eosio/chain/producer_schedule.hpp
+++ b/libraries/chain/include/eosio/chain/producer_schedule.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/types.hpp>
+#include <eosio/chain/block_timestamp.hpp>
 #include <chainbase/chainbase.hpp>
 #include <eosio/chain/authority.hpp>
 #include <eosio/chain/snapshot.hpp>
@@ -248,6 +249,12 @@ namespace eosio { namespace chain {
 
       uint32_t                                       version = 0; ///< sequentially incrementing version number
       vector<producer_authority>                     producers;
+
+      const producer_authority& get_scheduled_producer( block_timestamp_type t )const {
+         auto index = t.slot % (producers.size() * config::producer_repetitions);
+         index /= config::producer_repetitions;
+         return producers[index];
+      }
 
       friend bool operator == ( const producer_authority_schedule& a, const producer_authority_schedule& b )
       {

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -640,8 +640,8 @@ namespace eosio { namespace testing {
       bool validate() {
 
 
-        auto hbh = control->head_block_state()->header;
-        auto vn_hbh = validating_node->head_block_state()->header;
+        const auto& hbh = control->head_block_header();
+        const auto& vn_hbh = validating_node->head_block_header();
         bool ok = control->head_block_id() == validating_node->head_block_id() &&
                hbh.previous == vn_hbh.previous &&
                hbh.timestamp == vn_hbh.timestamp &&

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -398,7 +398,6 @@ namespace eosio { namespace testing {
 
    signed_block_ptr base_tester::_produce_block( fc::microseconds skip_time, bool skip_pending_trxs,
                                                  bool no_throw, std::vector<transaction_trace_ptr>& traces ) {
-      auto head = control->head_block_state();
       auto head_time = control->head_block_time();
       auto next_time = head_time + skip_time;
 
@@ -438,7 +437,7 @@ namespace eosio { namespace testing {
 
    void base_tester::_start_block(fc::time_point block_time) {
       auto head_block_number = control->head_block_num();
-      auto producer = control->head_block_state()->get_scheduled_producer(block_time);
+      auto producer = control->active_producers().get_scheduled_producer(block_time);
 
       auto last_produced_block_num = control->last_irreversible_block_num();
       auto itr = last_produced_block.find(producer.producer_name);
@@ -473,16 +472,17 @@ namespace eosio { namespace testing {
    signed_block_ptr base_tester::_finish_block() {
       FC_ASSERT( control->is_building_block(), "must first start a block before it can be finished" );
 
-      auto producer = control->head_block_state()->get_scheduled_producer( control->pending_block_time() );
+      auto auth = control->pending_block_signing_authority();
+      auto producer_name = control->pending_block_producer();
       vector<private_key_type> signing_keys;
 
-      auto default_active_key = get_public_key( producer.producer_name, "active");
-      producer.for_each_key([&](const public_key_type& key){
+      auto default_active_key = get_public_key( producer_name, "active");
+      producer_authority::for_each_key(auth, [&](const public_key_type& key){
          const auto& iter = block_signing_private_keys.find(key);
          if(iter != block_signing_private_keys.end()) {
             signing_keys.push_back(iter->second);
          } else if (key == default_active_key) {
-            signing_keys.emplace_back( get_private_key( producer.producer_name, "active") );
+            signing_keys.emplace_back( get_private_key( producer_name, "active") );
          }
       });
 
@@ -497,9 +497,9 @@ namespace eosio { namespace testing {
       } );
 
       control->commit_block();
-      last_produced_block[control->head_block_state()->header.producer] = control->head_block_state()->id();
+      last_produced_block[producer_name] = control->head_block_id();
 
-      return control->head_block_state()->block;
+      return control->head_block();
    }
 
    signed_block_ptr base_tester::produce_block( std::vector<transaction_trace_ptr>& traces ) {
@@ -547,7 +547,7 @@ namespace eosio { namespace testing {
    void base_tester::produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(const fc::microseconds target_elapsed_time) {
       fc::microseconds elapsed_time;
       while (elapsed_time < target_elapsed_time) {
-         for(uint32_t i = 0; i < control->head_block_state()->active_schedule.producers.size(); i++) {
+         for(uint32_t i = 0; i < control->active_producers().producers.size(); i++) {
             const auto time_to_skip = fc::milliseconds(config::producer_repetitions * config::block_interval_ms);
             produce_block(time_to_skip);
             elapsed_time += time_to_skip;

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -186,30 +186,6 @@ paths:
               schema:
                 description: Returns Nothing
 
-  /get_block_header_state:
-    post:
-      description: Retrieves the glock header state
-      operationId: get_block_header_state
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - block_num_or_id
-              properties:
-                block_num_or_id:
-                  type: string
-                  description: Provide a block_number or a block_id
-
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "https://docs.eosnetwork.com/openapi/v2.0/BlockHeaderState.yaml"
-
   /get_abi:
     post:
       description: Retrieves the ABI for a contract based on its account name

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -132,7 +132,6 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(get_activated_protocol_features, 200, http_params_types::possible_no_params),
       CHAIN_RO_CALL_POST(get_block, fc::variant, 200, http_params_types::params_required), // _POST because get_block() returns a lambda to be executed on the http thread pool
       CHAIN_RO_CALL(get_block_info, 200, http_params_types::params_required),
-      CHAIN_RO_CALL(get_block_header_state, 200, http_params_types::params_required),
       CHAIN_RO_CALL_POST(get_account, chain_apis::read_only::get_account_results, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_code, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_code_hash, 200, http_params_types::params_required),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1984,9 +1984,9 @@ fc::variant read_only::convert_block( const chain::signed_block_ptr& block, abi_
 
 fc::variant read_only::get_block_info(const read_only::get_block_info_params& params, const fc::time_point&) const {
 
-   signed_block_ptr block;
+   std::optional<signed_block_header> block;
    try {
-         block = db.fetch_block_by_number( params.block_num );
+         block = db.fetch_block_header_by_number( params.block_num );
    } catch (...)   {
       // assert below will handle the invalid block num
    }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2011,29 +2011,6 @@ fc::variant read_only::get_block_info(const read_only::get_block_info_params& pa
          ("ref_block_prefix", ref_block_prefix);
 }
 
-fc::variant read_only::get_block_header_state(const get_block_header_state_params& params, const fc::time_point&) const {
-   block_state_legacy_ptr b;
-   std::optional<uint64_t> block_num;
-   std::exception_ptr e;
-   try {
-      block_num = fc::to_uint64(params.block_num_or_id);
-   } catch( ... ) {}
-
-   if( block_num ) {
-      b = db.fetch_block_state_by_number(*block_num);
-   } else {
-      try {
-         b = db.fetch_block_state_by_id(fc::variant(params.block_num_or_id).as<block_id_type>());
-      } EOS_RETHROW_EXCEPTIONS(chain::block_id_type_exception, "Invalid block ID: ${block_num_or_id}", ("block_num_or_id", params.block_num_or_id))
-   }
-
-   EOS_ASSERT( b, unknown_block_exception, "Could not find reversible block: ${block}", ("block", params.block_num_or_id));
-
-   fc::variant vo;
-   fc::to_variant( static_cast<const block_header_state_legacy&>(*b), vo );
-   return vo;
-}
-
 void read_write::push_block(read_write::push_block_params&& params, next_function<read_write::push_block_results> next) {
    try {
       app().get_method<incoming::methods::block_sync>()(std::make_shared<signed_block>( std::move(params) ), std::optional<block_id_type>{}, block_state_legacy_ptr{});

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -409,12 +409,6 @@ public:
 
    fc::variant get_block_info(const get_block_info_params& params, const fc::time_point& deadline) const;
 
-   struct get_block_header_state_params {
-      string block_num_or_id;
-   };
-
-   fc::variant get_block_header_state(const get_block_header_state_params& params, const fc::time_point& deadline) const;
-
    struct get_table_rows_params {
       bool                 json = false;
       name                 code;
@@ -1067,7 +1061,6 @@ FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params,
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
 FC_REFLECT(eosio::chain_apis::read_only::get_raw_block_params, (block_num_or_id))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_info_params, (block_num))
-FC_REFLECT(eosio::chain_apis::read_only::get_block_header_state_params, (block_num_or_id))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_header_params, (block_num_or_id)(include_extensions))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_header_result, (id)(signed_block_header)(block_extensions))
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3711,7 +3711,7 @@ namespace eosio {
          controller& cc = my_impl->chain_plug->chain();
 
          // may have come in on a different connection and posted into dispatcher strand before this one
-         if( my_impl->dispatcher->have_block( id ) || cc.fetch_block_state_by_id( id ) ) { // thread-safe
+         if( my_impl->dispatcher->have_block( id ) || cc.fetch_block_by_id( id ) ) { // thread-safe
             my_impl->dispatcher->add_peer_block( id, c->connection_id );
             c->strand.post( [c, id]() {
                my_impl->sync_master->sync_recv_block( c, id, block_header::num_from_id(id), false );

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1788,7 +1788,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    _pending_block_mode = pending_block_mode::producing;
 
    // Not our turn
-   const auto& scheduled_producer = chain.active_producers().get_scheduled_producer(block_time);
+   const auto scheduled_producer = chain.active_producers().get_scheduled_producer(block_time);
 
    const auto current_watermark = _producer_watermarks.get_watermark(scheduled_producer.producer_name);
 
@@ -1947,12 +1947,11 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    LOG_AND_DROP();
 
    if (chain.is_building_block()) {
-      const auto& pending_block_signing_authority = chain.pending_block_signing_authority();
-      const auto& scheduled_producer_authority = chain.active_producers().get_scheduled_producer(block_time);
+      auto pending_block_signing_authority = chain.pending_block_signing_authority();
 
-      if (in_producing_mode() && pending_block_signing_authority != scheduled_producer_authority.authority) {
+      if (in_producing_mode() && pending_block_signing_authority != scheduled_producer.authority) {
          elog("Unexpected block signing authority, reverting to speculative mode! [expected: \"${expected}\", actual: \"${actual\"",
-              ("expected", scheduled_producer_authority.authority)("actual", pending_block_signing_authority));
+              ("expected", scheduled_producer.authority)("actual", pending_block_signing_authority));
          _pending_block_mode = pending_block_mode::speculating;
       }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -736,7 +736,7 @@ public:
 
       const auto& hb = chain.head_block();
       now             = fc::time_point::now();
-      if (hb->timestamp.next().to_time_point() >= now) {
+      if (hb && hb->timestamp.next().to_time_point() >= now) {
          _production_enabled = true;
       }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -734,9 +734,8 @@ public:
          handle_error(fc::std_exception_wrapper::from_current_exception(e));
       }
 
-      const auto& hb = chain.head_block();
       now             = fc::time_point::now();
-      if (hb && hb->timestamp.next().to_time_point() >= now) {
+      if (chain.head_block_timestamp().next().to_time_point() >= now) {
          _production_enabled = true;
       }
 
@@ -748,7 +747,8 @@ public:
               ("net", br.total_net_usage)("cpu", br.total_cpu_usage_us)
               ("elapsed", br.total_elapsed_time)("time", br.total_time)("latency", (now - block->timestamp).count() / 1000));
          const auto& hb_id = chain.head_block_id();
-         if (chain.get_read_mode() != db_read_mode::IRREVERSIBLE && hb_id != id && hb != nullptr) { // not applied to head
+         const auto& hb = chain.head_block();
+         if (chain.get_read_mode() != db_read_mode::IRREVERSIBLE && hb && hb_id != id && hb != nullptr) { // not applied to head
             ilog("Block not applied to head ${id}... #${n} @ ${t} signed by ${p} "
                  "[trxs: ${count}, lib: ${lib}, net: ${net}, cpu: ${cpu}, elapsed: ${elapsed}, time: ${time}, latency: ${latency} ms]",
                  ("p", hb->producer)("id", hb_id.str().substr(8, 16))("n", hb->block_num())("t", hb->timestamp)

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -734,9 +734,9 @@ public:
          handle_error(fc::std_exception_wrapper::from_current_exception(e));
       }
 
-      const auto& hbs = chain.head_block_state();
+      const auto& hb = chain.head_block();
       now             = fc::time_point::now();
-      if (hbs->header.timestamp.next().to_time_point() >= now) {
+      if (hb->timestamp.next().to_time_point() >= now) {
          _production_enabled = true;
       }
 
@@ -747,13 +747,14 @@ public:
               ("count", block->transactions.size())("lib", chain.last_irreversible_block_num())
               ("net", br.total_net_usage)("cpu", br.total_cpu_usage_us)
               ("elapsed", br.total_elapsed_time)("time", br.total_time)("latency", (now - block->timestamp).count() / 1000));
-         if (chain.get_read_mode() != db_read_mode::IRREVERSIBLE && hbs->id() != id && hbs->block != nullptr) { // not applied to head
+         const auto& hb_id = chain.head_block_id();
+         if (chain.get_read_mode() != db_read_mode::IRREVERSIBLE && hb_id != id && hb != nullptr) { // not applied to head
             ilog("Block not applied to head ${id}... #${n} @ ${t} signed by ${p} "
                  "[trxs: ${count}, lib: ${lib}, net: ${net}, cpu: ${cpu}, elapsed: ${elapsed}, time: ${time}, latency: ${latency} ms]",
-                 ("p", hbs->block->producer)("id", hbs->id().str().substr(8, 16))("n", hbs->block_num())("t", hbs->block->timestamp)
-                 ("count", hbs->block->transactions.size())("lib", chain.last_irreversible_block_num())
+                 ("p", hb->producer)("id", hb_id.str().substr(8, 16))("n", hb->block_num())("t", hb->timestamp)
+                 ("count", hb->transactions.size())("lib", chain.last_irreversible_block_num())
                  ("net", br.total_net_usage)("cpu", br.total_cpu_usage_us)("elapsed", br.total_elapsed_time)("time", br.total_time)
-                 ("latency", (now - hbs->block->timestamp).count() / 1000));
+                 ("latency", (now - hb->timestamp).count() / 1000));
          }
       }
       if (_update_incoming_block_metrics) {
@@ -1014,14 +1015,10 @@ void new_chain_banner(const eosio::chain::controller& db)
       "*******************************\n"
       "\n";
 
-   if( db.head_block_state()->header.timestamp.to_time_point() < (fc::time_point::now() - fc::milliseconds(200 * config::block_interval_ms)))
-   {
+   if( db.head_block_time() < (fc::time_point::now() - fc::milliseconds(200 * config::block_interval_ms))) {
       std::cerr << "Your genesis seems to have an old timestamp\n"
-         "Please consider using the --genesis-timestamp option to give your genesis a recent timestamp\n"
-         "\n"
-         ;
+         "Please consider using the --genesis-timestamp option to give your genesis a recent timestamp\n\n";
    }
-   return;
 }
 
 producer_plugin::producer_plugin()
@@ -1776,7 +1773,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    if (!chain_plug->accept_transactions())
       return start_block_result::waiting_for_block;
 
-   const auto& hbs = chain.head_block_state();
+   const auto& hb = chain.head_block();
 
    if (chain.get_terminate_at_block() > 0 && chain.get_terminate_at_block() <= chain.head_block_num()) {
       ilog("Reached configured maximum block ${num}; terminating", ("num", chain.get_terminate_at_block()));
@@ -1786,12 +1783,12 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
 
    const fc::time_point       now               = fc::time_point::now();
    const block_timestamp_type block_time        = calculate_pending_block_time();
-   const uint32_t             pending_block_num = hbs->block_num() + 1;
+   const uint32_t             pending_block_num = hb->block_num() + 1;
 
    _pending_block_mode = pending_block_mode::producing;
 
    // Not our turn
-   const auto& scheduled_producer = hbs->get_scheduled_producer(block_time);
+   const auto& scheduled_producer = chain.active_producers().get_scheduled_producer(block_time);
 
    const auto current_watermark = _producer_watermarks.get_watermark(scheduled_producer.producer_name);
 
@@ -1827,10 +1824,10 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
       // determine if our watermark excludes us from producing at this point
       if (current_watermark) {
          const block_timestamp_type block_timestamp{block_time};
-         if (current_watermark->first > hbs->block_num()) {
+         if (current_watermark->first > hb->block_num()) {
             elog("Not producing block because \"${producer}\" signed a block at a higher block number (${watermark}) than the current "
                  "fork's head (${head_block_num})",
-                 ("producer", scheduled_producer.producer_name)("watermark", current_watermark->first)("head_block_num", hbs->block_num()));
+                 ("producer", scheduled_producer.producer_name)("watermark", current_watermark->first)("head_block_num", hb->block_num()));
             _pending_block_mode = pending_block_mode::speculating;
          } else if (current_watermark->second >= block_timestamp) {
             elog("Not producing block because \"${producer}\" signed a block at the next block time or later (${watermark}) than the pending "
@@ -1881,7 +1878,8 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    try {
       uint16_t blocks_to_confirm = 0;
 
-      if (in_producing_mode() && hbs->dpos_irreversible_blocknum != hs_dpos_irreversible_blocknum) { // only if hotstuff not enabled
+      auto block_state = chain.head_block_state_legacy(); // null means if is active
+      if (in_producing_mode() && block_state && block_state->dpos_irreversible_blocknum != hs_dpos_irreversible_blocknum) { // only if hotstuff not enabled
          // determine how many blocks this producer can confirm
          // 1) if it is not a producer from this node, assume no confirmations (we will discard this block anyway)
          // 2) if it is a producer on this node that has never produced, the conservative approach is to assume no
@@ -1889,14 +1887,14 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
          // 3) if it is a producer on this node where this node knows the last block it produced, safely set it -UNLESS-
          // 4) the producer on this node's last watermark is higher (meaning on a different fork)
          if (current_watermark) {
-            auto watermark_bn = current_watermark->first;
-            if (watermark_bn < hbs->block_num()) {
-               blocks_to_confirm = (uint16_t)(std::min<uint32_t>(std::numeric_limits<uint16_t>::max(), (uint32_t)(hbs->block_num() - watermark_bn)));
+            uint32_t watermark_bn = current_watermark->first;
+            if (watermark_bn < hb->block_num()) {
+               blocks_to_confirm = (uint16_t)(std::min<uint32_t>(std::numeric_limits<uint16_t>::max(), (hb->block_num() - watermark_bn)));
             }
          }
 
          // can not confirm irreversible blocks
-         blocks_to_confirm = (uint16_t)(std::min<uint32_t>(blocks_to_confirm, (uint32_t)(hbs->block_num() - hbs->dpos_irreversible_blocknum)));
+         blocks_to_confirm = (uint16_t)(std::min<uint32_t>(blocks_to_confirm, (hb->block_num() - block_state->dpos_irreversible_blocknum)));
       }
 
       abort_block();
@@ -1959,7 +1957,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
 
       try {
          chain::subjective_billing& subjective_bill = chain.get_mutable_subjective_billing();
-         _account_fails.report_and_clear(hbs->block_num(), subjective_bill);
+         _account_fails.report_and_clear(pending_block_num, subjective_bill);
 
          if (!remove_expired_trxs(preprocess_deadline))
             return start_block_result::exhausted;
@@ -2498,7 +2496,7 @@ void producer_plugin_impl::schedule_production_loop() {
          chain::controller& chain = chain_plug->chain();
          fc_dlog(_log, "Waiting till another block is received and scheduling Speculative/Production Change");
          auto wake_time = block_timing_util::calculate_producer_wake_up_time(_produce_block_cpu_effort, chain.head_block_num(), calculate_pending_block_time(),
-                                                                             _producers, chain.head_block_state()->active_schedule.producers,
+                                                                             _producers, chain.active_producers().producers,
                                                                              _producer_watermarks);
          schedule_delayed_production_loop(weak_from_this(), wake_time);
       } else {
@@ -2517,7 +2515,7 @@ void producer_plugin_impl::schedule_production_loop() {
       fc_dlog(_log, "Speculative Block Created; Scheduling Speculative/Production Change");
       EOS_ASSERT(chain.is_building_block(), missing_pending_block_state, "speculating without pending_block_state");
       auto wake_time = block_timing_util::calculate_producer_wake_up_time(fc::microseconds{config::block_interval_us}, chain.pending_block_num(), chain.pending_block_timestamp(),
-                                                                          _producers, chain.head_block_state()->active_schedule.producers,
+                                                                          _producers, chain.active_producers().producers,
                                                                           _producer_watermarks);
       if (wake_time && fc::time_point::now() > *wake_time) {
          // if wake time has already passed then use the block deadline instead
@@ -2659,26 +2657,27 @@ void producer_plugin_impl::produce_block() {
 
    chain.commit_block();
 
-   block_state_legacy_ptr new_bs = chain.head_block_state();
+   const auto& id = chain.head_block_id();
+   const auto& new_b = chain.head_block();
    producer_plugin::produced_block_metrics metrics;
 
    br.total_time += fc::time_point::now() - start;
 
    ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} "
         "[trxs: ${count}, lib: ${lib}, confirmed: ${confs}, net: ${net}, cpu: ${cpu}, elapsed: ${et}, time: ${tt}]",
-        ("p", new_bs->header.producer)("id", new_bs->id().str().substr(8, 16))("n", new_bs->block_num())("t", new_bs->header.timestamp)
-        ("count", new_bs->block->transactions.size())("lib", chain.last_irreversible_block_num())("net", br.total_net_usage)
-        ("cpu", br.total_cpu_usage_us)("et", br.total_elapsed_time)("tt", br.total_time)("confs", new_bs->header.confirmed));
+        ("p", new_b->producer)("id", id.str().substr(8, 16))("n", new_b->block_num())("t", new_b->timestamp)
+        ("count", new_b->transactions.size())("lib", chain.last_irreversible_block_num())("net", br.total_net_usage)
+        ("cpu", br.total_cpu_usage_us)("et", br.total_elapsed_time)("tt", br.total_time)("confs", new_b->confirmed));
 
    _time_tracker.add_other_time();
-   _time_tracker.report(new_bs->block_num(), new_bs->block->producer, metrics);
+   _time_tracker.report(new_b->block_num(), new_b->producer, metrics);
    _time_tracker.clear();
 
    if (_update_produced_block_metrics) {
       metrics.unapplied_transactions_total = _unapplied_transactions.size();
       metrics.subjective_bill_account_size_total = chain.get_subjective_billing().get_account_cache_size();
       metrics.scheduled_trxs_total = chain.db().get_index<generated_transaction_multi_index, by_delay>().size();
-      metrics.trxs_produced_total = new_bs->block->transactions.size();
+      metrics.trxs_produced_total = new_b->transactions.size();
       metrics.cpu_usage_us = br.total_cpu_usage_us;
       metrics.total_elapsed_time_us = br.total_elapsed_time.count();
       metrics.total_time_us = br.total_time.count();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1788,7 +1788,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    _pending_block_mode = pending_block_mode::producing;
 
    // Not our turn
-   const auto& scheduled_producer = chain.active_producers().get_scheduled_producer(block_time);
+   const auto scheduled_producer = chain.active_producers().get_scheduled_producer(block_time);
 
    const auto current_watermark = _producer_watermarks.get_watermark(scheduled_producer.producer_name);
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1788,7 +1788,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    _pending_block_mode = pending_block_mode::producing;
 
    // Not our turn
-   const auto scheduled_producer = chain.active_producers().get_scheduled_producer(block_time);
+   const auto& scheduled_producer = chain.active_producers().get_scheduled_producer(block_time);
 
    const auto current_watermark = _producer_watermarks.get_watermark(scheduled_producer.producer_name);
 
@@ -1947,11 +1947,12 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    LOG_AND_DROP();
 
    if (chain.is_building_block()) {
-      auto pending_block_signing_authority = chain.pending_block_signing_authority();
+      const auto& pending_block_signing_authority = chain.pending_block_signing_authority();
+      const auto& scheduled_producer_authority = chain.active_producers().get_scheduled_producer(block_time);
 
-      if (in_producing_mode() && pending_block_signing_authority != scheduled_producer.authority) {
+      if (in_producing_mode() && pending_block_signing_authority != scheduled_producer_authority.authority) {
          elog("Unexpected block signing authority, reverting to speculative mode! [expected: \"${expected}\", actual: \"${actual\"",
-              ("expected", scheduled_producer.authority)("actual", pending_block_signing_authority));
+              ("expected", scheduled_producer_authority.authority)("actual", pending_block_signing_authority));
          _pending_block_mode = pending_block_mode::speculating;
       }
 

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -408,7 +408,7 @@ void state_history_plugin_impl::plugin_startup() {
       update_current();
       const auto& b = chain.head_block();
       const auto& id = chain.head_block_id();
-      if( chain_state_log && chain_state_log->empty() ) {
+      if( b && chain_state_log && chain_state_log->empty() ) {
          fc_ilog( _log, "Storing initial state on startup, this can take a considerable amount of time" );
          store_chain_state( id, *b, b->block_num() );
          fc_ilog( _log, "Done storing initial state on startup" );

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -206,7 +206,7 @@ public:
 
       try {
          store_traces(block, id);
-         store_chain_state(id, static_cast<signed_block_header>(*block), block->block_num());
+         store_chain_state(id, block->previous, block->block_num());
       } catch (const fc::exception& e) {
          fc_elog(_log, "fc::exception: ${details}", ("details", e.to_detail_string()));
          // Both app().quit() and exception throwing are required. Without app().quit(),
@@ -256,7 +256,7 @@ public:
    }
 
    // called from main thread
-   void store_chain_state(const block_id_type& id, const signed_block_header& block_header, uint32_t block_num) {
+   void store_chain_state(const block_id_type& id, const block_id_type& previous_id, uint32_t block_num) {
       if (!chain_state_log)
          return;
       bool fresh = chain_state_log->empty();
@@ -265,7 +265,7 @@ public:
 
       state_history_log_header header{
           .magic = ship_magic(ship_current_version, 0), .block_id = id, .payload_size = 0};
-      chain_state_log->pack_and_write_entry(header, block_header.previous, [this, fresh](auto&& buf) {
+      chain_state_log->pack_and_write_entry(header, previous_id, [this, fresh](auto&& buf) {
          pack_deltas(buf, chain_plug->chain().db(), fresh);
       });
    } // store_chain_state
@@ -406,11 +406,10 @@ void state_history_plugin_impl::plugin_startup() {
    try {
       const auto& chain = chain_plug->chain();
       update_current();
-      const auto& b = chain.head_block();
-      const auto& id = chain.head_block_id();
-      if( b && chain_state_log && chain_state_log->empty() ) {
+      uint32_t block_num = chain.head_block_num();
+      if( block_num > 0 && chain_state_log && chain_state_log->empty() ) {
          fc_ilog( _log, "Storing initial state on startup, this can take a considerable amount of time" );
-         store_chain_state( id, *b, b->block_num() );
+         store_chain_state( chain.head_block_id(), chain.head_block_header().previous, block_num );
          fc_ilog( _log, "Done storing initial state on startup" );
       }
       first_available_block = chain.earliest_available_block_num();

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -406,10 +406,11 @@ void state_history_plugin_impl::plugin_startup() {
    try {
       const auto& chain = chain_plug->chain();
       update_current();
-      auto bsp = chain.head_block_state();
-      if( bsp && chain_state_log && chain_state_log->empty() ) {
+      const auto& b = chain.head_block();
+      const auto& id = chain.head_block_id();
+      if( chain_state_log && chain_state_log->empty() ) {
          fc_ilog( _log, "Storing initial state on startup, this can take a considerable amount of time" );
-         store_chain_state( bsp->id(), bsp->header, bsp->block_num() );
+         store_chain_state( id, *b, b->block_num() );
          fc_ilog( _log, "Done storing initial state on startup" );
       }
       first_available_block = chain.earliest_available_block_num();

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -62,10 +62,10 @@ void test_control_plugin_impl::process_next_block_state(const chain::block_id_ty
    // Tests expect the shutdown only after signaling a producer shutdown and seeing a full production cycle
    const auto block_time = _chain.head_block_time() + fc::microseconds(chain::config::block_interval_us);
    // have to fetch bsp due to get_scheduled_producer call
-   const auto& bsp = _chain.fetch_block_state_by_id(id);
-   const auto& producer_authority = bsp->get_scheduled_producer(block_time);
+
+   const auto& producer_authority = _chain.active_producers().get_scheduled_producer(block_time);
    const auto producer_name = producer_authority.producer_name;
-   const auto slot = bsp->block->timestamp.slot % chain::config::producer_repetitions;
+   const auto slot = _chain.head_block_timestamp().slot % chain::config::producer_repetitions;
    if (_producer != account_name()) {
       if( _producer != producer_name ) _clean_producer_sequence = true;
       if( _clean_producer_sequence ) {

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -34,7 +34,6 @@ namespace eosio { namespace client { namespace http {
    const string get_raw_block_func = chain_func_base + "/get_raw_block";
    const string get_block_header_func = chain_func_base + "/get_block_header";
    const string get_block_info_func = chain_func_base + "/get_block_info";
-   const string get_block_header_state_func = chain_func_base + "/get_block_header_state";
    const string get_account_func = chain_func_base + "/get_account";
    const string get_table_func = chain_func_base + "/get_table_rows";
    const string get_table_by_scope_func = chain_func_base + "/get_table_by_scope";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3016,7 +3016,6 @@ int main( int argc, char** argv ) {
    get_block_params params;
    auto getBlock = get->add_subcommand("block", localized("Retrieve a full block from the blockchain"));
    getBlock->add_option("block", params.blockArg, localized("The number or ID of the block to retrieve"))->required();
-   getBlock->add_flag("--header-state", params.get_bhs, localized("Get block header state from fork database instead") );
    getBlock->add_flag("--info", params.get_binfo, localized("Get block info from the blockchain by block num only") );
    getBlock->add_flag("--raw", params.get_braw, localized("Get raw block from the blockchain") );
    getBlock->add_flag("--header", params.get_bheader, localized("Get block header from the blockchain") );
@@ -3024,7 +3023,7 @@ int main( int argc, char** argv ) {
 
    getBlock->callback([&params] {
       int num_flags = params.get_bhs + params.get_binfo + params.get_braw + params.get_bheader + params.get_bheader_extensions;
-      EOSC_ASSERT( num_flags <= 1, "ERROR: Only one of the following flags can be set: --header-state, --info, --raw, --header, --header-with-extensions." );
+      EOSC_ASSERT( num_flags <= 1, "ERROR: Only one of the following flags can be set: --info, --raw, --header, --header-with-extensions." );
       if (params.get_binfo) {
          std::optional<int64_t> block_num;
          try {
@@ -3037,9 +3036,7 @@ int main( int argc, char** argv ) {
          std::cout << fc::json::to_pretty_string(call(get_block_info_func, arg)) << std::endl;
       } else {
          const auto arg = fc::variant_object("block_num_or_id", params.blockArg);
-         if (params.get_bhs) {
-            std::cout << fc::json::to_pretty_string(call(get_block_header_state_func, arg)) << std::endl;
-         } else if (params.get_braw) {
+         if (params.get_braw) {
             std::cout << fc::json::to_pretty_string(call(get_raw_block_func, arg)) << std::endl;
          } else if (params.get_bheader || params.get_bheader_extensions) {
             std::cout << fc::json::to_pretty_string(

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -336,25 +336,6 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
         self.assertEqual(ret_json["payload"]["block_num"], 1)
 
-        # get_block_header_state with empty parameter
-        command = "get_block_header_state"
-        ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_block_header_state with empty content parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_block_header_state with invalid parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_block_header_state with valid parameter, the irreversible is not available, unknown block number
-        payload = {"block_num_or_id":1}
-        ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3100002)
-
         # get_account with empty parameter
         command = "get_account"
         ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)

--- a/tests/test_chain_plugin.cpp
+++ b/tests/test_chain_plugin.cpp
@@ -345,7 +345,7 @@ public:
         }
         produce_blocks( 250 );
 
-        auto producer_keys = control->head_block_state()->active_schedule.producers;
+        auto producer_keys = control->active_producers().producers;
         BOOST_CHECK_EQUAL( 21u, producer_keys.size() );
         BOOST_CHECK_EQUAL( name("defproducera"), producer_keys[0].producer_name );
 

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_test)
    copy_b->transaction_mroot = canonical_merkle( std::move(trx_digests) );
 
    // Re-sign the block
-   auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), main.control->head_block_state()->blockroot_merkle.get_root() ) );
-   auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, main.control->head_block_state()->pending_schedule.schedule_hash) );
+   auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), main.control->head_block_state_legacy()->blockroot_merkle.get_root() ) );
+   auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, main.control->head_block_state_legacy()->pending_schedule.schedule_hash) );
    copy_b->producer_signature = main.get_private_key(config::system_account_name, "active").sign(sig_digest);
 
    // Push block with invalid transaction to other chain
@@ -77,8 +77,8 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_mroot_test)
    copy_b->transactions.back().trx = std::move(invalid_packed_tx);
 
    // Re-sign the block
-   auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), main.control->head_block_state()->blockroot_merkle.get_root() ) );
-   auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, main.control->head_block_state()->pending_schedule.schedule_hash) );
+   auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), main.control->head_block_state_legacy()->blockroot_merkle.get_root() ) );
+   auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, main.control->head_block_state_legacy()->pending_schedule.schedule_hash) );
    copy_b->producer_signature = main.get_private_key(config::system_account_name, "active").sign(sig_digest);
 
    // Push block with invalid transaction to other chain
@@ -118,8 +118,8 @@ std::pair<signed_block_ptr, signed_block_ptr> corrupt_trx_in_block(validating_te
    copy_b->transaction_mroot = canonical_merkle( std::move(trx_digests) );
 
    // Re-sign the block
-   auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), main.control->head_block_state()->blockroot_merkle.get_root() ) );
-   auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, main.control->head_block_state()->pending_schedule.schedule_hash) );
+   auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), main.control->head_block_state_legacy()->blockroot_merkle.get_root() ) );
+   auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, main.control->head_block_state_legacy()->pending_schedule.schedule_hash) );
    copy_b->producer_signature = main.get_private_key(b->producer, "active").sign(sig_digest);
    return std::pair<signed_block_ptr, signed_block_ptr>(b, copy_b);
 }

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -272,7 +272,7 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
 
         // No producers will be set, since the total activated stake is less than 150,000,000
         produce_blocks_for_n_rounds(2); // 2 rounds since new producer schedule is set when the first block of next round is irreversible
-        auto active_schedule = control->head_block_state()->active_schedule;
+        auto active_schedule = control->active_producers();
         BOOST_TEST(active_schedule.producers.size() == 1u);
         BOOST_TEST(active_schedule.producers.front().producer_name == name("eosio"));
 
@@ -287,7 +287,7 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
 
         // Since the total vote stake is more than 150,000,000, the new producer set will be set
         produce_blocks_for_n_rounds(2); // 2 rounds since new producer schedule is set when the first block of next round is irreversible
-        active_schedule = control->head_block_state()->active_schedule;
+        active_schedule = control->active_producers();
         BOOST_REQUIRE(active_schedule.producers.size() == 21);
         BOOST_TEST(active_schedule.producers.at( 0).producer_name == name("proda"));
         BOOST_TEST(active_schedule.producers.at( 1).producer_name == name("prodb"));

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -156,10 +156,6 @@ BOOST_AUTO_TEST_CASE( signal_validated_blocks ) try {
       const auto& [ block, id ] = t;
       auto block_num = block->block_num();
       BOOST_CHECK(block);
-      const auto& bsp_by_id = chain.control->fetch_block_state_by_id(id);
-      BOOST_CHECK(bsp_by_id->block_num() == block_num);
-      const auto& bsp_by_number = chain.control->fetch_block_state_by_number(block_num);  // verify it can be found (has to be validated)
-      BOOST_CHECK(bsp_by_number->id() == id);
       BOOST_CHECK(chain.control->fetch_block_by_id(id) == block);
       BOOST_CHECK(chain.control->fetch_block_by_number(block_num) == block);
       BOOST_REQUIRE(chain.control->fetch_block_header_by_number(block_num));
@@ -175,10 +171,6 @@ BOOST_AUTO_TEST_CASE( signal_validated_blocks ) try {
       const auto& [ block, id ] = t;
       auto block_num = block->block_num();
       BOOST_CHECK(block);
-      const auto& bsp_by_id = validator.control->fetch_block_state_by_id(id);
-      BOOST_CHECK(bsp_by_id->block_num() == block_num);
-      const auto& bsp_by_number = validator.control->fetch_block_state_by_number(block_num);  // verify it can be found (has to be validated)
-      BOOST_CHECK(bsp_by_number->id() == id);
       BOOST_CHECK(validator.control->fetch_block_by_id(id) == block);
       BOOST_CHECK(validator.control->fetch_block_by_number(block_num) == block);
       BOOST_REQUIRE(validator.control->fetch_block_header_by_number(block_num));

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
 
          // Check the last irreversible block number is set correctly, with one producer, irreversibility should only just 1 block before
          const auto expected_last_irreversible_block_number = test.control->head_block_num() - 1;
-         BOOST_TEST(test.control->head_block_state()->dpos_irreversible_blocknum == expected_last_irreversible_block_number);
+         BOOST_TEST(test.control->head_block_state_legacy()->dpos_irreversible_blocknum == expected_last_irreversible_block_number);
          // Ensure that future block doesn't exist
          const auto nonexisting_future_block_num = test.control->head_block_num() + 1;
          BOOST_TEST(test.control->fetch_block_by_number(nonexisting_future_block_num) == nullptr);
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
 
          const auto next_expected_last_irreversible_block_number = test.control->head_block_num() - 1;
          // Check the last irreversible block number is updated correctly
-         BOOST_TEST(test.control->head_block_state()->dpos_irreversible_blocknum == next_expected_last_irreversible_block_number);
+         BOOST_TEST(test.control->head_block_state_legacy()->dpos_irreversible_blocknum == next_expected_last_irreversible_block_number);
          // Previous nonexisting future block should exist by now
          BOOST_CHECK_NO_THROW(test.control->fetch_block_by_number(nonexisting_future_block_num));
          // Check the latest head block match

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -473,7 +473,7 @@ public:
       }
       produce_blocks( 250 );
 
-      auto producer_keys = control->head_block_state()->active_schedule.producers;
+      auto producer_keys = control->active_producers().producers;
       BOOST_REQUIRE_EQUAL( 21u, producer_keys.size() );
       BOOST_REQUIRE_EQUAL( name("defproducera"), producer_keys[0].producer_name );
 

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
    // produce 6 blocks on bios
    for (int i = 0; i < 6; i ++) {
       bios.produce_block();
-      BOOST_REQUIRE_EQUAL( bios.control->head_block_state()->header.producer.to_string(), "a" );
+      BOOST_REQUIRE_EQUAL( bios.control->head_block()->producer.to_string(), "a" );
    }
 
    vector<fork_tracker> forks(7);
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
             auto copy_b = std::make_shared<signed_block>(b->clone());
             if (j == i) {
                // corrupt this block
-               fork.block_merkle = remote.control->head_block_state()->blockroot_merkle;
+               fork.block_merkle = remote.control->head_block_state_legacy()->blockroot_merkle;
                copy_b->action_mroot._hash[0] ^= 0x1ULL;
             } else if (j < i) {
                // link to a corrupted chain
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
 
             // re-sign the block
             auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), fork.block_merkle.get_root() ) );
-            auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, remote.control->head_block_state()->pending_schedule.schedule_hash) );
+            auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, remote.control->head_block_state_legacy()->pending_schedule.schedule_hash) );
             copy_b->producer_signature = remote.get_private_key("b"_n, "active").sign(sig_digest);
 
             // add this new block to our corrupted block merkle
@@ -117,9 +117,9 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
    }
 
    // make sure we can still produce a blocks until irreversibility moves
-   auto lib = bios.control->head_block_state()->dpos_irreversible_blocknum;
+   auto lib = bios.control->head_block_state_legacy()->dpos_irreversible_blocknum;
    size_t tries = 0;
-   while (bios.control->head_block_state()->dpos_irreversible_blocknum == lib && ++tries < 10000) {
+   while (bios.control->head_block_state_legacy()->dpos_irreversible_blocknum == lib && ++tries < 10000) {
       bios.produce_block();
    }
 
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE( prune_remove_branch ) try {
    auto nextproducer = [](tester &c, int skip_interval) ->account_name {
       auto head_time = c.control->head_block_time();
       auto next_time = head_time + fc::milliseconds(config::block_interval_ms * skip_interval);
-      return c.control->head_block_state()->get_scheduled_producer(next_time).producer_name;
+      return c.control->active_producers().get_scheduled_producer(next_time).producer_name;
    };
 
    // fork c: 2 producers: dan, sam

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -367,10 +367,9 @@ BOOST_AUTO_TEST_CASE( validator_accepts_valid_blocks ) try {
    BOOST_CHECK_EQUAL( n2.control->head_block_id(), id );
 
    BOOST_REQUIRE( first_block );
-   const auto& first_bsp = n2.control->fetch_block_state_by_id(first_id);
-   first_bsp->verify_signee();
-   BOOST_CHECK_EQUAL( first_header.calculate_id(), first_block->calculate_id() );
-   BOOST_CHECK( first_header.producer_signature == first_block->producer_signature );
+   const auto& first_bp = n2.control->fetch_block_by_id(first_id);
+   BOOST_CHECK_EQUAL( first_bp->calculate_id(), first_block->calculate_id() );
+   BOOST_CHECK( first_bp->producer_signature == first_block->producer_signature );
 
    c.disconnect();
 
@@ -495,8 +494,8 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
    BOOST_CHECK_EQUAL( does_account_exist( irreversible, "alice"_n ), true );
 
    {
-      auto bs = irreversible.control->fetch_block_state_by_id( fork_first_block_id );
-      BOOST_REQUIRE( bs && bs->id() == fork_first_block_id );
+      auto b = irreversible.control->fetch_block_by_id( fork_first_block_id );
+      BOOST_REQUIRE( b && b->calculate_id() == fork_first_block_id );
    }
 
    main.produce_block();
@@ -508,8 +507,8 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
    push_blocks( main, irreversible, hbn5 );
 
    {
-      auto bs = irreversible.control->fetch_block_state_by_id( fork_first_block_id );
-      BOOST_REQUIRE( !bs );
+      auto b = irreversible.control->fetch_block_by_id( fork_first_block_id );
+      BOOST_REQUIRE( !b );
    }
 
 } FC_LOG_AND_RETHROW()

--- a/unittests/special_accounts_tests.cpp
+++ b/unittests/special_accounts_tests.cpp
@@ -1,19 +1,10 @@
-#include <algorithm>
-#include <iterator>
-#include <vector>
-
 #include <eosio/chain/controller.hpp>
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/permission_object.hpp>
 #include <eosio/chain/global_property_object.hpp>
 #include <eosio/testing/tester.hpp>
 
-#include <fc/crypto/digest.hpp>
-
-#include <boost/range/algorithm/find.hpp>
-#include <boost/range/algorithm/find_if.hpp>
-#include <boost/range/algorithm/permutation.hpp>
-#include <boost/test/unit_test.hpp>
+#include <vector>
 
 using namespace eosio;
 using namespace chain;
@@ -44,7 +35,7 @@ BOOST_FIXTURE_TEST_CASE(accounts_exists, tester)
       auto producers = chain1_db.find<account_object, by_name>(config::producers_account_name);
       BOOST_CHECK(producers != nullptr);
 
-      const auto& active_producers = control->head_block_state()->active_schedule;
+      const auto& active_producers = control->active_producers();
 
       const auto& producers_active_authority = chain1_db.get<permission_object, by_owner>(boost::make_tuple(config::producers_account_name, config::active_name));
       auto expected_threshold = (active_producers.producers.size() * 2)/3 + 1;


### PR DESCRIPTION
- Removed most uses of `controller::head_block_state()`
  - Renamed `controller::head_block_state()` to `controller::head_block_state_legacy()` for remaning uses in tests
  - Added `controller::had_block_timestamp()`
- Removed `/v1/chain/get_block_header_state`
- Removed `controller::fetch_block_state_by_number()`
- Removed `controller::fetch_block_state_by_id()`