### PR TITLE
IF: Update signature-provider parsing for base64 BLS public keys

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1139,10 +1139,13 @@ void producer_plugin_impl::plugin_initialize(const boost::program_options::varia
             }
          } catch(secure_enclave_exception& e) {
             elog("Error with Secure Enclave signature provider: ${e}; ignoring ${val}", ("e", e.top_message())("val", key_spec_pair));
+            throw;
          } catch (fc::exception& e) {
             elog("Malformed signature provider: \"${val}\": ${e}, ignoring!", ("val", key_spec_pair)("e", e));
+            throw;
          } catch (...) {
             elog("Malformed signature provider: \"${val}\", ignoring!", ("val", key_spec_pair));
+            throw;
          }
       }
    }

--- a/plugins/signature_provider_plugin/signature_provider_plugin.cpp
+++ b/plugins/signature_provider_plugin/signature_provider_plugin.cpp
@@ -42,6 +42,9 @@ class signature_provider_plugin_impl {
       std::tuple<std::string, std::string, std::string> parse_spec(const std::string& spec) const {
          auto delim = spec.find("=");
          EOS_ASSERT(delim != std::string::npos, chain::plugin_config_exception, "Missing \"=\" in the key spec pair");
+         // public_key can be base64 encoded with trailing `=`
+         while( spec.size() > delim+1 && spec[delim+1] == '=' )
+            ++delim;
          auto pub_key_str = spec.substr(0, delim);
          auto spec_str = spec.substr(delim + 1);
 

--- a/plugins/signature_provider_plugin/signature_provider_plugin.cpp
+++ b/plugins/signature_provider_plugin/signature_provider_plugin.cpp
@@ -43,8 +43,10 @@ class signature_provider_plugin_impl {
          auto delim = spec.find("=");
          EOS_ASSERT(delim != std::string::npos, chain::plugin_config_exception, "Missing \"=\" in the key spec pair");
          // public_key can be base64 encoded with trailing `=`
+         // e.g. --signature-provider PUB_BLS_Fmgk<snip>iuA===KEY:PVT_BLS_NZhJ<snip>ZHFu
          while( spec.size() > delim+1 && spec[delim+1] == '=' )
             ++delim;
+         EOS_ASSERT(delim < spec.size() + 1, chain::plugin_config_exception, "Missing spec data in the key spec pair");
          auto pub_key_str = spec.substr(0, delim);
          auto spec_str = spec.substr(delim + 1);
 

--- a/tests/TestHarness/launcher.py
+++ b/tests/TestHarness/launcher.py
@@ -514,7 +514,7 @@ class cluster_generator:
             a(a(eosdcmd, '--plugin'), 'eosio::producer_plugin')
             producer_keys = list(sum([('--signature-provider', f'{key.pubkey}=KEY:{key.privkey}') for key in instance.keys], ()))
             eosdcmd.extend(producer_keys)
-            finalizer_keys = list(sum([('--signature-provider', f'{key.blspubkey}=KEY:{key.blsprivkey}') for key in instance.keys], ()))
+            finalizer_keys = list(sum([('--signature-provider', f'{key.blspubkey}=KEY:{key.blsprivkey}') for key in instance.keys if key.blspubkey is not None], ()))
             eosdcmd.extend(finalizer_keys)
             producer_names = list(sum([('--producer-name', p) for p in instance.producers], ()))
             eosdcmd.extend(producer_names)


### PR DESCRIPTION
BLS public keys are base64 encoded which include trailing `=`. Update the `signature-provider` parsing to expect these "extra" `=`s. 
Shutdown on startup for malformed `signature-provider` arguments. Previously nodeos would log an error and continue.

Resolves #2060 