### PR TITLE
IF: Sign and verify signature or proposed blocks

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -71,8 +71,7 @@ block_header_state block_header_state::next(block_header_state_input& input) con
 
    // header
    // ------
-   result.header = signed_block_header {
-      block_header {
+   result.header = {
       .timestamp         = input.timestamp, // [greg todo] do we have to do the slot++ stuff from the legacy version?
       .producer          = input.producer,
       .confirmed         = 0,
@@ -80,7 +79,7 @@ block_header_state block_header_state::next(block_header_state_input& input) con
       .transaction_mroot = input.transaction_mroot,
       .action_mroot      = input.action_mroot,
       .schedule_version  = header.schedule_version
-   }};
+   };
 
    // activated protocol features
    // ---------------------------

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -177,8 +177,6 @@ block_header_state block_header_state::next(block_header_state_input& input) con
  *
  *  Given a signed block header, generate the expected template based upon the header time,
  *  then validate that the provided header matches the template.
- *
- *  If the header specifies new_producers then apply them accordingly.
  */
 block_header_state block_header_state::next(const signed_block_header& h, validator_t& validator) const {
    auto producer = detail::get_scheduled_producer(active_proposer_policy->proposer_schedule.producers, h.timestamp).producer_name;

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -12,7 +12,7 @@ namespace eosio::chain {
 // digest_type           compute_finalizer_digest() const { return id; };
 
 
-producer_authority block_header_state::get_scheduled_producer(block_timestamp_type t) const {
+const producer_authority& block_header_state::get_scheduled_producer(block_timestamp_type t) const {
    return detail::get_scheduled_producer(active_proposer_policy->proposer_schedule.producers, t);
 }
 

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -71,7 +71,8 @@ block_header_state block_header_state::next(block_header_state_input& input) con
 
    // header
    // ------
-   result.header = block_header {
+   result.header = signed_block_header {
+      block_header {
       .timestamp         = input.timestamp, // [greg todo] do we have to do the slot++ stuff from the legacy version?
       .producer          = input.producer,
       .confirmed         = 0,
@@ -79,7 +80,7 @@ block_header_state block_header_state::next(block_header_state_input& input) con
       .transaction_mroot = input.transaction_mroot,
       .action_mroot      = input.action_mroot,
       .schedule_version  = header.schedule_version
-   };
+   }};
 
    // activated protocol features
    // ---------------------------
@@ -180,13 +181,13 @@ block_header_state block_header_state::next(block_header_state_input& input) con
  *
  *  If the header specifies new_producers then apply them accordingly.
  */
-block_header_state block_header_state::next(const signed_block_header& h, const protocol_feature_set& pfs,
-                                            validator_t& validator) const {
+block_header_state block_header_state::next(const signed_block_header& h, validator_t& validator) const {
    auto producer = detail::get_scheduled_producer(active_proposer_policy->proposer_schedule.producers, h.timestamp).producer_name;
    
    EOS_ASSERT( h.previous == block_id, unlinkable_block_exception, "previous mismatch" );
    EOS_ASSERT( h.producer == producer, wrong_producer, "wrong producer specified" );
    EOS_ASSERT( h.confirmed == 0, block_validate_exception, "invalid confirmed ${c}", ("c", h.confirmed) );
+   EOS_ASSERT( !h.new_producers, producer_schedule_exception, "Block header contains legacy producer schedule outdated by activation of WTMsig Block Signatures" );
 
    auto exts = h.validate_and_extract_header_extensions();
 
@@ -197,6 +198,7 @@ block_header_state block_header_state::next(const signed_block_header& h, const 
       auto  pfa_entry = exts.lower_bound(protocol_feature_activation::extension_id());
       auto& pfa_ext   = std::get<protocol_feature_activation>(pfa_entry->second);
       new_protocol_feature_activations = std::move(pfa_ext.protocol_features);
+      validator( timestamp(), activated_protocol_features->protocol_features, new_protocol_feature_activations );
    }
 
    // retrieve instant_finality_extension data from block header extension

--- a/libraries/chain/block_header_state_legacy.cpp
+++ b/libraries/chain/block_header_state_legacy.cpp
@@ -19,7 +19,7 @@ namespace eosio::chain {
       return blocknums[ index ];
    }
 
-   producer_authority block_header_state_legacy::get_scheduled_producer( block_timestamp_type t ) const {
+   const producer_authority& block_header_state_legacy::get_scheduled_producer( block_timestamp_type t ) const {
       return detail::get_scheduled_producer(active_schedule.producers, t);
    }
 
@@ -34,7 +34,7 @@ namespace eosio::chain {
         (when = header.timestamp).slot++;
       }
 
-      auto proauth = get_scheduled_producer(when);
+      const auto& proauth = get_scheduled_producer(when);
 
       auto itr = producer_to_last_produced.find( proauth.producer_name );
       if( itr != producer_to_last_produced.end() ) {

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -18,7 +18,7 @@ block_state::block_state(const block_header_state& prev, signed_block_ptr b, con
 {
    // ASSUMPTION FROM controller_impl::apply_block = all untrusted blocks will have their signatures pre-validated here
    if( !skip_validate_signee ) {
-      auto sigs = detail::extract_additional_signatures(b);
+      auto sigs = detail::extract_additional_signatures(block);
       verify_signee(sigs);
    }
 }
@@ -218,7 +218,7 @@ void block_state::sign( const signer_callback_type& signer ) {
    auto sigs = signer( block_id );
 
    EOS_ASSERT(!sigs.empty(), no_block_signatures, "Signer returned no signatures");
-   header.producer_signature = sigs.back();
+   block->producer_signature = sigs.back();
    sigs.pop_back();
 
    verify_signee(sigs);
@@ -237,7 +237,7 @@ void block_state::verify_signee(const std::vector<signature_type>& additional_si
    );
 
    std::set<public_key_type> keys;
-   keys.emplace(fc::crypto::public_key( header.producer_signature, block_id, true ));
+   keys.emplace(fc::crypto::public_key( block->producer_signature, block_id, true ));
 
    for (const auto& s: additional_signatures) {
       auto res = keys.emplace(s, block_id, true);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -332,7 +332,7 @@ struct assembled_block {
                                    },
                                    [&](assembled_block_if& ab) {
                                       auto bsp = std::make_shared<block_state>(ab.bhs, std::move(ab.trx_metas),
-                                                                               std::move(ab.trx_receipts), ab.qc);
+                                                                               std::move(ab.trx_receipts), ab.qc, signer);
                                       return completed_block{std::move(bsp)};
                                    }},
                         v);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -322,7 +322,7 @@ struct assembled_block {
    }
 
    completed_block complete_block(const protocol_feature_set& pfs, validator_t validator,
-                                  const signer_callback_type& signer) {
+                                  const signer_callback_type& signer, const block_signing_authority& valid_block_signing_authority) {
       return std::visit(overloaded{[&](assembled_block_legacy& ab) {
                                       auto bsp = std::make_shared<block_state_legacy>(
                                          std::move(ab.pending_block_header_state), std::move(ab.unsigned_block),
@@ -332,7 +332,8 @@ struct assembled_block {
                                    },
                                    [&](assembled_block_if& ab) {
                                       auto bsp = std::make_shared<block_state>(ab.bhs, std::move(ab.trx_metas),
-                                                                               std::move(ab.trx_receipts), ab.qc, signer);
+                                                                               std::move(ab.trx_receipts), ab.qc, signer,
+                                                                               valid_block_signing_authority);
                                       return completed_block{std::move(bsp)};
                                    }},
                         v);
@@ -4205,10 +4206,12 @@ void controller::assemble_and_complete_block( block_report& br, const signer_cal
    my->assemble_block();
 
    auto& ab = std::get<assembled_block>(my->pending->_block_stage);
+   const auto& valid_block_signing_authority = my->head_active_schedule_auth().get_scheduled_producer(ab.timestamp()).authority;
    my->pending->_block_stage = ab.complete_block(
       my->protocol_features.get_protocol_feature_set(),
       [](block_timestamp_type timestamp, const flat_set<digest_type>& cur_features, const vector<digest_type>& new_features) {},
-      signer_callback);
+      signer_callback,
+      valid_block_signing_authority);
 
    br = my->pending->_block_report;
 }

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -82,7 +82,7 @@ struct block_header_state {
 
    flat_set<digest_type> get_activated_protocol_features() const { return activated_protocol_features->protocol_features; }
    const vector<digest_type>& get_new_protocol_feature_activations() const;
-   producer_authority get_scheduled_producer(block_timestamp_type t) const;
+   const producer_authority& get_scheduled_producer(block_timestamp_type t) const;
 };
 
 using block_header_state_ptr = std::shared_ptr<block_header_state>;

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -42,7 +42,7 @@ struct block_header_state_core {
 struct block_header_state {
    // ------ data members ------------------------------------------------------------
    block_id_type                       block_id;
-   block_header                        header;
+   signed_block_header                 header;
    protocol_feature_activation_set_ptr activated_protocol_features;
 
    block_header_state_core             core;
@@ -73,8 +73,7 @@ struct block_header_state {
    const producer_authority_schedule& active_schedule_auth()  const { return active_proposer_policy->proposer_schedule; }
 
    block_header_state next(block_header_state_input& data) const;
-
-   block_header_state next(const signed_block_header& h, const protocol_feature_set& pfs, validator_t& validator) const;
+   block_header_state next(const signed_block_header& h, validator_t& validator) const;
 
    // block descending from this need the provided qc in the block extension
    bool is_needed(const quorum_certificate& qc) const {
@@ -84,12 +83,6 @@ struct block_header_state {
    flat_set<digest_type> get_activated_protocol_features() const { return activated_protocol_features->protocol_features; }
    const vector<digest_type>& get_new_protocol_feature_activations() const;
    producer_authority get_scheduled_producer(block_timestamp_type t) const;
-   uint32_t active_schedule_version() const;
-   signed_block_header make_block_header(const checksum256_type& transaction_mroot,
-                                         const checksum256_type& action_mroot,
-                                         const std::optional<producer_authority_schedule>& new_producers,
-                                         vector<digest_type>&& new_protocol_feature_activations,
-                                         const protocol_feature_set& pfs) const;
 };
 
 using block_header_state_ptr = std::shared_ptr<block_header_state>;

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -42,7 +42,7 @@ struct block_header_state_core {
 struct block_header_state {
    // ------ data members ------------------------------------------------------------
    block_id_type                       block_id;
-   signed_block_header                 header;
+   block_header                        header;
    protocol_feature_activation_set_ptr activated_protocol_features;
 
    block_header_state_core             core;

--- a/libraries/chain/include/eosio/chain/block_header_state_legacy.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state_legacy.hpp
@@ -170,7 +170,7 @@ struct block_header_state_legacy : public detail::block_header_state_legacy_comm
 
    uint32_t             calc_dpos_last_irreversible( account_name producer_of_next_block )const;
 
-   producer_authority     get_scheduled_producer( block_timestamp_type t )const;
+   const producer_authority& get_scheduled_producer( block_timestamp_type t )const;
    const block_id_type&   previous()const { return header.previous; }
    digest_type            sig_digest()const;
    void                   sign( const signer_callback_type& signer );

--- a/libraries/chain/include/eosio/chain/block_header_state_utils.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state_utils.hpp
@@ -20,7 +20,7 @@ namespace eosio::chain::detail {
       return block_timestamp_type{t.slot + (config::producer_repetitions - index) + config::producer_repetitions};
    }
 
-   inline producer_authority get_scheduled_producer(const vector<producer_authority>& producers, block_timestamp_type t) {
+   inline const producer_authority& get_scheduled_producer(const vector<producer_authority>& producers, block_timestamp_type t) {
       auto index = t.slot % (producers.size() * config::producer_repetitions);
       index /= config::producer_repetitions;
       return producers[index];

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -7,6 +7,8 @@
 
 namespace eosio::chain {
 
+using signer_callback_type = std::function<std::vector<signature_type>(const digest_type&)>;
+
 constexpr std::array weak_bls_sig_postfix = { 'W', 'E', 'A', 'K' };
 using weak_digest_t = std::array<uint8_t, sizeof(digest_type) + weak_bls_sig_postfix.size()>;
 
@@ -63,9 +65,13 @@ struct block_state : public block_header_state {     // block_header_state provi
                const validator_t& validator, bool skip_validate_signee);
 
    block_state(const block_header_state& bhs, deque<transaction_metadata_ptr>&& trx_metas,
-               deque<transaction_receipt>&& trx_receipts, const std::optional<quorum_certificate>& qc);
+               deque<transaction_receipt>&& trx_receipts, const std::optional<quorum_certificate>& qc,
+               const signer_callback_type& signer);
 
    explicit block_state(const block_state_legacy& bsp);
+
+   void sign(const signer_callback_type& signer);
+   void verify_signee(const std::vector<signature_type>& additional_signatures) const;
 };
 
 using block_state_ptr = std::shared_ptr<block_state>;

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -66,12 +66,12 @@ struct block_state : public block_header_state {     // block_header_state provi
 
    block_state(const block_header_state& bhs, deque<transaction_metadata_ptr>&& trx_metas,
                deque<transaction_receipt>&& trx_receipts, const std::optional<quorum_certificate>& qc,
-               const signer_callback_type& signer);
+               const signer_callback_type& signer, const block_signing_authority& valid_block_signing_authority);
 
    explicit block_state(const block_state_legacy& bsp);
 
-   void sign(const signer_callback_type& signer);
-   void verify_signee(const std::vector<signature_type>& additional_signatures) const;
+   void sign(const signer_callback_type& signer, const block_signing_authority& valid_block_signing_authority);
+   void verify_signee(const std::vector<signature_type>& additional_signatures, const block_signing_authority& valid_block_signing_authority) const;
 };
 
 using block_state_ptr = std::shared_ptr<block_state>;


### PR DESCRIPTION
Sign `block_id` of proposed blocks and verify signatures on validation nodes.

- Also adds validation of activated protocol features.
- Includes a test that protocol feature activation works after instant_finality is enabled.
- Existing tests cover block signing validation. Many tests failed when I signed with the wrong producer key.

Resolves #2142 