### PR TITLE
IF: Test: Transition to instant-finality with multiple producers

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -98,8 +98,8 @@ block_header_state block_header_state::next(block_header_state_input& input) con
 
    if(!proposer_policies.empty()) {
       auto it = proposer_policies.begin();
-      // -1 since this is called after the block is built, this will be the active schedule for the next block
-      if (it->first.slot <= input.timestamp.slot - 1) {
+      // +1 since this is called after the block is built, this will be the active schedule for the next block
+      if (it->first.slot <= input.timestamp.slot + 1) {
          result.active_proposer_policy = it->second;
          result.header.schedule_version = header.schedule_version + 1;
          result.active_proposer_policy->proposer_schedule.version = result.header.schedule_version;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/subjective_billing_test.py ${CMAKE_CU
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/get_account_test.py ${CMAKE_CURRENT_BINARY_DIR}/get_account_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_high_transaction_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_high_transaction_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_retry_transaction_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_retry_transaction_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/transition_to_if.py ${CMAKE_CURRENT_BINARY_DIR}/transition_to_if.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/trx_finality_status_test.py ${CMAKE_CURRENT_BINARY_DIR}/trx_finality_status_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/trx_finality_status_forked_test.py ${CMAKE_CURRENT_BINARY_DIR}/trx_finality_status_forked_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plugin_http_api_test.py ${CMAKE_CURRENT_BINARY_DIR}/plugin_http_api_test.py COPYONLY)
@@ -129,6 +130,9 @@ add_test(NAME cluster_launcher COMMAND tests/cluster_launcher.py -v ${UNSHARE} W
 set_property(TEST cluster_launcher PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME cluster_launcher_if COMMAND tests/cluster_launcher.py --activate-if -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST cluster_launcher_if PROPERTY LABELS nonparallelizable_tests)
+
+add_test(NAME transition_to_if COMMAND tests/transition_to_if.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST transition_to_if PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME ship_test COMMAND tests/ship_test.py -v --num-clients 10 --num-requests 5000 ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST ship_test PROPERTY LABELS nonparallelizable_tests)

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -482,6 +482,7 @@ class Cluster(object):
                         Path(instance.config_dir_name), eosdcmd, unstarted=instance.dont_start,
                         launch_time=launcher.launch_time, walletMgr=self.walletMgr, nodeosVers=self.nodeosVers)
             node.keys = instance.keys
+            node.isProducer = len(instance.producers) > 0
             if nodeNum == Node.biosNodeId:
                 self.biosNode = node
             else:
@@ -1000,7 +1001,9 @@ class Cluster(object):
         for n in (self.nodes + [self.biosNode]):
             if not n or not n.keys or not n.keys[0].blspubkey:
                 continue
-            if n.nodeId == Node.biosNodeId and not biosFinalizer:
+            if not n.isProducer:
+                continue
+            if n.nodeId == 'bios' and not biosFinalizer:
                 continue
             numFins = numFins + 1
 
@@ -1016,7 +1019,9 @@ class Cluster(object):
         for n in (self.nodes + [self.biosNode]):
             if not n or not n.keys or not n.keys[0].blspubkey:
                 continue
-            if n.nodeId == Node.biosNodeId and not biosFinalizer:
+            if not n.isProducer:
+                continue
+            if n.nodeId == 'bios' and not biosFinalizer:
                 continue
             setFinStr += f'    {{"description": "finalizer #{finNum}", '
             setFinStr += f'     "weight":1, '
@@ -1105,7 +1110,7 @@ class Cluster(object):
             return None
 
         if activateIF:
-            self.activateInstantFinality(biosFinalizer)
+            self.activateInstantFinality(biosFinalizer=biosFinalizer)
 
         Utils.Print("Creating accounts: %s " % ", ".join(producerKeys.keys()))
         producerKeys.pop(eosioName)
@@ -1204,7 +1209,7 @@ class Cluster(object):
         #
         # Could activate instant finality here, but have to wait for finality which with all the producers takes a long time
         #         if activateIF:
-        #             self.activateInstantFinality(launcher)
+        #             self.activateInstantFinality()
 
         eosioTokenAccount = copy.deepcopy(eosioAccount)
         eosioTokenAccount.name = 'eosio.token'

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -1460,8 +1460,8 @@ class Cluster(object):
         for f in self.filesToCleanup:
             os.remove(f)
 
-    # Create accounts, if account does not already exist, and validates that the last transaction is received on root node
     def setProds(self, producers):
+        """Call setprods with list of producers"""
         setProdsStr = '{"schedule": ['
         firstTime = True
         for name in producers:
@@ -1485,6 +1485,7 @@ class Cluster(object):
             return None
         return True
 
+    # Create accounts, if account does not already exist, and validates that the last transaction is received on root node
     def createAccounts(self, creator, waitForTransBlock=True, stakedDeposit=1000, validationNodeIndex=-1):
         if self.accounts is None:
             return True

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -10,6 +10,7 @@ import signal
 import sys
 from pathlib import Path
 from typing import List
+from dataclasses import InitVar, dataclass, field, is_dataclass, asdict
 
 from datetime import datetime
 from datetime import timedelta
@@ -20,6 +21,14 @@ from .accounts import Account
 from .testUtils import Utils
 from .testUtils import unhandledEnumType
 from .testUtils import ReturnType
+
+@dataclass
+class KeyStrings(object):
+    pubkey: str
+    privkey: str
+    blspubkey: str = None
+    blsprivkey: str = None
+    blspop: str = None
 
 # pylint: disable=too-many-public-methods
 class Node(Transactions):
@@ -66,6 +75,7 @@ class Node(Transactions):
         self.config_dir=config_dir
         self.launch_time=launch_time
         self.isProducer=False
+        self.keys: List[KeyStrings] = field(default_factory=list)
         self.configureVersion()
 
     def configureVersion(self):

--- a/tests/transition_to_if.py
+++ b/tests/transition_to_if.py
@@ -15,8 +15,6 @@ Print=Utils.Print
 errorExit=Utils.errorExit
 
 appArgs = AppArgs()
-appArgs.add(flag="--plugin",action='append',type=str,help="Run nodes with additional plugins")
-
 args=TestHelper.parse_args({"-d","-s","--keep-logs","--dump-error-details","-v","--leave-running","--unshared"},
                             applicationSpecificArgs=appArgs)
 pnodes=4
@@ -41,13 +39,9 @@ try:
     Print(f'producing nodes: {pnodes}, topology: {topo}, delay between nodes launch: {delay} second{"s" if delay != 1 else ""}')
 
     Print("Stand up cluster")
-    if args.plugin:
-        extraNodeosArgs = ''.join([i+j for i,j in zip([' --plugin '] * len(args.plugin), args.plugin)])
-    else:
-        extraNodeosArgs = ''
     # For now do not load system contract as it does not support setfinalizer
     if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, prodCount=prod_count, topo=topo, delay=delay, loadSystemContract=False,
-                      activateIF=False, extraNodeosArgs=extraNodeosArgs) is False:
+                      activateIF=False) is False:
         errorExit("Failed to stand up eos cluster.")
 
     assert cluster.biosNode.getInfo(exitOnError=True)["head_block_producer"] != "eosio", "launch should have waited for production to change"

--- a/tests/transition_to_if.py
+++ b/tests/transition_to_if.py
@@ -6,7 +6,7 @@ from TestHarness.TestHelper import AppArgs
 ###############################################################
 # transition_to_if
 #
-# Transition to instant-finality with multiple producers
+# Transition to instant-finality with multiple producers (at least 4).
 #
 ###############################################################
 
@@ -17,16 +17,14 @@ errorExit=Utils.errorExit
 appArgs = AppArgs()
 appArgs.add(flag="--plugin",action='append',type=str,help="Run nodes with additional plugins")
 
-args=TestHelper.parse_args({"-p","-n","-d","-s","--keep-logs","--prod-count",
-                            "--dump-error-details","-v","--leave-running"
-                            ,"--unshared"},
+args=TestHelper.parse_args({"-d","-s","--keep-logs","--dump-error-details","-v","--leave-running","--unshared"},
                             applicationSpecificArgs=appArgs)
-pnodes=args.p
+pnodes=4
 delay=args.d
 topo=args.s
 debug=args.v
-prod_count = args.prod_count
-total_nodes=args.n if args.n > 0 else pnodes
+prod_count = 1 # per node prod count
+total_nodes=pnodes
 dumpErrorDetails=args.dump_error_details
 
 Utils.Debug=debug
@@ -52,7 +50,28 @@ try:
                       activateIF=False, extraNodeosArgs=extraNodeosArgs) is False:
         errorExit("Failed to stand up eos cluster.")
 
-    cluster.activateInstantFinality(biosFinalizer=False)
+    assert cluster.biosNode.getInfo(exitOnError=True)["head_block_producer"] != "eosio", "launch should have waited for production to change"
+
+    assert cluster.activateInstantFinality(biosFinalizer=False), "Activate instant finality failed"
+
+    assert cluster.biosNode.waitForLibToAdvance(), "Lib should advance after instant finality activated"
+    assert cluster.biosNode.waitForProducer("defproducera"), "Did not see defproducera"
+    assert cluster.biosNode.waitForHeadToAdvance(blocksToAdvance=13) # into next producer
+    assert cluster.biosNode.waitForLibToAdvance(), "Lib stopped advancing"
+
+    info = cluster.biosNode.getInfo(exitOnError=True)
+    assert (info["head_block_num"] - info["last_irreversible_block_num"]) < 9, "Instant finality enabled LIB diff should be small"
+
+    # launch setup node_00 (defproducera - defproducerf), node_01 (defproducerg - defproducerk),
+    #              node_02 (defproducerl - defproducerp), node_03 (defproducerq - defproduceru)
+    # with setprods of (defproducera, defproducerg, defproducerl, defproducerq)
+    assert cluster.biosNode.waitForProducer("defproducerq"), "defproducerq did not produce"
+
+    # should take effect in first block of defproducerg slot (so defproducerh)
+    assert cluster.setProds(["defproducerb", "defproducerh", "defproducerm", "defproducerr"]), "setprods failed"
+    setProdsBlockNum = cluster.biosNode.getBlockNum()
+    cluster.biosNode.waitForBlock(setProdsBlockNum+12+12+1)
+    assert cluster.biosNode.getInfo(exitOnError=True)["head_block_producer"] == "defproducerh", "setprods should have taken effect"
 
     testSuccessful=True
 finally:

--- a/tests/transition_to_if.py
+++ b/tests/transition_to_if.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+from TestHarness import Cluster, TestHelper, Utils, WalletMgr
+from TestHarness.TestHelper import AppArgs
+
+###############################################################
+# transition_to_if
+#
+# Transition to instant-finality with multiple producers
+#
+###############################################################
+
+
+Print=Utils.Print
+errorExit=Utils.errorExit
+
+appArgs = AppArgs()
+appArgs.add(flag="--plugin",action='append',type=str,help="Run nodes with additional plugins")
+
+args=TestHelper.parse_args({"-p","-n","-d","-s","--keep-logs","--prod-count",
+                            "--dump-error-details","-v","--leave-running"
+                            ,"--unshared"},
+                            applicationSpecificArgs=appArgs)
+pnodes=args.p
+delay=args.d
+topo=args.s
+debug=args.v
+prod_count = args.prod_count
+total_nodes=args.n if args.n > 0 else pnodes
+dumpErrorDetails=args.dump_error_details
+
+Utils.Debug=debug
+testSuccessful=False
+
+cluster=Cluster(unshared=args.unshared, keepRunning=args.leave_running, keepLogs=args.keep_logs)
+walletMgr=WalletMgr(True)
+
+try:
+    TestHelper.printSystemInfo("BEGIN")
+
+    cluster.setWalletMgr(walletMgr)
+
+    Print(f'producing nodes: {pnodes}, topology: {topo}, delay between nodes launch: {delay} second{"s" if delay != 1 else ""}')
+
+    Print("Stand up cluster")
+    if args.plugin:
+        extraNodeosArgs = ''.join([i+j for i,j in zip([' --plugin '] * len(args.plugin), args.plugin)])
+    else:
+        extraNodeosArgs = ''
+    # For now do not load system contract as it does not support setfinalizer
+    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, prodCount=prod_count, topo=topo, delay=delay, loadSystemContract=False,
+                      activateIF=False, extraNodeosArgs=extraNodeosArgs) is False:
+        errorExit("Failed to stand up eos cluster.")
+
+    cluster.activateInstantFinality(biosFinalizer=False)
+
+    testSuccessful=True
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, dumpErrorDetails=dumpErrorDetails)
+
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/unittests/producer_schedule_if_tests.cpp
+++ b/unittests/producer_schedule_if_tests.cpp
@@ -72,10 +72,10 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule_after_instant_finality_activat
 
    // ---- Test first set of producers ----
    // Send set prods action and confirm schedule correctness
