### PR TITLE
add a CI "platform" with `assert()`s enabled (`NDEBUG` not defined)

### DIFF
--- a/.cicd/platforms/asserton.Dockerfile
+++ b/.cicd/platforms/asserton.Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+#the exact version of Ubuntu doesn't matter for the purpose of asserton builds. Feel free to upgrade in future
+FROM ubuntu:jammy
+ENV TZ="America/New_York"
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y build-essential      \
+                       cmake                \
+                       git                  \
+                       jq                   \
+                       libcurl4-openssl-dev \
+                       libgmp-dev           \
+                       llvm-11-dev          \
+                       ninja-build          \
+                       python3-numpy        \
+                       file                 \
+                       zlib1g-dev           \
+                       zstd
+
+ENV LEAP_PLATFORM_HAS_EXTRAS_CMAKE=1
+COPY <<-EOF /extras.cmake
+  # reset the build type to empty to disable any cmake default flags
+  set(CMAKE_BUILD_TYPE "" CACHE STRING "" FORCE)
+
+  set(CMAKE_C_FLAGS "-O3" CACHE STRING "")
+  set(CMAKE_CXX_FLAGS "-O3" CACHE STRING "")
+
+  set(LEAP_ENABLE_RELEASE_BUILD_TEST "Off" CACHE BOOL "")
+EOF

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,6 +135,7 @@ jobs:
         include:
           - cfg: {name: 'ubuntu20',      base: 'ubuntu20', builddir: 'ubuntu20'}
           - cfg: {name: 'ubuntu22',      base: 'ubuntu22', builddir: 'ubuntu22'}
+          - cfg: {name: 'asserton',      base: 'asserton', builddir: 'asserton'}
           - cfg: {name: 'ubuntu20repro', base: 'ubuntu20', builddir: 'reproducible'}
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-hightier"]
@@ -174,6 +175,7 @@ jobs:
         include:
           - cfg: {name: 'ubuntu20',      base: 'ubuntu20', builddir: 'ubuntu20'}
           - cfg: {name: 'ubuntu22',      base: 'ubuntu22', builddir: 'ubuntu22'}
+          - cfg: {name: 'asserton',      base: 'asserton', builddir: 'asserton'}
           - cfg: {name: 'ubuntu20repro', base: 'ubuntu20', builddir: 'reproducible'}
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-midtier"]
@@ -213,6 +215,7 @@ jobs:
         include:
           - cfg: {name: 'ubuntu20',      base: 'ubuntu20', builddir: 'ubuntu20'}
           - cfg: {name: 'ubuntu22',      base: 'ubuntu22', builddir: 'ubuntu22'}
+          - cfg: {name: 'asserton',      base: 'asserton', builddir: 'asserton'}
           - cfg: {name: 'ubuntu20repro', base: 'ubuntu20', builddir: 'reproducible'}
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-lowtier"]

--- a/.github/workflows/build_base.yaml
+++ b/.github/workflows/build_base.yaml
@@ -38,7 +38,7 @@ jobs:
           run: |
             # https://github.com/actions/runner/issues/2033
             chown -R $(id -u):$(id -g) $PWD
-            cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_LEAP_DEV_DEB=On -GNinja
+            cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_LEAP_DEV_DEB=On ${LEAP_PLATFORM_HAS_EXTRAS_CMAKE:+-C /extras.cmake} -GNinja
             cmake --build build
             tar -pc --exclude "*.o" build | zstd --long -T0 -9 > build.tar.zst
         - name: Upload builddir

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,11 @@ else()
   set(UNSHARE "")
 endif()
 
+option(LEAP_ENABLE_RELEASE_BUILD_TEST "Enables a test that verifies nodeos was compiled with compiler options typical for a release build" On)
+if(LEAP_ENABLE_RELEASE_BUILD_TEST)
+  add_test(NAME release-build-test COMMAND tests/release-build.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+endif()
+
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
 add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
 
@@ -179,7 +184,6 @@ set_property(TEST trx_finality_status_forked_test PROPERTY LABELS nonparalleliza
 
 add_test(NAME db_modes_test COMMAND tests/db_modes_test.sh -v WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_tests_properties(db_modes_test PROPERTIES COST 6000)
-add_test(NAME release-build-test COMMAND tests/release-build.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME version-label-test COMMAND tests/version-label.sh "v${VERSION_FULL}" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME full-version-label-test COMMAND tests/full-version-label.sh "v${VERSION_FULL}" ${CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME nested_container_multi_index_test COMMAND tests/nested_container_multi_index_test.py -n 2 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
A demo run with an `assert()` failure is at
https://github.com/AntelopeIO/leap/actions/runs/8150929931