### PR TITLE
IF: Use correct schedule for calculate_producer_wake_up_time

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4225,7 +4225,7 @@ account_name controller::pending_block_producer()const {
    return my->pending->producer();
 }
 
-block_signing_authority controller::pending_block_signing_authority() const {
+const block_signing_authority& controller::pending_block_signing_authority() const {
    EOS_ASSERT( my->pending, block_validate_exception, "no pending block" );
    return my->pending->pending_block_signing_authority();
 }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -252,7 +252,7 @@ namespace eosio::chain {
          time_point                     pending_block_time()const;
          block_timestamp_type           pending_block_timestamp()const;
          account_name                   pending_block_producer()const;
-         block_signing_authority        pending_block_signing_authority()const;
+         const block_signing_authority& pending_block_signing_authority()const;
          std::optional<block_id_type>   pending_producer_block_id()const;
          uint32_t                       pending_block_num()const;
 


### PR DESCRIPTION
Noticed wrong schedule being used while debugging other issues. Reverts back to `main` behavior.
Also avoid unneeded copy of `block_signing_authority`. 