### PR TITLE
[5.0] Report read-only API not enabled to caller

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2561,19 +2561,25 @@ void read_only::compute_transaction(compute_transaction_params params, next_func
 }
 
 void read_only::send_read_only_transaction(send_read_only_transaction_params params, next_function<send_read_only_transaction_results> next) {
-   static bool read_only_enabled = app().executor().get_read_threads() > 0;
-   EOS_ASSERT( read_only_enabled, unsupported_feature,
-               "read-only transactions execution not enabled on API node. Set read-only-threads > 0" );
+   try {
+      static bool read_only_enabled = app().executor().get_read_threads() > 0;
+      EOS_ASSERT( read_only_enabled, unsupported_feature,
+                  "read-only transactions execution not enabled on API node. Set read-only-threads > 0" );
 
-   send_transaction_params_t gen_params { .return_failure_trace = false,
-                                          .retry_trx            = false,
-                                          .retry_trx_num_blocks = std::nullopt,
-                                          .trx_type             = transaction_metadata::trx_type::read_only,
-                                          .transaction          = std::move(params.transaction) };
-   // run read-only trx exclusively on read-only threads
-   app().executor().post(priority::low, exec_queue::read_exclusive, [this, gen_params{std::move(gen_params)}, next{std::move(next)}]() mutable {
-      send_transaction_gen(*this, std::move(gen_params), std::move(next));
-   });
+      send_transaction_params_t gen_params { .return_failure_trace = false,
+                                             .retry_trx            = false,
+                                             .retry_trx_num_blocks = std::nullopt,
+                                             .trx_type             = transaction_metadata::trx_type::read_only,
+                                             .transaction          = std::move(params.transaction) };
+      // run read-only trx exclusively on read-only threads
+      app().executor().post(priority::low, exec_queue::read_exclusive, [this, gen_params{std::move(gen_params)}, next{std::move(next)}]() mutable {
+         send_transaction_gen(*this, std::move(gen_params), std::move(next));
+      });
+   } catch ( boost::interprocess::bad_alloc& ) {
+      handle_db_exhaustion();
+   } catch ( const std::bad_alloc& ) {
+      handle_bad_alloc();
+   } CATCH_AND_CALL(next);
 }
 
 read_only::get_transaction_id_result read_only::get_transaction_id( const read_only::get_transaction_id_params& params, const fc::time_point& ) const {

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -549,51 +549,51 @@ namespace eosio {
          try {
             throw;
          } catch (chain::unknown_block_exception& e) {
-            error_results results{400, "Unknown Block", error_results::error_info(e, verbose_http_errors)};
-            cb( 400, fc::variant( results ));
             fc_dlog( logger(), "Unknown block while processing ${api}.${call}: ${e}",
                      ("api", api_name)("call", call_name)("e", e.to_detail_string()) );
-         } catch (chain::invalid_http_request& e) {
-            error_results results{400, "Invalid Request", error_results::error_info(e, verbose_http_errors)};
+            error_results results{400, "Unknown Block", error_results::error_info(e, verbose_http_errors)};
             cb( 400, fc::variant( results ));
+         } catch (chain::invalid_http_request& e) {
             fc_dlog( logger(), "Invalid http request while processing ${api}.${call}: ${e}",
                      ("api", api_name)("call", call_name)("e", e.to_detail_string()) );
-         } catch (chain::account_query_exception& e) {
-            error_results results{400, "Account lookup", error_results::error_info(e, verbose_http_errors)};
+            error_results results{400, "Invalid Request", error_results::error_info(e, verbose_http_errors)};
             cb( 400, fc::variant( results ));
+         } catch (chain::account_query_exception& e) {
             fc_dlog( logger(), "Account query exception while processing ${api}.${call}: ${e}",
                      ("api", api_name)("call", call_name)("e", e.to_detail_string()) );
+            error_results results{400, "Account lookup", error_results::error_info(e, verbose_http_errors)};
+            cb( 400, fc::variant( results ));
          } catch (chain::unsatisfied_authorization& e) {
-            error_results results{401, "UnAuthorized", error_results::error_info(e, verbose_http_errors)};
-            cb( 401, fc::variant( results ));
             fc_dlog( logger(), "Auth error while processing ${api}.${call}: ${e}",
                      ("api", api_name)("call", call_name)("e", e.to_detail_string()) );
+            error_results results{401, "UnAuthorized", error_results::error_info(e, verbose_http_errors)};
+            cb( 401, fc::variant( results ));
          } catch (chain::tx_duplicate& e) {
-            error_results results{409, "Conflict", error_results::error_info(e, verbose_http_errors)};
-            cb( 409, fc::variant( results ));
             fc_dlog( logger(), "Duplicate trx while processing ${api}.${call}: ${e}",
                      ("api", api_name)("call", call_name)("e", e.to_detail_string()) );
+            error_results results{409, "Conflict", error_results::error_info(e, verbose_http_errors)};
+            cb( 409, fc::variant( results ));
          } catch (fc::eof_exception& e) {
-            error_results results{422, "Unprocessable Entity", error_results::error_info(e, verbose_http_errors)};
-            cb( 422, fc::variant( results ));
             fc_elog( logger(), "Unable to parse arguments to ${api}.${call}", ("api", api_name)( "call", call_name ) );
             fc_dlog( logger(), "Bad arguments: ${args}", ("args", body) );
+            error_results results{422, "Unprocessable Entity", error_results::error_info(e, verbose_http_errors)};
+            cb( 422, fc::variant( results ));
          } catch (fc::exception& e) {
-            error_results results{500, "Internal Service Error", error_results::error_info(e, verbose_http_errors)};
-            cb( 500, fc::variant( results ));
             fc_dlog( logger(), "Exception while processing ${api}.${call}: ${e}",
                      ("api", api_name)( "call", call_name )("e", e.to_detail_string()) );
-         } catch (std::exception& e) {
-            error_results results{500, "Internal Service Error", error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, e.what())), verbose_http_errors)};
+            error_results results{500, "Internal Service Error", error_results::error_info(e, verbose_http_errors)};
             cb( 500, fc::variant( results ));
