### PR TITLE
IF: Add a new set_finalizer (with weights, threshold, and local finalizer) to libtester and add more tests using it

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -255,7 +255,7 @@ namespace eosio { namespace testing {
 
          // libtester uses 1 as weight of each of the finalizer, sets (2/3 finalizers + 1)
          // as threshold, and makes all finalizers vote QC
-         transaction_trace_ptr  set_finalizers(const vector<account_name>& finalier_names);
+         transaction_trace_ptr  set_finalizers(const vector<account_name>& finalizer_names);
 
          // Finalizer policy input to set up a test: weights, threshold and local finalizers
          // which participate voting.

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -252,7 +252,24 @@ namespace eosio { namespace testing {
          transaction_trace_ptr       set_producers(const vector<account_name>& producer_names);
          transaction_trace_ptr       set_producer_schedule(const vector<producer_authority>& schedule);
          transaction_trace_ptr       set_producers_legacy(const vector<account_name>& producer_names);
-         transaction_trace_ptr       set_finalizers(const vector<account_name>& finalier_names);
+
+         // libtester uses 1 as weight of each of the finalizer, sets (2/3 finalizers + 1)
+         // as threshold, and makes all finalizers vote QC
+         transaction_trace_ptr  set_finalizers(const vector<account_name>& finalier_names);
+
+         // Finalizer policy input to set up a test: weights, threshold and local finalizers
+         // which participate voting.
+         struct finalizer_policy_input {
+            struct finalizer_info {
+               account_name name;
+               uint64_t     weight;
+            };
+
+            std::vector<finalizer_info> finalizers;
+            uint64_t                    threshold {0};
+            std::vector<account_name>   local_finalizers;
+         };
+         transaction_trace_ptr  set_finalizers(const finalizer_policy_input& input);
 
          void link_authority( account_name account, account_name code,  permission_name req, action_name type = {} );
          void unlink_authority( account_name account, account_name code, action_name type = {} );

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -3917,7 +3917,7 @@ BOOST_AUTO_TEST_CASE(set_finalizer_test) { try {
    BOOST_CHECK_GT(lib, lib_after_transition);
 } FC_LOG_AND_RETHROW() }
 
-void test_finality_transition(const vector<account_name> accounts, const base_tester::finalizer_policy_input& input, bool lib_advancing_expected) {
+void test_finality_transition(const vector<account_name>& accounts, const base_tester::finalizer_policy_input& input, bool lib_advancing_expected) {
    validating_tester t;
 
    uint32_t lib = 0;
@@ -3967,7 +3967,7 @@ BOOST_AUTO_TEST_CASE(threshold_equal_to_half_weight_sum_test) { try {
    };
 
    // threshold set to half of the weight sum of finalizers
-   base_tester::finalizer_policy_input ploicy_input = {
+   base_tester::finalizer_policy_input policy_input = {
       .finalizers       = { {.name = "alice"_n, .weight = 1},
                             {.name = "bob"_n,   .weight = 2},
                             {.name = "carol"_n, .weight = 3} },
@@ -3976,7 +3976,7 @@ BOOST_AUTO_TEST_CASE(threshold_equal_to_half_weight_sum_test) { try {
    };
 
    // threshold must be greater than half of the sum of the weights
-   BOOST_REQUIRE_THROW( test_finality_transition(account_names, ploicy_input, false), eosio_assert_message_exception );
+   BOOST_REQUIRE_THROW( test_finality_transition(account_names, policy_input, false), eosio_assert_message_exception );
 
 } FC_LOG_AND_RETHROW() }
 
@@ -3985,7 +3985,7 @@ BOOST_AUTO_TEST_CASE(votes_equal_to_threshold_test) { try {
       "alice"_n, "bob"_n, "carol"_n
    };
 
-   base_tester::finalizer_policy_input ploicy_input = {
+   base_tester::finalizer_policy_input policy_input = {
       .finalizers       = { {.name = "alice"_n, .weight = 1},
                             {.name = "bob"_n,   .weight = 3},
                             {.name = "carol"_n, .weight = 5} },
@@ -3994,7 +3994,7 @@ BOOST_AUTO_TEST_CASE(votes_equal_to_threshold_test) { try {
    };
 
    // Carol votes with weight 5 and threshold 5
-   test_finality_transition(account_names, ploicy_input, true); // lib_advancing_expected
+   test_finality_transition(account_names, policy_input, true); // lib_advancing_expected
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(votes_greater_than_threshold_test) { try {
@@ -4002,7 +4002,7 @@ BOOST_AUTO_TEST_CASE(votes_greater_than_threshold_test) { try {
       "alice"_n, "bob"_n, "carol"_n
    };
 
-   base_tester::finalizer_policy_input ploicy_input = {
+   base_tester::finalizer_policy_input policy_input = {
       .finalizers       = { {.name = "alice"_n, .weight = 1},
                             {.name = "bob"_n,   .weight = 4},
                             {.name = "carol"_n, .weight = 2} },
@@ -4011,7 +4011,7 @@ BOOST_AUTO_TEST_CASE(votes_greater_than_threshold_test) { try {
    };
 
    // alice and bob vote with weight 5 and threshold 4
-   test_finality_transition(account_names, ploicy_input, true); // lib_advancing_expected
+   test_finality_transition(account_names, policy_input, true); // lib_advancing_expected
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(votes_less_than_threshold_test) { try {
@@ -4019,7 +4019,7 @@ BOOST_AUTO_TEST_CASE(votes_less_than_threshold_test) { try {
       "alice"_n, "bob"_n, "carol"_n
    };
 
-   base_tester::finalizer_policy_input ploicy_input = {
+   base_tester::finalizer_policy_input policy_input = {
       .finalizers       = { {.name = "alice"_n, .weight = 1},
                             {.name = "bob"_n,   .weight = 3},
                             {.name = "carol"_n, .weight = 10} },
@@ -4028,7 +4028,7 @@ BOOST_AUTO_TEST_CASE(votes_less_than_threshold_test) { try {
    };
 
    // alice and bob vote with weight 4 but threshold 8. LIB cannot advance
-   test_finality_transition(account_names, ploicy_input, false); // not expecting lib advancing
+   test_finality_transition(account_names, policy_input, false); // not expecting lib advancing
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -3917,4 +3917,118 @@ BOOST_AUTO_TEST_CASE(set_finalizer_test) { try {
    BOOST_CHECK_GT(lib, lib_after_transition);
 } FC_LOG_AND_RETHROW() }
 
+void test_finality_transition(const vector<account_name> accounts, const base_tester::finalizer_policy_input& input, bool lib_advancing_expected) {
+   validating_tester t;
+
+   uint32_t lib = 0;
+   t.control->irreversible_block.connect([&](const block_signal_params& t) {
+      const auto& [ block, id ] = t;
+      lib = block->block_num();
+   });
+
+   t.produce_block();
+
+   // Create finalizer accounts
+   t.create_accounts(accounts);
+   t.produce_block();
+
+   // activate hotstuff
+   t.set_finalizers(input);
+   auto block = t.produce_block(); // this block contains the header extension for the instant finality
+
+   std::optional<block_header_extension> ext = block->extract_header_extension(instant_finality_extension::extension_id());
+   BOOST_TEST(!!ext);
+   std::optional<finalizer_policy> fin_policy = std::get<instant_finality_extension>(*ext).new_finalizer_policy;
+   BOOST_TEST(!!fin_policy);
+   BOOST_TEST(fin_policy->finalizers.size() == accounts.size());
+   BOOST_TEST(fin_policy->generation == 1);
+
+   block = t.produce_block(); // hotstuff now active
+   BOOST_TEST(block->confirmed == 0);
+   auto fb = t.control->fetch_block_by_id(block->calculate_id());
+   BOOST_REQUIRE(!!fb);
+   BOOST_TEST(fb == block);
+   ext = fb->extract_header_extension(instant_finality_extension::extension_id());
+   BOOST_REQUIRE(ext);
+
+   auto lib_after_transition = lib;
+
+   t.produce_blocks(4);
+   if( lib_advancing_expected ) {
+      BOOST_CHECK_GT(lib, lib_after_transition);
+   } else {
+      BOOST_CHECK_EQUAL(lib, lib_after_transition);
+   }
+}
+
+BOOST_AUTO_TEST_CASE(threshold_equal_to_half_weight_sum_test) { try {
+   vector<account_name> account_names = {
+      "alice"_n, "bob"_n, "carol"_n
+   };
+
+   // threshold set to half of the weight sum of finalizers
+   base_tester::finalizer_policy_input ploicy_input = {
+      .finalizers       = { {.name = "alice"_n, .weight = 1},
+                            {.name = "bob"_n,   .weight = 2},
+                            {.name = "carol"_n, .weight = 3} },
+      .threshold        = 3,
+      .local_finalizers = {"alice"_n, "bob"_n}
+   };
+
+   // threshold must be greater than half of the sum of the weights
+   BOOST_REQUIRE_THROW( test_finality_transition(account_names, ploicy_input, false), eosio_assert_message_exception );
+
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_CASE(votes_equal_to_threshold_test) { try {
+   vector<account_name> account_names = {
+      "alice"_n, "bob"_n, "carol"_n
+   };
+
+   base_tester::finalizer_policy_input ploicy_input = {
+      .finalizers       = { {.name = "alice"_n, .weight = 1},
+                            {.name = "bob"_n,   .weight = 3},
+                            {.name = "carol"_n, .weight = 5} },
+      .threshold        = 5,
+      .local_finalizers = {"carol"_n}
+   };
+
+   // Carol votes with weight 5 and threshold 5
+   test_finality_transition(account_names, ploicy_input, true); // lib_advancing_expected
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_CASE(votes_greater_than_threshold_test) { try {
+   vector<account_name> account_names = {
+      "alice"_n, "bob"_n, "carol"_n
+   };
+
+   base_tester::finalizer_policy_input ploicy_input = {
+      .finalizers       = { {.name = "alice"_n, .weight = 1},
+                            {.name = "bob"_n,   .weight = 4},
+                            {.name = "carol"_n, .weight = 2} },
+      .threshold        = 4,
+      .local_finalizers = {"alice"_n, "bob"_n}
+   };
+
+   // alice and bob vote with weight 5 and threshold 4
+   test_finality_transition(account_names, ploicy_input, true); // lib_advancing_expected
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_CASE(votes_less_than_threshold_test) { try {
+   vector<account_name> account_names = {
+      "alice"_n, "bob"_n, "carol"_n
+   };
+
+   base_tester::finalizer_policy_input ploicy_input = {
+      .finalizers       = { {.name = "alice"_n, .weight = 1},
+                            {.name = "bob"_n,   .weight = 3},
+                            {.name = "carol"_n, .weight = 10} },
+      .threshold        = 8,
+      .local_finalizers = {"alice"_n, "bob"_n}
+   };
+
+   // alice and bob vote with weight 4 but threshold 8. LIB cannot advance
+   test_finality_transition(account_names, ploicy_input, false); // not expecting lib advancing
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
* Add a new set_finalizer which takes  threshold, weight and local finalizers as arguments
* Using the new function, add tests `threshold_equal_to_half_weight_sum_test`, `votes_equal_to_threshold_test`, `votes_greater_than_threshold_test`, and `votes_less_than_threshold_test`.

Resolved https://github.com/AntelopeIO/leap/issues/2193