### PR TITLE
[3.2] change HTTP code on exceeding `http-max-bytes-in-flight-mb` or `http-max-in-flight-requests` to 503

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -250,9 +250,9 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
             ("max-body-size", bpo::value<uint32_t>()->default_value(my->plugin_state->max_body_size),
              "The maximum body size in bytes allowed for incoming RPC requests")
             ("http-max-bytes-in-flight-mb", bpo::value<int64_t>()->default_value(500),
-             "Maximum size in megabytes http_plugin should use for processing http requests. -1 for unlimited. 429 error response when exceeded." )
+             "Maximum size in megabytes http_plugin should use for processing http requests. -1 for unlimited. 503 error response when exceeded." )
             ("http-max-in-flight-requests", bpo::value<int32_t>()->default_value(-1),
-             "Maximum number of requests http_plugin should use for processing http requests. 429 error response when exceeded." )
+             "Maximum number of requests http_plugin should use for processing http requests. 503 error response when exceeded." )
             ("http-max-response-time-ms", bpo::value<int64_t>()->default_value(30),
              "Maximum time for processing a request, -1 for unlimited")
             ("verbose-http-errors", bpo::bool_switch()->default_value(false),

--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -202,13 +202,13 @@ public:
    virtual bool verify_max_bytes_in_flight() override {
       auto bytes_in_flight_size = plugin_state_->bytes_in_flight.load();
       if(bytes_in_flight_size > plugin_state_->max_bytes_in_flight) {
-         fc_dlog(plugin_state_->logger, "429 - too many bytes in flight: ${bytes}", ("bytes", bytes_in_flight_size));
+         fc_dlog(plugin_state_->logger, "503 - too many bytes in flight: ${bytes}", ("bytes", bytes_in_flight_size));
          error_results::error_info ei;
-         ei.code = static_cast<int64_t>(http::status::too_many_requests);
+         ei.code = static_cast<int64_t>(http::status::service_unavailable);
          ei.name = "Busy";
          ei.what = "Too many bytes in flight: " + std::to_string( bytes_in_flight_size );
-         error_results results{static_cast<uint16_t>(http::status::too_many_requests), "Busy", ei};
-         send_response( fc::json::to_string( results, fc::time_point::maximum() ), static_cast<unsigned int>(http::status::too_many_requests) );
+         error_results results{static_cast<uint16_t>(http::status::service_unavailable), "Busy", ei};
+         send_response( fc::json::to_string( results, fc::time_point::maximum() ), static_cast<unsigned int>(http::status::service_unavailable) );
          return false;
       }
       return true;
@@ -220,13 +220,13 @@ public:
 
       auto requests_in_flight_num = plugin_state_->requests_in_flight.load();
       if(requests_in_flight_num > plugin_state_->max_requests_in_flight) {
-         fc_dlog(plugin_state_->logger, "429 - too many requests in flight: ${requests}", ("requests", requests_in_flight_num));
+         fc_dlog(plugin_state_->logger, "503 - too many requests in flight: ${requests}", ("requests", requests_in_flight_num));
          error_results::error_info ei;
-         ei.code = static_cast<int64_t>(http::status::too_many_requests);
+         ei.code = static_cast<int64_t>(http::status::service_unavailable);
          ei.name = "Busy";
          ei.what = "Too many requests in flight: " + std::to_string( requests_in_flight_num );
-         error_results results{static_cast<uint16_t>(http::status::too_many_requests), "Busy", ei};
-         send_response( fc::json::to_string( results, fc::time_point::maximum() ), static_cast<unsigned int>(http::status::too_many_requests) );
+         error_results results{static_cast<uint16_t>(http::status::service_unavailable), "Busy", ei};
+         send_response( fc::json::to_string( results, fc::time_point::maximum() ), static_cast<unsigned int>(http::status::service_unavailable) );
          return false;
       }
       return true;


### PR DESCRIPTION
4xx response codes are for errors caused by the client where 5xx is for errors on the server side. The server exceeding its configured resource quota should be a 5xx error not a 4xx error. Change this from 429 to 503 (which is what it was in 2.0, fwiw). A 5xx error in this condition makes it easier for failover tooling, among other things. Resolves #2129