### PR TITLE
[5.0] fix crash/UB when exceeding `http-max-requests-in-flight`

### DIFF
--- a/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp
@@ -492,8 +492,9 @@ public:
 
    void run_session() {
       if(auto error_str = verify_max_requests_in_flight(); !error_str.empty()) {
+         res_->keep_alive(false);
          send_busy_response(std::move(error_str));
-         return do_eof();
+         return;
       }
 
       do_read_header();


### PR DESCRIPTION
When `verify_max_requests_in_flight()` indicates we've exceeded max requests in flight, `send_busy_response()`, via `send_response()`, queues up an `async_write()` on the socket. But once this `async_write()` returns, `do_eof()` would be called which closes the socket while operations are pending. This causes bad things to happen.

Instead, set the `keep_alive(false)` on the response, which flags `needs_eof()` so that,
https://github.com/AntelopeIO/leap/blob/3394e0be5c59dc701b3fdd1e72130f50c9dd39e5/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp#L478
will be set to `true`, which means the socket will be properly disposed of once the `async_write()` completes,
https://github.com/AntelopeIO/leap/blob/3394e0be5c59dc701b3fdd1e72130f50c9dd39e5/plugins/http_plugin/include/eosio/http_plugin/beast_http_session.hpp#L368-L372