### PR TITLE
[5.0] move some tests that open localhost sockets to NP tests

### DIFF
--- a/plugins/http_plugin/tests/CMakeLists.txt
+++ b/plugins/http_plugin/tests/CMakeLists.txt
@@ -11,3 +11,4 @@ target_include_directories( http_plugin_unit_tests PUBLIC
                             ${CMAKE_SOURCE_DIR}/plugins/http_plugin/include )
 
 add_test( NAME http_plugin_unit_tests COMMAND http_plugin_unit_tests )
+set_property(TEST http_plugin_unit_tests PROPERTY LABELS nonparallelizable_tests)

--- a/plugins/state_history_plugin/tests/CMakeLists.txt
+++ b/plugins/state_history_plugin/tests/CMakeLists.txt
@@ -3,3 +3,4 @@ target_link_libraries(test_state_history state_history_plugin eosio_testing eosi
 target_include_directories( test_state_history PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include" )
 
 add_test(test_state_history test_state_history)
+set_property(TEST test_state_history PROPERTY LABELS nonparallelizable_tests)

--- a/tests/trx_generator/CMakeLists.txt
+++ b/tests/trx_generator/CMakeLists.txt
@@ -8,3 +8,4 @@ add_executable(trx_generator_tests trx_generator_tests.cpp trx_provider.cpp trx_
 target_link_libraries(trx_generator_tests PRIVATE eosio_chain fc Boost::program_options ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS})
 target_include_directories(trx_generator_tests PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(trx_generator_tests trx_generator_tests)
+set_property(TEST trx_generator_tests PROPERTY LABELS nonparallelizable_tests)


### PR DESCRIPTION
Any test that listens on a localhost socket is required to be in NP tests currently. Resolves #2213