### PR TITLE
[5.0] remove per-row `tellp()` during snapshot creation boosting performance

### DIFF
--- a/libraries/chain/snapshot.cpp
+++ b/libraries/chain/snapshot.cpp
@@ -153,13 +153,7 @@ void ostream_snapshot_writer::write_start_section( const std::string& section_na
 }
 
 void ostream_snapshot_writer::write_row( const detail::abstract_snapshot_row_writer& row_writer ) {
-   auto restore = snapshot.tellp();
-   try {
-      row_writer.write(snapshot);
-   } catch (...) {
-      snapshot.seekp(restore);
-      throw;
-   }
+   row_writer.write(snapshot);
    row_count++;
 }
 


### PR DESCRIPTION
(at least in gcc 13.2.1's libstdc++, and libc++ 17.0.2 as used in 5.0's pinned builds) calling `ofstream::tellp()` always results in an `lseek(SEEK_CUR)` syscall. Thus, snapshot code was generating a syscall per-row write. This alone is substantial overhead, but libc++ seems to also flush its buffer on these calls resulting in an additional (typically tiny) `write()` call once write per row. These tiny write calls cause builds with libc++ (the pinned builds) to perform substantially worse creating snapshots -- easily 5x+ slower than with libstdc++ in my tests. I suspect there are certain configurations that are well above 10x slower.

I can't find any reasonable explanation for the current code's existing defensive pattern. Sure, if a row fails to write it'd rewind future writes to be on top of the failed row.. but the snapshot would still be incorrect (missing contents). The original author of this code is also uncertain of the purpose for this defense. So.. just remove it: an exception while writing a row will still cause the snapshot to fail anyways.

Normally I'd consider this a performance improvement and thus not eligible for a release branch. But the huge (5x+) performance delta between non-pinned & pinned builds looks more like a defect so I'll set this to 5.0 to start with. Pending feedback from the team we can move this forward/backward.

After this change, builds with gcc 13.2.1 and the pinned clang+libc++ 17.0.2 both wrote an EOS snapshot in a little under one minute for me.

fwiw I am seeing libstdc++ use 8KB and libc++ use 4KB for their write buffer by default. imo this feels too small, and it wouldn't surprise me if in some configurations these "small" `write()`s hinder performance some how. But I played around with increasing the buffer size up to 32KB and saw no real improvement in snapshot creation performance in my configuration.