### PR TITLE
[5.0] more robust `chain_api_plugin` check in `producer_plugin`

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1214,7 +1214,7 @@ void producer_plugin_impl::plugin_initialize(const boost::program_options::varia
    } else if (_producers.empty()) {
       //appbase initializes configured plugins before auto-start plugins, so if chain_api_plugin is enabled it's
       // initialized before producer_plugin (i.e. before this code here)
-      if (app().get_plugin("eosio::chain_api_plugin").get_state() == abstract_plugin::initialized) {
+      if (abstract_plugin* capi = app().find_plugin("eosio::chain_api_plugin"); capi && capi->get_state() == abstract_plugin::initialized) {
          // default to 3 threads for non producer nodes running chain_api_plugin if not specified
          _ro_thread_pool_size = 3;
          ilog("chain_api_plugin configured, defaulting read-only-threads to ${t}", ("t", _ro_thread_pool_size));

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1212,14 +1212,12 @@ void producer_plugin_impl::plugin_initialize(const boost::program_options::varia
    if (options.count("read-only-threads")) {
       _ro_thread_pool_size = options.at("read-only-threads").as<uint32_t>();
    } else if (_producers.empty()) {
-      if (options.count("plugin")) {
-         const auto& v = options.at("plugin").as<std::vector<std::string>>();
-         auto        i = std::find_if(v.cbegin(), v.cend(), [](const std::string& p) { return p == "eosio::chain_api_plugin"; });
-         if (i != v.cend()) {
-            // default to 3 threads for non producer nodes running chain_api_plugin if not specified
-            _ro_thread_pool_size = 3;
-            ilog("chain_api_plugin configured, defaulting read-only-threads to ${t}", ("t", _ro_thread_pool_size));
-         }
+      //appbase initializes configured plugins before auto-start plugins, so if chain_api_plugin is enabled it's
+      // initialized before producer_plugin (i.e. before this code here)
+      if (app().get_plugin("eosio::chain_api_plugin").get_state() == abstract_plugin::initialized) {
+         // default to 3 threads for non producer nodes running chain_api_plugin if not specified
+         _ro_thread_pool_size = 3;
+         ilog("chain_api_plugin configured, defaulting read-only-threads to ${t}", ("t", _ro_thread_pool_size));
       }
    }
    EOS_ASSERT(producer_plugin::test_mode_ || _ro_thread_pool_size == 0 || _producers.empty(), plugin_config_exception,


### PR DESCRIPTION
Make this check more robust to handle the esoteric config pattern in #2104

Tests needed?