### PR TITLE
[3.2 -> 4.0] TraceAPI: Correctly convert return value via ABI

### DIFF
--- a/plugins/trace_api_plugin/abi_data_handler.cpp
+++ b/plugins/trace_api_plugin/abi_data_handler.cpp
@@ -31,7 +31,10 @@ namespace eosio::trace_api {
                   auto params = serializer_p->binary_to_variant(type_name, action.data, abi_yield);
                   if constexpr (std::is_same_v<T, action_trace_v1>) {
                      if(action.return_value.size() > 0) {
-                        ret_data = serializer_p->binary_to_variant(type_name, action.return_value, abi_yield);
+                        auto return_type_name = serializer_p->get_action_result_type(action_name);
+                        if (!return_type_name.empty()) {
+                           ret_data = serializer_p->binary_to_variant(return_type_name, action.return_value, abi_yield);
+                        }
                      }
                   }
                   return {params, ret_data};

--- a/plugins/trace_api_plugin/request_handler.cpp
+++ b/plugins/trace_api_plugin/request_handler.cpp
@@ -41,25 +41,22 @@ namespace {
          yield();
 
          const auto& a = actions.at(index);
-         auto common_mvo = fc::mutable_variant_object();
+         auto action_variant = fc::mutable_variant_object();
 
-         common_mvo("global_sequence", a.global_sequence)
+         action_variant("global_sequence", a.global_sequence)
                ("receiver", a.receiver.to_string())
                ("account", a.account.to_string())
                ("action", a.action.to_string())
                ("authorization", process_authorizations(a.authorization, yield))
                ("data", fc::to_hex(a.data.data(), a.data.size()));
 
-         auto action_variant = fc::mutable_variant_object();
          if constexpr(std::is_same_v<ActionTrace, action_trace_v0>){
-            action_variant(std::move(common_mvo));
             auto [params, return_data] = data_handler(a, yield);
             if (!params.is_null()) {
                action_variant("params", params);
             }
          }
          else if constexpr(std::is_same_v<ActionTrace, action_trace_v1>){
-            action_variant(std::move(common_mvo));
             action_variant("return_value", fc::to_hex(a.return_value.data(),a.return_value.size())) ;
             auto [params, return_data] = data_handler(a, yield);
             if (!params.is_null()) {


### PR DESCRIPTION
- Use action result type ABI for action return value conversion by ABI.
- Only attempt conversion if an action return value ABI is available.
- Updated tests to verify action return value handling.

Note: No replay of data is needed. `trace_api_plugin` was storing the data correctly on disk.

Merges `release/3.0` into `release/4.0` including #2246 

Resolves #2228 