### PR TITLE
IF: reenable weak vote related tests

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1860,6 +1860,18 @@ struct controller_impl {
       );
    }
 
+   digest_type get_strong_digest_by_id( const block_id_type& id ) const {
+      return fork_db.apply<digest_type>(
+         overloaded{
+            [](const fork_database_legacy_t&) -> digest_type { return digest_type{}; },
+            [&](const fork_database_if_t& forkdb) -> digest_type {
+               auto bsp = forkdb.get_block(id);
+               return bsp ? bsp->strong_digest : digest_type{};
+            }
+         }
+      );
+   }
+
    fc::sha256 calculate_integrity_hash() {
       fc::sha256::encoder enc;
       auto hash_writer = std::make_shared<integrity_hash_snapshot_writer>(enc);
@@ -4462,6 +4474,10 @@ block_id_type controller::get_block_id_for_num( uint32_t block_num )const { try 
 
    return id;
 } FC_CAPTURE_AND_RETHROW( (block_num) ) }
+
+digest_type controller::get_strong_digest_by_id( const block_id_type& id ) const {
+   return my->get_strong_digest_by_id(id);
+}
 
 fc::sha256 controller::calculate_integrity_hash() { try {
    return my->calculate_integrity_hash();

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -289,6 +289,8 @@ namespace eosio::chain {
          std::optional<signed_block_header> fetch_block_header_by_id( const block_id_type& id )const;
          // thread-safe
          block_id_type get_block_id_for_num( uint32_t block_num )const;
+         // thread-safe
+         digest_type get_strong_digest_by_id( const block_id_type& id ) const; // used in unittests
 
          fc::sha256 calculate_integrity_hash();
          void write_snapshot( const snapshot_writer_ptr& snapshot );

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -255,7 +255,7 @@ namespace eosio { namespace testing {
 
          // libtester uses 1 as weight of each of the finalizer, sets (2/3 finalizers + 1)
          // as threshold, and makes all finalizers vote QC
-         transaction_trace_ptr  set_finalizers(const vector<account_name>& finalizer_names);
+         std::pair<transaction_trace_ptr, std::vector<fc::crypto::blslib::bls_private_key>> set_finalizers(const vector<account_name>& finalizer_names);
 
          // Finalizer policy input to set up a test: weights, threshold and local finalizers
          // which participate voting.
@@ -269,7 +269,7 @@ namespace eosio { namespace testing {
             uint64_t                    threshold {0};
             std::vector<account_name>   local_finalizers;
          };
-         transaction_trace_ptr  set_finalizers(const finalizer_policy_input& input);
+         std::pair<transaction_trace_ptr, std::vector<fc::crypto::blslib::bls_private_key>> set_finalizers(const finalizer_policy_input& input);
 
          void link_authority( account_name account, account_name code,  permission_name req, action_name type = {} );
          void unlink_authority( account_name account, account_name code, action_name type = {} );

--- a/unittests/finality_test_cluster.hpp
+++ b/unittests/finality_test_cluster.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <eosio/chain/hotstuff/finalizer_authority.hpp>
+#include <fc/crypto/bls_private_key.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
@@ -78,6 +79,7 @@ private:
       eosio::testing::tester                  node;
       uint32_t                                prev_lib_num{0};
       std::vector<eosio::chain::vote_message> votes;
+      fc::crypto::blslib::bls_private_key     priv_key;
    };
 
    std::array<node_info, 3> nodes;

--- a/unittests/finality_tests.cpp
+++ b/unittests/finality_tests.cpp
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(two_weak_votes) { try {
    BOOST_REQUIRE(cluster.produce_blocks_and_verify_lib_advancing());
 } FC_LOG_AND_RETHROW() }
 
-BOOST_AUTO_TEST_CASE(interwined_weak_votes) { try {
+BOOST_AUTO_TEST_CASE(intertwined_weak_votes) { try {
    finality_test_cluster cluster;
 
    // Weak vote

--- a/unittests/finality_tests.cpp
+++ b/unittests/finality_tests.cpp
@@ -188,7 +188,6 @@ BOOST_AUTO_TEST_CASE(long_delayed_votes) { try {
    cluster.process_node1_vote();
    // the vote makes a strong QC for the current block, prompting LIB advance on node0
    BOOST_REQUIRE(cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    for (auto i = 2; i < 100; ++i) {
@@ -221,14 +220,11 @@ BOOST_AUTO_TEST_CASE(lost_votes) { try {
 
    // the vote makes a strong QC for the current block, prompting LIB advance on node0
    BOOST_REQUIRE(cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    BOOST_REQUIRE(cluster.produce_blocks_and_verify_lib_advancing());
 } FC_LOG_AND_RETHROW() }
 
-#warning "Re-enable these tests"
-#if 0
 BOOST_AUTO_TEST_CASE(one_weak_vote) { try {
    finality_test_cluster cluster;
 
@@ -236,7 +232,6 @@ BOOST_AUTO_TEST_CASE(one_weak_vote) { try {
    cluster.produce_and_push_block();
    // Change the vote to a weak vote and process it
    cluster.process_node1_vote(0, finality_test_cluster::vote_mode::weak);
-
    // A weak QC is created and LIB does not advance on node0
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
    // The strong QC extension for prior block makes LIB advance on node1
@@ -248,13 +243,12 @@ BOOST_AUTO_TEST_CASE(one_weak_vote) { try {
    // its final_on_strong_qc_block_num is nullopt due to previous QC was weak.
    // Cannot advance LIB.
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
+   // no 2-chain was formed as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    cluster.produce_and_push_block();
    cluster.process_node1_vote();
    BOOST_REQUIRE(cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    cluster.produce_and_push_block();
@@ -262,7 +256,6 @@ BOOST_AUTO_TEST_CASE(one_weak_vote) { try {
    // the vote makes a strong QC and a higher final_on_strong_qc,
    // prompting LIB advance on node0
    BOOST_REQUIRE(cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(cluster.node1_lib_advancing());
 
    // now a 3 chain has formed.
@@ -285,21 +278,19 @@ BOOST_AUTO_TEST_CASE(two_weak_votes) { try {
    cluster.process_node1_vote(finality_test_cluster::vote_mode::weak);
    // A weak QC cannot advance LIB on node0
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
+   // no 2-chain was formed as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    cluster.produce_and_push_block();
    cluster.process_node1_vote();
    // the vote makes a strong QC for the current block, prompting LIB advance on node0
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    cluster.produce_and_push_block();
    cluster.process_node1_vote();
    // the vote makes a strong QC for the current block, prompting LIB advance on node0
    BOOST_REQUIRE(cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    // now a 3 chain has formed.
@@ -324,7 +315,7 @@ BOOST_AUTO_TEST_CASE(interwined_weak_votes) { try {
    // its final_on_strong_qc_block_num is nullopt due to previous QC was weak.
    // Cannot advance LIB.
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
+   // no 2-chain was formed as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    // Weak vote
@@ -332,7 +323,6 @@ BOOST_AUTO_TEST_CASE(interwined_weak_votes) { try {
    cluster.process_node1_vote(finality_test_cluster::vote_mode::weak);
    // A weak QC cannot advance LIB on node0
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    // Strong vote
@@ -340,7 +330,7 @@ BOOST_AUTO_TEST_CASE(interwined_weak_votes) { try {
    cluster.process_node1_vote();
    // the vote makes a strong QC for the current block, prompting LIB advance on node0
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
+   // no 2-chain was formed as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    // Strong vote
@@ -374,13 +364,11 @@ BOOST_AUTO_TEST_CASE(weak_delayed_lost_vote) { try {
    // The vote makes a strong QC, but final_on_strong_qc is null.
    // Do not advance LIB
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    // A lost vote
    cluster.produce_and_push_block();
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    // The delayed vote arrives
@@ -429,13 +417,11 @@ BOOST_AUTO_TEST_CASE(delayed_strong_weak_lost_vote) { try {
    // The vote makes a strong QC, but final_on_strong_qc is null.
    // LIB did not advance.
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    // A lost vote
    cluster.produce_and_push_block();
    BOOST_REQUIRE(!cluster.node0_lib_advancing());
-   // the block does not has a QC extension as prior block was not a strong block
    BOOST_REQUIRE(!cluster.node1_lib_advancing());
 
    // The delayed vote arrives
@@ -455,7 +441,6 @@ BOOST_AUTO_TEST_CASE(delayed_strong_weak_lost_vote) { try {
 
    BOOST_REQUIRE(cluster.produce_blocks_and_verify_lib_advancing());
 } FC_LOG_AND_RETHROW() }
-#endif
 
 // verify duplicate votes do not affect LIB advancing
 BOOST_AUTO_TEST_CASE(duplicate_votes) { try {


### PR DESCRIPTION
Prior to https://github.com/AntelopeIO/leap/pull/2135, weak votes and strong votes were signed using the same digest. The weak votes related tests in finality_tests.cpp were constructed based on the same digest; those tests had to be disabled to get #2135 to move ahead.

This PR fixes the issue. All disabled tests have been re-enabled.

Resolved https://github.com/AntelopeIO/leap/issues/2193 