### PR TITLE
don't do `set_new_handler()` workaround for LLVM 9+ where it's unnecessary

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -220,13 +220,18 @@ struct controller_impl {
              // Read-write tasks are not being executed.
    };
 
-   // LLVM sets the new handler, we need to reset this to throw a bad_alloc exception so we can possibly exit cleanly
-   // and not just abort.
+#if LLVM_VERSION_MAJOR < 9
+   // LLVM versions prior to 9 do a set_new_handler() in a static global initializer. Reset LLVM's custom handler
+   // back to the default behavior of throwing bad_alloc so we can possibly exit cleanly and not just abort as LLVM's
+   // handler does.
+   // LLVM 9+ doesn't install this handler unless calling InitLLVM(), which we don't.
+   // See https://reviews.llvm.org/D64505
    struct reset_new_handler {
       reset_new_handler() { std::set_new_handler([](){ throw std::bad_alloc(); }); }
    };
 
    reset_new_handler               rnh; // placed here to allow for this to be set before constructing the other fields
+#endif
    controller&                     self;
    std::function<void()>           shutdown;
    chainbase::database             db;


### PR DESCRIPTION
See comment in code. There isn't really a problem with the existing code being there afaik, so I suppose this is just adding an indicator to remove this workaround completely once the LLVM requirement is strictly 9+