+         } catch (std::exception& e) {
             fc_dlog( logger(), "STD Exception encountered while processing ${api}.${call}: ${e}",
                      ("api", api_name)("call", call_name)("e", e.what()) );
+            error_results results{500, "Internal Service Error", error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, e.what())), verbose_http_errors)};
+            cb( 500, fc::variant( results ));
          } catch (...) {
+            fc_elog( logger(), "Unknown Exception encountered while processing ${api}.${call}",
+                     ("api", api_name)( "call", call_name ) );
             error_results results{500, "Internal Service Error",
                error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, "Unknown Exception" )), verbose_http_errors)};
             cb( 500, fc::variant( results ));
-            fc_elog( logger(), "Unknown Exception encountered while processing ${api}.${call}",
-                     ("api", api_name)( "call", call_name ) );
          }
       } catch (...) {
          std::cerr << "Exception attempting to handle exception for " << api_name << "." << call_name << std::endl;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1928,7 +1928,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
       const auto& pending_block_signing_authority = chain.pending_block_signing_authority();
 
       if (in_producing_mode() && pending_block_signing_authority != scheduled_producer.authority) {
-         elog("Unexpected block signing authority, reverting to speculative mode! [expected: \"${expected}\", actual: \"${actual\"",
+         elog("Unexpected block signing authority, reverting to speculative mode! [expected: \"${expected}\", actual: \"${actual}\"",
               ("expected", scheduled_producer.authority)("actual", pending_block_signing_authority));
          _pending_block_mode = pending_block_mode::speculating;
       }

--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -208,8 +208,8 @@ namespace eosio::testing {
 
              if (!(response.result() == boost::beast::http::status::accepted ||
                    response.result() == boost::beast::http::status::ok)) {
-                elog("async_http_request Failed with response http status code: ${status}",
-                     ("status", response.result_int()));
+                elog("async_http_request Failed with response http status code: ${s}, response: ${r}",
+                     ("s", response.result_int())("r", response.body()));
              }
              ++this->_acknowledged;
           });


### PR DESCRIPTION
Report `read-only transactions execution not enabled on API node. Set read-only-threads > 0` to caller when `/v1/chain/send_read_only_transaction` is not supported because of no configured `read-only-threads`. Note this is handled correctly in 4.0.x.

Includes some misc fixes found while debugging this issue.
- Log http errors before calling the callback `cb`, as `cb` may throw; e.g. `cb` not set.
- Add missing `}` in a `producer_plugin` error log, so the error is reported correctly.
- Add the response to the `trx_provider` error log when the `http` call fails.