### PR TITLE
IF: Unification: Implement get_best_qc in block_state

### DIFF
--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -102,5 +102,45 @@ namespace eosio::chain {
    ,_cached_trxs( std::move(trx_metas) )
    {}
 #endif
+
+   std::optional<qc_data_t> block_state::get_best_qc() const {
+      auto block_number = block_num();
+
+      // if pending_qc does not have a valid QC, consider valid_qc only
+      if( !pending_qc.is_valid() ) {
+         if( valid_qc ) {
+            return qc_data_t{ quorum_certificate{ block_number, valid_qc.value() },
+                              qc_info_t{ block_number, valid_qc.value().is_strong() }};
+         } else {
+            return std::nullopt;;
+         }
+      }
+
+      // extract valid QC from pending_qc
+      valid_quorum_certificate valid_qc_from_pending(pending_qc);
+
+      // if valid_qc does not have value, consider valid_qc_from_pending only
+      if( !valid_qc ) {
+         return qc_data_t{ quorum_certificate{ block_number, valid_qc_from_pending },
+                           qc_info_t{ block_number, valid_qc_from_pending.is_strong() }};
+      }
+
+      // Both valid_qc and valid_qc_from_pending have value. Compare them and select a better one.
+      // Strong beats weak. Break tie with highest accumulated weight.
+      auto valid_qc_is_better = false;
+      if( valid_qc.value().is_strong() && !valid_qc_from_pending.is_strong() ) {
+         valid_qc_is_better = true;
+      } else if( !valid_qc.value().is_strong() && valid_qc_from_pending.is_strong() ) {
+         valid_qc_is_better = false;
+      } else if( valid_qc.value().accumulated_weight() >= valid_qc_from_pending.accumulated_weight() ) {
+         valid_qc_is_better = true;
+      } else {
+         valid_qc_is_better = false;
+      }
+
+      const auto& qc = valid_qc_is_better ? valid_qc.value() : valid_qc_from_pending;
+      return qc_data_t{ quorum_certificate{ block_number, qc },
+                        qc_info_t{ block_number, qc.is_strong() }};
+   }
    
 } /// eosio::chain

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -103,33 +103,34 @@ namespace eosio::chain {
    {}
 #endif
 
-   std::optional<qc_data_t> block_state::get_best_qc() const {
+   std::optional<quorum_certificate> block_state::get_best_qc() const {
       auto block_number = block_num();
 
       // if pending_qc does not have a valid QC, consider valid_qc only
       if( !pending_qc.is_quorum_met() ) {
          if( valid_qc ) {
-            return qc_data_t{ quorum_certificate{ block_number, *valid_qc },
-                              qc_info_t{ block_number, valid_qc->is_strong() }};
+            return quorum_certificate{ block_number, *valid_qc };
          } else {
             return std::nullopt;;
          }
       }
 
+#warning TODO valid_quorum_certificate constructor can assert. Implement an extract method in pending_quorum_certificate for this.
       // extract valid QC from pending_qc
       valid_quorum_certificate valid_qc_from_pending(pending_qc);
 
       // if valid_qc does not have value, consider valid_qc_from_pending only
       if( !valid_qc ) {
-         return qc_data_t{ quorum_certificate{ block_number, valid_qc_from_pending },
-                           qc_info_t{ block_number, valid_qc_from_pending.is_strong() }};
+         return quorum_certificate{ block_number, valid_qc_from_pending };
       }
 
       // Both valid_qc and valid_qc_from_pending have value. Compare them and select a better one.
-      // Strong beats weak. Break tie with highest accumulated weight.
-      const auto& best_qc = std::max(*valid_qc, valid_qc_from_pending);
-      return qc_data_t{ quorum_certificate{ block_number, best_qc },
-                        qc_info_t{ block_number, best_qc.is_strong() }};
+      // Strong beats weak. Tie break by valid_qc.
+      const auto& best_qc =
+         valid_qc->is_strong() == valid_qc_from_pending.is_strong() ?
+         *valid_qc : // tie broke by valid_qc
+         valid_qc->is_strong() ? *valid_qc : valid_qc_from_pending; // strong beats weak
+      return quorum_certificate{ block_number, best_qc };
    }
    
 } /// eosio::chain

--- a/libraries/chain/hotstuff/hotstuff.cpp
+++ b/libraries/chain/hotstuff/hotstuff.cpp
@@ -184,18 +184,6 @@ valid_quorum_certificate::valid_quorum_certificate(
       _weak_votes = vector_to_bitset(weak_votes);
 }
 
-// Strong beats weak. Break tie with highest accumulated weight.
-bool valid_quorum_certificate::operator<(const valid_quorum_certificate& other) const {
-   if( is_strong() != other.is_strong() ) {
-      return other.is_strong();
-   }
-   if( accumulated_weight() != other.accumulated_weight() ) {
-      return accumulated_weight() < other.accumulated_weight();
-   }
-
-   return false;
-}
-
 quorum_certificate_message valid_quorum_certificate::to_msg() const {
    return {
       .proposal_id    = _proposal_id,

--- a/libraries/chain/hotstuff/hotstuff.cpp
+++ b/libraries/chain/hotstuff/hotstuff.cpp
@@ -184,6 +184,18 @@ valid_quorum_certificate::valid_quorum_certificate(
       _weak_votes = vector_to_bitset(weak_votes);
 }
 
+// Strong beats weak. Break tie with highest accumulated weight.
+bool valid_quorum_certificate::operator<(const valid_quorum_certificate& other) const {
+   if( is_strong() != other.is_strong() ) {
+      return other.is_strong();
+   }
+   if( accumulated_weight() != other.accumulated_weight() ) {
+      return accumulated_weight() < other.accumulated_weight();
+   }
+
+   return false;
+}
+
 quorum_certificate_message valid_quorum_certificate::to_msg() const {
    return {
       .proposal_id    = _proposal_id,

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -29,6 +29,7 @@ namespace eosio::chain {
       bool                   is_valid()          const { return validated; } 
       void                   set_valid(bool b)         { validated = b; }
       uint32_t               irreversible_blocknum() const { return 0; } // [greg todo] equivalent of dpos_irreversible_blocknum
+      std::optional<qc_data_t> get_best_qc()     const; 
       
       protocol_feature_activation_set_ptr get_activated_protocol_features() const { return block_header_state::activated_protocol_features; }
       deque<transaction_metadata_ptr>     extract_trxs_metas() { return {}; }; //  [greg todo] see impl in block_state_legacy.hpp

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -29,7 +29,7 @@ namespace eosio::chain {
       bool                   is_valid()          const { return validated; } 
       void                   set_valid(bool b)         { validated = b; }
       uint32_t               irreversible_blocknum() const { return 0; } // [greg todo] equivalent of dpos_irreversible_blocknum
-      std::optional<qc_data_t> get_best_qc()     const; 
+      std::optional<quorum_certificate> get_best_qc() const;
       
       protocol_feature_activation_set_ptr get_activated_protocol_features() const { return block_header_state::activated_protocol_features; }
       deque<transaction_metadata_ptr>     extract_trxs_metas() { return {}; }; //  [greg todo] see impl in block_state_legacy.hpp

--- a/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
@@ -157,7 +157,6 @@ namespace eosio::chain {
       size_t num_strong() const { return _strong_votes.count(); }
 
       bool   is_quorum_met() const;
-      bool   is_valid()      const { return _state == state_t::strong || _state == state_t::weak_achieved || _state == state_t::weak_final; }
 
       void reset(const fc::sha256& proposal_id, const digest_type& proposal_digest, size_t num_finalizers, size_t quorum);
 
@@ -212,7 +211,11 @@ namespace eosio::chain {
       bool is_weak()   const { return !!_weak_votes; }
       bool is_strong() const { return !_weak_votes; }
 
-      uint32_t accumulated_weight() const { return (_strong_votes ? _strong_votes.value().count() : 0) + (_weak_votes ? _weak_votes.value().count() : 0); }
+      bool     operator<(const valid_quorum_certificate& other) const;
+
+      // When it is strong, _weak_votes does not exist. No need to have a separate
+      // calculation for strong
+      uint32_t accumulated_weight() const { return (_strong_votes ? _strong_votes->count() : 0) + (_weak_votes ? _weak_votes->count() : 0); }
 
       // ================== begin compatibility functions =======================
       // these are present just to make the tests still work. will be removed.

--- a/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
@@ -211,12 +211,6 @@ namespace eosio::chain {
       bool is_weak()   const { return !!_weak_votes; }
       bool is_strong() const { return !_weak_votes; }
 
-      bool     operator<(const valid_quorum_certificate& other) const;
-
-      // When it is strong, _weak_votes does not exist. No need to have a separate
-      // calculation for strong
-      uint32_t accumulated_weight() const { return (_strong_votes ? _strong_votes->count() : 0) + (_weak_votes ? _weak_votes->count() : 0); }
-
       // ================== begin compatibility functions =======================
       // these are present just to make the tests still work. will be removed.
       // these assume *only* strong votes.

--- a/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
@@ -157,6 +157,7 @@ namespace eosio::chain {
       size_t num_strong() const { return _strong_votes.count(); }
 
       bool   is_quorum_met() const;
+      bool   is_valid()      const { return _state == state_t::strong || _state == state_t::weak_achieved || _state == state_t::weak_final; }
 
       void reset(const fc::sha256& proposal_id, const digest_type& proposal_digest, size_t num_finalizers, size_t quorum);
 
@@ -210,6 +211,8 @@ namespace eosio::chain {
 
       bool is_weak()   const { return !!_weak_votes; }
       bool is_strong() const { return !_weak_votes; }
+
+      uint32_t accumulated_weight() const { return (_strong_votes ? _strong_votes.value().count() : 0) + (_weak_votes ? _weak_votes.value().count() : 0); }
 
       // ================== begin compatibility functions =======================
       // these are present just to make the tests still work. will be removed.


### PR DESCRIPTION
If `pending_qc` does not have a valid QC, return valid_qc. Otherwise, extract the valid QC from `pending_qc`. Compare that to `valid_qc` to determine which is better: Strong beats Weak. Break tie with `valid_qc`.  Return the better one.

Resolved https://github.com/AntelopeIO/leap/issues/2075