### PR TITLE
IF: Fix fork database deadlock

### DIFF
--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -10,7 +10,7 @@
 #include <fc/io/fstream.hpp>
 #include <fc/io/cfile.hpp>
 #include <fstream>
-#include <shared_mutex>
+#include <mutex>
 
 namespace eosio::chain {
    using boost::multi_index_container;
@@ -57,7 +57,7 @@ namespace eosio::chain {
                                          BOOST_MULTI_INDEX_CONST_MEM_FUN(bs, const block_id_type&, id)>,
                            composite_key_compare<std::greater<bool>, std::greater<uint32_t>, std::greater<uint32_t>, sha256_less>>>>;
 
-      std::shared_mutex      mtx;
+      std::mutex             mtx;
       fork_multi_index_type  index;
       bsp                    root; // Only uses the block_header_state_legacy portion
       bsp                    head;
@@ -313,7 +313,7 @@ namespace eosio::chain {
 
    template<class bsp>
    fork_database_t<bsp>::bhsp fork_database_t<bsp>::get_block_header( const block_id_type& id ) const {
-      std::shared_lock g( my->mtx );
+      std::lock_guard g( my->mtx );
       return my->get_block_header_impl( id );
    }
 
@@ -381,19 +381,19 @@ namespace eosio::chain {
 
    template<class bsp>
    bsp fork_database_t<bsp>::root() const {
-      std::shared_lock g( my->mtx );
+      std::lock_guard g( my->mtx );
       return my->root;
    }
 
    template<class bsp>
    bsp fork_database_t<bsp>::head() const {
-      std::shared_lock g( my->mtx );
+      std::lock_guard g( my->mtx );
       return my->head;
    }
 
    template<class bsp>
    bsp fork_database_t<bsp>::pending_head() const {
-      std::shared_lock g( my->mtx );
+      std::lock_guard g( my->mtx );
       const auto& indx = my->index.template get<by_lib_block_num>();
 
       auto itr = indx.lower_bound( false );
@@ -407,9 +407,8 @@ namespace eosio::chain {
 
    template <class bsp>
    fork_database_t<bsp>::branch_type
-   fork_database_t<bsp>::fetch_branch(const block_id_type& h,
-                                          uint32_t trim_after_block_num) const {
-      std::shared_lock g(my->mtx);
+   fork_database_t<bsp>::fetch_branch(const block_id_type& h, uint32_t trim_after_block_num) const {
+      std::lock_guard g(my->mtx);
       return my->fetch_branch_impl(h, trim_after_block_num);
    }
 
@@ -427,7 +426,7 @@ namespace eosio::chain {
 
    template<class bsp>
    bsp fork_database_t<bsp>::search_on_branch( const block_id_type& h, uint32_t block_num ) const {
-      std::shared_lock g( my->mtx );
+      std::lock_guard g( my->mtx );
       return my->search_on_branch_impl( h, block_num );
    }
 
@@ -448,7 +447,7 @@ namespace eosio::chain {
    template <class bsp>
    fork_database_t<bsp>::branch_type_pair
    fork_database_t<bsp>::fetch_branch_from(const block_id_type& first, const block_id_type& second) const {
-      std::shared_lock g(my->mtx);
+      std::lock_guard g(my->mtx);
       return my->fetch_branch_from_impl(first, second);
    }
 
@@ -570,7 +569,7 @@ namespace eosio::chain {
 
    template<class bsp>
    bsp fork_database_t<bsp>::get_block(const block_id_type& id) const {
-      std::shared_lock g( my->mtx );
+      std::lock_guard g( my->mtx );
       return my->get_block_impl(id);
    }
 

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -10,6 +10,7 @@
 #include <fc/io/fstream.hpp>
 #include <fc/io/cfile.hpp>
 #include <fstream>
+#include <shared_mutex>
 
 namespace eosio::chain {
    using boost::multi_index_container;
@@ -56,6 +57,7 @@ namespace eosio::chain {
                                          BOOST_MULTI_INDEX_CONST_MEM_FUN(bs, const block_id_type&, id)>,
                            composite_key_compare<std::greater<bool>, std::greater<uint32_t>, std::greater<uint32_t>, sha256_less>>>>;
 
+      std::shared_mutex      mtx;
       fork_multi_index_type  index;
       bsp                    root; // Only uses the block_header_state_legacy portion
       bsp                    head;
@@ -88,6 +90,7 @@ namespace eosio::chain {
 
    template<class bsp>
    void fork_database_t<bsp>::open( const std::filesystem::path& fork_db_file, validator_t& validator ) {
+      std::lock_guard g( my->mtx );
       my->open_impl( fork_db_file, validator );
    }
 
@@ -163,6 +166,7 @@ namespace eosio::chain {
 
    template<class bsp>
    void fork_database_t<bsp>::close(const std::filesystem::path& fork_db_file) {
+      std::lock_guard g( my->mtx );
       my->close_impl(fork_db_file);
    }
 
@@ -234,6 +238,7 @@ namespace eosio::chain {
 
    template<class bsp>
    void fork_database_t<bsp>::reset( const bhs& root_bhs ) {
+      std::lock_guard g( my->mtx );
       my->reset_impl(root_bhs);
    }
 
@@ -248,6 +253,7 @@ namespace eosio::chain {
 
    template<class bsp>
    void fork_database_t<bsp>::rollback_head_to_root() {
+      std::lock_guard g( my->mtx );
       my->rollback_head_to_root_impl();
    }
 
@@ -266,6 +272,7 @@ namespace eosio::chain {
 
    template<class bsp>
    void fork_database_t<bsp>::advance_root( const block_id_type& id ) {
+      std::lock_guard g( my->mtx );
       my->advance_root_impl( id );
    }
 
@@ -306,6 +313,7 @@ namespace eosio::chain {
 
    template<class bsp>
    fork_database_t<bsp>::bhsp fork_database_t<bsp>::get_block_header( const block_id_type& id ) const {
+      std::shared_lock g( my->mtx );
       return my->get_block_header_impl( id );
    }
 
@@ -362,6 +370,7 @@ namespace eosio::chain {
 
    template<class bsp>
    void fork_database_t<bsp>::add( const bsp& n, bool ignore_duplicate ) {
+      std::lock_guard g( my->mtx );
       my->add_impl( n, ignore_duplicate, false,
                     []( block_timestamp_type timestamp,
                         const flat_set<digest_type>& cur_features,
@@ -372,16 +381,19 @@ namespace eosio::chain {
 
    template<class bsp>
    bsp fork_database_t<bsp>::root() const {
+      std::shared_lock g( my->mtx );
       return my->root;
    }
 
    template<class bsp>
    bsp fork_database_t<bsp>::head() const {
+      std::shared_lock g( my->mtx );
       return my->head;
    }
 
    template<class bsp>
    bsp fork_database_t<bsp>::pending_head() const {
+      std::shared_lock g( my->mtx );
       const auto& indx = my->index.template get<by_lib_block_num>();
 
       auto itr = indx.lower_bound( false );
@@ -397,6 +409,7 @@ namespace eosio::chain {
    fork_database_t<bsp>::branch_type
    fork_database_t<bsp>::fetch_branch(const block_id_type& h,
                                           uint32_t trim_after_block_num) const {
+      std::shared_lock g(my->mtx);
       return my->fetch_branch_impl(h, trim_after_block_num);
    }
 
@@ -414,6 +427,7 @@ namespace eosio::chain {
 
    template<class bsp>
    bsp fork_database_t<bsp>::search_on_branch( const block_id_type& h, uint32_t block_num ) const {
+      std::shared_lock g( my->mtx );
       return my->search_on_branch_impl( h, block_num );
    }
 
@@ -434,6 +448,7 @@ namespace eosio::chain {
    template <class bsp>
    fork_database_t<bsp>::branch_type_pair
    fork_database_t<bsp>::fetch_branch_from(const block_id_type& first, const block_id_type& second) const {
+      std::shared_lock g(my->mtx);
       return my->fetch_branch_from_impl(first, second);
    }
 
@@ -500,6 +515,7 @@ namespace eosio::chain {
    /// remove all of the invalid forks built off of this id including this id
    template<class bsp>
    void fork_database_t<bsp>::remove( const block_id_type& id ) {
+      std::lock_guard g( my->mtx );
       return my->remove_impl( id );
    }
 
@@ -527,6 +543,7 @@ namespace eosio::chain {
 
    template<class bsp>
    void fork_database_t<bsp>::mark_valid( const bsp& h ) {
+      std::lock_guard g( my->mtx );
       my->mark_valid_impl( h );
    }
 
@@ -553,6 +570,7 @@ namespace eosio::chain {
 
    template<class bsp>
    bsp fork_database_t<bsp>::get_block(const block_id_type& id) const {
+      std::shared_lock g( my->mtx );
       return my->get_block_impl(id);
    }
 
@@ -567,7 +585,10 @@ namespace eosio::chain {
    // ------------------ fork_database -------------------------
 
    fork_database::fork_database(const std::filesystem::path& data_dir)
-      : data_dir(data_dir) {
+      : data_dir(data_dir)
+        // currently needed because chain_head is accessed before fork database open
+      , fork_db_legacy{std::make_unique<fork_database_legacy_t>(fork_database_legacy_t::legacy_magic_number)}
+   {
    }
 
    fork_database::~fork_database() {
@@ -579,7 +600,6 @@ namespace eosio::chain {
    }
 
    void fork_database::open( validator_t& validator ) {
-      std::lock_guard g(m);
       if (!std::filesystem::is_directory(data_dir))
          std::filesystem::create_directories(data_dir);
 
@@ -603,12 +623,14 @@ namespace eosio::chain {
             );
 
             if (totem == fork_database_legacy_t::legacy_magic_number) {
+               // fork_db_legacy created in constructor
                apply_legacy<void>([&](auto& forkdb) {
                   forkdb.open(fork_db_file, validator);
                });
             } else {
                // file is instant-finality data, so switch to fork_database_if_t
-               vforkdb.emplace<fork_database_if_t>(fork_database_if_t::magic_number);
+               fork_db_if = std::make_unique<fork_database_if_t>(fork_database_if_t::magic_number);
+               legacy = false;
                apply_if<void>([&](auto& forkdb) {
                   forkdb.open(fork_db_file, validator);
                });
@@ -618,11 +640,13 @@ namespace eosio::chain {
    }
 
    void fork_database::switch_from_legacy() {
-      std::lock_guard g(m);
       // no need to close fork_db because we don't want to write anything out, file is removed on open
-      block_state_legacy_ptr head = std::get<fork_database_legacy_t>(vforkdb).chain_head; // will throw if called after transistion
+      // threads may be accessing (or locked on mutex about to access legacy forkdb) so don't delete it until program exit
+      assert(legacy);
+      block_state_legacy_ptr head = fork_db_legacy->chain_head; // will throw if called after transistion
       auto new_head = std::make_shared<block_state>(*head);
-      vforkdb.emplace<fork_database_if_t>(fork_database_if_t::magic_number);
+      fork_db_if = std::make_unique<fork_database_if_t>(fork_database_if_t::magic_number);
+      legacy = false;
       apply_if<void>([&](auto& forkdb) {
          forkdb.chain_head = new_head;
          forkdb.reset(*new_head);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1146,6 +1146,7 @@ void chain_plugin_impl::plugin_shutdown() {
    applied_transaction_connection.reset();
    block_start_connection.reset();
    chain.reset();
+   dlog("exit shutdown");
 }
 
 void chain_plugin::plugin_shutdown() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -272,6 +272,8 @@ set_property(TEST nodeos_voting_if_lr_test PROPERTY LABELS long_running_tests)
 
 add_test(NAME nodeos_under_min_avail_ram_lr_test COMMAND tests/nodeos_under_min_avail_ram.py -v --wallet-port 9904 ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_under_min_avail_ram_lr_test PROPERTY LABELS long_running_tests)
+add_test(NAME nodeos_under_min_avail_ram_if_lr_test COMMAND tests/nodeos_under_min_avail_ram.py -v --active-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST nodeos_under_min_avail_ram_if_lr_test PROPERTY LABELS long_running_tests)
 
 add_test(NAME nodeos_irreversible_mode_lr_test COMMAND tests/nodeos_irreversible_mode_test.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_irreversible_mode_lr_test PROPERTY LABELS long_running_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -272,7 +272,7 @@ set_property(TEST nodeos_voting_if_lr_test PROPERTY LABELS long_running_tests)
 
 add_test(NAME nodeos_under_min_avail_ram_lr_test COMMAND tests/nodeos_under_min_avail_ram.py -v --wallet-port 9904 ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_under_min_avail_ram_lr_test PROPERTY LABELS long_running_tests)
-add_test(NAME nodeos_under_min_avail_ram_if_lr_test COMMAND tests/nodeos_under_min_avail_ram.py -v --active-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME nodeos_under_min_avail_ram_if_lr_test COMMAND tests/nodeos_under_min_avail_ram.py -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_under_min_avail_ram_if_lr_test PROPERTY LABELS long_running_tests)
 
 add_test(NAME nodeos_irreversible_mode_lr_test COMMAND tests/nodeos_irreversible_mode_test.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -223,8 +223,9 @@ set_property(TEST trx_finality_status_if_test PROPERTY LABELS nonparallelizable_
 
 add_test(NAME trx_finality_status_forked_test COMMAND tests/trx_finality_status_forked_test.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST trx_finality_status_forked_test PROPERTY LABELS nonparallelizable_tests)
-add_test(NAME trx_finality_status_forked_if_test COMMAND tests/trx_finality_status_forked_test.py -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-set_property(TEST trx_finality_status_forked_if_test PROPERTY LABELS nonparallelizable_tests)
+# requires https://github.com/AntelopeIO/leap/issues/2189
+#add_test(NAME trx_finality_status_forked_if_test COMMAND tests/trx_finality_status_forked_test.py -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+#set_property(TEST trx_finality_status_forked_if_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME db_modes_test COMMAND tests/db_modes_test.sh -v WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_tests_properties(db_modes_test PROPERTIES COST 6000)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -359,9 +359,8 @@ set_property(TEST light_validation_sync_if_test PROPERTY LABELS nonparallelizabl
 
 add_test(NAME auto_bp_peering_test COMMAND tests/auto_bp_peering_test.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST auto_bp_peering_test PROPERTY LABELS long_running_tests)
-# requires https://github.com/AntelopeIO/leap/issues/2175 & https://github.com/AntelopeIO/leap/issues/2173
-#add_test(NAME auto_bp_peering_if_test COMMAND tests/auto_bp_peering_test.py -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#set_property(TEST auto_bp_peering_if_test PROPERTY LABELS long_running_tests)
+add_test(NAME auto_bp_peering_if_test COMMAND tests/auto_bp_peering_test.py -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST auto_bp_peering_if_test PROPERTY LABELS long_running_tests)
 
 add_test(NAME gelf_test COMMAND tests/gelf_test.py ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST gelf_test PROPERTY LABELS nonparallelizable_tests)

--- a/tests/nodeos_under_min_avail_ram.py
+++ b/tests/nodeos_under_min_avail_ram.py
@@ -18,11 +18,12 @@ from TestHarness.accounts import NamedAccounts
 Print=Utils.Print
 errorExit=Utils.errorExit
 
-args = TestHelper.parse_args({"--dump-error-details","--keep-logs","-v","--leave-running","--wallet-port","--unshared"})
+args = TestHelper.parse_args({"--activate-if","--dump-error-details","--keep-logs","-v","--leave-running","--wallet-port","--unshared"})
 Utils.Debug=args.v
 pNodes=4
 totalNodes=5
 cluster=Cluster(unshared=args.unshared, keepRunning=args.leave_running, keepLogs=args.keep_logs)
+activateIF=args.activate_if
 dumpErrorDetails=args.dump_error_details
 walletPort=args.wallet_port
 
@@ -42,7 +43,7 @@ try:
     maxRAMFlag="--chain-state-db-size-mb"
     maxRAMValue=1010
     extraNodeosArgs=" %s %d %s %d  --http-max-response-time-ms 990000 " % (minRAMFlag, minRAMValue, maxRAMFlag, maxRAMValue)
-    if cluster.launch(onlyBios=False, pnodes=pNodes, totalNodes=totalNodes, totalProducers=totalNodes, activateIF=True, extraNodeosArgs=extraNodeosArgs) is False:
+    if cluster.launch(onlyBios=False, pnodes=pNodes, totalNodes=totalNodes, totalProducers=totalNodes, activateIF=activateIF, extraNodeosArgs=extraNodeosArgs) is False:
         Utils.cmdError("launcher")
         errorExit("Failed to stand up eos cluster.")
 

--- a/tests/trx_finality_status_forked_test.py
+++ b/tests/trx_finality_status_forked_test.py
@@ -130,6 +130,8 @@ try:
 
     assert not nonProdNode.verifyAlive(), "Bridge node should have been killed if test was functioning correctly."
 
+    assert prodC.waitForNextBlock(), "Prod node C should continue to advance, even after bridge node is killed"
+
     def getState(status):
         assert status is not None, "ERROR: getTransactionStatus failed to return any status"
         assert "state" in status, \
@@ -149,8 +151,8 @@ try:
     forkedOutState = "FORKED_OUT"
     unknownState = "UNKNOWN"
 
-    assert state == localState, \
-        f"ERROR: getTransactionStatus didn't return \"{localState}\" state.\n\nstatus: {json.dumps(retStatus, indent=1)}"
+    assert state == localState or state == inBlockState, \
+        f"ERROR: getTransactionStatus didn't return \"{localState}\" or \"{inBlockState}\" state.\n\nstatus: {json.dumps(retStatus, indent=1)}"
 
     assert prodC.waitForNextBlock(), "Production node C should continue to advance, even after bridge node is killed"
 


### PR DESCRIPTION
Fix for deadlock caused by holding a fork database lock while posting tasks to chain thread pool which also tried to access fork database.

- log_irreversible
  - Grabs fork database lock in `fork_db.apply`
    - In the apply, posts a task to chain thread pool
    - Waits on task via `future.get()`
  - Meanwhile a vote comes in that posts a task to chain thread pool that tries to access the fork database
    - If you use up all your thread pool threads trying to get a lock on fork database then you deadlock

There is a reason I am not a fan of recursive mutexes. https://github.com/AntelopeIO/leap/pull/2113#discussion_r1459796518
I should have listened to my own advice. Recursive mutexes are an indication that your design is wrong. In this case it provided a crutch that let us hit a deadlock in a much more obscure way.

This PR removes the fork database recursive mutex.
- Moves fork database mutex back down into the individual fork database implementations.
- Uses an atomic bool for determining which fork database implementation to use.

Also enable tests:
- auto_bp_peering_if_test 

Fix for flaky test:
- trx_finality_status_forked_test.py