### PR TITLE
IF: Bring back is_needed to avoid adding redundant QCs to blocks; enforce sensible finalizer policy in setfinalizers host function

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -663,7 +663,11 @@ struct building_block {
                            EOS_ASSERT( qc->block_height <= block_header::num_from_id(parent_id()), block_validate_exception,
                                        "most recent ancestor QC block number (${a}) cannot be greater than parent's block number (${p})",
                                        ("a", qc->block_height)("p", block_header::num_from_id(parent_id())) );
-                           qc_data = qc_data_t{ *qc, qc_info_t{ qc->block_height, qc->qc.is_strong() }};
+                           if( bb.parent.is_needed(*qc) ) {
+                              qc_data = qc_data_t{ *qc, qc_info_t{ qc->block_height, qc->qc.is_strong() }};
+                           } else {
+                              qc_data = qc_data_t{ {}, qc_info_t{ qc->block_height, qc->qc.is_strong() }};
+                           }
                            break;
                         }
                      }

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -20,7 +20,7 @@ struct building_block_input {
 };
 
 struct qc_data_t {
-   quorum_certificate qc;                                  // Comes from traversing branch from parent and calling get_best_qc()
+   std::optional<quorum_certificate> qc;                   // Comes from traversing branch from parent and calling get_best_qc()
                                                            // assert(qc->block_num <= num_from_id(previous));
    qc_info_t          qc_info;                             // describes the above qc
 };
@@ -78,6 +78,11 @@ struct block_header_state {
    block_header_state next(block_header_state_input& data) const;
 
    block_header_state next(const signed_block_header& h, const protocol_feature_set& pfs, validator_t& validator) const;
+
+   // block descending from this need the provided qc in the block extension
+   bool is_needed(const quorum_certificate& qc) const {
+      return !core.last_qc_block_num || qc.block_height > *core.last_qc_block_num;
+   }
 
    flat_set<digest_type> get_activated_protocol_features() const { return activated_protocol_features->protocol_features; }
    const vector<digest_type>& get_new_protocol_feature_activations() const;

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -196,7 +196,7 @@ namespace eosio { namespace chain { namespace webassembly {
                                                                 .public_key{fc::crypto::blslib::bls_public_key{*pk}}});
       }
 
-      EOS_ASSERT( weight_sum >= finpol.threshold && finpol.threshold > weight_sum / 2, wasm_execution_error, "Finalizer policy threshold (${t}) cannot be met by finalizer weights (${w})", ("t", finpol.threshold)("w", weight_sum) );
+      EOS_ASSERT( weight_sum >= finpol.threshold && finpol.threshold > weight_sum / 2, wasm_execution_error, "Finalizer policy threshold (${t}) must be greater than half of the sum of the weights (${w}), and less than or equal to the sum of the weights", ("t", finpol.threshold)("w", weight_sum) );
 
       context.control.set_proposed_finalizers( finpol );
    }

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -196,7 +196,7 @@ namespace eosio { namespace chain { namespace webassembly {
                                                                 .public_key{fc::crypto::blslib::bls_public_key{*pk}}});
       }
 
-      EOS_ASSERT( finpol.threshold > weight_sum / 2, wasm_execution_error, "Finalizer policy threshold cannot be met by finalizer weights" );
+      EOS_ASSERT( weight_sum >= finpol.threshold && finpol.threshold > weight_sum / 2, wasm_execution_error, "Finalizer policy threshold (${t}) cannot be met by finalizer weights (${w})", ("t", finpol.threshold)("w", weight_sum) );
 
       context.control.set_proposed_finalizers( finpol );
    }


### PR DESCRIPTION
* If the QC claim in the to-be-assembled block is the same (same block number and strong/weak status) as the QC claim in the previous block, then the QC should not be included in the block extension. `is_needed` was removed by https://github.com/AntelopeIO/leap/pull/2111 due to test failure. There was actually a bug in the original use of `is_needed`. It should have been used against parent block. This PR brings back `is_needed` and fixes the bug.

* If the sum of weights is less than threshold, the quorum will never be met. This PR asserts that the sum of the weights is greater than or equal to the threshold within the setfinalizers host function, 

Resolved https://github.com/AntelopeIO/leap/issues/2136