### PR TITLE
upgrade to `actions/upload-artifact@v4`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
         with:
           submodules: recursive
       - name: Download builddir
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{matrix.platform}}-build
       - name: Build packages
@@ -112,17 +112,19 @@ jobs:
         run: |
           python3 -c "from TestHarness import Cluster"
       - name: Upload dev package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.platform != 'reproducible'
         with:
           name: leap-dev-${{matrix.platform}}-amd64
           path: build/leap-dev*.deb
+          compression-level: 0
       - name: Upload leap package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.platform == 'reproducible'
         with:
           name: leap-deb-amd64
           path: build/leap_*.deb
+          compression-level: 0
 
   tests:
     name: Tests (${{matrix.cfg.name}})
@@ -142,7 +144,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download builddir
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{matrix.cfg.builddir}}-build
       - name: Run Parallel Tests
@@ -153,12 +155,13 @@ jobs:
           cd build
           ctest --output-on-failure -j $(nproc) -LE "(nonparallelizable_tests|long_running_tests)" --timeout 420
       - name: Upload core files from failed tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{matrix.cfg.name}}-tests-logs
           if-no-files-found: ignore
           path: /cores
+          compression-level: 0
       - name: Check CPU Features
         run: awk 'BEGIN {err = 1} /bmi2/ && /adx/ {err = 0} END {exit err}' /proc/cpuinfo
 
@@ -177,7 +180,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download builddir
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{matrix.cfg.builddir}}-build
       - name: Run tests in parallel containers
@@ -192,13 +195,14 @@ jobs:
         run: docker run --mount type=bind,source=/var/lib/systemd/coredump,target=/cores alpine sh -c 'tar -C /cores/ -c .' | tar x
         if: failure()
       - name: Upload logs from failed tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{matrix.cfg.name}}-np-logs
           path: |
             *-logs.tar.gz
             core*.zst
+          compression-level: 0
 
   lr-tests:
     name: LR Tests (${{matrix.cfg.name}})
@@ -215,7 +219,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download builddir
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{matrix.cfg.builddir}}-build
       - name: Run tests in parallel containers
@@ -230,13 +234,14 @@ jobs:
         run: docker run --mount type=bind,source=/var/lib/systemd/coredump,target=/cores alpine sh -c 'tar -C /cores/ -c .' | tar x
         if: failure()
       - name: Upload logs from failed tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{matrix.cfg.name}}-lr-logs
           path: |
             *-logs.tar.gz
             core*.zst
+          compression-level: 0
 
   libtester-tests:
     name: libtester tests
@@ -265,7 +270,7 @@ jobs:
           submodules: recursive
       - if: ${{ matrix.test != 'deb-install' }}
         name: Download leap builddir
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{matrix.platform}}-build
       - if: ${{ matrix.test != 'deb-install' }}
@@ -287,7 +292,7 @@ jobs:
           rm -r *
       - if: ${{ matrix.test == 'deb-install' }}
         name: Download leap-dev
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: leap-dev-${{matrix.platform}}-amd64
       - if: ${{ matrix.test == 'deb-install' }}

--- a/.github/workflows/build_base.yaml
+++ b/.github/workflows/build_base.yaml
@@ -42,7 +42,8 @@ jobs:
             cmake --build build
             tar -pc --exclude "*.o" build | zstd --long -T0 -9 > build.tar.zst
         - name: Upload builddir
-          uses: AntelopeIO/upload-artifact-large-chunks-action@v1
+          uses: actions/upload-artifact@v4
           with:
             name: ${{matrix.platform}}-build
             path: build.tar.zst
+            compression-level: 0


### PR DESCRIPTION
Upgrade to `actions/upload-artifact@v4`. This has a couple nice benefits (as advertised by v4),

Upload performance is substantially better than v3, so much so that we can get rid of my `upload-artifact-large-chunks-action` and just rely on the canonical `upload-artifact` going forward.

More interestingly, artifacts are viewable and downloadable before the workflow completes. This has long been an annoyance to me so great to see this resolved. It's nice to, for example, grab the build or the leap-dev or some logs before the entire workflow has completed (i.e. before LR tests take.. a long time to complete). It'll also be hugely beneficial to usages of `asset-artifact-download-action` for similar reasons. For example, a workflow that's still in progress but has a leap-dev.deb completed can be used immediately instead of waiting for LR tests to complete. Sadly, I believe, `asset-artifact-download-action` will need to be refactored to deal with this new possibility (I believe it waits for the workflow to be completed currently). Maybe one day..