### PR TITLE
[5.0] P2P: Pause net_plugin during snapshot write

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -256,6 +256,8 @@ namespace eosio { namespace chain {
 
          fc::sha256 calculate_integrity_hash();
          void write_snapshot( const snapshot_writer_ptr& snapshot );
+         // thread-safe
+         bool is_writing_snapshot()const;
 
          bool sender_avoids_whitelist_blacklist_enforcement( account_name sender )const;
          void check_actor_list( const flat_set<account_name>& actors )const;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -538,7 +538,7 @@ namespace eosio {
       void start_monitors();
 
       // we currently pause on snapshot generation
-      void wait_if_paused() {
+      void wait_if_paused() const {
          controller& cc = chain_plug->chain();
          while (cc.is_writing_snapshot()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -522,6 +522,11 @@ namespace eosio {
       mutable fc::mutex             chain_info_mtx; // protects chain_info_t
       chain_info_t                  chain_info GUARDED_BY(chain_info_mtx);
 
+      alignas(hardware_destructive_interference_size)
+      std::mutex                            pause_mtx;
+      std::condition_variable               pause_cv;
+      bool                                  paused = false;
+
    public:
       void update_chain_info();
       chain_info_t get_chain_info() const;
@@ -536,6 +541,28 @@ namespace eosio {
 
       void start_expire_timer();
       void start_monitors();
+
+      void wait_if_paused() {
+         controller& cc = chain_plug->chain();
+         if (!cc.is_writing_snapshot())
+            return;
+
+         std::unique_lock l(pause_mtx);
+         paused = true;
+         while (!pause_cv.wait_for(l, std::chrono::milliseconds(10), [&]{ return !paused; } )) {
+            if (!cc.is_writing_snapshot()) {
+               paused = false;
+            }
+         }
+      }
+
+      void unpause() {
+         std::lock_guard g(pause_mtx);
+         if (paused) {
+            paused = false;
+            pause_cv.notify_all();
+         }
+      }
 
       void expire();
       /** \name Peer Timestamps
@@ -2897,6 +2924,8 @@ namespace eosio {
             return;
          }
 
+         my_impl->wait_if_paused();
+
          boost::asio::async_read( *socket,
             pending_message_buffer.get_buffer_sequence_for_boost_async_read(), completion_handler,
             boost::asio::bind_executor( strand,
@@ -3890,6 +3919,7 @@ namespace eosio {
 
    // called from application thread
    void net_plugin_impl::on_accepted_block_header(const block_state_ptr& bs) {
+      unpause();
       update_chain_info();
 
       dispatcher->strand.post([bs]() {


### PR DESCRIPTION
Pause `net_plugin` while generating snapshot. With the threads of the `net_plugin` continuing to run they queue up many blocks to be processed consuming large amounts of RAM.

Verification testing in progress.

Resolves #2021
Resolves #1128