### PR TITLE
IF: Transition from dpos to instant-finality

### DIFF
--- a/docs/block_production/lifecycle.md
+++ b/docs/block_production/lifecycle.md
@@ -12,7 +12,7 @@ flowchart TD
        direction TB
        start -- "stage = &Oslash;" --> sb
        sb("start_block()"):::fun -- "stage = building_block" --> et
-       et["execute transactions" ] -- "stage = building_block" --> fb("finalize_block()"):::fun
+       et["execute transactions" ] -- "stage = building_block" --> fb("finish_block()"):::fun
        fb -- "stage = assembled block" --> cb["add transaction metadata and create completed block"]
        cb -- "stage = completed block" --> commit("commit_block() (where we [maybe] add to fork_db and mark valid)"):::fun
 

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -182,7 +182,7 @@ block_header_state block_header_state::next(const signed_block_header& h, const 
 
    // retrieve instant_finality_extension data from block header extension
    // --------------------------------------------------------------------
-   EOS_ASSERT(exts.count(instant_finality_extension::extension_id() > 0), misc_exception,
+   EOS_ASSERT(exts.count(instant_finality_extension::extension_id()) > 0, invalid_block_header_extension,
               "Instant Finality Extension is expected to be present in all block headers after switch to IF");
    auto  if_entry = exts.lower_bound(instant_finality_extension::extension_id());
    auto& if_ext   = std::get<instant_finality_extension>(if_entry->second);

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -96,7 +96,8 @@ block_header_state block_header_state::next(block_header_state_input& input) con
 
    if(!proposer_policies.empty()) {
       auto it = proposer_policies.begin();
-      if (it->first <= input.timestamp) {
+      // -1 since this is called after the block is built, this will be the active schedule for the next block
+      if (it->first.slot <= input.timestamp.slot - 1) {
          result.active_proposer_policy = it->second;
          result.header.schedule_version = header.schedule_version + 1;
          result.active_proposer_policy->proposer_schedule.version = result.header.schedule_version;

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -109,7 +109,7 @@ block_header_state block_header_state::next(block_header_state_input& input) con
 
    if (input.new_proposer_policy) {
       // called when assembling the block
-      result.proposer_policies[result.header.timestamp] = input.new_proposer_policy;
+      result.proposer_policies[input.new_proposer_policy->active_time] = input.new_proposer_policy;
    }
 
    // finalizer policy

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -21,20 +21,20 @@ block_state::block_state(const block_header_state& bhs, deque<transaction_metada
    block->transactions = std::move(trx_receipts);
 }
 
-// Used for transition from dbpos to instant-finality
+// Used for transition from dpos to instant-finality
 block_state::block_state(const block_state_legacy& bsp) {
    block_header_state::id = bsp.id();
    header = bsp.header;
    activated_protocol_features = bsp.activated_protocol_features;
    std::optional<block_header_extension> ext = bsp.block->extract_header_extension(instant_finality_extension::extension_id());
-   assert(ext); // required by current transistion mechanism
+   assert(ext); // required by current transition mechanism
    const auto& if_extension = std::get<instant_finality_extension>(*ext);
-   assert(if_extension.new_finalizer_policy); // required by current transistion mechanism
+   assert(if_extension.new_finalizer_policy); // required by current transition mechanism
    active_finalizer_policy = std::make_shared<finalizer_policy>(*if_extension.new_finalizer_policy);
    active_proposer_policy = std::make_shared<proposer_policy>();
    active_proposer_policy->active_time = bsp.timestamp();
    active_proposer_policy->proposer_schedule = bsp.active_schedule;
-   header_exts = bsp.header_exts; // not needed, but copy over just in case
+   header_exts = bsp.header_exts;
    block = bsp.block;
    validated = bsp.is_valid();
    pub_keys_recovered = bsp._pub_keys_recovered;

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -1,5 +1,6 @@
 #include <eosio/chain/block_state.hpp>
 #include <eosio/chain/block_header_state_utils.hpp>
+#include <eosio/chain/block_state_legacy.hpp>
 #include <eosio/chain/exceptions.hpp>
 
 namespace eosio::chain {
@@ -16,7 +17,29 @@ block_state::block_state(const block_header_state& bhs, deque<transaction_metada
    , block(std::make_shared<signed_block>(signed_block_header{bhs.header})) // [greg todo] do we need signatures?
    , pub_keys_recovered(true) // probably not needed
    , cached_trxs(std::move(trx_metas))
-{}
+{
+   block->transactions = std::move(trx_receipts);
+}
+
+// Used for transition from dbpos to instant-finality
+block_state::block_state(const block_state_legacy& bsp) {
+   block_header_state::id = bsp.id();
+   header = bsp.header;
+   activated_protocol_features = bsp.activated_protocol_features;
+   std::optional<block_header_extension> ext = bsp.block->extract_header_extension(instant_finality_extension::extension_id());
+   assert(ext); // required by current transistion mechanism
+   const auto& if_extension = std::get<instant_finality_extension>(*ext);
+   assert(if_extension.new_finalizer_policy); // required by current transistion mechanism
+   active_finalizer_policy = std::make_shared<finalizer_policy>(*if_extension.new_finalizer_policy);
+   active_proposer_policy = std::make_shared<proposer_policy>();
+   active_proposer_policy->active_time = bsp.timestamp();
+   active_proposer_policy->proposer_schedule = bsp.active_schedule;
+   header_exts = bsp.header_exts; // not needed, but copy over just in case
+   block = bsp.block;
+   validated = bsp.is_valid();
+   pub_keys_recovered = bsp._pub_keys_recovered;
+   cached_trxs = bsp._cached_trxs;
+}
 
 deque<transaction_metadata_ptr> block_state::extract_trxs_metas() {
    pub_keys_recovered = false;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -179,7 +179,7 @@ struct block_data_t {
    account_name         head_block_producer() const { return std::visit([](const auto& bd) { return bd.head->producer(); }, v); }
 
    void transition_fork_db_to_if(const auto& vbsp) {
-      std::visit([](auto& bd) { bd.fork_db.close(); }, v);
+      // no need to close fork_db because we don't want to write anything out, file is removed on open
       auto bsp = std::make_shared<block_state>(*std::get<block_state_legacy_ptr>(vbsp));
       v.emplace<block_data_new_t>(std::visit([](const auto& bd) { return bd.fork_db.get_data_dir(); }, v));
       std::visit(overloaded{
@@ -187,7 +187,6 @@ struct block_data_t {
                     [&](block_data_new_t& bd) {
                        bd.head = bsp;
                        bd.fork_db.reset(*bd.head);
-                       bd.fork_db.open({}); // no-op
                     }
                  }, v);
    }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -178,7 +178,7 @@ struct block_data_t {
    block_timestamp_type head_block_time() const { return std::visit([](const auto& bd) { return bd.head->timestamp(); }, v); }
    account_name         head_block_producer() const { return std::visit([](const auto& bd) { return bd.head->producer(); }, v); }
 
-   void transistion_fork_db_to_if(const auto& vbsp) {
+   void transition_fork_db_to_if(const auto& vbsp) {
       std::visit([](auto& bd) { bd.fork_db.close(); }, v);
       auto bsp = std::make_shared<block_state>(*std::get<block_state_legacy_ptr>(vbsp));
       v.emplace<block_data_new_t>(std::visit([](const auto& bd) { return bd.fork_db.get_data_dir(); }, v));
@@ -2720,7 +2720,7 @@ struct controller_impl {
             log_irreversible();
          }
 
-         // TODO: temp transistion to instant-finality, happens immediately after block with new_finalizer_policy
+         // TODO: temp transition to instant-finality, happens immediately after block with new_finalizer_policy
          auto transition = [&](auto& fork_db, auto& head) -> bool {
             const auto& bsp = std::get<std::decay_t<decltype(head)>>(cb.bsp);
             std::optional<block_header_extension> ext = bsp->block->extract_header_extension(instant_finality_extension::extension_id());
@@ -2737,7 +2737,7 @@ struct controller_impl {
             return false;
          };
          if (block_data.apply_dpos<bool>(transition)) {
-            block_data.transistion_fork_db_to_if(cb.bsp);
+            block_data.transition_fork_db_to_if(cb.bsp);
          }
 
       } catch (...) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2608,7 +2608,7 @@ struct controller_impl {
       guard_pending.cancel();
    } /// start_block
 
-   void finalize_block()
+   void finish_block()
    {
       EOS_ASSERT( pending, block_validate_exception, "it is not valid to finalize when there is no pending block");
       EOS_ASSERT( std::holds_alternative<building_block>(pending->_block_stage), block_validate_exception, "already called finalize_block");
@@ -2888,7 +2888,7 @@ struct controller_impl {
                               ("lhs", r)("rhs", static_cast<const transaction_receipt_header&>(receipt)) );
                }
 
-               finalize_block();
+               finish_block();
 
                auto& ab = std::get<assembled_block>(pending->_block_stage);
 
@@ -3749,10 +3749,10 @@ void controller::start_block( block_timestamp_type when,
                     bs, std::optional<block_id_type>(), deadline );
 }
 
-void controller::finalize_block( block_report& br, const signer_callback_type& signer_callback ) {
+void controller::finish_block( block_report& br, const signer_callback_type& signer_callback ) {
    validate_db_available_size();
 
-   my->finalize_block();
+   my->finish_block();
 
    auto& ab = std::get<assembled_block>(my->pending->_block_stage);
    my->pending->_block_stage = ab.make_completed_block(

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -69,7 +69,7 @@ namespace eosio::chain {
       fork_multi_index_type  index;
       bsp                    root; // Only uses the block_header_state_legacy portion
       bsp                    head;
-      std::filesystem::path  datadir;
+      const std::filesystem::path  datadir;
 
       explicit         fork_database_impl( const std::filesystem::path& data_dir ) : datadir(data_dir) {}
 
@@ -100,6 +100,11 @@ namespace eosio::chain {
    void fork_database<bsp>::open( validator_t& validator ) {
       std::lock_guard g( my->mtx );
       my->open_impl( validator );
+   }
+
+   template<class bsp>
+   std::filesystem::path fork_database<bsp>::get_data_dir() const {
+      return my->datadir;
    }
 
    template<class bsp>

--- a/libraries/chain/hotstuff/chain_pacemaker.cpp
+++ b/libraries/chain/hotstuff/chain_pacemaker.cpp
@@ -175,7 +175,7 @@ namespace eosio::chain {
             if (_active_finalizer_policy.generation == 0) {
                ilog("Switching to instant finality at block ${b}", ("b", block->block_num()));
                // switching from dpos to hotstuff, all nodes will switch at same block height
-               // block header extension is set in finalize_block to value set by host function set_finalizers
+               // block header extension is set in finish_block to value set by host function set_finalizers
                _chain->set_hs_irreversible_block_num(block->block_num()); // can be any value <= dpos lib
             }
             auto if_extension = std::get<instant_finality_extension>(*ext);

--- a/libraries/chain/hotstuff/chain_pacemaker.cpp
+++ b/libraries/chain/hotstuff/chain_pacemaker.cpp
@@ -176,7 +176,7 @@ namespace eosio::chain {
                ilog("Switching to instant finality at block ${b}", ("b", block->block_num()));
                // switching from dpos to hotstuff, all nodes will switch at same block height
                // block header extension is set in finish_block to value set by host function set_finalizers
-               _chain->set_hs_irreversible_block_num(block->block_num()); // can be any value <= dpos lib
+               _chain->set_if_irreversible_block_num(block->block_num()); // can be any value <= dpos lib
             }
             auto if_extension = std::get<instant_finality_extension>(*ext);
 #warning Revisit after finalizer policy change design is complete as this is not necessarily when we will change active finalizer policy.

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -98,6 +98,8 @@ using block_header_state_ptr = std::shared_ptr<block_header_state>;
 
 }
 
-// [greg todo] which members need to be serialized to disk when saving fork_db
-// obviously many are missing below.
-FC_REFLECT( eosio::chain::block_header_state,  (id))
+FC_REFLECT( eosio::chain::block_header_state_core,
+            (last_final_block_num)(final_on_strong_qc_block_num)(last_qc_block_num)(finalizer_policy_generation))
+FC_REFLECT( eosio::chain::block_header_state,
+            (id)(header)(activated_protocol_features)(core)(proposal_mtree)(finality_mtree)
+            (active_finalizer_policy)(active_proposer_policy)(proposer_policies)(finalizer_policies)(header_exts))

--- a/libraries/chain/include/eosio/chain/block_header_state_legacy.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state_legacy.hpp
@@ -120,7 +120,7 @@ protected:
  *     start_block -> (global_property_object.proposed_schedule_block_num == dpos_lib)
  *        building_block._new_pending_producer_schedule = producers
  *
- *     finalize_block ->
+ *     finish_block ->
  *        block_header.extensions.wtmsig_block_signatures = producers
  *        block_header.new_producers                      = producers
  *

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -7,10 +7,12 @@
 
 namespace eosio::chain {
 
+struct block_state_legacy;
+
 struct block_state : public block_header_state {     // block_header_state provides parent link
    // ------ data members -------------------------------------------------------------
    signed_block_ptr           block;
-   bool                       validated;             // We have executed the block's trxs and verified that action merkle root (block id) matches.
+   bool                       validated = false;     // We have executed the block's trxs and verified that action merkle root (block id) matches.
    digest_type                strong_digest;         // finalizer_digest (strong, cached so we can quickly validate votes)
    digest_type                weak_digest;           // finalizer_digest (weak, cached so we can quickly validate votes)
    pending_quorum_certificate pending_qc;            // where we accumulate votes we receive
@@ -47,6 +49,8 @@ struct block_state : public block_header_state {     // block_header_state provi
 
    block_state(const block_header_state& bhs, deque<transaction_metadata_ptr>&& trx_metas,
                deque<transaction_receipt>&& trx_receipts);
+
+   explicit block_state(const block_state_legacy& bsp);
 };
 
 using block_state_ptr = std::shared_ptr<block_state>;

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -57,4 +57,5 @@ using block_state_ptr = std::shared_ptr<block_state>;
    
 } // namespace eosio::chain
 
-FC_REFLECT_DERIVED( eosio::chain::block_state, (eosio::chain::block_header_state), (block)(validated)(strong_digest)(weak_digest)(pending_qc)(valid_qc) )
+// not exporting pending_qc or valid_qc
+FC_REFLECT_DERIVED( eosio::chain::block_state, (eosio::chain::block_header_state), (block)(validated)(strong_digest)(weak_digest) )

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -57,5 +57,4 @@ using block_state_ptr = std::shared_ptr<block_state>;
    
 } // namespace eosio::chain
 
-// [greg todo] which members need to be serialized to disk when saving fork_db
-FC_REFLECT_DERIVED( eosio::chain::block_state, (eosio::chain::block_header_state), (block)(validated) )
+FC_REFLECT_DERIVED( eosio::chain::block_state, (eosio::chain::block_header_state), (block)(validated)(strong_digest)(weak_digest)(pending_qc)(valid_qc) )

--- a/libraries/chain/include/eosio/chain/block_state_legacy.hpp
+++ b/libraries/chain/include/eosio/chain/block_state_legacy.hpp
@@ -52,6 +52,7 @@ namespace eosio::chain {
       friend struct fc::reflector<block_state_legacy>;
       friend struct controller_impl;
       friend struct completed_block;
+      friend struct block_state;
 
       bool is_pub_keys_recovered()const { return _pub_keys_recovered; }
       

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -183,7 +183,7 @@ namespace eosio::chain {
             fc::microseconds   total_time{};
          };
 
-         void finalize_block( block_report& br, const signer_callback_type& signer_callback );
+         void finish_block( block_report& br, const signer_callback_type& signer_callback );
          void sign_block( const signer_callback_type& signer_callback );
          void commit_block();
          

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -287,10 +287,6 @@ namespace eosio::chain {
          std::optional<signed_block_header> fetch_block_header_by_number( uint32_t block_num )const;
          // thread-safe
          std::optional<signed_block_header> fetch_block_header_by_id( const block_id_type& id )const;
-         // return block_state_legacy from forkdb, thread-safe
-         block_state_legacy_ptr fetch_block_state_by_number( uint32_t block_num )const;
-         // return block_state_legacy from forkdb, thread-safe
-         block_state_legacy_ptr fetch_block_state_by_id( block_id_type id )const;
          // thread-safe
          block_id_type get_block_id_for_num( uint32_t block_num )const;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -270,7 +270,7 @@ namespace eosio::chain {
 
          // Called by qc_chain to indicate the current irreversible block num
          // After hotstuff is activated, this should be called on startup by qc_chain
-         void set_hs_irreversible_block_num(uint32_t block_num);
+         void set_if_irreversible_block_num(uint32_t block_num);
 
          uint32_t last_irreversible_block_num() const;
          block_id_type last_irreversible_block_id() const;

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -34,6 +34,8 @@ namespace eosio::chain {
       explicit fork_database( const std::filesystem::path& data_dir );
       ~fork_database();
 
+      std::filesystem::path get_data_dir() const;
+
       void open( validator_t& validator );
       void close();
 

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -133,17 +133,9 @@ public:
       }
    }
 
-   template<class BRANCH_TYPE>
-   void add_forked( const BRANCH_TYPE& forked_branch ) {
-      // forked_branch is in reverse order
-      for( auto ritr = forked_branch.rbegin(), rend = forked_branch.rend(); ritr != rend; ++ritr ) {
-         const auto& bsptr = *ritr;
-         for( auto itr = bsptr->trxs_metas().begin(), end = bsptr->trxs_metas().end(); itr != end; ++itr ) {
-            const auto& trx = *itr;
-            auto insert_itr = queue.insert( { trx, trx_enum_type::forked } );
-            if( insert_itr.second ) added( insert_itr.first );
-         }
-      }
+   void add_forked( const transaction_metadata_ptr& trx ) {
+      auto insert_itr = queue.insert( { trx, trx_enum_type::forked } );
+      if( insert_itr.second ) added( insert_itr.first );
    }
 
    void add_aborted( deque<transaction_metadata_ptr> aborted_trxs ) {

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -117,7 +117,7 @@ void resource_limits_manager::set_block_parameters(const elastic_limit_parameter
       c.cpu_limit_parameters = cpu_limit_parameters;
       c.net_limit_parameters = net_limit_parameters;
 
-      // set_block_parameters is called by controller::finalize_block,
+      // set_block_parameters is called by controller::finish_block,
       // where transaction specific logging is not possible
       if (auto dm_logger = _get_deep_mind_logger(false)) {
          dm_logger->on_update_resource_limits_config(c);
@@ -359,7 +359,7 @@ void resource_limits_manager::process_account_limit_updates() {
          multi_index.remove(*itr);
       }
 
-      // process_account_limit_updates is called by controller::finalize_block,
+      // process_account_limit_updates is called by controller::finish_block,
       // where transaction specific logging is not possible
       if (auto dm_logger = _get_deep_mind_logger(false)) {
          dm_logger->on_update_resource_limits_state(state);
@@ -381,7 +381,7 @@ void resource_limits_manager::process_block_usage(uint32_t block_num) {
       state.update_virtual_net_limit(config);
       state.pending_net_usage = 0;
 
-      // process_block_usage is called by controller::finalize_block,
+      // process_block_usage is called by controller::finish,
       // where transaction specific logging is not possible
       if (auto dm_logger = _get_deep_mind_logger(false)) {
          dm_logger->on_update_resource_limits_state(state);

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -606,9 +606,9 @@ namespace eosio { namespace testing {
 
       signed_block_ptr produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms) )override {
          auto sb = _produce_block(skip_time, false);
-         auto bsf = validating_node->create_block_state_future( sb->calculate_id(), sb );
+         auto btf = validating_node->create_block_token_future( sb->calculate_id(), sb );
          controller::block_report br;
-         validating_node->push_block( br, bsf.get(), {}, trx_meta_cache_lookup{} );
+         validating_node->push_block( br, btf.get(), {}, trx_meta_cache_lookup{} );
 
          return sb;
       }
@@ -618,17 +618,17 @@ namespace eosio { namespace testing {
       }
 
       void validate_push_block(const signed_block_ptr& sb) {
-         auto bsf = validating_node->create_block_state_future( sb->calculate_id(), sb );
+         auto btf = validating_node->create_block_token_future( sb->calculate_id(), sb );
          controller::block_report br;
-         validating_node->push_block( br, bsf.get(), {}, trx_meta_cache_lookup{} );
+         validating_node->push_block( br, btf.get(), {}, trx_meta_cache_lookup{} );
       }
 
       signed_block_ptr produce_empty_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms) )override {
          unapplied_transactions.add_aborted( control->abort_block() );
          auto sb = _produce_block(skip_time, true);
-         auto bsf = validating_node->create_block_state_future( sb->calculate_id(), sb );
+         auto btf = validating_node->create_block_token_future( sb->calculate_id(), sb );
          controller::block_report br;
-         validating_node->push_block( br, bsf.get(), {}, trx_meta_cache_lookup{} );
+         validating_node->push_block( br, btf.get(), {}, trx_meta_cache_lookup{} );
 
          return sb;
       }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -376,11 +376,11 @@ namespace eosio { namespace testing {
    }
 
    void base_tester::push_block(signed_block_ptr b) {
-      auto bsf = control->create_block_state_future(b->calculate_id(), b);
+      auto btf = control->create_block_token_future(b->calculate_id(), b);
       unapplied_transactions.add_aborted( control->abort_block() );
       controller::block_report br;
-      control->push_block( br, bsf.get(), [this]( const branch_type_legacy& forked_branch ) {
-         unapplied_transactions.add_forked( forked_branch );
+      control->push_block( br, btf.get(), [this]( const transaction_metadata_ptr& trx ) {
+         unapplied_transactions.add_forked( trx );
       }, [this]( const transaction_id_type& id ) {
          return unapplied_transactions.get_trx( id );
       } );
@@ -1115,10 +1115,10 @@ namespace eosio { namespace testing {
 
             auto block = a.control->fetch_block_by_number(i);
             if( block ) { //&& !b.control->is_known_block(block->id()) ) {
-               auto bsf = b.control->create_block_state_future( block->calculate_id(), block );
+               auto btf = b.control->create_block_token_future( block->calculate_id(), block );
                b.control->abort_block();
                controller::block_report br;
-               b.control->push_block(br, bsf.get(), {}, trx_meta_cache_lookup{}); //, eosio::chain::validation_steps::created_block);
+               b.control->push_block(br, btf.get(), {}, trx_meta_cache_lookup{}); //, eosio::chain::validation_steps::created_block);
             }
          }
       };

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -487,7 +487,7 @@ namespace eosio { namespace testing {
       });
 
       controller::block_report br;
-      control->finalize_block( br, [&]( digest_type d ) {
+      control->finish_block( br, [&]( digest_type d ) {
          std::vector<signature_type> result;
          result.reserve(signing_keys.size());
          for (const auto& k: signing_keys)

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -33,7 +33,7 @@ namespace eosio::chain::plugin_interface {
    namespace incoming {
       namespace methods {
          // synchronously push a block/trx to a single provider, block_state_legacy_ptr may be null
-         using block_sync            = method_decl<chain_plugin_interface, bool(const signed_block_ptr&, const std::optional<block_id_type>&, const block_state_legacy_ptr&), first_provider_policy>;
+         using block_sync            = method_decl<chain_plugin_interface, bool(const signed_block_ptr&, const std::optional<block_id_type>&, const std::optional<block_token>&), first_provider_policy>;
          using transaction_async     = method_decl<chain_plugin_interface, void(const packed_transaction_ptr&, bool, transaction_metadata::trx_type, bool, next_function<transaction_trace_ptr>), first_provider_policy>;
       }
    }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1183,8 +1183,8 @@ chain_apis::read_only chain_plugin::get_read_only_api(const fc::microseconds& ht
 }
 
 
-bool chain_plugin::accept_block(const signed_block_ptr& block, const block_id_type& id, const block_state_legacy_ptr& bsp ) {
-   return my->incoming_block_sync_method(block, id, bsp);
+bool chain_plugin::accept_block(const signed_block_ptr& block, const block_id_type& id, const std::optional<block_token>& obt ) {
+   return my->incoming_block_sync_method(block, id, obt);
 }
 
 void chain_plugin::accept_transaction(const chain::packed_transaction_ptr& trx, next_function<chain::transaction_trace_ptr> next) {
@@ -2013,7 +2013,7 @@ fc::variant read_only::get_block_info(const read_only::get_block_info_params& pa
 
 void read_write::push_block(read_write::push_block_params&& params, next_function<read_write::push_block_results> next) {
    try {
-      app().get_method<incoming::methods::block_sync>()(std::make_shared<signed_block>( std::move(params) ), std::optional<block_id_type>{}, block_state_legacy_ptr{});
+      app().get_method<incoming::methods::block_sync>()(std::make_shared<signed_block>( std::move(params) ), std::optional<block_id_type>{}, std::optional<block_token>{});
    } catch ( boost::interprocess::bad_alloc& ) {
       handle_db_exhaustion();
    } catch ( const std::bad_alloc& ) {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -1012,7 +1012,7 @@ public:
    chain_apis::read_write get_read_write_api(const fc::microseconds& http_max_response_time);
    chain_apis::read_only get_read_only_api(const fc::microseconds& http_max_response_time) const;
 
-   bool accept_block( const chain::signed_block_ptr& block, const chain::block_id_type& id, const chain::block_state_legacy_ptr& bsp );
+   bool accept_block( const chain::signed_block_ptr& block, const chain::block_id_type& id, const std::optional<chain::block_token>& obt );
    void accept_transaction(const chain::packed_transaction_ptr& trx, chain::plugin_interface::next_function<chain::transaction_trace_ptr> next);
 
    // Only call this after plugin_initialize()!

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1100,7 +1100,7 @@ namespace eosio {
       // returns calculated number of blocks combined latency
       uint32_t calc_block_latency();
 
-      void process_signed_block( const block_id_type& id, signed_block_ptr block, block_state_legacy_ptr bsp );
+      void process_signed_block( const block_id_type& id, signed_block_ptr block, const std::optional<block_token>& obt );
 
       fc::variant_object get_logger_variant() const {
          fc::mutable_variant_object mvo;
@@ -3718,7 +3718,7 @@ namespace eosio {
          controller& cc = my_impl->chain_plug->chain();
 
          // may have come in on a different connection and posted into dispatcher strand before this one
-         if( my_impl->dispatcher->have_block( id ) || cc.fetch_block_by_id( id ) ) { // thread-safe
+         if( my_impl->dispatcher->have_block( id ) || cc.block_exists( id ) ) { // thread-safe
             my_impl->dispatcher->add_peer_block( id, c->connection_id );
             c->strand.post( [c, id]() {
                my_impl->sync_master->sync_recv_block( c, id, block_header::num_from_id(id), false );
@@ -3726,11 +3726,11 @@ namespace eosio {
             return;
          }
 
-         block_state_legacy_ptr bsp;
+         std::optional<block_token> obt;
          bool exception = false;
          try {
             // this may return null if block is not immediately ready to be processed
-            bsp = cc.create_block_state( id, ptr );
+            obt = cc.create_block_token( id, ptr );
          } catch( const fc::exception& ex ) {
             exception = true;
             fc_ilog( logger, "bad block exception connection ${cid}: #${n} ${id}...: ${m}",
@@ -3749,17 +3749,18 @@ namespace eosio {
          }
 
 
-         uint32_t block_num = bsp ? bsp->block_num() : 0;
+         uint32_t block_num = obt ? obt->block_num() : 0;
 
          if( block_num != 0 ) {
+            assert(obt);
             fc_dlog( logger, "validated block header, broadcasting immediately, connection ${cid}, blk num = ${num}, id = ${id}",
-                     ("cid", cid)("num", block_num)("id", bsp->id()) );
-            my_impl->dispatcher->add_peer_block( bsp->id(), cid ); // no need to send back to sender
-            my_impl->dispatcher->bcast_block( bsp->block, bsp->id() );
+                     ("cid", cid)("num", block_num)("id", obt->id()) );
+            my_impl->dispatcher->add_peer_block( obt->id(), cid ); // no need to send back to sender
+            my_impl->dispatcher->bcast_block( obt->block(), obt->id() );
          }
 
-         app().executor().post(priority::medium, exec_queue::read_write, [ptr{std::move(ptr)}, bsp{std::move(bsp)}, id, c{std::move(c)}]() mutable {
-            c->process_signed_block( id, std::move(ptr), std::move(bsp) );
+         app().executor().post(priority::medium, exec_queue::read_write, [ptr{std::move(ptr)}, obt{std::move(obt)}, id, c{std::move(c)}]() mutable {
+            c->process_signed_block( id, std::move(ptr), obt );
          });
 
          if( block_num != 0 ) {
@@ -3770,14 +3771,14 @@ namespace eosio {
    }
 
    // called from application thread
-   void connection::process_signed_block( const block_id_type& blk_id, signed_block_ptr block, block_state_legacy_ptr bsp ) {
+   void connection::process_signed_block( const block_id_type& blk_id, signed_block_ptr block, const std::optional<block_token>& obt ) {
       controller& cc = my_impl->chain_plug->chain();
       uint32_t blk_num = block_header::num_from_id(blk_id);
       // use c in this method instead of this to highlight that all methods called on c-> must be thread safe
       connection_ptr c = shared_from_this();
 
       try {
-         if( blk_num <= cc.last_irreversible_block_num() || cc.fetch_block_by_id(blk_id) ) {
+         if( blk_num <= cc.last_irreversible_block_num() || cc.block_exists(blk_id) ) {
             c->strand.post( [sync_master = my_impl->sync_master.get(),
                              dispatcher = my_impl->dispatcher.get(), c, blk_id, blk_num]() {
                dispatcher->add_peer_block( blk_id, c->connection_id );
@@ -3794,12 +3795,12 @@ namespace eosio {
 
       fc::microseconds age( fc::time_point::now() - block->timestamp);
       fc_dlog( logger, "received signed_block: #${n} block age in secs = ${age}, connection ${cid}, ${v}",
-               ("n", blk_num)("age", age.to_seconds())("cid", c->connection_id)("v", bsp ? "pre-validated" : "validation pending") );
+               ("n", blk_num)("age", age.to_seconds())("cid", c->connection_id)("v", obt ? "pre-validated" : "validation pending") );
 
       go_away_reason reason = no_reason;
       bool accepted = false;
       try {
-         accepted = my_impl->chain_plug->accept_block(block, blk_id, bsp);
+         accepted = my_impl->chain_plug->accept_block(block, blk_id, obt);
          my_impl->update_chain_info();
       } catch( const unlinkable_block_exception &ex) {
          fc_ilog(logger, "unlinkable_block_exception connection ${cid}: #${n} ${id}...: ${m}",

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2646,7 +2646,7 @@ void producer_plugin_impl::produce_block() {
 
    // idump( (fc::time_point::now() - chain.pending_block_time()) );
    controller::block_report br;
-   chain.finalize_block(br, [&](const digest_type& d) {
+   chain.finish_block(br, [&](const digest_type& d) {
       auto                   debug_logger = maybe_make_debug_time_logger();
       vector<signature_type> sigs;
       sigs.reserve(relevant_providers.size());

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -666,7 +666,7 @@ public:
       _time_tracker.clear();
    }
 
-   bool on_incoming_block(const signed_block_ptr& block, const std::optional<block_id_type>& block_id, const block_state_legacy_ptr& bsp) {
+   bool on_incoming_block(const signed_block_ptr& block, const std::optional<block_id_type>& block_id, const std::optional<block_token>& obt) {
       auto& chain = chain_plug->chain();
       if (in_producing_mode()) {
          fc_wlog(_log, "dropped incoming block #${num} id: ${id}", ("num", block->block_num())("id", block_id ? (*block_id).str() : "UNKNOWN"));
@@ -687,16 +687,15 @@ public:
 
       EOS_ASSERT(block->timestamp < (now + fc::seconds(7)), block_from_the_future, "received a block from the future, ignoring it: ${id}", ("id", id));
 
-      /* de-dupe here... no point in aborting block if we already know the block */
-      auto existing = chain.fetch_block_by_id(id);
-      if (existing) {
+      // de-dupe here... no point in aborting block if we already know the block
+      if (chain.block_exists(id)) {
          return true; // return true because the block is valid
       } 
 
       // start processing of block
-      std::future<block_state_legacy_ptr> bsf;
-      if (!bsp) {
-         bsf = chain.create_block_state_future(id, block);
+      std::future<block_token> btf;
+      if (!obt) {
+         btf = chain.create_block_token_future(id, block);
       }
 
       // abort the pending block
@@ -711,11 +710,11 @@ public:
 
       controller::block_report br;
       try {
-         const block_state_legacy_ptr& bspr = bsp ? bsp : bsf.get();
+         const block_token& bt = obt ? *obt : btf.get();
          chain.push_block(
             br,
-            bspr,
-            [this](const branch_type_legacy& forked_branch) { _unapplied_transactions.add_forked(forked_branch); },
+            bt,
+            [this](const transaction_metadata_ptr& trx) { _unapplied_transactions.add_forked(trx); },
             [this](const transaction_id_type& id) { return _unapplied_transactions.get_trx(id); });
       } catch (const guard_exception& e) {
          chain_plugin::handle_guard_exception(e);
@@ -1280,8 +1279,8 @@ void producer_plugin_impl::plugin_initialize(const boost::program_options::varia
    ilog("read-only-threads ${s}, max read-only trx time to be enforced: ${t} us", ("s", _ro_thread_pool_size)("t", _ro_max_trx_time_us));
 
    _incoming_block_sync_provider = app().get_method<incoming::methods::block_sync>().register_provider(
-      [this](const signed_block_ptr& block, const std::optional<block_id_type>& block_id, const block_state_legacy_ptr& bsp) {
-         return on_incoming_block(block, block_id, bsp);
+      [this](const signed_block_ptr& block, const std::optional<block_id_type>& block_id, const std::optional<block_token>& obt) {
+         return on_incoming_block(block, block_id, obt);
       });
 
    _incoming_transaction_async_provider =

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,8 @@ add_test(NAME nodeos_sanity_test COMMAND tests/nodeos_run_test.py -v --sanity-te
 set_property(TEST nodeos_sanity_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME nodeos_run_test COMMAND tests/nodeos_run_test.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_run_test PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME nodeos_if_test COMMAND tests/nodeos_run_test.py -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST nodeos_if_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME block_log_util_test COMMAND tests/block_log_util_test.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST block_log_util_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME block_log_retain_blocks_test COMMAND tests/block_log_retain_blocks_test.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -1187,6 +1187,10 @@ class Cluster(object):
         if not biosNode.waitForTransactionsInBlock(transIds):
             Utils.Print('ERROR: Failed to validate creation of system accounts')
             return None
+        #
+        # Could activate instant finality here, but have to wait for finality which with all the producers takes a long time
+        #         if activateIF:
+        #             self.activateInstantFinality(launcher)
 
         eosioTokenAccount = copy.deepcopy(eosioAccount)
         eosioTokenAccount.name = 'eosio.token'

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -44,10 +44,10 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_test)
 
    // Push block with invalid transaction to other chain
    tester validator;
-   auto bsf = validator.control->create_block_state_future( copy_b->calculate_id(), copy_b );
+   auto btf = validator.control->create_block_token_future( copy_b->calculate_id(), copy_b );
    validator.control->abort_block();
    controller::block_report br;
-   BOOST_REQUIRE_EXCEPTION(validator.control->push_block( br, bsf.get(), {}, trx_meta_cache_lookup{} ), fc::exception ,
+   BOOST_REQUIRE_EXCEPTION(validator.control->push_block( br, btf.get(), {}, trx_meta_cache_lookup{} ), fc::exception ,
    [] (const fc::exception &e)->bool {
       return e.code() == account_name_exists_exception::code_value ;
    }) ;
@@ -83,10 +83,10 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_mroot_test)
 
    // Push block with invalid transaction to other chain
    tester validator;
-   auto bsf = validator.control->create_block_state_future( copy_b->calculate_id(), copy_b );
+   auto btf = validator.control->create_block_token_future( copy_b->calculate_id(), copy_b );
    validator.control->abort_block();
    controller::block_report br;
-   BOOST_REQUIRE_EXCEPTION(validator.control->push_block( br, bsf.get(), {}, trx_meta_cache_lookup{} ), fc::exception,
+   BOOST_REQUIRE_EXCEPTION(validator.control->push_block( br, btf.get(), {}, trx_meta_cache_lookup{} ), fc::exception,
                            [] (const fc::exception &e)->bool {
                               return e.code() == block_validate_exception::code_value &&
                                      e.to_detail_string().find("invalid block transaction merkle root") != std::string::npos;

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -161,6 +161,7 @@ BOOST_AUTO_TEST_CASE( signal_validated_blocks ) try {
       auto block_num = block->block_num();
       BOOST_CHECK(block);
       BOOST_CHECK(chain.control->fetch_block_by_id(id) == block);
+      BOOST_CHECK(chain.control->block_exists(id));
       BOOST_CHECK(chain.control->fetch_block_by_number(block_num) == block);
       BOOST_REQUIRE(chain.control->fetch_block_header_by_number(block_num));
       BOOST_CHECK(chain.control->fetch_block_header_by_number(block_num)->calculate_id() == id);
@@ -176,6 +177,7 @@ BOOST_AUTO_TEST_CASE( signal_validated_blocks ) try {
       auto block_num = block->block_num();
       BOOST_CHECK(block);
       BOOST_CHECK(validator.control->fetch_block_by_id(id) == block);
+      BOOST_CHECK(validator.control->block_exists(id));
       BOOST_CHECK(validator.control->fetch_block_by_number(block_num) == block);
       BOOST_REQUIRE(validator.control->fetch_block_header_by_number(block_num));
       BOOST_CHECK(validator.control->fetch_block_header_by_number(block_num)->calculate_id() == id);

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -510,7 +510,7 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
    {
       auto b = irreversible.control->fetch_block_by_id( fork_first_block_id );
       BOOST_REQUIRE( !b );
-      BOOST_TEST( irreversible.control->block_exists(fork_first_block_id) );
+      BOOST_TEST( !irreversible.control->block_exists(fork_first_block_id) );
    }
 
 } FC_LOG_AND_RETHROW()

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -266,10 +266,10 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    signed_block bad_block = std::move(*b);
    bad_block.action_mroot = bad_block.previous;
    auto bad_id = bad_block.calculate_id();
-   auto bad_block_bsf = c.control->create_block_state_future( bad_id, std::make_shared<signed_block>(std::move(bad_block)) );
+   auto bad_block_btf = c.control->create_block_token_future( bad_id, std::make_shared<signed_block>(std::move(bad_block)) );
    c.control->abort_block();
    controller::block_report br;
-   BOOST_REQUIRE_EXCEPTION(c.control->push_block( br, bad_block_bsf.get(), {}, trx_meta_cache_lookup{} ), fc::exception,
+   BOOST_REQUIRE_EXCEPTION(c.control->push_block( br, bad_block_btf.get(), {}, trx_meta_cache_lookup{} ), fc::exception,
       [] (const fc::exception &ex)->bool {
          return ex.to_detail_string().find("block signed by unexpected key") != std::string::npos;
       });
@@ -496,6 +496,7 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
    {
       auto b = irreversible.control->fetch_block_by_id( fork_first_block_id );
       BOOST_REQUIRE( b && b->calculate_id() == fork_first_block_id );
+      BOOST_TEST( irreversible.control->block_exists(fork_first_block_id) );
    }
 
    main.produce_block();
@@ -509,6 +510,7 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
    {
       auto b = irreversible.control->fetch_block_by_id( fork_first_block_id );
       BOOST_REQUIRE( !b );
+      BOOST_TEST( irreversible.control->block_exists(fork_first_block_id) );
    }
 
 } FC_LOG_AND_RETHROW()

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -2252,12 +2252,12 @@ BOOST_AUTO_TEST_CASE( block_validation_after_stage_1_test ) { try {
    tester2.produce_block();
 
    // Push the block with delayed transaction to the second chain
-   auto bsf = tester2.control->create_block_state_future( copy_b->calculate_id(), copy_b );
+   auto btf = tester2.control->create_block_token_future( copy_b->calculate_id(), copy_b );
    tester2.control->abort_block();
    controller::block_report br;
 
    // The block is invalidated
-   BOOST_REQUIRE_EXCEPTION(tester2.control->push_block( br, bsf.get(), {}, trx_meta_cache_lookup{} ),
+   BOOST_REQUIRE_EXCEPTION(tester2.control->push_block( br, btf.get(), {}, trx_meta_cache_lookup{} ),
       fc::exception,
       fc_exception_message_starts_with("transaction cannot be delayed")
    );

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -78,6 +78,20 @@ auto create_test_block_state( deque<transaction_metadata_ptr> trx_metas ) {
    return bsp;
 }
 
+using branch_type_legacy = fork_database<block_state_legacy_ptr>::branch_type;
+
+template<class BRANCH_TYPE>
+void add_forked( unapplied_transaction_queue& queue, const BRANCH_TYPE& forked_branch ) {
+   // forked_branch is in reverse order
+   for( auto ritr = forked_branch.rbegin(), rend = forked_branch.rend(); ritr != rend; ++ritr ) {
+      const auto& bsptr = *ritr;
+      for( auto itr = bsptr->trxs_metas().begin(), end = bsptr->trxs_metas().end(); itr != end; ++itr ) {
+         const auto& trx = *itr;
+         queue.add_forked(trx);
+      }
+   }
+}
+
 // given a current itr make sure expected number of items are iterated over
 void verify_order( unapplied_transaction_queue& q, unapplied_transaction_queue::iterator itr, size_t expected ) {
    size_t size = 0;
@@ -136,7 +150,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_test ) try {
    auto bs1 = create_test_block_state( { trx1, trx2 } );
    auto bs2 = create_test_block_state( { trx3, trx4, trx5 } );
    auto bs3 = create_test_block_state( { trx6 } );
-   q.add_forked( branch_type_legacy{ bs3, bs2, bs1, bs1 } ); // bs1 duplicate ignored
+   add_forked( q, branch_type_legacy{ bs3, bs2, bs1, bs1 } ); // bs1 duplicate ignored
    BOOST_CHECK( q.size() == 6u );
    BOOST_REQUIRE( next( q ) == trx1 );
    BOOST_CHECK( q.size() == 5u );
@@ -155,9 +169,9 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_test ) try {
 
    // fifo forked
    auto bs4 = create_test_block_state( { trx7 } );
-   q.add_forked( branch_type_legacy{ bs1 } );
-   q.add_forked( branch_type_legacy{ bs3, bs2 } );
-   q.add_forked( branch_type_legacy{ bs4 } );
+   add_forked( q, branch_type_legacy{ bs1 } );
+   add_forked( q, branch_type_legacy{ bs3, bs2 } );
+   add_forked( q, branch_type_legacy{ bs4 } );
    BOOST_CHECK( q.size() == 7u );
    BOOST_REQUIRE( next( q ) == trx1 );
    BOOST_CHECK( q.size() == 6u );
@@ -189,10 +203,10 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_test ) try {
    // fifo forked, multi forks
    auto bs5 = create_test_block_state( { trx11, trx12, trx13 } );
    auto bs6 = create_test_block_state( { trx11, trx15 } );
-   q.add_forked( branch_type_legacy{ bs3, bs2, bs1 } );
-   q.add_forked( branch_type_legacy{ bs4 } );
-   q.add_forked( branch_type_legacy{ bs3, bs2 } ); // dups ignored
-   q.add_forked( branch_type_legacy{ bs6, bs5 } );
+   add_forked( q, branch_type_legacy{ bs3, bs2, bs1 } );
+   add_forked( q, branch_type_legacy{ bs4 } );
+   add_forked( q, branch_type_legacy{ bs3, bs2 } ); // dups ignored
+   add_forked( q, branch_type_legacy{ bs6, bs5 } );
    BOOST_CHECK_EQUAL( q.size(), 11u );
    BOOST_REQUIRE( next( q ) == trx1 );
    BOOST_CHECK( q.size() == 10u );
@@ -220,10 +234,10 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_test ) try {
    BOOST_CHECK( q.empty() );
 
    // altogether, order fifo: forked, aborted
-   q.add_forked( branch_type_legacy{ bs3, bs2, bs1 } );
+   add_forked( q, branch_type_legacy{ bs3, bs2, bs1 } );
    q.add_aborted( { trx9, trx14 } );
    q.add_aborted( { trx18, trx19 } );
-   q.add_forked( branch_type_legacy{ bs6, bs5, bs4 } );
+   add_forked( q, branch_type_legacy{ bs6, bs5, bs4 } );
    // verify order
    verify_order( q, q.begin(), 15 );
    // verify type order
@@ -289,7 +303,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_test ) try {
    BOOST_REQUIRE( next( q ) == trx22 );
    BOOST_CHECK( q.empty() );
 
-   q.add_forked( branch_type_legacy{ bs3, bs2, bs1 } );
+   add_forked( q, branch_type_legacy{ bs3, bs2, bs1 } );
    q.add_aborted( { trx9, trx11 } );
    q.clear();
    BOOST_CHECK( q.empty() );


### PR DESCRIPTION
- Transition from dpos to instant-finality on the block after `set_finalizer` host function call. This is a temporary method of transition until we work out the algorithm to use in production.
  - `fork_database` switched over after block with `set_finalizer` call.
- Add `block_token` as a wrapper of `block_state_ptr` and `block_state_legacy_ptr`.
  - `block_state` no longer used outside of chain library except for leap-util `blocklog_actions::read_log` which will be fixed by #2083 
- Enable `instant-finality` `nodeos_run_test.py` integration test which tests transition.
- Performance improvement via `controller::block_exists` instead of always pulling the complete block out of the block log.
- Fixes producer schedule switch bug after instant-finality is enabled.
- LIB does not advance after switching to instant-finality. This is expected as we are not generating vote messages yet.

Resolves #2045 