### PR TITLE
IF: Implement proposer policy change

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -127,7 +127,7 @@ block_header_state block_header_state::next(block_header_state_input& input) con
  */
 block_header_state block_header_state::next(const signed_block_header& h, const protocol_feature_set& pfs,
                                             validator_t& validator) const {
-   auto producer = detail::get_scheduled_producer(proposer_policy->proposer_schedule.producers, h.timestamp).producer_name;
+   auto producer = detail::get_scheduled_producer(active_proposer_policy->proposer_schedule.producers, h.timestamp).producer_name;
    
    EOS_ASSERT( h.previous == id, unlinkable_block_exception, "previous mismatch" );
    EOS_ASSERT( h.producer == producer, wrong_producer, "wrong producer specified" );

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -915,7 +915,7 @@ struct pending_state {
       _db_session.push();
    }
 
-   //bool is_dpos() const { return std::visit([](const auto& stage) { return stage.is_dpos(); }, _block_stage); }
+   bool is_dpos() const { return std::visit([](const auto& stage) { return stage.is_dpos(); }, _block_stage); }
    
    const block_signing_authority& pending_block_signing_authority() const {
       return std::visit(

--- a/libraries/chain/include/eosio/chain/block_header_state_utils.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state_utils.hpp
@@ -12,10 +12,10 @@ namespace eosio::chain::detail {
       return digest && protocol_features.find(*digest) != protocol_features.end();
    }
 
-   inline uint32_t get_next_next_round_block_num(block_timestamp_type t, uint32_t block_num) {
+   inline block_timestamp_type get_next_next_round_block_time( block_timestamp_type t) {
       auto index = t.slot % config::producer_repetitions; // current index in current round
-      //                 (increment to the end of this round  ) + next round
-      return block_num + (config::producer_repetitions - index) + config::producer_repetitions;
+      //                                   (increment to the end of this round  ) + next round
+      return block_timestamp_type{t.slot + (config::producer_repetitions - index) + config::producer_repetitions};
    }
 
    inline producer_authority get_scheduled_producer(const vector<producer_authority>& producers, block_timestamp_type t) {

--- a/libraries/chain/include/eosio/chain/block_state_legacy.hpp
+++ b/libraries/chain/include/eosio/chain/block_state_legacy.hpp
@@ -42,7 +42,7 @@ namespace eosio { namespace chain {
       
       protocol_feature_activation_set_ptr    get_activated_protocol_features() const { return activated_protocol_features; }
       const producer_authority_schedule&     active_schedule_auth()  const { return block_header_state_legacy_common::active_schedule; }
-      const producer_authority_schedule&     pending_schedule_auth() const { return block_header_state_legacy::pending_schedule.schedule; }
+      const producer_authority_schedule*     pending_schedule_auth() const { return &block_header_state_legacy::pending_schedule.schedule; }
       const deque<transaction_metadata_ptr>& trxs_metas()            const { return _cached_trxs; }
 
       

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -250,8 +250,13 @@ namespace eosio::chain {
 
          const producer_authority_schedule&         active_producers()const;
          const producer_authority_schedule&         head_active_producers()const;
-         const producer_authority_schedule&         pending_producers()const;
-         std::optional<producer_authority_schedule> proposed_producers()const;
+         // pending for pre-instant-finality, next proposed that will take affect, null if none are pending/proposed
+         const producer_authority_schedule*         next_producers()const;
+         // post-instant-finality this always returns empty std::optional
+         std::optional<producer_authority_schedule> proposed_producers_legacy()const;
+         // pre-instant-finality this always returns a valid producer_authority_schedule
+         // post-instant-finality this always returns nullptr
+         const producer_authority_schedule*         pending_producers_legacy()const;
 
          // Called by qc_chain to indicate the current irreversible block num
          // After hotstuff is activated, this should be called on startup by qc_chain

--- a/libraries/chain/include/eosio/chain/hotstuff/instant_finality_extension.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff/instant_finality_extension.hpp
@@ -17,7 +17,7 @@ struct instant_finality_extension : fc::reflect_init {
    instant_finality_extension() = default;
    instant_finality_extension(std::optional<qc_info_t> qc_info,
                               std::optional<finalizer_policy> new_finalizer_policy,
-                              std::optional<proposer_policy> new_proposer_policy) :
+                              std::shared_ptr<proposer_policy> new_proposer_policy) :
       qc_info(qc_info),
       new_finalizer_policy(std::move(new_finalizer_policy)),
       new_proposer_policy(std::move(new_proposer_policy))
@@ -25,9 +25,9 @@ struct instant_finality_extension : fc::reflect_init {
 
    void reflector_init();
 
-   std::optional<qc_info_t>         qc_info;
-   std::optional<finalizer_policy>  new_finalizer_policy;
-   std::optional<proposer_policy>   new_proposer_policy;
+   std::optional<qc_info_t>           qc_info;
+   std::optional<finalizer_policy>    new_finalizer_policy;
+   std::shared_ptr<proposer_policy>   new_proposer_policy;
 };
 
 } /// eosio::chain

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1800,9 +1800,9 @@ read_only::get_producers( const read_only::get_producers_params& params, const f
 read_only::get_producer_schedule_result read_only::get_producer_schedule( const read_only::get_producer_schedule_params& p, const fc::time_point& ) const {
    read_only::get_producer_schedule_result result;
    to_variant(db.active_producers(), result.active);
-   if(!db.pending_producers().producers.empty())
-      to_variant(db.pending_producers(), result.pending);
-   auto proposed = db.proposed_producers();
+   if (const auto* pending = db.next_producers()) // not applicable for instant-finality
+      to_variant(*pending, result.pending);
+   auto proposed = db.proposed_producers_legacy(); // empty for instant-finality
    if(proposed && !proposed->producers.empty())
       to_variant(*proposed, result.proposed);
    return result;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3929,7 +3929,9 @@ namespace eosio {
    }
 
    void net_plugin_impl::on_accepted_block() {
-      on_pending_schedule(chain_plug->chain().pending_producers());
+      if (const auto* next_producers = chain_plug->chain().next_producers()) {
+         on_pending_schedule(*next_producers);
+      }
       on_active_schedule(chain_plug->chain().active_producers());
    }
 

--- a/unittests/block_header_tests.cpp
+++ b/unittests/block_header_tests.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_with_empty_values_test)
    emplace_extension(
       header.header_extensions,
       instant_finality_extension::extension_id(),
-      fc::raw::pack( instant_finality_extension{qc_info_t{last_qc_block_num, is_last_qc_strong}, std::optional<finalizer_policy>{}, std::optional<proposer_policy>{}} )
+      fc::raw::pack( instant_finality_extension{qc_info_t{last_qc_block_num, is_last_qc_strong}, std::optional<finalizer_policy>{}, std::shared_ptr<proposer_policy>{}} )
    );
 
    std::optional<block_header_extension> ext = header.extract_header_extension(instant_finality_extension::extension_id());
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_uniqueness_test)
    emplace_extension(
       header.header_extensions,
       instant_finality_extension::extension_id(),
-      fc::raw::pack( instant_finality_extension{qc_info_t{0, false}, {std::nullopt}, {std::nullopt}} )
+      fc::raw::pack( instant_finality_extension{qc_info_t{0, false}, {std::nullopt}, std::shared_ptr<proposer_policy>{}} )
    );
 
    std::vector<finalizer_authority> finalizers { {"test description", 50, fc::crypto::blslib::bls_public_key{"PUB_BLS_MPPeebAPxt/ibL2XPuZVGpADjGn+YEVPPoYmTZeBD6Ok2E19M8SnmDGSdZBf2qwSuJim+8H83EsTpEn3OiStWBiFeJYfVRLlEsZuSF0SYYwtVteY48n+KeE1IWzlSAkSyBqiGA==" }} };
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_uniqueness_test)
    new_finalizer_policy.threshold = 100;
    new_finalizer_policy.finalizers = finalizers;
 
-   proposer_policy new_proposer_policy {1, block_timestamp_type{200}, {} };
+   proposer_policy_ptr new_proposer_policy = std::make_shared<proposer_policy>(1, block_timestamp_type{200}, producer_authority_schedule{} );
 
    emplace_extension(
       header.header_extensions,
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_with_values_test)
    new_finalizer_policy.threshold = 100;
    new_finalizer_policy.finalizers = finalizers;
 
-   proposer_policy new_proposer_policy {1, block_timestamp_type{200}, {} };
+   proposer_policy_ptr new_proposer_policy = std::make_shared<proposer_policy>(1, block_timestamp_type{200}, producer_authority_schedule{} );
 
    emplace_extension(
       header.header_extensions,

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -27,11 +27,14 @@ BOOST_AUTO_TEST_CASE( replace_producer_keys ) try {
       }
    }
 
-   const auto old_pending_version = tester.control->pending_producers().version;
+   // TODO: Add test with instant-finality enabled
+   BOOST_REQUIRE(tester.control->pending_producers_legacy());
+   const auto old_pending_version = tester.control->pending_producers_legacy()->version;
    const auto old_version = tester.control->active_producers().version;
    BOOST_REQUIRE_NO_THROW(tester.control->replace_producer_keys(new_key));
    const auto new_version = tester.control->active_producers().version;
-   const auto pending_version = tester.control->pending_producers().version;
+   BOOST_REQUIRE(tester.control->pending_producers_legacy());
+   const auto pending_version = tester.control->pending_producers_legacy()->version;
    // make sure version not been changed
    BOOST_REQUIRE(old_version == new_version);
    BOOST_REQUIRE(old_version == pending_version);
@@ -44,7 +47,8 @@ BOOST_AUTO_TEST_CASE( replace_producer_keys ) try {
 
    const uint32_t expected_threshold = 1;
    const weight_type expected_key_weight = 1;
-   for(const auto& prod : tester.control->pending_producers().producers) {
+   BOOST_REQUIRE(tester.control->pending_producers_legacy());
+   for(const auto& prod : tester.control->pending_producers_legacy()->producers) {
       BOOST_REQUIRE_EQUAL(std::get<block_signing_authority_v0>(prod.authority).threshold, expected_threshold);
       for(const auto& key : std::get<block_signing_authority_v0>(prod.authority).keys){
          BOOST_REQUIRE_EQUAL(key.key, new_key);

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -137,12 +137,13 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, validating_tester ) t
                                };
    //wdump((fc::json::to_pretty_string(res)));
    wlog("set producer schedule to [alice,bob]");
-   BOOST_REQUIRE_EQUAL( true, control->proposed_producers().has_value() );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *control->proposed_producers() ) );
-   BOOST_CHECK_EQUAL( control->pending_producers().version, 0u );
+   BOOST_REQUIRE_EQUAL( true, control->proposed_producers_legacy().has_value() );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *control->proposed_producers_legacy() ) );
+   BOOST_REQUIRE(control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( control->pending_producers_legacy()->version, 0u );
    produce_block(); // Starts new block which promotes the proposed schedule to pending
-   BOOST_CHECK_EQUAL( control->pending_producers().version, 1u );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->pending_producers() ) );
+   BOOST_CHECK_EQUAL( control->pending_producers_legacy()->version, 1u );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *control->pending_producers_legacy() ) );
    BOOST_CHECK_EQUAL( control->active_producers().version, 0u );
    produce_block();
    produce_block(); // Starts new block which promotes the pending schedule to active
@@ -157,15 +158,16 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, validating_tester ) t
                                  producer_authority{"carol"_n, block_signing_authority_v0{1, {{get_public_key("carol"_n, "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob,carol]");
-   BOOST_REQUIRE_EQUAL( true, control->proposed_producers().has_value() );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *control->proposed_producers() ) );
+   BOOST_REQUIRE_EQUAL( true, control->proposed_producers_legacy().has_value() );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *control->proposed_producers_legacy() ) );
 
    produce_block();
    produce_blocks(23); // Alice produces the last block of her first round.
                     // Bob's first block (which advances LIB to Alice's last block) is started but not finalized.
    BOOST_REQUIRE_EQUAL( control->head_block_producer(), "alice"_n );
    BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "bob"_n );
