### PR TITLE
IF:Unification: Process received Vote message

### DIFF
--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -103,6 +103,7 @@ namespace eosio::chain {
    {}
 #endif
 
+   // Called from net threads
    bool block_state::aggregate_vote(const hs_vote_message& vote) {
       const auto& finalizers = finalizer_policy->finalizers;
       auto it = std::find_if(finalizers.begin(),

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -114,6 +114,7 @@ namespace eosio::chain {
          const digest_type& digest = vote.strong ? strong_finalizer_digest : weak_finalizer_digest;
 
          return pending_qc.add_vote(vote.strong,
+#warning TODO change to use std::span if possible
                                     std::vector<uint8_t>{digest.data(), digest.data() + digest.data_size()},
                                     index,
                                     vote.finalizer_key,

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -55,14 +55,14 @@ void block_state::set_trxs_metas( deque<transaction_metadata_ptr>&& trxs_metas, 
 
 // Called from net threads
 bool block_state::aggregate_vote(const hs_vote_message& vote) {
-   const auto& finalizers = finalizer_policy->finalizers;
+   const auto& finalizers = active_finalizer_policy->finalizers;
    auto it = std::find_if(finalizers.begin(),
                           finalizers.end(),
                           [&](const auto& finalizer) { return finalizer.public_key == vote.finalizer_key; });
 
    if (it != finalizers.end()) {
       auto index = std::distance(finalizers.begin(), it);
-      const digest_type& digest = vote.strong ? strong_finalizer_digest : weak_finalizer_digest;
+      const digest_type& digest = vote.strong ? strong_digest : weak_digest;
       return pending_qc.add_vote(vote.strong,
 #warning TODO change to use std::span if possible
                                  std::vector<uint8_t>{digest.data(), digest.data() + digest.data_size()},

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -111,19 +111,13 @@ namespace eosio::chain {
 
       if (it != finalizers.end()) {
          auto index = std::distance(finalizers.begin(), it);
-         if( vote.strong ) {
-            std::vector<uint8_t> d(strong_finalizer_digest.data(), strong_finalizer_digest.data() + strong_finalizer_digest.data_size());
-            return pending_qc.add_strong_vote( d,
-                                               index,
-                                               vote.finalizer_key,
-                                               vote.sig );
-         } else {
-            std::vector<uint8_t> d(weak_finalizer_digest.data(), weak_finalizer_digest.data() + weak_finalizer_digest.data_size());
-            return pending_qc.add_weak_vote( d,
-                                             index,
-                                             vote.finalizer_key,
-                                             vote.sig );
-         }
+         const digest_type& digest = vote.strong ? strong_finalizer_digest : weak_finalizer_digest;
+
+         return pending_qc.add_vote(vote.strong,
+                                    std::vector<uint8_t>{digest.data(), digest.data() + digest.data_size()},
+                                    index,
+                                    vote.finalizer_key,
+                                    vote.sig);
       } else {
          wlog( "finalizer_key (${k}) in vote is not in finalizer policy", ("k", vote.finalizer_key) );
          return false;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -301,19 +301,16 @@ struct block_data_t {
       }, v);
    }
 
-   // called from net thread
+    // called from net thread
 	 bool aggregate_vote(const hs_vote_message& vote) {
 	    return std::visit(
 	       overloaded{[](const block_data_legacy_t&) {
-	                     EOS_ASSERT(false, misc_exception, "attempting to call aggregate_vote in legacy mode");
+                        // We can be late in switching to Instant Finality
+                        // and receive votes from those already having switched.
 	                     return false; },
 	                  [&](const block_data_new_t& bd) {
 	                     auto bsp = bd.fork_db.get_block(vote.proposal_id);
-	                     if (bsp) {
-	                        return bsp->aggregate_vote(vote);
-	                     } else {
-	                        return false;
-                        }; }
+	                     return bsp && bsp->aggregate_vote(vote); }
                     },
 	       v);
 	 }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -249,6 +249,7 @@ struct block_data_t {
       }, v);
    }
 
+   // called from net thread
 	bool aggregate_vote(const hs_vote_message& vote) {
 	   return std::visit(
 	      overloaded{[](const block_data_legacy_t&) {
@@ -259,9 +260,8 @@ struct block_data_t {
 	                    if (bsp) {
 	                       return bsp->aggregate_vote(vote);
 	                    } else {
-	                       wlog("no block exists for the vote (proposal_id: ${id}", ("id", vote.proposal_id));
 	                       return false;
-	                    }}
+                       }; }
                    },
 	      v);
 	}

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4024,8 +4024,8 @@ void controller::get_finalizer_state( finalizer_state& fs ) const {
 }
 
 // called from net threads
-void controller::process_vote_message( const hs_vote_message& vote ) {
-   my->block_data.aggregate_vote(vote);
+bool controller::process_vote_message( const hs_vote_message& vote ) {
+   return my->block_data.aggregate_vote(vote);
 };
 
 const producer_authority_schedule& controller::active_producers()const {

--- a/libraries/chain/hotstuff/hotstuff.cpp
+++ b/libraries/chain/hotstuff/hotstuff.cpp
@@ -22,10 +22,14 @@ inline std::vector<uint32_t> bitset_to_vector(const hs_bitset& bs) {
 
 bool pending_quorum_certificate::votes_t::add_vote(const std::vector<uint8_t>& proposal_digest, size_t index,
                                                    const bls_public_key& pubkey, const bls_signature& new_sig) {
-   if (_bitset[index])
+   if (_bitset[index]) {
+      wlog( "finalizer ${i} has already voted", ("i", index) );
       return false; // shouldn't be already present
-   if (!fc::crypto::blslib::verify(pubkey, proposal_digest, new_sig))
+   }
+   if (!fc::crypto::blslib::verify(pubkey, proposal_digest, new_sig)) {
+      wlog( "signature from finalizer ${i} cannot be verified", ("i", index) );
       return false;
+   }
    _bitset.set(index);
    _sig = fc::crypto::blslib::aggregate({_sig, new_sig}); // works even if _sig is default initialized (fp2::zero())
    return true;

--- a/libraries/chain/hotstuff/hotstuff.cpp
+++ b/libraries/chain/hotstuff/hotstuff.cpp
@@ -41,6 +41,10 @@ void pending_quorum_certificate::votes_t::reset(size_t num_finalizers) {
    _sig = bls_signature();
 }
 
+pending_quorum_certificate::pending_quorum_certificate()
+   : _mtx(std::make_unique<std::mutex>()) {
+}
+
 pending_quorum_certificate::pending_quorum_certificate(size_t num_finalizers, size_t quorum)
    : _num_finalizers(num_finalizers)
    , _quorum(quorum)

--- a/libraries/chain/hotstuff/hotstuff.cpp
+++ b/libraries/chain/hotstuff/hotstuff.cpp
@@ -23,7 +23,6 @@ inline std::vector<uint32_t> bitset_to_vector(const hs_bitset& bs) {
 bool pending_quorum_certificate::votes_t::add_vote(const std::vector<uint8_t>& proposal_digest, size_t index,
                                                    const bls_public_key& pubkey, const bls_signature& new_sig) {
    if (_bitset[index]) {
-      wlog( "finalizer ${i} has already voted", ("i", index) );
       return false; // shouldn't be already present
    }
    if (!fc::crypto::blslib::verify(pubkey, proposal_digest, new_sig)) {

--- a/libraries/chain/hotstuff/qc_chain.cpp
+++ b/libraries/chain/hotstuff/qc_chain.cpp
@@ -372,7 +372,7 @@ namespace eosio::chain {
                              ("id", _id));
                      
                      //fc_tlog(_logger, " === update_high_qc : _current_qc ===");
-                     update_high_qc(_current_qc);
+                     update_high_qc(_current_qc.to_valid_quorum_certificate());
                      fc_dlog(_logger, " === ${id} quorum met on #${block_num} ${phase_counter} ${proposal_id} ",
                              ("block_num", p->block_num())
                              ("phase_counter", p->phase_counter)

--- a/libraries/chain/hotstuff/test/hotstuff_tools.cpp
+++ b/libraries/chain/hotstuff/test/hotstuff_tools.cpp
@@ -109,58 +109,58 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
 
    {
       pending_quorum_certificate qc(2, 1); // 2 finalizers, quorum = 1
-      BOOST_CHECK_EQUAL(qc._state, state_t::unrestricted);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::unrestricted);
 
       // add one weak vote
       // -----------------
       weak_vote(qc, digest, 0);
-      BOOST_CHECK_EQUAL(qc._state, state_t::weak_achieved);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_achieved);
       BOOST_CHECK(qc.is_quorum_met());
 
       // add duplicate weak vote
       // -----------------------
       bool ok = weak_vote(qc, digest, 0);
       BOOST_CHECK(!ok); // vote was a duplicate
-      BOOST_CHECK_EQUAL(qc._state, state_t::weak_achieved);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_achieved);
       BOOST_CHECK(qc.is_quorum_met());
 
       // add another weak vote
       // ---------------------
       weak_vote(qc, digest, 1);
-      BOOST_CHECK_EQUAL(qc._state, state_t::weak_final);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_final);
    }
 
    {
       pending_quorum_certificate qc(2, 1); // 2 finalizers, quorum = 1
-      BOOST_CHECK_EQUAL(qc._state, state_t::unrestricted);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::unrestricted);
 
       // add a weak vote
       // ---------------
       weak_vote(qc, digest, 0);
-      BOOST_CHECK_EQUAL(qc._state, state_t::weak_achieved);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_achieved);
       BOOST_CHECK(qc.is_quorum_met());
 
       // add a strong vote
       // -----------------
       strong_vote(qc, digest, 1);
-      BOOST_CHECK_EQUAL(qc._state, state_t::strong);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::strong);
       BOOST_CHECK(qc.is_quorum_met());
    }
 
    {
       pending_quorum_certificate qc(2, 1); // 2 finalizers, quorum = 1
-      BOOST_CHECK_EQUAL(qc._state, state_t::unrestricted);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::unrestricted);
 
       // add a strong vote
       // -----------------
       strong_vote(qc, digest, 1);
-      BOOST_CHECK_EQUAL(qc._state, state_t::strong);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::strong);
       BOOST_CHECK(qc.is_quorum_met());
 
       // add a strong vote
       // -----------------
       strong_vote(qc, digest, 1);
-      BOOST_CHECK_EQUAL(qc._state, state_t::strong);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::strong);
       BOOST_CHECK(qc.is_quorum_met());
    }
 
@@ -170,13 +170,13 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
       // add a weak vote
       // ---------------
       weak_vote(qc, digest, 0);
-      BOOST_CHECK_EQUAL(qc._state, state_t::unrestricted);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::unrestricted);
       BOOST_CHECK(!qc.is_quorum_met());
 
       // add a strong vote
       // -----------------
       strong_vote(qc, digest, 1);
-      BOOST_CHECK_EQUAL(qc._state, state_t::weak_achieved);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_achieved);
       BOOST_CHECK(qc.is_quorum_met());
 
       {
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
          // add a weak vote
          // ---------------
          weak_vote(qc2, digest, 2);
-         BOOST_CHECK_EQUAL(qc2._state, state_t::weak_final);
+         BOOST_CHECK_EQUAL(qc2.state(), state_t::weak_final);
          BOOST_CHECK(qc2.is_quorum_met());
       }
    }
