### PR TITLE
IF: Reject blocks with unsupported claims of last QC in block header extension

### DIFF
--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -3,6 +3,8 @@
 #include <eosio/chain/block_state_legacy.hpp>
 #include <eosio/chain/exceptions.hpp>
 
+#include <fc/crypto/bls_utils.hpp>
+
 namespace eosio::chain {
 
 block_state::block_state(const block_header_state& prev, signed_block_ptr b, const protocol_feature_set& pfs,
@@ -86,7 +88,61 @@ std::pair<bool, std::optional<uint32_t>> block_state::aggregate_vote(const hs_vo
       return {};
    }
 }
-   
+
+// Called from net threads
+void block_state::verify_qc(const valid_quorum_certificate& qc) const {
+   const auto& finalizers = active_finalizer_policy->finalizers;
+   auto num_finalizers = finalizers.size();
+
+   // utility to accumulate voted weights
+   auto weights = [&] ( const hs_bitset& votes_bitset ) -> uint64_t {
+      uint64_t sum = 0;
+      auto n = std::min(num_finalizers, votes_bitset.size());
+      for (auto i = 0u; i < n; ++i) {
+         if( votes_bitset[i] ) { // ith finalizer voted
+            sum += finalizers[i].weight;
+         }
+      }
+      return sum;
+   };
+
+   // compute strong and weak accumulated weights
+   auto strong_weights = qc._strong_votes ? weights( *qc._strong_votes ) : 0;
+   auto weak_weights = qc._weak_votes ? weights( *qc._weak_votes ) : 0;
+
+   // verfify quorum is met
+   if( qc.is_strong() ) {
+      EOS_ASSERT( strong_weights >= active_finalizer_policy->threshold,  block_validate_exception, "strong quorum is not met, strong_weights: ${s}, threshold: ${t}", ("s", strong_weights)("t", active_finalizer_policy->threshold) );
+   } else {
+      EOS_ASSERT( strong_weights + weak_weights >= active_finalizer_policy->threshold,  block_validate_exception, "weak quorum is not met, strong_weights: ${s}, weak_weights: ${w}, threshold: ${t}", ("s", strong_weights)("w", weak_weights)("t", active_finalizer_policy->threshold) );
+   }
+
+   std::vector<bls_public_key> pubkeys;
+   std::vector<std::vector<uint8_t>> digests;
+
+   // utility to aggregate public keys and digests for verification
+   auto prepare_pubkeys_digests = [&] ( const auto& votes_bitset, const auto& digest ) {
+      auto n = std::min(num_finalizers, votes_bitset.size());
+      for (auto i = 0u; i < n; ++i) {
+         if( votes_bitset[i] ) { // ith finalizer voted the digest
+            pubkeys.emplace_back(finalizers[i].public_key);
+            digests.emplace_back(std::vector<uint8_t>{digest.data(), digest.data() + digest.data_size()});
+         }
+      }
+   };
+
+   // aggregate public keys and digests for strong and weak votes
+   if( qc._strong_votes ) {
+      prepare_pubkeys_digests(*qc._strong_votes, strong_digest);
+   }
+   if( qc._weak_votes ) {
+      prepare_pubkeys_digests(*qc._weak_votes, weak_digest);
+   }
+
+   // validate aggregayed signature
+   EOS_ASSERT( fc::crypto::blslib::aggregate_verify( pubkeys, digests, qc._sig ),  block_validate_exception, "signature validation failed" );
+}
+
 std::optional<quorum_certificate> block_state::get_best_qc() const {
    auto block_number = block_num();
 

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -112,9 +112,15 @@ void block_state::verify_qc(const valid_quorum_certificate& qc) const {
 
    // verfify quorum is met
    if( qc.is_strong() ) {
-      EOS_ASSERT( strong_weights >= active_finalizer_policy->threshold,  block_validate_exception, "strong quorum is not met, strong_weights: ${s}, threshold: ${t}", ("s", strong_weights)("t", active_finalizer_policy->threshold) );
+      EOS_ASSERT( strong_weights >= active_finalizer_policy->threshold,
+                  block_validate_exception,
+                  "strong quorum is not met, strong_weights: ${s}, threshold: ${t}",
+                  ("s", strong_weights)("t", active_finalizer_policy->threshold) );
    } else {
-      EOS_ASSERT( strong_weights + weak_weights >= active_finalizer_policy->threshold,  block_validate_exception, "weak quorum is not met, strong_weights: ${s}, weak_weights: ${w}, threshold: ${t}", ("s", strong_weights)("w", weak_weights)("t", active_finalizer_policy->threshold) );
+      EOS_ASSERT( strong_weights + weak_weights >= active_finalizer_policy->threshold,
+                  block_validate_exception,
+                  "weak quorum is not met, strong_weights: ${s}, weak_weights: ${w}, threshold: ${t}",
+                  ("s", strong_weights)("w", weak_weights)("t", active_finalizer_policy->threshold) );
    }
 
    std::vector<bls_public_key> pubkeys;
@@ -123,6 +129,8 @@ void block_state::verify_qc(const valid_quorum_certificate& qc) const {
    // utility to aggregate public keys and digests for verification
    auto prepare_pubkeys_digests = [&] ( const auto& votes_bitset, const auto& digest ) {
       auto n = std::min(num_finalizers, votes_bitset.size());
+      pubkeys.reserve(n);
+      digests.reserve(n);
       for (auto i = 0u; i < n; ++i) {
          if( votes_bitset[i] ) { // ith finalizer voted the digest
             pubkeys.emplace_back(finalizers[i].public_key);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3037,7 +3037,7 @@ struct controller_impl {
          auto bsp = fork_db_fetch_bsp_by_num( qc_ext.qc.block_height );
          // Only save the QC from block extension if the claimed block does not
          // have valid_qc or the new QC is better than valid_qc.
-         if( !bsp->valid_qc || (qc_ext.qc.qc.is_strong() && bsp->valid_qc->is_weak()) ) {
+         if( bsp && !bsp->valid_qc || (qc_ext.qc.qc.is_strong() && bsp->valid_qc->is_weak()) ) {
             bsp->valid_qc = qc_ext.qc.qc;
 
             if( bsp->valid_qc->is_strong() && bsp->core.final_on_strong_qc_block_num ) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3030,87 +3030,162 @@ struct controller_impl {
    }
 
    void integrate_received_qc_to_block(const block_id_type& id, const signed_block_ptr& b) {
-      // extract QC from block extensions
-      auto block_exts = b->validate_and_extract_extensions();
-      if( block_exts.count(quorum_certificate_extension::extension_id()) > 0 ) {
-         const auto& qc_ext = std::get<quorum_certificate_extension>(block_exts. lower_bound(quorum_certificate_extension::extension_id())->second);
-         auto bsp = fork_db_fetch_bsp_by_num( qc_ext.qc.block_height );
-         // Only save the QC from block extension if the claimed block does not
-         // have valid_qc or the new QC is better than valid_qc.
-         if( bsp && !bsp->valid_qc || (qc_ext.qc.qc.is_strong() && bsp->valid_qc->is_weak()) ) {
-            bsp->valid_qc = qc_ext.qc.qc;
+      // extract QC from block extension
+      const auto& block_exts = b->validate_and_extract_extensions();
+      if( block_exts.count(quorum_certificate_extension::extension_id()) == 0 ) {
+         return;
+      }
+      const auto& qc_ext = std::get<quorum_certificate_extension>(block_exts. lower_bound(quorum_certificate_extension::extension_id())->second);
+      const auto& new_qc = qc_ext.qc.qc;
 
-            if( bsp->valid_qc->is_strong() && bsp->core.final_on_strong_qc_block_num ) {
-               // We evaluate a block extension qc and advance lib if strong.
-               // This is done before evaluating the block. It is possible the block
-               // will not be valid or forked out. This is safe because the block is
-               // just acting as a carrier of this info. It doesn't matter if the block
-               // is actually valid as it simply is used as a network message for this data.
-               set_if_irreversible_block_num(*bsp->core.final_on_strong_qc_block_num);
-            }
-         }
+      const auto bsp = fork_db_fetch_bsp_by_num( qc_ext.qc.block_height );
+      if( !bsp ) {
+         return;
+      }
+
+      // Don't save the QC from block extension if the claimed block has a better valid_qc.
+      if (bsp->valid_qc && (bsp->valid_qc->is_strong() || new_qc.is_weak())) {
+         return;
+      }
+
+      // save the QC
+      bsp->valid_qc = new_qc;
+
+      // advance LIB if QC is strong and final_on_strong_qc_block_num has value
+      if( new_qc.is_strong() && bsp->core.final_on_strong_qc_block_num ) {
+         // We evaluate a block extension qc and advance lib if strong.
+         // This is done before evaluating the block. It is possible the block
+         // will not be valid or forked out. This is safe because the block is
+         // just acting as a carrier of this info. It doesn't matter if the block
+         // is actually valid as it simply is used as a network message for this data.
+         set_if_irreversible_block_num(*bsp->core.final_on_strong_qc_block_num);
       }
    }
 
-   // Verify QC claim made by instant_finality_extension in block header extension
+   // Verify QC claim made by instant_finality_extension in header extension
    // and quorum_certificate_extension in block extension are valid.
    // Called from net-threads. It is thread safe as signed_block is never modified
    // after creation.
    void verify_qc_claim( const signed_block_ptr& b, const block_header_state& prev ) {
-      // If block header extension does not have instant_finality_extension,
-      // just return
+      auto block_exts = b->validate_and_extract_extensions();
+
       std::optional<block_header_extension> header_ext = b->extract_header_extension(instant_finality_extension::extension_id());
       if( !header_ext ) {
+         EOS_ASSERT( block_exts.count(quorum_certificate_extension::extension_id()) == 0,
+                     block_validate_exception,
+                     "A block cannot provide QC block extension without QC header extension" );
+
+         // If header extension does not have instant_finality_extension,
+         // do not continue.
          return;
       }
 
-      // If qc_info is not included, just return
       const auto& if_ext = std::get<instant_finality_extension>(*header_ext);
       if( !if_ext.qc_info ) {
+         EOS_ASSERT( block_exts.count(quorum_certificate_extension::extension_id()) == 0,
+                     block_validate_exception,
+                     "A block cannot provide QC block extension without QC claim" );
+
+         // If header extension does not have QC claim,
+         // do not continue.
          return;
       }
 
-      // extract received QC information
-      qc_info_t received_qc_info{ *if_ext.qc_info };
+      // extract QC claim
+      qc_info_t qc_claim{ *if_ext.qc_info };
 
-      // if previous block's header extension has the same claim, just return
-      // (previous block had already validated the claim)
+      // extract previous header extension
       std::optional<block_header_extension> prev_header_ext = prev.header.extract_header_extension(instant_finality_extension::extension_id());
-      if( prev_header_ext ) {
-         auto prev_if_ext = std::get<instant_finality_extension>(*prev_header_ext);
-         if( prev_if_ext.qc_info && prev_if_ext.qc_info->last_qc_block_num == received_qc_info.last_qc_block_num && prev_if_ext.qc_info->is_last_qc_strong == received_qc_info.is_last_qc_strong ) {
-            return;
+
+      // A block should not be able to claim there was a QC on a block that
+      // is prior to the transition to IF.
+      EOS_ASSERT( prev_header_ext,
+                  block_validate_exception,
+                  "Previous header extension must include instant_finality_extension " );
+
+      auto prev_if_ext = std::get<instant_finality_extension>(*prev_header_ext);
+      auto prev_qc_info = prev_if_ext.qc_info;
+
+      // validate QC claim against previous block QC info
+      if( prev_qc_info ) {
+         // new claimed QC block nubmber cannot be smaller than previous block's
+         EOS_ASSERT( qc_claim.last_qc_block_num >= prev_qc_info->last_qc_block_num,
+                     block_validate_exception,
+                     "claimed last_qc_block_num (${n1}) must be equal to or greater than previous block's last_qc_block_num (${n2})",
+                     ("n1", qc_claim.last_qc_block_num)("n2", prev_qc_info->last_qc_block_num) );
+
+         if( qc_claim.last_qc_block_num == prev_qc_info->last_qc_block_num ) {
+            if( qc_claim.is_last_qc_strong == prev_qc_info->is_last_qc_strong ) {
+               // QC block extension is redundant
+               EOS_ASSERT( block_exts.count(quorum_certificate_extension::extension_id()) == 0,
+                           block_validate_exception,
+                           "A block should not provide QC block extension if QC claim is the same as previous block" );
+
+               // if previous block's header extension has the same claim, just return
+               // (previous block already validated the claim)
+               return;
+            }
+
+            // new claimed QC must be stricter than previous if block number is the same
+            EOS_ASSERT( qc_claim.is_last_qc_strong || !prev_qc_info->is_last_qc_strong,
+                        block_validate_exception,
+                        "claimed QC (${s1}) must be stricter than previous block's (${s2}) if block number is the same",
+                       ("s1", qc_claim.is_last_qc_strong)("s2", prev_qc_info->is_last_qc_strong) );
          }
       }
 
-      // extract QC from block extensions
-      auto block_exts = b->validate_and_extract_extensions();
-      EOS_ASSERT( block_exts.count(quorum_certificate_extension::extension_id()) > 0,
-                  block_validate_exception,
-                  "received block has finality header extension but does not have QC block extension" );
-      const auto& qc_ext = std::get<quorum_certificate_extension>(block_exts. lower_bound(quorum_certificate_extension::extension_id())->second);
-      const auto& received_qc = qc_ext.qc;
-      const auto& valid_qc = qc_ext.qc.qc;
+      if( block_exts.count(quorum_certificate_extension::extension_id()) == 0 ) {
+         // If claim is a strong QC and there wasn't already an identical claim
+         // in the previous block (checked earlier), QC proof must be provided
+         EOS_ASSERT( !qc_claim.is_last_qc_strong,
+                     block_validate_exception,
+                     "QC block extension must be provided if the claimed QC block is strong" );
+
+         // Conditions:
+         //    * the claim is that the last QC is a weak QC,
+         //    * it wasn't already satisfied by the claim in the prior block,
+         //    * and there is no block extension
+         // Actions:
+         //    * if it claims a block number lower than that of the current
+         //      last irreversible block, then the new block should be rejected;
+         //    * if it claims a block number greater than that of the current last
+         //      irreversible block, then the new block must have a corresponding
+         //      QC in the extension that must be validated;
+         //    * if it claims a block number exactly equal to that of the current
+         //      last irreversible block number, then the claim of the QC being
+         //      weak can be accepted without a block extension.
+         //
+         EOS_ASSERT( qc_claim.last_qc_block_num == if_irreversible_block_num,
+                     block_validate_exception,
+                     "QC block extension must be included if the claimed QC block is not current irreversible block" );
+
+         return;
+      }
+
+      const auto& qc_ext = std::get<quorum_certificate_extension>(block_exts.lower_bound(quorum_certificate_extension::extension_id())->second);
+      const auto& qc_proof = qc_ext.qc;
 
       // Check QC information in header extension and block extension match
-      EOS_ASSERT( received_qc.block_height == received_qc_info.last_qc_block_num,
+      EOS_ASSERT( qc_proof.block_height == qc_claim.last_qc_block_num,
                   block_validate_exception,
                   "QC block number (${n1}) in block extension does not match last_qc_block_num (${n2}) in header extension",
-                  ("n1", received_qc.block_height)("n2", received_qc_info.last_qc_block_num) );
-      EOS_ASSERT( valid_qc.is_strong() == received_qc_info.is_last_qc_strong,
+                  ("n1", qc_proof.block_height)("n2", qc_claim.last_qc_block_num) );
+
+      // Verify claimed strictness is the same as in proof
+      EOS_ASSERT( qc_proof.qc.is_strong() == qc_claim.is_last_qc_strong,
                   block_validate_exception,
                   "QC is_strong (${s1}) in block extension does not match is_last_qc_strong (${22}) in header extension",
-                  ("s1", valid_qc.is_strong())("s2", received_qc_info.is_last_qc_strong) );
+                  ("s1", qc_proof.qc.is_strong())("s2", qc_claim.is_last_qc_strong) );
 
       // find the claimed block's block state
-      auto claimed_block_bsp = fork_db_fetch_bsp_by_num( received_qc_info.last_qc_block_num );
-      EOS_ASSERT( claimed_block_bsp,
+      auto bsp = fork_db_fetch_bsp_by_num( qc_claim.last_qc_block_num );
+      EOS_ASSERT( bsp,
                   block_validate_exception,
                   "Block state was not found in forkdb for block number ${b}",
-                  ("b", valid_qc.is_strong()) );
+                  ("b", qc_claim.last_qc_block_num) );
 
-      // verify the claims
-      claimed_block_bsp->verify_qc(valid_qc);
+      // verify the QC proof against the claimed block
+      bsp->verify_qc(qc_proof.qc);
    }
 
    // thread safe, expected to be called from thread other than the main thread

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3106,7 +3106,7 @@ struct controller_impl {
       auto claimed_block_bsp = fork_db_fetch_bsp_by_num( received_qc_info.last_qc_block_num );
       EOS_ASSERT( claimed_block_bsp,
                   block_validate_exception,
-                  "Block state was not founf in forkdb for block number ${b}",
+                  "Block state was not found in forkdb for block number ${b}",
                   ("b", valid_qc.is_strong()) );
 
       // verify the claims

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -39,6 +39,7 @@ struct block_state : public block_header_state {     // block_header_state provi
    void                                set_trxs_metas(deque<transaction_metadata_ptr>&& trxs_metas, bool keys_recovered);
    const deque<transaction_metadata_ptr>& trxs_metas()  const { return cached_trxs; }
    std::pair<bool, std::optional<uint32_t>> aggregate_vote(const hs_vote_message& vote); // aggregate vote into pending_qc
+   void verify_qc(const valid_quorum_certificate& qc) const; // verify given qc is valid with respect block_state
 
    using bhs_t  = block_header_state;
    using bhsp_t = block_header_state_ptr;

--- a/unittests/block_state_tests.cpp
+++ b/unittests/block_state_tests.cpp
@@ -1,4 +1,5 @@
 #include <eosio/chain/block_state.hpp>
+#include <eosio/testing/tester.hpp>
 
 #include <fc/exception/exception.hpp>
 #include <fc/crypto/bls_private_key.hpp>
@@ -84,6 +85,211 @@ BOOST_AUTO_TEST_CASE(aggregate_vote_test) try {
 
       hs_vote_message vote {block_id, true, new_public_key, private_key[0].sign(strong_digest_data) };
       BOOST_REQUIRE(!bsp->aggregate_vote(vote).first);
+   }
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(verify_qc_test) try {
+   using namespace eosio::chain;
+   using namespace fc::crypto::blslib;
+
+   // prepare digests
+   digest_type strong_digest(fc::sha256("0000000000000000000000000000002"));
+   std::vector<uint8_t> strong_digest_data(strong_digest.data(), strong_digest.data() + strong_digest.data_size());
+   digest_type weak_digest(fc::sha256("0000000000000000000000000000003"));
+   std::vector<uint8_t> weak_digest_data(weak_digest.data(), weak_digest.data() + weak_digest.data_size());
+
+   // initialize a set of private keys
+   std::vector<bls_private_key> private_key {
+      bls_private_key("PVT_BLS_r4ZpChd87ooyzl6MIkw23k7PRX8xptp7TczLJHCIIW88h/hS"),
+      bls_private_key("PVT_BLS_/l7xzXANaB+GrlTsbZEuTiSOiWTtpBoog+TZnirxUUSaAfCo"),
+      bls_private_key("PVT_BLS_3FoY73Q/gED3ejyg8cvnGqHrMmx4cLKwh/e0sbcsCxpCeqn3")
+   };
+   auto num_finalizers = private_key.size();
+
+   // construct finalizers, with weight 1, 2, 3 respectively
+   std::vector<bls_public_key> public_key(num_finalizers);
+   std::vector<finalizer_authority> finalizers(num_finalizers);
+   for (size_t i = 0; i < num_finalizers; ++i) {
+      public_key[i] = private_key[i].get_public_key();
+      uint64_t weight = i + 1;
+      finalizers[i] = finalizer_authority{ "test", weight, public_key[i] };
+   }
+
+   // consturct a test bsp
+   block_state_ptr bsp = std::make_shared<block_state>();
+   constexpr uint32_t generation = 1;
+   constexpr uint64_t threshold = 4; // 2/3 of total weights of 6
+   bsp->active_finalizer_policy = std::make_shared<finalizer_policy>( generation, threshold, finalizers );
+   bsp->strong_digest = strong_digest;
+   bsp->weak_digest = weak_digest;
+
+   auto bitset_to_vector = [](const hs_bitset& bs) {
+      std::vector<uint32_t> r;
+      r.resize(bs.num_blocks());
+      boost::to_block_range(bs, r.begin());
+      return r;
+   };
+
+   {  // valid strong QC
+      hs_bitset strong_votes(num_finalizers);
+      strong_votes[0] = 1;  // finalizer 0 voted with weight 1
+      strong_votes[2] = 1;  // finalizer 2 voted with weight 3
+
+      bls_signature sig_0 = private_key[0].sign(strong_digest_data);
+      bls_signature sig_2 = private_key[2].sign(strong_digest_data);
+      bls_signature agg_sig;
+      agg_sig = fc::crypto::blslib::aggregate({agg_sig, sig_0});
+      agg_sig = fc::crypto::blslib::aggregate({agg_sig, sig_2});
+
+      // create a valid_quorum_certificate
+      valid_quorum_certificate qc({}, {}, bitset_to_vector(strong_votes), {}, agg_sig);
+
+      BOOST_REQUIRE_NO_THROW( bsp->verify_qc(qc) );
+   }
+
+   {  // valid weak QC
+      hs_bitset strong_votes(num_finalizers);
+      strong_votes[0] = 1;  // finalizer 0 voted with weight 1
+      bls_signature strong_sig = private_key[0].sign(strong_digest_data);
+
+      hs_bitset weak_votes(num_finalizers);
+      weak_votes[2] = 1;  // finalizer 2 voted with weight 3
+      bls_signature weak_sig = private_key[2].sign(weak_digest_data);
+
+      bls_signature agg_sig;
+      agg_sig = fc::crypto::blslib::aggregate({agg_sig, strong_sig});
+      agg_sig = fc::crypto::blslib::aggregate({agg_sig, weak_sig});
+
+      valid_quorum_certificate qc({}, {}, bitset_to_vector(strong_votes), bitset_to_vector(weak_votes), agg_sig);
+      BOOST_REQUIRE_NO_THROW( bsp->verify_qc(qc) );
+   }
+
+   {  // valid strong QC signed by all finalizers
+      hs_bitset strong_votes(num_finalizers);
+      std::vector<bls_signature> sigs(num_finalizers);
+      bls_signature agg_sig;
+
+      for (auto i = 0u; i < num_finalizers; ++i) {
+         strong_votes[i] = 1;
+         sigs[i] = private_key[i].sign(strong_digest_data);
+         agg_sig = fc::crypto::blslib::aggregate({agg_sig, sigs[i]});
+      }
+
+      // create a valid_quorum_certificate
+      valid_quorum_certificate qc({}, {}, bitset_to_vector(strong_votes), {}, agg_sig);
+
+      BOOST_REQUIRE_NO_THROW( bsp->verify_qc(qc) );
+   }
+
+   {  // valid weak QC signed by all finalizers
+      hs_bitset weak_votes(num_finalizers);
+      std::vector<bls_signature> sigs(num_finalizers);
+      bls_signature agg_sig;
+
+      for (auto i = 0u; i < num_finalizers; ++i) {
+         weak_votes[i] = 1;
+         sigs[i] = private_key[i].sign(weak_digest_data);
+         agg_sig = fc::crypto::blslib::aggregate({agg_sig, sigs[i]});
+      }
+
+      // create a valid_quorum_certificate
+      valid_quorum_certificate qc({}, {}, {}, bitset_to_vector(weak_votes), agg_sig);
+
+      BOOST_REQUIRE_NO_THROW( bsp->verify_qc(qc) );
+   }
+
+   {  // strong QC quorem not met
+      hs_bitset strong_votes(num_finalizers);
+      strong_votes[2] = 1;  // finalizer 2 voted with weight 3 (threshold is 4)
+
+      bls_signature sig_2 = private_key[2].sign(strong_digest_data);
+      bls_signature agg_sig = fc::crypto::blslib::aggregate({agg_sig, sig_2});
+
+      // create a valid_quorum_certificate
+      valid_quorum_certificate qc({}, {}, bitset_to_vector(strong_votes), {}, agg_sig);
+
+      BOOST_CHECK_EXCEPTION( bsp->verify_qc(qc), block_validate_exception, eosio::testing::fc_exception_message_starts_with("strong quorum is not met") );
+   }
+
+   {  // weak QC quorem not met
+      hs_bitset weak_votes(num_finalizers);
+      weak_votes[2] = 1;  // finalizer 2 voted with weight 3 (threshold is 4)
+
+      bls_signature sig_2 = private_key[2].sign(weak_digest_data);
+      bls_signature agg_sig = fc::crypto::blslib::aggregate({agg_sig, sig_2});
+
+      // create a valid_quorum_certificate
+      valid_quorum_certificate qc({}, {}, {}, bitset_to_vector(weak_votes), agg_sig);
+
+      BOOST_CHECK_EXCEPTION( bsp->verify_qc(qc), block_validate_exception, eosio::testing::fc_exception_message_starts_with("weak quorum is not met") );
+   }
+
+   {  // strong QC with a wrong signing private key
+      hs_bitset strong_votes(num_finalizers);
+      strong_votes[0] = 1;  // finalizer 0 voted with weight 1
+      strong_votes[2] = 1;  // finalizer 2 voted with weight 3
+
+      bls_signature sig_0 = private_key[0].sign(strong_digest_data);
+      bls_signature sig_2 = private_key[1].sign(strong_digest_data); // signed by finalizer 1 which is not set in strong_votes
+      bls_signature sig;
+      sig = fc::crypto::blslib::aggregate({sig, sig_0});
+      sig = fc::crypto::blslib::aggregate({sig, sig_2});
+
+      // create a valid_quorum_certificate
+      valid_quorum_certificate qc({}, {}, bitset_to_vector(strong_votes), {}, sig);
+
+      BOOST_CHECK_EXCEPTION( bsp->verify_qc(qc), block_validate_exception, eosio::testing::fc_exception_message_is("signature validation failed") );
+   }
+
+   {  // strong QC with a wrong digest
+      hs_bitset strong_votes(num_finalizers);
+      strong_votes[0] = 1;  // finalizer 0 voted with weight 1
+      strong_votes[2] = 1;  // finalizer 2 voted with weight 3
+
+      bls_signature sig_0 = private_key[0].sign(weak_digest_data); // should have used strong digest
+      bls_signature sig_2 = private_key[2].sign(strong_digest_data);
+      bls_signature sig;
+      sig = fc::crypto::blslib::aggregate({sig, sig_0});
+      sig = fc::crypto::blslib::aggregate({sig, sig_2});
+
+      // create a valid_quorum_certificate
+      valid_quorum_certificate qc({}, {}, bitset_to_vector(strong_votes), {}, sig);
+
+      BOOST_CHECK_EXCEPTION( bsp->verify_qc(qc), block_validate_exception, eosio::testing::fc_exception_message_is("signature validation failed") );
+   }
+
+   {  // weak QC with a wrong signing private key
+      hs_bitset strong_votes(num_finalizers);
+      strong_votes[0] = 1;  // finalizer 0 voted with weight 1
+      bls_signature strong_sig = private_key[0].sign(strong_digest_data);
+
+      hs_bitset weak_votes(num_finalizers);
+      weak_votes[2] = 1;  // finalizer 2 voted with weight 3
+      bls_signature weak_sig = private_key[1].sign(weak_digest_data); // wrong key
+
+      bls_signature sig;
+      sig = fc::crypto::blslib::aggregate({sig, strong_sig});
+      sig = fc::crypto::blslib::aggregate({sig, weak_sig});
+
+      valid_quorum_certificate qc({}, {}, bitset_to_vector(strong_votes), bitset_to_vector(weak_votes), sig);
+      BOOST_CHECK_EXCEPTION( bsp->verify_qc(qc), block_validate_exception, eosio::testing::fc_exception_message_is("signature validation failed") );
+   }
+
+   {  // weak QC with a wrong digest
+      hs_bitset strong_votes(num_finalizers);
+      strong_votes[0] = 1;  // finalizer 0 voted with weight 1
+      bls_signature strong_sig = private_key[0].sign(weak_digest_data); // wrong digest
+
+      hs_bitset weak_votes(num_finalizers);
+      weak_votes[2] = 1;  // finalizer 2 voted with weight 3
+      bls_signature weak_sig = private_key[2].sign(weak_digest_data);
+
+      bls_signature sig;
+      sig = fc::crypto::blslib::aggregate({sig, strong_sig});
+      sig = fc::crypto::blslib::aggregate({sig, weak_sig});
+
+      valid_quorum_certificate qc({}, {}, bitset_to_vector(strong_votes), bitset_to_vector(weak_votes), sig);
+      BOOST_CHECK_EXCEPTION( bsp->verify_qc(qc), block_validate_exception, eosio::testing::fc_exception_message_is("signature validation failed") );
    }
 } FC_LOG_AND_RETHROW();
 


### PR DESCRIPTION
* Validate the claim in a block header extension for instant finality about the block number of the last block in its ancestry for which it has seen a QC. 
* Validate the claim as to whether this QC was strong or weak.
* Reject the block if the claims cannot be validated.
* Advance LIB if the QC is strong.

Resolved https://github.com/AntelopeIO/leap/issues/2071