### PR TITLE
IF: Remove `fork_database::get_block_header` and simplify `create_block_s…

### DIFF
--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -39,8 +39,7 @@ namespace eosio::chain {
       void open( validator_t& validator );
       void close();
 
-      bhsp get_block_header( const block_id_type& id ) const;
-      bsp  get_block( const block_id_type& id ) const;
+      bsp  get_block( const block_id_type& id, bool check_root = false ) const;
 
       /**
        *  Purges any existing blocks from the fork database and resets the root block_header_state to the provided value.


### PR DESCRIPTION
Resolves #2283 .

Remove `fork_database::get_block_header` and simplify `create_block_state_i`.

Make sure we can still load Leap V5 fork databases from disk.

The only difference between `fork_database::get_block_header` and `fork_database::get_block` was that the former checked the `root`. It was also relying on the fact that `block_state` is `public block_header_state` to return the same pointer downcasted.

I have added an optional `check_root` parameter to `fork_database::get_block` instead.

This allowed to make `create_block_state_i` a template instead of having two separate implementations.