@@ -196,13 +196,13 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
       // add a weak vote
       // ---------------
       weak_vote(qc, digest, 0);
-      BOOST_CHECK_EQUAL(qc._state, state_t::unrestricted);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::unrestricted);
       BOOST_CHECK(!qc.is_quorum_met());
 
       // add a strong vote
       // -----------------
       strong_vote(qc, digest, 1);
-      BOOST_CHECK_EQUAL(qc._state, state_t::weak_achieved);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_achieved);
       BOOST_CHECK(qc.is_quorum_met());
 
       {
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
          // add a strong vote
          // -----------------
          strong_vote(qc2, digest, 2);
-         BOOST_CHECK_EQUAL(qc2._state, state_t::strong);
+         BOOST_CHECK_EQUAL(qc2.state(), state_t::strong);
          BOOST_CHECK(qc2.is_quorum_met());
       }
    }
@@ -222,13 +222,13 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
       // add a weak vote
       // ---------------
       weak_vote(qc, digest, 0);
-      BOOST_CHECK_EQUAL(qc._state, state_t::unrestricted);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::unrestricted);
       BOOST_CHECK(!qc.is_quorum_met());
 
       // add a weak vote
       // ---------------
       weak_vote(qc, digest, 1);
-      BOOST_CHECK_EQUAL(qc._state, state_t::weak_final);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_final);
       BOOST_CHECK(qc.is_quorum_met());
 
       {
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
          // add a weak vote
          // ---------------
          weak_vote(qc2, digest, 2);
-         BOOST_CHECK_EQUAL(qc2._state, state_t::weak_final);
+         BOOST_CHECK_EQUAL(qc2.state(), state_t::weak_final);
          BOOST_CHECK(qc2.is_quorum_met());
       }
    }
