### PR TITLE
[5.0 -> main] Also need to switch to lib_catchup if in head_catchup when starting to sync

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2214,7 +2214,7 @@ namespace eosio {
          return;
       }
 
-      if( sync_state == in_sync ) {
+      if( sync_state != lib_catchup ) {
          set_state( lib_catchup );
       }
       sync_next_expected_num = std::max( chain_info.lib_num + 1, sync_next_expected_num );


### PR DESCRIPTION
If you are starting to sync with a node then you expect to be in `lib_catchup`. Need to switch to `lib_catchup` even if you are in `head_catchup`. Observed node not syncing when LIB was stuck in an integration test. The node would remain in `head_catchup` and never switch to `lib_catchup`. Since the `sync-fetch-span` was set to 5, it would keep syncing the same 5 blocks and never leave `head_catchup`.

Merges `release/5.0` into `main` including #2133 