-   BOOST_CHECK_EQUAL( control->pending_producers().version, 2u );
+   BOOST_REQUIRE(control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( control->pending_producers_legacy()->version, 2u );
 
    produce_blocks(12); // Bob produces his first 11 blocks
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
@@ -202,12 +204,13 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
                                  producer_authority{"carol"_n, block_signing_authority_v0{ 1, {{get_public_key("carol"_n, "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob,carol]");
-   BOOST_REQUIRE_EQUAL( true, control->proposed_producers().has_value() );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *control->proposed_producers() ) );
-   BOOST_CHECK_EQUAL( control->pending_producers().version, 0u );
+   BOOST_REQUIRE_EQUAL( true, control->proposed_producers_legacy().has_value() );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *control->proposed_producers_legacy() ) );
+   BOOST_REQUIRE(control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( control->pending_producers_legacy()->version, 0u );
    produce_block(); // Starts new block which promotes the proposed schedule to pending
-   BOOST_CHECK_EQUAL( control->pending_producers().version, 1u );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->pending_producers() ) );
+   BOOST_CHECK_EQUAL( control->pending_producers_legacy()->version, 1u );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *control->pending_producers_legacy() ) );
    BOOST_CHECK_EQUAL( control->active_producers().version, 0u );
    produce_block();
    produce_block(); // Starts new block which promotes the pending schedule to active
