### PR TITLE
IF: Unification: Sign finalizer_digest of received block header and send out vote

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2832,21 +2832,16 @@ struct controller_impl {
 
       // A vote is created and signed by each finalizer configured on the node that
       // in active finalizer policy
-#warning possible optimization: when setting finalizer policy, update finalizer_keys_on_the_node to indicate if it is active to save going over bhs.finalizer_policy->finalizers
-      // go over each active finalizer and check if it is configured on the node
       for (const auto& f: bhs.finalizer_policy->finalizers) {
          auto it = finalizer_keys_on_the_node.find( f.public_key );
          if( it != finalizer_keys_on_the_node.end() ) {
             const auto& private_key = it->second;
+            const auto& digest = bhs.compute_finalizer_digest();
 
-            // signing can take long time, do it asynchronously
-            auto sig_fut = post_async_task(thread_pool.get_executor(),
-                                           [&]() {
-                                              const auto& digest = bhs.compute_finalizer_digest();
-                                              return private_key.sign(std::vector<uint8_t>(digest.data(), digest.data() + digest.data_size())); });
+            auto sig =  private_key.sign(std::vector<uint8_t>(digest.data(), digest.data() + digest.data_size()));
 
             // construct the vote message
-            hs_vote_message vote{ bhs.id, strong, private_key.get_public_key(), sig_fut.get() };
+            hs_vote_message vote{ bhs.id, strong, private_key.get_public_key(), sig };
 
             // net plugin subscribed this signal. it will broadcast the vote message
             // on receiving the signal
@@ -3436,7 +3431,7 @@ struct controller_impl {
       wasmif.code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
    }
 
-   void set_finalizer_keys_on_the_node(const bls_pub_priv_key_map_t finalizer_keys) {
+   void set_finalizer_keys_on_the_node(const bls_pub_priv_key_map_t& finalizer_keys) {
       for (const auto& k : finalizer_keys) {
          finalizer_keys_on_the_node[bls_public_key{k.first}] = bls_private_key{k.second};
       }
@@ -4496,7 +4491,7 @@ void controller::code_block_num_last_used(const digest_type& code_hash, uint8_t 
    return my->code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
 }
 
-void controller::set_finalizer_keys_on_the_node(const bls_pub_priv_key_map_t finalizer_keys) {
+void controller::set_finalizer_keys_on_the_node(const bls_pub_priv_key_map_t& finalizer_keys) {
    my->set_finalizer_keys_on_the_node(finalizer_keys);
 }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -884,7 +884,7 @@ struct controller_impl {
    named_thread_pool<chain>        thread_pool;
    deep_mind_handler*              deep_mind_logger = nullptr;
    bool                            okay_to_print_integrity_hash_on_stop = false;
-   bls_key_map_t                   finalizer_keys_on_the_node;
+   bls_key_map_t                   node_finalizer_keys;
 
    thread_local static platform_timer timer; // a copy for main thread and each read-only thread
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
@@ -2833,8 +2833,8 @@ struct controller_impl {
       // A vote is created and signed by each finalizer configured on the node that
       // in active finalizer policy
       for (const auto& f: bhs.finalizer_policy->finalizers) {
-         auto it = finalizer_keys_on_the_node.find( f.public_key );
-         if( it != finalizer_keys_on_the_node.end() ) {
+         auto it = node_finalizer_keys.find( f.public_key );
+         if( it != node_finalizer_keys.end() ) {
             const auto& private_key = it->second;
             const auto& digest = bhs.compute_finalizer_digest();
 
@@ -3431,9 +3431,9 @@ struct controller_impl {
       wasmif.code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
    }
 
-   void set_finalizer_keys_on_the_node(const bls_pub_priv_key_map_t& finalizer_keys) {
+   void set_node_finalizer_keys(const bls_pub_priv_key_map_t& finalizer_keys) {
       for (const auto& k : finalizer_keys) {
-         finalizer_keys_on_the_node[bls_public_key{k.first}] = bls_private_key{k.second};
+         node_finalizer_keys[bls_public_key{k.first}] = bls_private_key{k.second};
       }
    }
 
@@ -4491,8 +4491,8 @@ void controller::code_block_num_last_used(const digest_type& code_hash, uint8_t 
    return my->code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
 }
 
-void controller::set_finalizer_keys_on_the_node(const bls_pub_priv_key_map_t& finalizer_keys) {
-   my->set_finalizer_keys_on_the_node(finalizer_keys);
+void controller::set_node_finalizer_keys(const bls_pub_priv_key_map_t& finalizer_keys) {
+   my->set_node_finalizer_keys(finalizer_keys);
 }
 
 /// Protocol feature activation handlers:

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -317,6 +317,15 @@ struct block_data_t {
       }, v);
    }
 
+   block_state_ptr fork_db_fetch_bsp_by_num(uint32_t block_num) const {
+      return std::visit(overloaded{
+                           [](const block_data_legacy_t&) -> block_state_ptr { return nullptr; },
+                           [&](const block_data_new_t& bd) -> block_state_ptr {
+                              auto bsp = bd.fork_db.search_on_branch(bd.fork_db.head()->id(), block_num);
+                              return bsp; }
+                       }, v);
+   }
+
    template <class R, class F>
    R apply(F& f) {
       if constexpr (std::is_same_v<void, R>)
@@ -2978,22 +2987,22 @@ struct controller_impl {
       } FC_CAPTURE_AND_RETHROW();
    } /// apply_block
 
-   void create_and_send_vote_msg(const block_header_state& bhs) {
+   void create_and_send_vote_msg(const block_state_ptr& bsp) {
 #warning use decide_vote() for strong after it is implementd by https://github.com/AntelopeIO/leap/issues/2070
       bool strong = true;
 
       // A vote is created and signed by each finalizer configured on the node that
       // in active finalizer policy
-      for (const auto& f: bhs.active_finalizer_policy->finalizers) {
+      for (const auto& f: bsp->active_finalizer_policy->finalizers) {
          auto it = node_finalizer_keys.find( f.public_key );
          if( it != node_finalizer_keys.end() ) {
             const auto& private_key = it->second;
-            const auto& digest = bhs.compute_finalizer_digest();
+            const auto& digest = bsp->compute_finalizer_digest();
 
             auto sig =  private_key.sign(std::vector<uint8_t>(digest.data(), digest.data() + digest.data_size()));
 
             // construct the vote message
-            hs_vote_message vote{ bhs.id, strong, private_key.get_public_key(), sig };
+            hs_vote_message vote{ bsp->id(), strong, private_key.get_public_key(), sig };
 
             // net plugin subscribed this signal. it will broadcast the vote message
             // on receiving the signal
@@ -3025,6 +3034,17 @@ struct controller_impl {
       return block_token{bsp};
    }
 
+   void integrate_received_qc_to_block(const block_id_type& id, const signed_block_ptr& b) {
+#warning validate received QC before integrate it: https://github.com/AntelopeIO/leap/issues/2071
+      // extract QC from block extensions
+      auto block_exts = b->validate_and_extract_extensions();
+      if( block_exts.count(quorum_certificate_extension::extension_id()) > 0 ) {
+         const auto& qc_ext = std::get<quorum_certificate_extension>(block_exts. lower_bound(quorum_certificate_extension::extension_id())->second);
+         auto last_qc_block_bsp = block_data.fork_db_fetch_bsp_by_num( qc_ext.qc.block_height );
+         last_qc_block_bsp->valid_qc = qc_ext.qc.qc;
+      }
+   }
+
    // thread safe, expected to be called from thread other than the main thread
    block_token create_block_state_i( const block_id_type& id, const signed_block_ptr& b, const block_header_state& prev ) {
       auto trx_mroot = calculate_trx_merkle( b->transactions, true );
@@ -3045,6 +3065,12 @@ struct controller_impl {
 
       EOS_ASSERT( id == bsp->id(), block_validate_exception,
                   "provided id ${id} does not match block id ${bid}", ("id", id)("bid", bsp->id()) );
+
+      create_and_send_vote_msg(bsp);
+
+      // integrate the received QC into the claimed block
+      integrate_received_qc_to_block(id, b);
+
       return block_token{bsp};
    }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3041,6 +3041,7 @@ struct controller_impl {
       if( block_exts.count(quorum_certificate_extension::extension_id()) > 0 ) {
          const auto& qc_ext = std::get<quorum_certificate_extension>(block_exts. lower_bound(quorum_certificate_extension::extension_id())->second);
          auto last_qc_block_bsp = block_data.fork_db_fetch_bsp_by_num( qc_ext.qc.block_height );
+#warning a mutex might be needed for updating valid_pc
          last_qc_block_bsp->valid_qc = qc_ext.qc.qc;
       }
    }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2984,7 +2984,7 @@ struct controller_impl {
 
       // A vote is created and signed by each finalizer configured on the node that
       // in active finalizer policy
-      for (const auto& f: bhs.finalizer_policy->finalizers) {
+      for (const auto& f: bhs.active_finalizer_policy->finalizers) {
          auto it = node_finalizer_keys.find( f.public_key );
          if( it != node_finalizer_keys.end() ) {
             const auto& private_key = it->second;

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -61,6 +61,7 @@ struct block_header_state {
    flat_map<uint32_t, finalizer_policy_ptr> finalizer_policies;
 
    // ------ functions -----------------------------------------------------------------
+#warning TDDO https://github.com/AntelopeIO/leap/issues/2080
    digest_type           compute_finalizer_digest() const { return id; };
    block_timestamp_type  timestamp() const { return header.timestamp; }
    account_name          producer() const  { return header.producer; }

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -61,7 +61,7 @@ struct block_header_state {
    flat_map<uint32_t, finalizer_policy_ptr> finalizer_policies;
 
    // ------ functions -----------------------------------------------------------------
-   digest_type           compute_finalizer_digest() const;
+   digest_type           compute_finalizer_digest() const { return id; };
    block_timestamp_type  timestamp() const { return header.timestamp; }
    account_name          producer() const  { return header.producer; }
    const block_id_type&  previous() const  { return header.previous; }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -384,7 +384,7 @@ namespace eosio::chain {
       void set_to_read_window();
       bool is_write_window() const;
       void code_block_num_last_used(const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, uint32_t block_num);
-      void set_finalizer_keys_on_the_node(const bls_pub_priv_key_map_t finalizer_keys);
+      void set_finalizer_keys_on_the_node(const bls_pub_priv_key_map_t& finalizer_keys);
 
       private:
          friend class apply_context;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -362,6 +362,7 @@ namespace eosio::chain {
          signal<void(const block_signal_params&)>  accepted_block;
          signal<void(const block_signal_params&)>  irreversible_block;
          signal<void(std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&>)> applied_transaction;
+         signal<void(const hs_vote_message&)>      voted_block;
 
          const apply_handler* find_apply_handler( account_name contract, scope_name scope, action_name act )const;
          wasm_interface& get_wasm_interface();
@@ -383,6 +384,7 @@ namespace eosio::chain {
       void set_to_read_window();
       bool is_write_window() const;
       void code_block_num_last_used(const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, uint32_t block_num);
+      void set_finalizer_keys_on_the_node(const bls_pub_priv_key_map_t finalizer_keys);
 
       private:
          friend class apply_context;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -384,7 +384,7 @@ namespace eosio::chain {
       void set_to_read_window();
       bool is_write_window() const;
       void code_block_num_last_used(const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, uint32_t block_num);
-      void set_finalizer_keys_on_the_node(const bls_pub_priv_key_map_t& finalizer_keys);
+      void set_node_finalizer_keys(const bls_pub_priv_key_map_t& finalizer_keys);
 
       private:
          friend class apply_context;

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -16,9 +16,10 @@ namespace eosio::chain::plugin_interface {
    namespace channels {
       using rejected_block         = channel_decl<struct rejected_block_tag,        signed_block_ptr>;
       using accepted_block_header  = channel_decl<struct accepted_block_header_tag, block_signal_params>;
-      using accepted_block         = channel_decl<struct accepted_block_tag, block_signal_params>;
-      using irreversible_block     = channel_decl<struct irreversible_block_tag,block_signal_params>;
+      using accepted_block         = channel_decl<struct accepted_block_tag,        block_signal_params>;
+      using irreversible_block     = channel_decl<struct irreversible_block_tag,    block_signal_params>;
       using applied_transaction    = channel_decl<struct applied_transaction_tag,   transaction_trace_ptr>;
+      using voted_block            = channel_decl<struct voted_block_tag,           hs_vote_message>;
    }
 
    namespace methods {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -534,6 +534,7 @@ namespace eosio {
 
       void on_accepted_block_header( const signed_block_ptr& block, const block_id_type& id );
       void on_accepted_block();
+      void on_voted_block ( const hs_vote_message& vote );
 
       void transaction_ack(const std::pair<fc::exception_ptr, packed_transaction_ptr>&);
       void on_irreversible_block( const block_id_type& id, uint32_t block_num );
@@ -3933,6 +3934,11 @@ namespace eosio {
       on_active_schedule(chain_plug->chain().active_producers());
    }
 
+   // called from application thread
+   void net_plugin_impl::on_voted_block(const hs_vote_message& vote) {
+      bcast_hs_message(std::nullopt, chain::hs_message{ vote });
+   }
+
    void net_plugin_impl::bcast_hs_message( const std::optional<uint32_t>& exclude_peer, const chain::hs_message& msg ) {
       fc_dlog(logger, "sending hs msg: ${msg}", ("msg", msg));
 
@@ -4359,6 +4365,9 @@ namespace eosio {
             my->on_irreversible_block( id, block->block_num() );
          } );
 
+         cc.voted_block.connect( [my = shared_from_this()]( const hs_vote_message& vote ) {
+            my->on_voted_block(vote);
+         } );
       }
 
       {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -492,7 +492,7 @@ public:
 
    using signature_provider_type = signature_provider_plugin::signature_provider_type;
    std::map<chain::public_key_type, signature_provider_type> _signature_providers;
-   chain::bls_pub_priv_key_map_t                  _finalizer_keys; // public, private
+   chain::bls_pub_priv_key_map_t                     _finalizer_keys; // public, private
    std::set<chain::account_name>                     _producers;
    boost::asio::deadline_timer                       _timer;
    block_timing_util::producer_watermarks            _producer_watermarks;
@@ -1340,7 +1340,7 @@ void producer_plugin_impl::plugin_startup() {
          EOS_ASSERT(_producers.empty() || chain_plug->accept_transactions(), plugin_config_exception,
                     "node cannot have any producer-name configured because no block production is possible with no [api|p2p]-accepted-transactions");
 
-         chain.set_finalizer_keys_on_the_node(_finalizer_keys);
+         chain.set_node_finalizer_keys(_finalizer_keys);
 
 #warning TODO remove create_pacemaker
          chain.create_pacemaker(_producers, std::move(_finalizer_keys), hotstuff_logger);

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1340,6 +1340,9 @@ void producer_plugin_impl::plugin_startup() {
          EOS_ASSERT(_producers.empty() || chain_plug->accept_transactions(), plugin_config_exception,
                     "node cannot have any producer-name configured because no block production is possible with no [api|p2p]-accepted-transactions");
 
+         chain.set_finalizer_keys_on_the_node(_finalizer_keys);
+
+#warning TODO remove create_pacemaker
          chain.create_pacemaker(_producers, std::move(_finalizer_keys), hotstuff_logger);
          _finalizer_keys.clear();
 


### PR DESCRIPTION
* Controller signs `finalizer_digest` of received block and emits a signal to net plugin
* Net plugin broadcasts the vote on receiving the signal

Note: 
* This PR only signs strong finalizer_digest.
* Calling of `create_and_send_vote_msg` will be in another final PR.

Resolved https://github.com/AntelopeIO/leap/issues/2069