@@ -248,13 +248,13 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
       // add a weak vote
       // ---------------
       weak_vote(qc, digest, 0);
-      BOOST_CHECK_EQUAL(qc._state, state_t::unrestricted);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::unrestricted);
       BOOST_CHECK(!qc.is_quorum_met());
 
       // add a weak vote
       // ---------------
       weak_vote(qc, digest, 1);
-      BOOST_CHECK_EQUAL(qc._state, state_t::weak_final);
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_final);
       BOOST_CHECK(qc.is_quorum_met());
 
       {
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
          // add a strong vote
          // -----------------
          strong_vote(qc2, digest, 2);
-         BOOST_CHECK_EQUAL(qc2._state, state_t::weak_final);
+         BOOST_CHECK_EQUAL(qc2.state(), state_t::weak_final);
          BOOST_CHECK(qc2.is_quorum_met());
       }
    }

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -11,7 +11,8 @@ namespace eosio::chain {
       // ------ data members -------------------------------------------------------------
       signed_block_ptr           block;
       bool                       validated;             // We have executed the block's trxs and verified that action merkle root (block id) matches.
-      digest_type                finalizer_digest;
+      digest_type                strong_finalizer_digest;
+      digest_type                weak_finalizer_digest;
       pending_quorum_certificate pending_qc;            // where we accumulate votes we receive
       std::optional<valid_quorum_certificate> valid_qc; // qc received from the network
 
@@ -32,6 +33,8 @@ namespace eosio::chain {
       
       protocol_feature_activation_set_ptr get_activated_protocol_features() const { return block_header_state::activated_protocol_features; }
       deque<transaction_metadata_ptr>     extract_trxs_metas() { return {}; }; //  [greg todo] see impl in block_state_legacy.hpp
+
+      bool aggregate_vote(const hs_vote_message& vote); // aggregate vote into pending_qc
    };
 
 using block_state_ptr = std::shared_ptr<block_state>;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -317,7 +317,7 @@ namespace eosio::chain {
          void set_proposed_finalizers( const finalizer_policy& fin_set );
          void get_finalizer_state( finalizer_state& fs ) const;
          // called from net threads
-         void notify_hs_message( const uint32_t connection_id, const hs_message& msg );
+         void process_vote_message( const hs_vote_message& msg );
 
          bool light_validation_allowed() const;
          bool skip_auth_check()const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -317,7 +317,7 @@ namespace eosio::chain {
          void set_proposed_finalizers( const finalizer_policy& fin_set );
          void get_finalizer_state( finalizer_state& fs ) const;
          // called from net threads
-         void process_vote_message( const hs_vote_message& msg );
+         bool process_vote_message( const hs_vote_message& msg );
 
          bool light_validation_allowed() const;
          bool skip_auth_check()const;

--- a/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
@@ -146,7 +146,7 @@ namespace eosio::chain {
          void reset(size_t num_finalizers);
       };
 
-      pending_quorum_certificate() = default;
+      pending_quorum_certificate();
 
       explicit pending_quorum_certificate(size_t num_finalizers, size_t quorum);
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1095,7 +1095,7 @@ namespace eosio {
       void handle_message( const block_id_type& id, signed_block_ptr ptr );
       void handle_message( const packed_transaction& msg ) = delete; // packed_transaction_ptr overload used instead
       void handle_message( packed_transaction_ptr trx );
-      void handle_message( const chain::hs_message& msg );
+      void handle_message( const chain::hs_vote_message& msg );
 
       // returns calculated number of blocks combined latency
       uint32_t calc_block_latency();
@@ -1177,9 +1177,9 @@ namespace eosio {
          c->handle_message( msg );
       }
 
-      void operator()( const chain::hs_message& msg ) const {
+      void operator()( const chain::hs_vote_message& msg ) const {
          // continue call to handle_message on connection strand
-         peer_dlog( c, "handle hs_message" );
+         peer_dlog( c, "handle hs_vote_message" );
          c->handle_message( msg );
       }
    };
@@ -3673,10 +3673,10 @@ namespace eosio {
       }
    }
 
-   void connection::handle_message( const chain::hs_message& msg ) {
-      peer_dlog(this, "received hs: ${msg}", ("msg", msg));
+   void connection::handle_message( const chain::hs_vote_message& msg ) {
+      peer_dlog(this, "received vote: ${msg}", ("msg", msg));
       controller& cc = my_impl->chain_plug->chain();
-      cc.notify_hs_message(connection_id, msg);
+      cc.process_vote_message(msg);
    }
 
    size_t calc_trx_size( const packed_transaction_ptr& trx ) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3676,7 +3676,11 @@ namespace eosio {
    void connection::handle_message( const chain::hs_vote_message& msg ) {
       peer_dlog(this, "received vote: ${msg}", ("msg", msg));
       controller& cc = my_impl->chain_plug->chain();
-      cc.process_vote_message(msg);
+      if( cc.process_vote_message(msg) ) {
+#warning TDDO remove hs_message
+         hs_message hs_msg{msg};
+         my_impl->bcast_hs_message(connection_id, hs_msg);
+      }
    }
 
    size_t calc_trx_size( const packed_transaction_ptr& trx ) {

--- a/unittests/block_state_tests.cpp
+++ b/unittests/block_state_tests.cpp
@@ -39,9 +39,9 @@ BOOST_AUTO_TEST_CASE(aggregate_vote_test) try {
 
    {  // all finalizers can aggregate votes
       block_state_ptr bsp = std::make_shared<block_state>();
-      bsp->finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
-      bsp->strong_finalizer_digest = strong_digest;
-      bsp->weak_finalizer_digest = weak_digest;
+      bsp->active_finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
+      bsp->strong_digest = strong_digest;
+      bsp->weak_digest = weak_digest;
       bsp->pending_qc = pending_quorum_certificate{ num_finalizers, 1 };
 
       for (size_t i = 0; i < num_finalizers; ++i) {
@@ -54,8 +54,8 @@ BOOST_AUTO_TEST_CASE(aggregate_vote_test) try {
 
    {  // public and private keys mismatched
       block_state_ptr bsp = std::make_shared<block_state>();
-      bsp->finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
-      bsp->strong_finalizer_digest = strong_digest;
+      bsp->active_finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
+      bsp->strong_digest = strong_digest;
       bsp->pending_qc = pending_quorum_certificate{ num_finalizers, 1 };
 
       hs_vote_message vote {block_id, true, public_key[0], private_key[1].sign(strong_digest_data) };
@@ -64,8 +64,8 @@ BOOST_AUTO_TEST_CASE(aggregate_vote_test) try {
 
    {  // duplicate votes 
       block_state_ptr bsp = std::make_shared<block_state>();
-      bsp->finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
-      bsp->strong_finalizer_digest = strong_digest;
+      bsp->active_finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
+      bsp->strong_digest = strong_digest;
       bsp->pending_qc = pending_quorum_certificate{ num_finalizers, 1 };
 
       hs_vote_message vote {block_id, true, public_key[0], private_key[0].sign(strong_digest_data) };
@@ -75,8 +75,8 @@ BOOST_AUTO_TEST_CASE(aggregate_vote_test) try {
 
    {  // public key does not exit in finalizer set
       block_state_ptr bsp = std::make_shared<block_state>();
-      bsp->finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
-      bsp->strong_finalizer_digest = strong_digest;
+      bsp->active_finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
+      bsp->strong_digest = strong_digest;
       bsp->pending_qc = pending_quorum_certificate{ num_finalizers, 1 };
 
       bls_private_key new_private_key{ "PVT_BLS_warwI76e+pPX9wLFZKPFagngeFM8bm6J8D5w0iiHpxW7PiId" };

--- a/unittests/block_state_tests.cpp
+++ b/unittests/block_state_tests.cpp
@@ -1,0 +1,90 @@
+#include <eosio/chain/block_state.hpp>
+
+#include <fc/exception/exception.hpp>
+#include <fc/crypto/bls_private_key.hpp>
+#include <fc/crypto/bls_utils.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(block_state_tests)
+
+BOOST_AUTO_TEST_CASE(aggregate_vote_test) try {
+   using namespace eosio::chain;
+   using namespace fc::crypto::blslib;
+
+   digest_type block_id(fc::sha256("0000000000000000000000000000001"));
+
+   digest_type strong_digest(fc::sha256("0000000000000000000000000000002"));
+   std::vector<uint8_t> strong_digest_data(strong_digest.data(), strong_digest.data() + strong_digest.data_size());
+
+   digest_type weak_digest(fc::sha256("0000000000000000000000000000003"));
+   std::vector<uint8_t> weak_digest_data(weak_digest.data(), weak_digest.data() + weak_digest.data_size());
+
+   const size_t num_finalizers = 3;
+
+   // initialize a set of private keys
+   std::vector<bls_private_key> private_key {
+      bls_private_key("PVT_BLS_r4ZpChd87ooyzl6MIkw23k7PRX8xptp7TczLJHCIIW88h/hS"),
+      bls_private_key("PVT_BLS_/l7xzXANaB+GrlTsbZEuTiSOiWTtpBoog+TZnirxUUSaAfCo"),
+      bls_private_key("PVT_BLS_3FoY73Q/gED3ejyg8cvnGqHrMmx4cLKwh/e0sbcsCxpCeqn3"),
+   };
+
+   // construct finalizers
+   std::vector<bls_public_key> public_key(num_finalizers);
+   std::vector<finalizer_authority> finalizers(num_finalizers);
+   for (size_t i = 0; i < num_finalizers; ++i) {
+      public_key[i] = private_key[i].get_public_key();
+      finalizers[i] = finalizer_authority{ "test", 1, public_key[i] };
+   }
+
+   {  // all finalizers can aggregate votes
+      block_state_ptr bsp = std::make_shared<block_state>();
+      bsp->finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
+      bsp->strong_finalizer_digest = strong_digest;
+      bsp->weak_finalizer_digest = weak_digest;
+      bsp->pending_qc = pending_quorum_certificate{ num_finalizers, 1 };
+
+      for (size_t i = 0; i < num_finalizers; ++i) {
+         bool strong = (i % 2 == 0); // alternate strong and weak
+         auto sig = strong ? private_key[i].sign(strong_digest_data) : private_key[i].sign(weak_digest_data);
+         hs_vote_message vote{ block_id, strong, public_key[i], sig };
+         BOOST_REQUIRE(bsp->aggregate_vote(vote));
+      }
+   }
+
+   {  // public and private keys mismatched
+      block_state_ptr bsp = std::make_shared<block_state>();
+      bsp->finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
+      bsp->strong_finalizer_digest = strong_digest;
+      bsp->pending_qc = pending_quorum_certificate{ num_finalizers, 1 };
+
+      hs_vote_message vote {block_id, true, public_key[0], private_key[1].sign(strong_digest_data) };
+      BOOST_REQUIRE(!bsp->aggregate_vote(vote));
+   }
+
+   {  // duplicate votes 
+      block_state_ptr bsp = std::make_shared<block_state>();
+      bsp->finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
+      bsp->strong_finalizer_digest = strong_digest;
+      bsp->pending_qc = pending_quorum_certificate{ num_finalizers, 1 };
+
+      hs_vote_message vote {block_id, true, public_key[0], private_key[0].sign(strong_digest_data) };
+      BOOST_REQUIRE(bsp->aggregate_vote(vote));
+      BOOST_REQUIRE(!bsp->aggregate_vote(vote));
+   }
+
+   {  // public key does not exit in finalizer set
+      block_state_ptr bsp = std::make_shared<block_state>();
+      bsp->finalizer_policy = std::make_shared<finalizer_policy>( 10, 15, finalizers );
+      bsp->strong_finalizer_digest = strong_digest;
+      bsp->pending_qc = pending_quorum_certificate{ num_finalizers, 1 };
+
+      bls_private_key new_private_key{ "PVT_BLS_warwI76e+pPX9wLFZKPFagngeFM8bm6J8D5w0iiHpxW7PiId" };
+      bls_public_key new_public_key{ new_private_key.get_public_key() };
+
+      hs_vote_message vote {block_id, true, new_public_key, private_key[0].sign(strong_digest_data) };
+      BOOST_REQUIRE(!bsp->aggregate_vote(vote));
+   }
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Process vote messages received from net plugin:
* aggregated the vote signature into the pending QC for the block the vote corresponds to
* added tests

Changing `proposal_id` to `block_id` in vote message and removing `proposal_digest` from pending_quorum_certificate will be done after unification as they should be part of the bigger cleaning up effort: https://github.com/AntelopeIO/leap/issues/2072

Resolved https://github.com/AntelopeIO/leap/issues/2046

Replaced https://github.com/AntelopeIO/leap/pull/2067