-   set_producers(producers);
+   auto trace = set_producers(producers);
    const auto first_prod_schd = get_producer_authorities(producers);
-   // TODO: update expected when lib for instant_finality is working, will change from 26 at that time, 4+12+12
-   confirm_schedule_correctness(first_prod_schd, 1, 26);
+   // called in first round so complete it, skip one round of 12 and start on next round, so block 24
+   confirm_schedule_correctness(first_prod_schd, 1, 24);
 
    // ---- Test second set of producers ----
    vector<account_name> second_set_of_producer = {
@@ -84,8 +84,8 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule_after_instant_finality_activat
    // Send set prods action and confirm schedule correctness
    set_producers(second_set_of_producer);
    const auto second_prod_schd = get_producer_authorities(second_set_of_producer);
-   // TODO: update expected when lib for instant_finality is working, will change from 50 at that time, 26+12+12
-   confirm_schedule_correctness(second_prod_schd, 2, 50);
+   // called after block 24, so next,next is 48
+   confirm_schedule_correctness(second_prod_schd, 2, 48);
 
    // ---- Test deliberately miss some blocks ----
    const int64_t num_of_missed_blocks = 5000;


### PR DESCRIPTION
- Adds integration test that verifies transition to instant-finality works with multiple producers producing before transition
- Adds integration test for `setprods` after transition to instant-finality
- Fix issue found with `setprods` to activate new proposer policy at correct block (the first block of the producer)

Resolves #1512