### PR TITLE
[5.0] only register prometheus handlers when `prometheus_plugin` enabled; fixing memory leak

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4597,7 +4597,6 @@ namespace eosio {
    // called from any thread
    void connections_manager::start_conn_timers() {
       start_conn_timer(connector_period, {}, timer_type::check); // this locks mutex
-      start_conn_timer(connector_period, {}, timer_type::stats); // this locks mutex
       if (update_p2p_connection_metrics) {
          start_conn_timer(connector_period + connector_period / 2, {}, timer_type::stats); // this locks mutex
       }

--- a/plugins/prometheus_plugin/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/prometheus_plugin.cpp
@@ -18,13 +18,9 @@ namespace eosio {
    struct prometheus_plugin_impl {
 
       eosio::chain::named_thread_pool<struct prom> _prometheus_thread_pool;
-      boost::asio::io_context::strand              _prometheus_strand;
+      boost::asio::io_context::strand              _prometheus_strand{_prometheus_thread_pool.get_executor()};
       metrics::catalog_type                        _catalog;
       fc::microseconds                             _max_response_time_us;
-
-      prometheus_plugin_impl(): _prometheus_strand(_prometheus_thread_pool.get_executor()){ 
-         _catalog.register_update_handlers(_prometheus_strand);
-      }
    };
 
    prometheus_plugin::prometheus_plugin()
@@ -53,6 +49,7 @@ namespace eosio {
 
 
    void prometheus_plugin::plugin_initialize(const variables_map& options) {
+      my->_catalog.register_update_handlers(my->_prometheus_strand);
 
       auto& _http_plugin = app().get_plugin<http_plugin>();
       my->_max_response_time_us = _http_plugin.get_max_response_time();

--- a/plugins/prometheus_plugin/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/prometheus_plugin.cpp
@@ -24,7 +24,7 @@ namespace eosio {
    };
 
    prometheus_plugin::prometheus_plugin()
-   : my(new prometheus_plugin_impl{}) {
+   : my(new prometheus_plugin_impl) {
    }
 
    prometheus_plugin::~prometheus_plugin() = default;


### PR DESCRIPTION
appbase plugins are constructed no matter if they are enabled or not. This meant no matter whether the `prometheus_plugin` was enabled it would install its handlers in to `http_plugin`, `net_plugin`, etc. These handlers always `post()` to `prometheus_plugin`'s strand. But when `prometheus_plugin` isn't enabled its strand is never serviced leading to an endlessly growing queue that is never drained. Each HTTP request would add on to this queue, for example.

Move the handler registration to `plugin_initialize()` so handlers will only be registered when the plugin is enabled ergo when the strand will be pumped. (this is actually how it was prior to #1074, which makes me wonder if there was a need for this change, but I am not immediately seeing one)

Resolves #2030 