@@ -221,13 +224,14 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
                                  producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{ get_public_key("bob"_n,   "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob]");
-   BOOST_REQUIRE_EQUAL( true, control->proposed_producers().has_value() );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *control->proposed_producers() ) );
+   BOOST_REQUIRE_EQUAL( true, control->proposed_producers_legacy().has_value() );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *control->proposed_producers_legacy() ) );
 
    produce_blocks(48);
    BOOST_REQUIRE_EQUAL( control->head_block_producer(), "bob"_n );
    BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "carol"_n );
-   BOOST_CHECK_EQUAL( control->pending_producers().version, 2u );
+   BOOST_REQUIRE(control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( control->pending_producers_legacy()->version, 2u );
 
    produce_blocks(47);
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
@@ -264,14 +268,16 @@ BOOST_AUTO_TEST_CASE( empty_producer_schedule_has_no_effect ) try {
                                  producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{ get_public_key("bob"_n,   "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob]");
-   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().has_value() );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *c.control->proposed_producers() ) );
-   BOOST_CHECK_EQUAL( c.control->pending_producers().producers.size(), 0u );
+   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers_legacy().has_value() );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *c.control->proposed_producers_legacy() ) );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->producers.size(), 0u );
 
    // Start a new block which promotes the proposed schedule to pending
    c.produce_block();
