### PR TITLE
IF: use the same way to determine if instant finality is active

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2804,7 +2804,7 @@ struct controller_impl {
       const bool instant_finality_active = instant_finality_lib > 0;
       auto trx_mroot = calculate_trx_merkle( b->transactions, instant_finality_active );
       EOS_ASSERT( b->transaction_mroot == trx_mroot, block_validate_exception,
-                     "invalid block transaction merkle root ${b} != ${c}", ("b", b->transaction_mroot)("c", trx_mroot) );
+                  "invalid block transaction merkle root ${b} != ${c}", ("b", b->transaction_mroot)("c", trx_mroot) );
 
       const bool skip_validate_signee = false;
       auto bsp = std::make_shared<block_state_legacy>(

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2796,16 +2796,8 @@ struct controller_impl {
 
    // thread safe, expected to be called from thread other than the main thread
    block_state_legacy_ptr create_block_state_i( const block_id_type& id, const signed_block_ptr& b, const block_header_state_legacy& prev ) {
-      bool hs_active = false;
-      if (!b->header_extensions.empty()) {
-         std::optional<block_header_extension> instant_finality_ext = b->extract_header_extension(instant_finality_extension::extension_id());
-#warning change to use instant_finality_ext https://github.com/AntelopeIO/leap/issues/1508
-         if (instant_finality_ext) {
-            const auto& ext = std::get<instant_finality_extension>(*instant_finality_ext);
-            hs_active = !!ext.new_proposer_policy;
-         }
-      }
-
+      uint32_t hs_lib = hs_irreversible_block_num.load();
+      const bool hs_active = hs_lib > 0;
       auto trx_mroot = calculate_trx_merkle( b->transactions, hs_active );
       EOS_ASSERT( b->transaction_mroot == trx_mroot, block_validate_exception,
                   "invalid block transaction merkle root ${b} != ${c}", ("b", b->transaction_mroot)("c", trx_mroot) );

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2796,16 +2796,15 @@ struct controller_impl {
 
    // thread safe, expected to be called from thread other than the main thread
    block_state_legacy_ptr create_block_state_i( const block_id_type& id, const signed_block_ptr& b, const block_header_state_legacy& prev ) {
-      uint32_t hs_lib = hs_irreversible_block_num.load();
-      const bool hs_active = hs_lib > 0;
-      auto trx_mroot = calculate_trx_merkle( b->transactions, hs_active );
-      if( b->transaction_mroot != trx_mroot ) {
-         // Call of create_block_state_i can happen right before hs_irreversible_block_num
-         // is set. Fall back to verify in the other way.
-         trx_mroot = calculate_trx_merkle( b->transactions, !hs_active );
-         EOS_ASSERT( b->transaction_mroot == trx_mroot, block_validate_exception,
+      // There is a small race condition at time of activation where create_block_state_i
+      // is called right before hs_irreversible_block_num is set. If that happens,
+      // the block is considered invalid, and the node will attempt to sync the block
+      // in the future and succeed
+      uint32_t instant_finality_lib = hs_irreversible_block_num.load();
+      const bool instant_finality_active = instant_finality_lib > 0;
+      auto trx_mroot = calculate_trx_merkle( b->transactions, instant_finality_active );
+      EOS_ASSERT( b->transaction_mroot == trx_mroot, block_validate_exception,
                      "invalid block transaction merkle root ${b} != ${c}", ("b", b->transaction_mroot)("c", trx_mroot) );
-      }
 
       const bool skip_validate_signee = false;
       auto bsp = std::make_shared<block_state_legacy>(


### PR DESCRIPTION
https://github.com/AntelopeIO/leap/issues/2028 reports `transaction_mroot` difference between when it is first calculated and when it is recreated in `create_block_state_i`. The difference  is caused by the way how `hs_active` is determined for mroot calculation. When `transaction_mroot`  is first created, `hs_lib > 0` is used as an indication of `hs_active`; in `create_block_state_i`, only presence of `instant_finality_extension` is used.

This inconsistency causes integration test failures too.

This PR changes to use  the same `hs_lib > 0` as the indication.

Resolved https://github.com/AntelopeIO/leap/issues/2028