### PR TITLE
IF: Don't drop late blocks

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -123,7 +123,7 @@ block_header_state block_header_state::next(block_header_state_input& input) con
 block_header_state block_header_state::next(const signed_block_header& h, validator_t& validator) const {
    auto producer = detail::get_scheduled_producer(active_proposer_policy->proposer_schedule.producers, h.timestamp).producer_name;
    
-   EOS_ASSERT( h.previous == block_id, unlinkable_block_exception, "previous mismatch" );
+   EOS_ASSERT( h.previous == block_id, unlinkable_block_exception, "previous mismatch ${p} != ${id}", ("p", h.previous)("id", block_id) );
    EOS_ASSERT( h.producer == producer, wrong_producer, "wrong producer specified" );
    EOS_ASSERT( h.confirmed == 0, block_validate_exception, "invalid confirmed ${c}", ("c", h.confirmed) );
    EOS_ASSERT( !h.new_producers, producer_schedule_exception, "Block header contains legacy producer schedule outdated by activation of WTMsig Block Signatures" );

--- a/libraries/chain/block_header_state_legacy.cpp
+++ b/libraries/chain/block_header_state_legacy.cpp
@@ -227,7 +227,7 @@ namespace eosio::chain {
    )&&
    {
       EOS_ASSERT( h.timestamp == timestamp, block_validate_exception, "timestamp mismatch" );
-      EOS_ASSERT( h.previous == previous, unlinkable_block_exception, "previous mismatch" );
+      EOS_ASSERT( h.previous == previous, unlinkable_block_exception, "previous mismatch ${p} != ${id}", ("p", h.previous)("id", previous) );
       EOS_ASSERT( h.confirmed == confirmed, block_validate_exception, "confirmed mismatch" );
       EOS_ASSERT( h.producer == producer, wrong_producer, "wrong producer specified" );
       EOS_ASSERT( h.schedule_version == active_schedule_version, producer_schedule_exception, "schedule_version in signed block is corrupted" );

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1229,6 +1229,12 @@ struct controller_impl {
                                     : forkdb.fetch_branch( fork_db_head(forkdb, irreversible_mode())->id(), new_lib );
          try {
             auto should_process = [&](auto& bsp) {
+               // Only make irreversible blocks that have been validated. Blocks in the fork database may not be on our current best head
+               // and therefore have not been validated.
+               // An alternative more complex implementation would be to do a fork switch here and validate all blocks so they can be then made
+               // irreversible. Instead this moves irreversible as much as possible and allows the next maybe_switch_forks call to apply these
+               // non-validated blocks. After the maybe_switch_forks call (before next produced block or on next received block), irreversible
+               // can then move forward on the then validated blocks.
                return read_mode == db_read_mode::IRREVERSIBLE || bsp->is_valid();
             };
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1218,15 +1218,15 @@ struct controller_impl {
                      ("lib_num", lib_num)("bn", fork_db_root_block_num()) );
       }
 
-      uint32_t if_lib = block_header::num_from_id(if_irreversible_block_id);
-      const uint32_t new_lib = if_lib > 0 ? if_lib : fork_db_head_irreversible_blocknum();
+      uint32_t if_lib_num = block_header::num_from_id(if_irreversible_block_id);
+      const uint32_t new_lib_num = if_lib_num > 0 ? if_lib_num : fork_db_head_irreversible_blocknum();
 
-      if( new_lib <= lib_num )
+      if( new_lib_num <= lib_num )
          return;
 
       auto mark_branch_irreversible = [&, this](auto& forkdb) {
-         auto branch = (if_lib > 0) ? forkdb.fetch_branch( if_irreversible_block_id, new_lib)
-                                    : forkdb.fetch_branch( fork_db_head(forkdb, irreversible_mode())->id(), new_lib );
+         auto branch = (if_lib_num > 0) ? forkdb.fetch_branch( if_irreversible_block_id, new_lib_num)
+                                    : forkdb.fetch_branch( fork_db_head(forkdb, irreversible_mode())->id(), new_lib_num );
          try {
             auto should_process = [&](auto& bsp) {
                // Only make irreversible blocks that have been validated. Blocks in the fork database may not be on our current best head
@@ -3932,9 +3932,11 @@ struct controller_impl {
    }
 
    void set_if_irreversible_block_id(const block_id_type& id) {
-      if( block_header::num_from_id(id) > block_header::num_from_id(if_irreversible_block_id) ) {
+      const block_num_type id_num = block_header::num_from_id(id);
+      const block_num_type current_num = block_header::num_from_id(if_irreversible_block_id);
+      if( id_num > current_num ) {
+         dlog("set irreversible block ${bn}: ${id}, old ${obn}: ${oid}", ("bn", id_num)("id", id)("obn", current_num)("oid", if_irreversible_block_id));
          if_irreversible_block_id = id;
-         dlog("irreversible block ${bn} : ${id}", ("bn", block_header::num_from_id(id))("id", id));
       }
    }
 

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -140,6 +140,7 @@ namespace eosio::chain {
 
       BHSP             get_block_header_impl( const block_id_type& id ) const;
       BSP              get_block_impl( const block_id_type& id ) const;
+      bool             block_exists_impl( const block_id_type& id ) const;
       void             reset_root_impl( const BHS& root_bhs );
       void             rollback_head_to_root_impl();
       void             advance_root_impl( const block_id_type& id );
@@ -407,7 +408,7 @@ namespace eosio::chain {
 
       auto prev_bh = get_block_header_impl( n->previous() );
       EOS_ASSERT( prev_bh, unlinkable_block_exception,
-                  "unlinkable block", ("id", n->id())("previous", n->previous()) );
+                  "forkdb unlinkable block ${id} previous ${p}", ("id", n->id())("p", n->previous()) );
 
       if (validate) {
          try {
@@ -748,6 +749,17 @@ namespace eosio::chain {
       if( itr != index.end() )
          return *itr;
       return {};
+   }
+
+   template<class BSP>
+   bool fork_database_t<BSP>::block_exists(const block_id_type& id) const {
+      std::lock_guard g( my->mtx );
+      return my->block_exists_impl(id);
+   }
+
+   template<class BSP>
+   bool fork_database_impl<BSP>::block_exists_impl(const block_id_type& id) const {
+      return index.find( id ) != index.end();
    }
 
    // ------------------ fork_database -------------------------

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -271,9 +271,7 @@ namespace eosio::chain {
          // post-instant-finality this always returns nullptr
          const producer_authority_schedule*         pending_producers_legacy()const;
 
-         // Called by qc_chain to indicate the current irreversible block num
-         // After hotstuff is activated, this should be called on startup by qc_chain
-         void set_if_irreversible_block_num(uint32_t block_num);
+         void set_if_irreversible_block_id(const block_id_type& id);
          uint32_t if_irreversible_block_num() const;
 
          uint32_t last_irreversible_block_num() const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -198,14 +198,17 @@ namespace eosio::chain {
 
          /**
           * @param br returns statistics for block
-          * @param bt block to push, created by create_block_handle
+          * @param b block to push, created by create_block_handle
           * @param cb calls cb with forked applied transactions for each forked block
           * @param trx_lookup user provided lookup function for externally cached transaction_metadata
           */
          void push_block( block_report& br,
-                          const block_handle& bt,
+                          const block_handle& b,
                           const forked_callback_t& cb,
                           const trx_meta_cache_lookup& trx_lookup );
+
+         /// Accept block into fork_database
+         void accept_block(const block_handle& b);
 
          boost::asio::io_context& get_thread_pool();
 

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -47,6 +47,7 @@ namespace eosio::chain {
 
       BHSP get_block_header( const block_id_type& id ) const;
       BSP  get_block( const block_id_type& id ) const;
+      bool block_exists( const block_id_type& id ) const;
 
       /**
        *  Purges any existing blocks from the fork database and resets the root block_header_state to the provided value.

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -34,7 +34,7 @@ namespace eosio::chain::plugin_interface {
    namespace incoming {
       namespace methods {
          // synchronously push a block/trx to a single provider, block_state_legacy_ptr may be null
-         using block_sync            = method_decl<chain_plugin_interface, bool(const signed_block_ptr&, const std::optional<block_id_type>&, const std::optional<block_handle>&), first_provider_policy>;
+         using block_sync            = method_decl<chain_plugin_interface, bool(const signed_block_ptr&, const block_id_type&, const std::optional<block_handle>&), first_provider_policy>;
          using transaction_async     = method_decl<chain_plugin_interface, void(const packed_transaction_ptr&, bool, transaction_metadata::trx_type, bool, next_function<transaction_trace_ptr>), first_provider_policy>;
       }
    }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2025,7 +2025,8 @@ fc::variant read_only::get_block_info(const read_only::get_block_info_params& pa
 
 void read_write::push_block(read_write::push_block_params&& params, next_function<read_write::push_block_results> next) {
    try {
-      app().get_method<incoming::methods::block_sync>()(std::make_shared<signed_block>( std::move(params) ), std::optional<block_id_type>{}, std::optional<block_handle>{});
+      auto b = std::make_shared<signed_block>( std::move(params) );
+      app().get_method<incoming::methods::block_sync>()(b, b->calculate_id(), std::optional<block_handle>{});
    } catch ( boost::interprocess::bad_alloc& ) {
       handle_db_exhaustion();
    } catch ( const std::bad_alloc& ) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3905,7 +3905,7 @@ namespace eosio {
             if( reason == unlinkable || reason == no_reason ) {
                dispatcher->add_unlinkable_block( std::move(block), blk_id );
             }
-            // reason==no_reason means accept_block() return false because we are producing, don't call rejected_block which sends handshake
+            // reason==no_reason means accept_block() return false which is a fatal error, don't call rejected_block which sends handshake
             if( reason != no_reason ) {
                sync_master->rejected_block( c, blk_num, sync_manager::closing_mode::handshake );
             }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -667,37 +667,45 @@ public:
       _time_tracker.clear();
    }
 
-   bool on_incoming_block(const signed_block_ptr& block, const std::optional<block_id_type>& block_id, const std::optional<block_handle>& obt) {
-      auto& chain = chain_plug->chain();
-      if (in_producing_mode()) {
-         fc_wlog(_log, "dropped incoming block #${num} id: ${id}", ("num", block->block_num())("id", block_id ? (*block_id).str() : "UNKNOWN"));
-         return false;
-      }
-
-      // start a new speculative block, speculative start_block may have been interrupted
-      auto ensure = fc::make_scoped_exit([this]() { schedule_production_loop(); });
-
+   bool on_incoming_block(const signed_block_ptr& block, const block_id_type& id, const std::optional<block_handle>& obt) {
       auto now = fc::time_point::now();
-      const auto& id      = block_id ? *block_id : block->calculate_id();
-      auto        blk_num = block->block_num();
-
-      if (now - block->timestamp < fc::minutes(5) || (blk_num % 1000 == 0)) // only log every 1000 during sync
-         fc_dlog(_log, "received incoming block ${n} ${id}", ("n", blk_num)("id", id));
+      auto& chain = chain_plug->chain();
+      auto blk_num = block->block_num();
 
       _time_tracker.add_idle_time(now);
 
-      EOS_ASSERT(block->timestamp < (now + fc::seconds(7)), block_from_the_future, "received a block from the future, ignoring it: ${id}", ("id", id));
+      // start a new speculative block, speculative start_block may have been interrupted
+      auto ensure = fc::make_scoped_exit([this]() {
+         // avoid schedule_production_loop if in_producing_mode(); speculative block was not interrupted and we don't want to abort block
+         if (!in_producing_mode()) {
+            schedule_production_loop();
+         } else {
+            _time_tracker.add_other_time();
+         }
+      });
 
-      // de-dupe here... no point in aborting block if we already know the block
+      // de-dupe here... no point in aborting block if we already know the block; avoid exception in create_block_handle_future
       if (chain.block_exists(id)) {
-         return true; // return true because the block is valid
-      } 
+         return true; // return true because the block is accepted
+      }
+
+      EOS_ASSERT(block->timestamp < (now + fc::seconds(7)), block_from_the_future, "received a block from the future, ignoring it: ${id}", ("id", id));
 
       // start processing of block
       std::future<block_handle> btf;
       if (!obt) {
          btf = chain.create_block_handle_future(id, block);
       }
+
+      if (in_producing_mode()) {
+         fc_ilog(_log, "producing, incoming block #${num} id: ${id}", ("num", blk_num)("id", id));
+         const block_handle& bh = obt ? *obt : btf.get();
+         chain.accept_block(bh);
+         return true; // return true because block was accepted
+      }
+
+      if (now - block->timestamp < fc::minutes(5) || (blk_num % 1000 == 0)) // only log every 1000 during sync
+         fc_dlog(_log, "received incoming block ${n} ${id}", ("n", blk_num)("id", id));
 
       // abort the pending block
       abort_block();
@@ -711,10 +719,10 @@ public:
 
       controller::block_report br;
       try {
-         const block_handle& bt = obt ? *obt : btf.get();
+         const block_handle& bh = obt ? *obt : btf.get();
          chain.push_block(
             br,
-            bt,
+            bh,
             [this](const transaction_metadata_ptr& trx) { _unapplied_transactions.add_forked(trx); },
             [this](const transaction_id_type& id) { return _unapplied_transactions.get_trx(id); });
       } catch (const guard_exception& e) {
@@ -1284,7 +1292,7 @@ void producer_plugin_impl::plugin_initialize(const boost::program_options::varia
    ilog("read-only-threads ${s}, max read-only trx time to be enforced: ${t} us", ("s", _ro_thread_pool_size)("t", _ro_max_trx_time_us));
 
    _incoming_block_sync_provider = app().get_method<incoming::methods::block_sync>().register_provider(
-      [this](const signed_block_ptr& block, const std::optional<block_id_type>& block_id, const std::optional<block_handle>& obt) {
+      [this](const signed_block_ptr& block, const block_id_type& block_id, const std::optional<block_handle>& obt) {
          return on_incoming_block(block, block_id, obt);
       });
 

--- a/tests/lib_advance_test.py
+++ b/tests/lib_advance_test.py
@@ -139,11 +139,13 @@ try:
     assert prodA.getIrreversibleBlockNum() > max(libProdABeforeKill, libProdDBeforeKill)
     assert prodD.getIrreversibleBlockNum() > max(libProdABeforeKill, libProdDBeforeKill)
 
+    # instant finality does not drop late blocks and should never get unlinkable blocks for this test case
+    allowedUnlinkableBlocks = afterBlockNum-beforeBlockNum if not activateIF else 0
     logFile = Utils.getNodeDataDir(prodNode3.nodeId) + "/stderr.txt"
     f = open(logFile)
     contents = f.read()
-    if contents.count("3030001 unlinkable_block_exception: Unlinkable block") > (afterBlockNum-beforeBlockNum):  # a few are fine
-        errorExit(f"Node{prodNode3.nodeId} has more than {afterBlockNum-beforeBlockNum} unlinkable blocks: {logFile}.")
+    if contents.count("3030001 unlinkable_block_exception: Unlinkable block") > (allowedUnlinkableBlocks):
+        errorExit(f"Node{prodNode3.nodeId} has more than {allowedUnlinkableBlocks} unlinkable blocks: {logFile}.")
 
     testSuccessful=True
 finally:

--- a/tests/lib_advance_test.py
+++ b/tests/lib_advance_test.py
@@ -139,8 +139,8 @@ try:
     assert prodA.getIrreversibleBlockNum() > max(libProdABeforeKill, libProdDBeforeKill)
     assert prodD.getIrreversibleBlockNum() > max(libProdABeforeKill, libProdDBeforeKill)
 
-    # instant finality does not drop late blocks and should never get unlinkable blocks for this test case
-    allowedUnlinkableBlocks = afterBlockNum-beforeBlockNum if not activateIF else 0
+    # instant finality does not drop late blocks, but can still get unlinkable when syncing and getting a produced block
+    allowedUnlinkableBlocks = afterBlockNum-beforeBlockNum if not activateIF else 5
     logFile = Utils.getNodeDataDir(prodNode3.nodeId) + "/stderr.txt"
     f = open(logFile)
     contents = f.read()


### PR DESCRIPTION
- Instead of dropping blocks when producing, incorporate blocks received while producing into the fork database.
  - Potentially fork switch to newly incorporated blocks before producing a block
  - Use block id instead of block number for irreversible so that correct fork branch is made irreversible

Resolves #2159 