-   BOOST_CHECK_EQUAL( c.control->pending_producers().version, 1u );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, c.control->pending_producers() ) );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->version, 1u );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *c.control->pending_producers_legacy() ) );
    BOOST_CHECK_EQUAL( c.control->active_producers().version, 0u );
 
    // Start a new block which promotes the pending schedule to active
@@ -282,22 +288,25 @@ BOOST_AUTO_TEST_CASE( empty_producer_schedule_has_no_effect ) try {
 
    res = c.set_producers_legacy( {} );
    wlog("set producer schedule to []");
-   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().has_value() );
-   BOOST_CHECK_EQUAL( c.control->proposed_producers()->producers.size(), 0u );
-   BOOST_CHECK_EQUAL( c.control->proposed_producers()->version, 2u );
+   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers_legacy().has_value() );
+   BOOST_CHECK_EQUAL( c.control->proposed_producers_legacy()->producers.size(), 0u );
+   BOOST_CHECK_EQUAL( c.control->proposed_producers_legacy()->version, 2u );
 
    c.produce_blocks(12);
-   BOOST_CHECK_EQUAL( c.control->pending_producers().version, 1u );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->version, 1u );
 
    // Empty producer schedule does get promoted from proposed to pending
    c.produce_block();
-   BOOST_CHECK_EQUAL( c.control->pending_producers().version, 2u );
-   BOOST_CHECK_EQUAL( false, c.control->proposed_producers().has_value() );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->version, 2u );
+   BOOST_CHECK_EQUAL( false, c.control->proposed_producers_legacy().has_value() );
 
    // However it should not get promoted from pending to active
    c.produce_blocks(24);
    BOOST_CHECK_EQUAL( c.control->active_producers().version, 1u );
