### PR TITLE
IF: Enable integration tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -172,14 +172,12 @@ add_test(NAME distributed-transactions-test COMMAND tests/distributed-transactio
 set_property(TEST distributed-transactions-test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME distributed-transactions-speculative-test COMMAND tests/distributed-transactions-test.py -d 2 -p 4 -n 6 --speculative -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST distributed-transactions-speculative-test PROPERTY LABELS nonparallelizable_tests)
-# requires https://github.com/AntelopeIO/leap/issues/2175
-#add_test(NAME distributed-transactions-if-test COMMAND tests/distributed-transactions-test.py -d 2 -p 4 -n 6 --activate-if -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#set_property(TEST distributed-transactions-if-test PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME distributed-transactions-if-test COMMAND tests/distributed-transactions-test.py -d 2 -p 4 -n 6 --activate-if -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST distributed-transactions-if-test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME restart-scenarios-test-resync COMMAND tests/restart-scenarios-test.py -c resync -p4 -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST restart-scenarios-test-resync PROPERTY LABELS nonparallelizable_tests)
-# requires https://github.com/AntelopeIO/leap/issues/2175
-#add_test(NAME restart-scenarios-if-test-resync COMMAND tests/restart-scenarios-test.py -c resync -p4 -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#set_property(TEST restart-scenarios-if-test-resync PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME restart-scenarios-if-test-resync COMMAND tests/restart-scenarios-test.py -c resync -p4 -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST restart-scenarios-if-test-resync PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME restart-scenarios-test-hard_replay COMMAND tests/restart-scenarios-test.py -c hardReplay -p4 -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST restart-scenarios-test-hard_replay PROPERTY LABELS nonparallelizable_tests)
 # requires https://github.com/AntelopeIO/leap/issues/2141
@@ -314,9 +312,8 @@ set_property(TEST nodeos_producer_watermark_if_lr_test PROPERTY LABELS long_runn
 
 add_test(NAME nodeos_high_transaction_lr_test COMMAND tests/nodeos_high_transaction_test.py -p 4 -n 8 --num-transactions 10000 --max-transactions-per-second 500 ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_high_transaction_lr_test PROPERTY LABELS long_running_tests)
-# requires https://github.com/AntelopeIO/leap/issues/2175
-#add_test(NAME nodeos_high_transaction_if_lr_test COMMAND tests/nodeos_high_transaction_test.py --activate-if -p 4 -n 8 --num-transactions 10000 --max-transactions-per-second 500 ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#set_property(TEST nodeos_high_transaction_if_lr_test PROPERTY LABELS long_running_tests)
+add_test(NAME nodeos_high_transaction_if_lr_test COMMAND tests/nodeos_high_transaction_test.py --activate-if -p 4 -n 8 --num-transactions 10000 --max-transactions-per-second 500 ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST nodeos_high_transaction_if_lr_test PROPERTY LABELS long_running_tests)
 
 add_test(NAME nodeos_retry_transaction_lr_test COMMAND tests/nodeos_retry_transaction_test.py -v --num-transactions 100 --max-transactions-per-second 10 --total-accounts 5 ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_retry_transaction_lr_test PROPERTY LABELS long_running_tests)

--- a/tests/ship_streamer_test.py
+++ b/tests/ship_streamer_test.py
@@ -169,9 +169,8 @@ try:
     assert status is not None and status is not False, "ERROR: Failed to spinup Transaction Generators"
 
     prodNode0.waitForProducer("defproducerc")
-    prodNode0.waitForProducer("defproducera")
 
-    block_range = 450
+    block_range = 350
     end_block_num = start_block_num + block_range
 
     shipClient = "tests/ship_streamer"


### PR DESCRIPTION
Enable:
- distributed-transactions-if-test
- restart-scenarios-if-test-resync
- nodeos_high_transaction_if_lr_test

These should pass after fixes: #2185 and #2182 