### PR TITLE
[5.0] Test: Check for unlinkable blocks while syncing - 2

### DIFF
--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -195,7 +195,7 @@ try:
         logFile = Utils.getNodeDataDir(catchupNodeNum) + "/stderr.txt"
         f = open(logFile)
         contents = f.read()
-        if contents.count("unlinkable_block_exception") > 3: # a few are fine
+        if contents.count("3030001 unlinkable_block_exception: Unlinkable block") > 10: # a few are fine
             errorExit(f"Node{catchupNodeNum} has unlinkable blocks: {logFile}.")
 
     testSuccessful=True


### PR DESCRIPTION
Lin was correct on: https://github.com/AntelopeIO/leap/pull/2008#discussion_r1432885079
Test needs a bit more tolerance of a few unlinkable blocks. See https://github.com/AntelopeIO/leap/actions/runs/7280646786/job/19839818772

Resolves #2006 