-   BOOST_CHECK_EQUAL( c.control->pending_producers().version, 2u );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->version, 2u );
 
    // Setting a new producer schedule should still use version 2
    res = c.set_producers_legacy( {"alice"_n,"bob"_n,"carol"_n} );
@@ -307,15 +316,16 @@ BOOST_AUTO_TEST_CASE( empty_producer_schedule_has_no_effect ) try {
                                  producer_authority{"carol"_n, block_signing_authority_v0{ 1, {{get_public_key("carol"_n, "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob,carol]");
-   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().has_value() );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *c.control->proposed_producers() ) );
-   BOOST_CHECK_EQUAL( c.control->proposed_producers()->version, 2u );
+   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers_legacy().has_value() );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *c.control->proposed_producers_legacy() ) );
+   BOOST_CHECK_EQUAL( c.control->proposed_producers_legacy()->version, 2u );
 
    // Produce enough blocks to promote the proposed schedule to pending, which it can do because the existing pending has zero producers
    c.produce_blocks(24);
    BOOST_CHECK_EQUAL( c.control->active_producers().version, 1u );
-   BOOST_CHECK_EQUAL( c.control->pending_producers().version, 2u );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, c.control->pending_producers() ) );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->version, 2u );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *c.control->pending_producers_legacy() ) );
 
    // Produce enough blocks to promote the pending schedule to active
    c.produce_blocks(24);
@@ -342,12 +352,14 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
                                  producer_authority{"carol"_n, block_signing_authority_v0{ 1, {{c.get_public_key("carol"_n, "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob,carol]");
-   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().has_value() );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *c.control->proposed_producers() ) );
-   BOOST_CHECK_EQUAL( c.control->pending_producers().version, 0u );
+   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers_legacy().has_value() );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *c.control->proposed_producers_legacy() ) );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->version, 0u );
    c.produce_block(); // Starts new block which promotes the proposed schedule to pending
-   BOOST_CHECK_EQUAL( c.control->pending_producers().version, 1u );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, c.control->pending_producers() ) );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->version, 1u );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *c.control->pending_producers_legacy() ) );
    BOOST_CHECK_EQUAL( c.control->active_producers().version, 0u );
    c.produce_block();
    c.produce_block(); // Starts new block which promotes the pending schedule to active
@@ -364,16 +376,18 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
                                  producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{c.get_public_key("bob"_n,   "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob]");
-   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().has_value() );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *c.control->proposed_producers() ) );
+   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers_legacy().has_value() );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *c.control->proposed_producers_legacy() ) );
 
    produce_until_transition( c, "bob"_n, "carol"_n );
    produce_until_transition( c, "alice"_n, "bob"_n );
-   BOOST_CHECK_EQUAL( c.control->pending_producers().version, 2u );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->version, 2u );
    BOOST_CHECK_EQUAL( c.control->active_producers().version, 1u );
 
    produce_until_transition( c, "carol"_n, "alice"_n );
-   BOOST_CHECK_EQUAL( c.control->pending_producers().version, 2u );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->version, 2u );
    BOOST_CHECK_EQUAL( c.control->active_producers().version, 1u );
 
    produce_until_transition( c, "bob"_n, "carol"_n );
@@ -388,8 +402,8 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
 
    res = c.set_producers( {"alice"_n,"bob"_n,"carol"_n} );
    wlog("set producer schedule to [alice,bob,carol]");
