### PR TITLE
[3.2] TraceAPI: Correctly convert return value via ABI

### DIFF
--- a/plugins/trace_api_plugin/abi_data_handler.cpp
+++ b/plugins/trace_api_plugin/abi_data_handler.cpp
@@ -31,7 +31,10 @@ namespace eosio::trace_api {
                   auto params = serializer_p->binary_to_variant(type_name, action.data, abi_yield);
                   if constexpr (std::is_same_v<T, action_trace_v1>) {
                      if(action.return_value.size() > 0) {
-                        ret_data = serializer_p->binary_to_variant(type_name, action.return_value, abi_yield);
+                        auto return_type_name = serializer_p->get_action_result_type(action_name);
+                        if (!return_type_name.empty()) {
+                           ret_data = serializer_p->binary_to_variant(return_type_name, action.return_value, abi_yield);
+                        }
                      }
                   }
                   return {params, ret_data};

--- a/plugins/trace_api_plugin/request_handler.cpp
+++ b/plugins/trace_api_plugin/request_handler.cpp
@@ -41,25 +41,22 @@ namespace {
          yield();
 
          const auto& a = actions.at(index);
-         auto common_mvo = fc::mutable_variant_object();
+         auto action_variant = fc::mutable_variant_object();
 
-         common_mvo("global_sequence", a.global_sequence)
+         action_variant("global_sequence", a.global_sequence)
                ("receiver", a.receiver.to_string())
                ("account", a.account.to_string())
                ("action", a.action.to_string())
                ("authorization", process_authorizations(a.authorization, yield))
                ("data", fc::to_hex(a.data.data(), a.data.size()));
 
-         auto action_variant = fc::mutable_variant_object();
          if constexpr(std::is_same_v<ActionTrace, action_trace_v0>){
-            action_variant(std::move(common_mvo));
             auto [params, return_data] = data_handler(a, yield);
             if (!params.is_null()) {
                action_variant("params", params);
             }
          }
          else if constexpr(std::is_same_v<ActionTrace, action_trace_v1>){
-            action_variant(std::move(common_mvo));
             action_variant("return_value", fc::to_hex(a.return_value.data(),a.return_value.size())) ;
             auto [params, return_data] = data_handler(a, yield);
             if (!params.is_null()) {

--- a/plugins/trace_api_plugin/test/test_data_handlers.cpp
+++ b/plugins/trace_api_plugin/test/test_data_handlers.cpp
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
             ("c", 2)
             ("d", 3);
 
-      auto actual = handler.serialize_to_variant(action_trace_t);
+      auto actual = handler.serialize_to_variant(action_trace_t, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
       BOOST_REQUIRE(!std::get<1>(actual));

--- a/plugins/trace_api_plugin/test/test_data_handlers.cpp
+++ b/plugins/trace_api_plugin/test/test_data_handlers.cpp
@@ -22,6 +22,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       auto actual = handler.serialize_to_variant(action_trace_t, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
+      BOOST_REQUIRE(!std::get<1>(actual));
    }
 
    BOOST_AUTO_TEST_CASE(empty_data_v1)
@@ -37,6 +38,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       auto actual = handler.serialize_to_variant(action_trace_t, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
+      BOOST_REQUIRE(!std::get<1>(actual));
    }
 
    BOOST_AUTO_TEST_CASE(no_abi)
@@ -51,6 +53,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       auto actual = handler.serialize_to_variant(action_trace_t, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
+      BOOST_REQUIRE(!std::get<1>(actual));
    }
 
    BOOST_AUTO_TEST_CASE(no_abi_v1)
@@ -66,6 +69,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       auto actual = handler.serialize_to_variant(action_trace_t, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
+      BOOST_REQUIRE(!std::get<1>(actual));
    }
 
    BOOST_AUTO_TEST_CASE(basic_abi)
@@ -99,20 +103,22 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       auto actual = handler.serialize_to_variant(action_trace_t, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
+      BOOST_REQUIRE(!std::get<1>(actual));
    }
 
    BOOST_AUTO_TEST_CASE(basic_abi_v1)
    {
       auto action = action_trace_v1 {
          { 0, "alice"_n, "alice"_n, "foo"_n, {}, {0x00, 0x01, 0x02, 0x03}},
-         {0x04, 0x05, 0x06, 0x07}
+         {0x04, 0x05, 0x06}
       };
 
       std::variant<action_trace_v0, action_trace_v1> action_trace_t = action;
 
       auto abi = chain::abi_def ( {},
          {
-            { "foo", "", { {"a", "varuint32"}, {"b", "varuint32"}, {"c", "varuint32"}, {"d", "varuint32"} } }
+            { "foo", "", { {"a", "varuint32"}, {"b", "varuint32"}, {"c", "varuint32"}, {"d", "varuint32"} } },
+            { "foor", "", { {"e", "varuint32"}, {"f", "varuint32"}, {"g", "varuint32"} } }
          },
          {
             { "foo"_n, "foo", ""}
@@ -120,6 +126,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
          {}, {}, {}
       );
       abi.version = "eosio::abi/1.";
+      abi.action_results = { std::vector<chain::action_result_def>{ chain::action_result_def{ "foo"_n, "foor"} } };
 
       abi_data_handler handler(exception_handler{});
       handler.add_abi("alice"_n, abi);
@@ -129,10 +136,16 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
             ("b", 1)
             ("c", 2)
             ("d", 3);
+      fc::variant expected_return = fc::mutable_variant_object()
+            ("e", 4)
+            ("f", 5)
+            ("g", 6);
 
       auto actual = handler.serialize_to_variant(action_trace_t, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
+      BOOST_REQUIRE(std::get<1>(actual));
+      BOOST_TEST(to_kv(expected_return) == to_kv(*std::get<1>(actual)), boost::test_tools::per_element());
    }
 
    BOOST_AUTO_TEST_CASE(abi_fail_yield)
@@ -209,6 +222,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       auto actual = handler.serialize_to_variant(action_trace_t, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
+      BOOST_REQUIRE(!std::get<1>(actual));
    }
 
    BOOST_AUTO_TEST_CASE(basic_abi_wrong_type_v1)
@@ -238,6 +252,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
       auto actual = handler.serialize_to_variant(action_trace_t, [](){});
 
       BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
+      BOOST_REQUIRE(!std::get<1>(actual));
    }
 
    BOOST_AUTO_TEST_CASE(basic_abi_insufficient_data)
@@ -269,6 +284,44 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
 
       BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
       BOOST_TEST(log_called);
+      BOOST_REQUIRE(!std::get<1>(actual));
    }
+
+   // If no ABI provided for return type then do not attempt to decode it
+   BOOST_AUTO_TEST_CASE(basic_abi_no_return_abi_when_return_value_provided)
+   {
+      auto action = action_trace_v1 {
+         { 0, "alice"_n, "alice"_n, "foo"_n, {}, {0x00, 0x01, 0x02, 0x03}},
+         {0x04, 0x05, 0x06}
+      };
+
+      std::variant<action_trace_v0, action_trace_v1> action_trace_t = action;
+
+      auto abi = chain::abi_def ( {},
+         {
+            { "foo", "", { {"a", "varuint32"}, {"b", "varuint32"}, {"c", "varuint32"}, {"d", "varuint32"} } },
+         },
+         {
+            { "foo"_n, "foo", ""}
+         },
+         {}, {}, {}
+      );
+      abi.version = "eosio::abi/1.";
+
+      abi_data_handler handler(exception_handler{});
+      handler.add_abi("alice"_n, std::move(abi));
+
+      fc::variant expected = fc::mutable_variant_object()
+            ("a", 0)
+            ("b", 1)
+            ("c", 2)
+            ("d", 3);
+
+      auto actual = handler.serialize_to_variant(action_trace_t);
+
+      BOOST_TEST(to_kv(expected) == to_kv(std::get<0>(actual)), boost::test_tools::per_element());
+      BOOST_REQUIRE(!std::get<1>(actual));
+   }
+
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Use action result type ABI for action return value conversion by ABI.
- Only attempt conversion if an action return value ABI is available.
- Updated tests to verify action return value handling.

Resolves #2228 