### PR TITLE
IF: Change Fork_db root to store block state

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3351,7 +3351,7 @@ struct controller_impl {
             auto existing = forkdb.get_block( id );
             EOS_ASSERT( !existing, fork_database_exception, "we already know about this block: ${id}", ("id", id) );
 
-            auto prev = forkdb.get_block( b->previous, true );
+            auto prev = forkdb.get_block( b->previous, check_root_t::yes );
             EOS_ASSERT( prev, unlinkable_block_exception,
                         "unlinkable block ${id} previous ${p}", ("id", id)("p", b->previous) );
 
@@ -3372,7 +3372,7 @@ struct controller_impl {
          EOS_ASSERT( !existing, fork_database_exception, "we already know about this block: ${id}", ("id", id) );
 
          // previous not found could mean that previous block not applied yet
-         auto prev = forkdb.get_block( b->previous, true );
+         auto prev = forkdb.get_block( b->previous, check_root_t::yes );
          if( !prev ) return {};
 
          return create_block_state_i( id, b, *prev );

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1019,7 +1019,7 @@ struct controller_impl {
       fork_db.apply<void>([&](auto& forkdb) {
          std::visit([&](const auto& bsp) {
             if constexpr (std::is_same_v<std::decay_t<decltype(bsp)>, std::decay_t<decltype(forkdb.head())>>)
-               forkdb.reset_root(*bsp);
+               forkdb.reset_root(bsp);
          }, chain_head.internal());
       });
    }

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -18,6 +18,8 @@ namespace eosio::chain {
    /**
     * History:
     * Version 1: initial version of the new refactored fork database portable format
+    * Version 2: Savanna version, store either `block_state`, `block_state_legacy` or both versions,
+    *            root is full `block_state`, not just the header.
     */
 
    struct block_state_accessor {
@@ -118,7 +120,7 @@ namespace eosio::chain {
 
       std::mutex             mtx;
       fork_multi_index_type  index;
-      bsp_t                  root; // Only uses the block_header_state portion of block_state
+      bsp_t                  root;
       bsp_t                  head;
       const uint32_t         magic_number;
 
@@ -130,7 +132,7 @@ namespace eosio::chain {
 
       bsp_t            get_block_impl( const block_id_type& id, bool check_root = false ) const;
       bool             block_exists_impl( const block_id_type& id ) const;
-      void             reset_root_impl( const bhs_t& root_bhs );
+      void             reset_root_impl( const bsp_t& root_bs );
       void             rollback_head_to_root_impl();
       void             advance_root_impl( const block_id_type& id );
       void             remove_impl( const block_id_type& id );
@@ -188,8 +190,8 @@ namespace eosio::chain {
                        ("max", fork_database::max_supported_version)
             );
 
-            bhs_t state;
-            fc::raw::unpack( ds, state );
+            bsp_t state = std::make_shared<bs_t>();
+            fc::raw::unpack( ds, *state );
             reset_root_impl( state );
 
             unsigned_int size; fc::raw::unpack( ds, size );
@@ -247,7 +249,7 @@ namespace eosio::chain {
       std::ofstream out( fork_db_file.generic_string().c_str(), std::ios::out | std::ios::binary | std::ofstream::trunc );
       fc::raw::pack( out, magic_number );
       fc::raw::pack( out, fork_database::max_supported_version ); // write out current version which is always max_supported_version
-      fc::raw::pack( out, *static_cast<bhs_t*>(&*root) );
+      fc::raw::pack( out, *root );
       uint32_t num_blocks_in_fork_db = index.size();
       fc::raw::pack( out, unsigned_int{num_blocks_in_fork_db} );
 
@@ -297,16 +299,15 @@ namespace eosio::chain {
    }
 
    template<class BSP>
-   void fork_database_t<BSP>::reset_root( const bhs_t& root_bhs ) {
+   void fork_database_t<BSP>::reset_root( const bsp_t& root_bsp ) {
       std::lock_guard g( my->mtx );
-      my->reset_root_impl(root_bhs);
+      my->reset_root_impl(root_bsp);
    }
 
    template<class BSP>
-   void fork_database_impl<BSP>::reset_root_impl( const bhs_t& root_bhs ) {
+   void fork_database_impl<BSP>::reset_root_impl( const bsp_t& root_bsp ) {
       index.clear();
-      root = std::make_shared<bs_t>();
-      static_cast<bhs_t&>(*root) = root_bhs;
+      root = root_bsp;
       bs_accessor_t::set_valid(*root, true);
       head = root;
    }
@@ -758,7 +759,7 @@ namespace eosio::chain {
       fork_db_s = std::make_unique<fork_database_if_t>(fork_database_if_t::magic_number);
       legacy = false;
       apply_s<void>([&](auto& forkdb) {
-         forkdb.reset_root(*new_head);
+         forkdb.reset_root(new_head);
       });
       return block_handle{new_head};
    }

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -51,8 +51,7 @@ namespace eosio::chain {
       void open( const std::filesystem::path& fork_db_file, validator_t& validator );
       void close( const std::filesystem::path& fork_db_file );
 
-      bhsp_t get_block_header( const block_id_type& id ) const;
-      bsp_t  get_block( const block_id_type& id ) const;
+      bsp_t get_block( const block_id_type& id, bool check_root = false ) const;
       bool block_exists( const block_id_type& id ) const;
 
       /**

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -58,7 +58,7 @@ namespace eosio::chain {
        *  Purges any existing blocks from the fork database and resets the root block_header_state to the provided value.
        *  The head will also be reset to point to the root.
        */
-      void reset_root( const bhs_t& root_bhs );
+      void reset_root( const bsp_t& root_bhs );
 
       /**
        *  Removes validated flag from all blocks in fork database and resets head to point to the root.

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -11,6 +11,7 @@ namespace eosio::chain {
    using block_branch_t = std::vector<signed_block_ptr>;
    enum class mark_valid_t { no, yes };
    enum class ignore_duplicate_t { no, yes };
+   enum class check_root_t { no, yes };
 
    // Used for logging of comparison values used for best fork determination
    std::string log_fork_comparison(const block_state& bs);
@@ -51,7 +52,7 @@ namespace eosio::chain {
       void open( const std::filesystem::path& fork_db_file, validator_t& validator );
       void close( const std::filesystem::path& fork_db_file );
 
-      bsp_t get_block( const block_id_type& id, bool check_root = false ) const;
+      bsp_t get_block( const block_id_type& id, check_root_t check_root = check_root_t::no ) const;
       bool block_exists( const block_id_type& id ) const;
 
       /**

--- a/unittests/finalizer_vote_tests.cpp
+++ b/unittests/finalizer_vote_tests.cpp
@@ -123,7 +123,7 @@ struct simulator_t {
 
       auto genesis = make_bsp(proposal_t{0, "n0"}, bsp(), finpol);
       bsp_vec.push_back(genesis);
-      forkdb.reset_root(*genesis);
+      forkdb.reset_root(genesis);
 
       block_ref genesis_ref(genesis->id(), genesis->timestamp());
       my_finalizer.fsi = fsi_t{block_timestamp_type(0), genesis_ref, genesis_ref};

--- a/unittests/fork_db_tests.cpp
+++ b/unittests/fork_db_tests.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(add_remove_test) try {
    // keep track of all those added for easy verification
    std::vector<block_state_ptr> all { bsp11a, bsp12a, bsp13a, bsp11b, bsp12b, bsp12bb, bsp12bbb, bsp13b, bsp13bb, bsp13bbb, bsp14b, bsp11c, bsp12c, bsp13c };
 
-   forkdb.reset_root(*root);
+   forkdb.reset_root(root);
    forkdb.add(bsp11a, mark_valid_t::no, ignore_duplicate_t::no);
    forkdb.add(bsp11b, mark_valid_t::no, ignore_duplicate_t::no);
    forkdb.add(bsp11c, mark_valid_t::no, ignore_duplicate_t::no);


### PR DESCRIPTION
Resolves #2283 .

Removes `fork_database::get_block_header` and simplifies `create_block_state_i`.

The only difference between `fork_database::get_block_header` and `fork_database::get_block` was that the former checked the `root`. It was also relying on the fact that `block_state` is `public block_header_state` to return the same pointer downcasted.

I have added an optional `check_root` parameter to `fork_database::get_block` instead.

This allowed to make `create_block_state_i` a template instead of having two separate implementations.

New disk format and compatibility mode will be addressed in #2285 .