### PR TITLE
improve `authority_checker`'s performance: don't use exceptions as flow control for non-existing permissions

### DIFF
--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -479,7 +479,12 @@ namespace eosio { namespace chain {
 
       auto effective_provided_delay =  (provided_delay >= delay_max_limit) ? fc::microseconds::maximum() : provided_delay;
 
-      auto checker = make_auth_checker( [&](const permission_level& p){ return get_permission(p).auth; },
+      auto checker = make_auth_checker( [&](const permission_level& p) -> const shared_authority* {
+                                          if(const permission_object* po = find_permission(p))
+                                             return &po->auth;
+                                          else
+                                             return nullptr;
+                                        },
                                         _control.get_global_properties().configuration.max_authority_depth,
                                         provided_keys,
                                         provided_permissions,
@@ -580,7 +585,12 @@ namespace eosio { namespace chain {
 
       auto delay_max_limit = fc::seconds( _control.get_global_properties().configuration.max_transaction_delay );
 
-      auto checker = make_auth_checker( [&](const permission_level& p){ return get_permission(p).auth; },
+      auto checker = make_auth_checker( [&](const permission_level& p) -> const shared_authority* {
+                                          if(const permission_object* po = find_permission(p))
+                                             return &po->auth;
+                                          else
+                                             return nullptr;
+                                        },
                                         _control.get_global_properties().configuration.max_authority_depth,
                                         provided_keys,
                                         provided_permissions,
@@ -611,7 +621,12 @@ namespace eosio { namespace chain {
                                                                        fc::microseconds provided_delay
                                                                      )const
    {
-      auto checker = make_auth_checker( [&](const permission_level& p){ return get_permission(p).auth; },
+      auto checker = make_auth_checker( [&](const permission_level& p) -> const shared_authority* {
+                                          if(const permission_object* po = find_permission(p))
+                                             return &po->auth;
+                                          else
+                                             return nullptr;
+                                        },
                                         _control.get_global_properties().configuration.max_authority_depth,
                                         candidate_keys,
                                         {},

--- a/libraries/chain/include/eosio/chain/authority_checker.hpp
+++ b/libraries/chain/include/eosio/chain/authority_checker.hpp
@@ -236,7 +236,7 @@ namespace detail {
 
                      auto res = cached_permissions.emplace( permission.permission, being_evaluated );
                      itr = res.first;
-                     r = checker.satisfied( std::forward<decltype(*auth)>(*auth), cached_permissions, recursion_depth + 1 );
+                     r = checker.satisfied( *auth, cached_permissions, recursion_depth + 1 );
 
                      if( r ) {
                         total_weight += permission.weight;

--- a/libraries/chain/include/eosio/chain/authority_checker.hpp
+++ b/libraries/chain/include/eosio/chain/authority_checker.hpp
@@ -28,8 +28,8 @@ namespace detail {
     * then determine whether that list of keys is sufficient to satisfy the authority. This class takes a list of keys and
     * provides the @ref satisfied method to determine whether that list of keys satisfies a provided authority.
     *
-    * @tparam F A callable which takes a single argument of type @ref AccountPermission and returns the corresponding
-    * authority
+    * @tparam F A callable which takes a single argument of type @ref AccountPermission and returns a pointer to
+    * the corresponding authority if it exists, or a nullptr.
     */
    template<typename PermissionToAuthorityFunc>
    class authority_checker {
@@ -225,19 +225,18 @@ namespace detail {
                      bool r = false;
                      typename permission_cache_type::iterator itr = cached_permissions.end();
 
-                     bool propagate_error = false;
+                     std::invoke_result_t<decltype(checker.permission_to_authority), const permission_level> auth = nullptr;
                      try {
-                        auto&& auth = checker.permission_to_authority( permission.permission );
-                        propagate_error = true;
-                        auto res = cached_permissions.emplace( permission.permission, being_evaluated );
-                        itr = res.first;
-                        r = checker.satisfied( std::forward<decltype(auth)>(auth), cached_permissions, recursion_depth + 1 );
-                     } catch( const permission_query_exception& ) {
-                        if( propagate_error )
-                           throw;
-                        else
-                           return total_weight; // if the permission doesn't exist, continue without it
+                        auth = checker.permission_to_authority( permission.permission );
                      }
+                     catch( const permission_query_exception& ) {}
+                     //permission was either invalid (threw permission_query_exception), or wasn't found
+                     if(!auth)
+                        return total_weight;
+
+                     auto res = cached_permissions.emplace( permission.permission, being_evaluated );
+                     itr = res.first;
+                     r = checker.satisfied( std::forward<decltype(*auth)>(*auth), cached_permissions, recursion_depth + 1 );
 
                      if( r ) {
                         total_weight += permission.weight;


### PR DESCRIPTION
Periodically I've seen significant overhead handling exceptions in nodeos while it's live on EOS. It can even approach nearly 10% of main thread time in some of the worst cases. And these exceptions come about even when just applying blocks -- not processing speculative transactions.

What appears to be happening is contracts performing a `send_inline` causing the `authority_checker` to in some situations generate a fury of exceptions for missing `eosio.code` as it counts up weights.

This refactors the `authority_checker` to not lean on an exception to indicate a non-existing permission, a nullptr is returned indicating a non-existing permission instead.