-   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().has_value() );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *c.control->proposed_producers() ) );
+   BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers_legacy().has_value() );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *c.control->proposed_producers_legacy() ) );
 
    produce_until_transition( c, "bob"_n, "alice"_n );
 
@@ -415,7 +429,8 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
       BOOST_CHECK_EQUAL( carol_itr->second, carol_last_produced_block_num );
    }
 
-   BOOST_CHECK_EQUAL( c.control->pending_producers().version, 3u );
+   BOOST_REQUIRE(c.control->pending_producers_legacy());
+   BOOST_CHECK_EQUAL( c.control->pending_producers_legacy()->version, 3u );
    BOOST_REQUIRE_EQUAL( c.control->active_producers().version, 2u );
 
    produce_until_transition( c, "bob"_n, "alice"_n );
@@ -495,7 +510,7 @@ BOOST_FIXTURE_TEST_CASE( satisfiable_msig_test, validating_tester ) try {
       fc_exception_message_is( "producer schedule includes an unsatisfiable authority for alice" )
    );
 
-   BOOST_REQUIRE_EQUAL( false, control->proposed_producers().has_value() );
+   BOOST_REQUIRE_EQUAL( false, control->proposed_producers_legacy().has_value() );
 
 } FC_LOG_AND_RETHROW()
 
@@ -514,7 +529,7 @@ BOOST_FIXTURE_TEST_CASE( duplicate_producers_test, validating_tester ) try {
       fc_exception_message_is( "duplicate producer name in producer schedule" )
    );
 
-   BOOST_REQUIRE_EQUAL( false, control->proposed_producers().has_value() );
+   BOOST_REQUIRE_EQUAL( false, control->proposed_producers_legacy().has_value() );
 
 } FC_LOG_AND_RETHROW()
 
@@ -532,7 +547,7 @@ BOOST_FIXTURE_TEST_CASE( duplicate_keys_test, validating_tester ) try {
       fc_exception_message_is( "producer schedule includes a duplicated key for alice" )
    );
 
-   BOOST_REQUIRE_EQUAL( false, control->proposed_producers().has_value() );
+   BOOST_REQUIRE_EQUAL( false, control->proposed_producers_legacy().has_value() );
 
    // ensure that multiple producers are allowed to share keys
    vector<producer_authority> sch2 = {
@@ -541,7 +556,7 @@ BOOST_FIXTURE_TEST_CASE( duplicate_keys_test, validating_tester ) try {
    };
 
    set_producer_schedule( sch2 );
-   BOOST_REQUIRE_EQUAL( true, control->proposed_producers().has_value() );
+   BOOST_REQUIRE_EQUAL( true, control->proposed_producers_legacy().has_value() );
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( large_authority_overflow_test ) try {
@@ -603,7 +618,7 @@ BOOST_AUTO_TEST_CASE( extra_signatures_test ) try {
    };
 
    main.set_producer_schedule( sch1 );
-   BOOST_REQUIRE_EQUAL( true, main.control->proposed_producers().has_value() );
+   BOOST_REQUIRE_EQUAL( true, main.control->proposed_producers_legacy().has_value() );
 
    main.block_signing_private_keys.emplace(get_public_key("alice"_n, "bs1"), get_private_key("alice"_n, "bs1"));
    main.block_signing_private_keys.emplace(get_public_key("alice"_n, "bs2"), get_private_key("alice"_n, "bs2"));


### PR DESCRIPTION
- Implement proposer policy change design: https://hackmd.io/@9xzIZ7ZaRwegCHgQW02r3Q/BkQ4Oc4Up
- Producer schedule is changed after `set_proposed_producer` in the next, next producer round.
  - For example: Producer A [ b1, b2, .. b12 ], Producer B [ b1, b2, .. b12 ], Producer X [ b1, b2, .. b12 ]
    - If `set_proposed_producer` is called in trx in any blocks of Producer A [ b1, b2, .. b12], the schedule change happens at Producer X [b1]. 
- public controller `pending_producers()` and `proposed_producers` renamed to `_legacy`.
- Added `next_producers()` for use by external enties.
