### PR TITLE
IF: Support replay over instant finality transition

### DIFF
--- a/libraries/chain/block_header_state_legacy.cpp
+++ b/libraries/chain/block_header_state_legacy.cpp
@@ -423,7 +423,7 @@ namespace eosio::chain {
       std::tie(is_satisfied, relevant_sig_count) = producer_authority::keys_satisfy_and_relevant(keys, valid_block_signing_authority);
 
       EOS_ASSERT(relevant_sig_count == keys.size(), wrong_signing_key,
-                 "block signed by unexpected key",
+                 "block signed by unexpected key: ${signing_keys}, expected: ${authority}. ${c} != ${s}",
                  ("signing_keys", keys)("authority", valid_block_signing_authority));
 
       EOS_ASSERT(is_satisfied, wrong_signing_key,

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1050,7 +1050,7 @@ struct controller_impl {
 
    std::optional<block_id_type> fetch_block_id_on_head_branch_by_num(uint32_t block_num) const {
       return fork_db.apply<std::optional<block_id_type>>([&](const auto& forkdb) -> std::optional<block_id_type> {
-         auto bsp = forkdb.search_on_head_branch(block_num);
+         auto bsp = forkdb.search_on_head_branch(block_num, include_root_t::yes);
          if (bsp) return bsp->id();
          return {};
       });
@@ -1062,7 +1062,7 @@ struct controller_impl {
          overloaded{
             [](const fork_database_legacy_t&) -> block_state_ptr { return nullptr; },
             [&](const fork_database_if_t&forkdb) -> block_state_ptr {
-               auto bsp = forkdb.search_on_head_branch(block_num);
+               auto bsp = forkdb.search_on_head_branch(block_num, include_root_t::yes);
                return bsp;
             }
          }
@@ -1075,7 +1075,7 @@ struct controller_impl {
          overloaded{
             [](const fork_database_legacy_t&) -> block_state_ptr { return nullptr; },
             [&](const fork_database_if_t&forkdb) -> block_state_ptr {
-               auto bsp = forkdb.search_on_branch(id, block_num);
+               auto bsp = forkdb.search_on_branch(id, block_num, include_root_t::yes);
                return bsp;
             }
          }
@@ -1246,7 +1246,7 @@ struct controller_impl {
 
       auto mark_branch_irreversible = [&, this](auto& forkdb) {
          auto branch = (if_lib_num > 0) ? forkdb.fetch_branch( if_irreversible_block_id, new_lib_num)
-                                    : forkdb.fetch_branch( fork_db_head(forkdb, irreversible_mode())->id(), new_lib_num );
+                                        : forkdb.fetch_branch( fork_db_head(forkdb, irreversible_mode())->id(), new_lib_num );
          try {
             auto should_process = [&](auto& bsp) {
                // Only make irreversible blocks that have been validated. Blocks in the fork database may not be on our current best head
@@ -3403,7 +3403,7 @@ struct controller_impl {
             auto existing = forkdb.get_block( id );
             EOS_ASSERT( !existing, fork_database_exception, "we already know about this block: ${id}", ("id", id) );
 
-            auto prev = forkdb.get_block( b->previous, check_root_t::yes );
+            auto prev = forkdb.get_block( b->previous, include_root_t::yes );
             EOS_ASSERT( prev, unlinkable_block_exception,
                         "unlinkable block ${id} previous ${p}", ("id", id)("p", b->previous) );
 
@@ -3424,7 +3424,7 @@ struct controller_impl {
          EOS_ASSERT( !existing, fork_database_exception, "we already know about this block: ${id}", ("id", id) );
 
          // previous not found could mean that previous block not applied yet
-         auto prev = forkdb.get_block( b->previous, check_root_t::yes );
+         auto prev = forkdb.get_block( b->previous, include_root_t::yes );
          if( !prev ) return {};
 
          return create_block_state_i( id, b, *prev );

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -765,19 +765,17 @@ namespace eosio::chain {
       }
    }
 
-   block_handle fork_database::switch_from_legacy(const block_handle& bh) {
+   void fork_database::switch_from_legacy(const block_handle& bh) {
       // no need to close fork_db because we don't want to write anything out, file is removed on open
       // threads may be accessing (or locked on mutex about to access legacy forkdb) so don't delete it until program exit
       assert(legacy);
-      assert(std::holds_alternative<block_state_legacy_ptr>(bh.internal()));
-      block_state_legacy_ptr head = std::get<block_state_legacy_ptr>(bh.internal()); // will throw if called after transistion
-      auto new_head = std::make_shared<block_state>(*head);
+      assert(std::holds_alternative<block_state_ptr>(bh.internal()));
+      block_state_ptr new_head = std::get<block_state_ptr>(bh.internal());
       fork_db_s = std::make_unique<fork_database_if_t>(fork_database_if_t::magic_number);
       legacy = false;
       apply_s<void>([&](auto& forkdb) {
          forkdb.reset_root(*new_head);
       });
-      return block_handle{new_head};
    }
 
    block_branch_t fork_database::fetch_branch_from_head() const {

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -712,7 +712,7 @@ namespace eosio::chain {
 
    fork_database::fork_database(const std::filesystem::path& data_dir)
       : data_dir(data_dir)
-        // currently needed because chain_head is accessed before fork database open
+        // genesis starts with legacy
       , fork_db_l{std::make_unique<fork_database_legacy_t>(fork_database_legacy_t::legacy_magic_number)}
    {
    }

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -148,8 +148,8 @@ namespace eosio::chain {
       void open( validator_t& validator );
       void close();
 
-      // expected to be called from main thread, accesses chain_head
-      block_handle switch_from_legacy(const block_handle& bh);
+      // expected to be called from main thread
+      void switch_from_legacy(const block_handle& bh);
 
       bool fork_db_if_present() const { return !!fork_db_s; }
       bool fork_db_legacy_present() const { return !!fork_db_l; }

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -11,7 +11,7 @@ namespace eosio::chain {
    using block_branch_t = std::vector<signed_block_ptr>;
    enum class mark_valid_t { no, yes };
    enum class ignore_duplicate_t { no, yes };
-   enum class check_root_t { no, yes };
+   enum class include_root_t { no, yes };
 
    // Used for logging of comparison values used for best fork determination
    std::string log_fork_comparison(const block_state& bs);
@@ -52,7 +52,7 @@ namespace eosio::chain {
       void open( const std::filesystem::path& fork_db_file, validator_t& validator );
       void close( const std::filesystem::path& fork_db_file );
 
-      bsp_t get_block( const block_id_type& id, check_root_t check_root = check_root_t::no ) const;
+      bsp_t get_block( const block_id_type& id, include_root_t include_root = include_root_t::no ) const;
       bool block_exists( const block_id_type& id ) const;
 
       /**
@@ -107,12 +107,12 @@ namespace eosio::chain {
        *  Returns the block state with a block number of `block_num` that is on the branch that
        *  contains a block with an id of`h`, or the empty shared pointer if no such block can be found.
        */
-      bsp_t search_on_branch( const block_id_type& h, uint32_t block_num ) const;
+      bsp_t search_on_branch( const block_id_type& h, uint32_t block_num, include_root_t include_root = include_root_t::no ) const;
 
       /**
        * search_on_branch( head()->id(), block_num)
        */
-      bsp_t search_on_head_branch( uint32_t block_num ) const;
+      bsp_t search_on_head_branch( uint32_t block_num, include_root_t include_root = include_root_t::no ) const;
 
       /**
        *  Given two head blocks, return two branches of the fork graph that

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -191,9 +191,8 @@ add_test(NAME restart-scenarios-if-test-resync COMMAND tests/restart-scenarios-t
 set_property(TEST restart-scenarios-if-test-resync PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME restart-scenarios-test-hard_replay COMMAND tests/restart-scenarios-test.py -c hardReplay -p4 -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST restart-scenarios-test-hard_replay PROPERTY LABELS nonparallelizable_tests)
-# requires https://github.com/AntelopeIO/leap/issues/2141
-#add_test(NAME restart-scenarios-if-test-hard_replay COMMAND tests/restart-scenarios-test.py -c hardReplay -p4 -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#set_property(TEST restart-scenarios-if-test-hard_replay PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME restart-scenarios-if-test-hard_replay COMMAND tests/restart-scenarios-test.py -c hardReplay -p4 -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST restart-scenarios-if-test-hard_replay PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME restart-scenarios-test-none COMMAND tests/restart-scenarios-test.py -c none --kill-sig term -p4 -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST restart-scenarios-test-none PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME restart-scenarios-if-test-none COMMAND tests/restart-scenarios-test.py -c none --kill-sig term -p4 -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -206,11 +205,14 @@ add_test(NAME terminate-scenarios-test-hard_replay COMMAND tests/terminate-scena
 set_property(TEST terminate-scenarios-test-hard_replay PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME terminate-scenarios-if-test-resync COMMAND tests/terminate-scenarios-test.py -c resync --terminate-at-block 10 --kill-sig term --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST terminate-scenarios-if-test-resync PROPERTY LABELS nonparallelizable_tests)
-# requires https://github.com/AntelopeIO/leap/issues/2141
-#add_test(NAME terminate-scenarios-if-test-replay COMMAND tests/terminate-scenarios-test.py -c replay --terminate-at-block 10 --kill-sig term --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#set_property(TEST terminate-scenarios-if-test-replay PROPERTY LABELS nonparallelizable_tests)
-#add_test(NAME terminate-scenarios-if-test-hard_replay COMMAND tests/terminate-scenarios-test.py -c hardReplay --terminate-at-block 10 --kill-sig term --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#set_property(TEST terminate-scenarios-if-test-hard_replay PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME terminate-scenarios-if-test-replay COMMAND tests/terminate-scenarios-test.py -c replay --terminate-at-block 10 --kill-sig term --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST terminate-scenarios-if-test-replay PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME terminate-scenarios-if-test-hard_replay COMMAND tests/terminate-scenarios-test.py -c hardReplay --terminate-at-block 10 --kill-sig term --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST terminate-scenarios-if-test-hard_replay PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME terminate-scenarios-if-test-replay-pass-transition COMMAND tests/terminate-scenarios-test.py -c replay --terminate-at-block 150 --kill-sig term --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST terminate-scenarios-if-test-replay-pass-transition PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME terminate-scenarios-if-test-hard_replay-pass-transition COMMAND tests/terminate-scenarios-test.py -c hardReplay --terminate-at-block 150 --kill-sig term --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST terminate-scenarios-if-test-hard_replay-pass-transition PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME validate_dirty_db_test COMMAND tests/validate-dirty-db.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST validate_dirty_db_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME keosd_auto_launch_test COMMAND tests/keosd_auto_launch_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -285,7 +287,7 @@ set_property(TEST nodeos_under_min_avail_ram_if_lr_test PROPERTY LABELS long_run
 
 add_test(NAME nodeos_irreversible_mode_lr_test COMMAND tests/nodeos_irreversible_mode_test.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_irreversible_mode_lr_test PROPERTY LABELS long_running_tests)
-# requires https://github.com/AntelopeIO/leap/issues/2141
+# requires https://github.com/AntelopeIO/leap/issues/2286
 #add_test(NAME nodeos_irreversible_mode_if_lr_test COMMAND tests/nodeos_irreversible_mode_test.py -v --activate-if ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 #set_property(TEST nodeos_irreversible_mode_if_lr_test PROPERTY LABELS long_running_tests)
 

--- a/tests/terminate-scenarios-test.py
+++ b/tests/terminate-scenarios-test.py
@@ -58,6 +58,9 @@ try:
     if not cluster.waitOnClusterBlockNumSync(3):
         errorExit("Cluster never stabilized")
 
+    # make sure enough blocks produced to verify truncate works on restart
+    cluster.getNode(0).waitForBlock(terminate+5)
+
     Print("Kill cluster node instance.")
     if cluster.killSomeEosInstances(1, killSignal) is False:
         errorExit("Failed to kill Eos instances")

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -1726,7 +1726,7 @@ BOOST_AUTO_TEST_CASE( producer_schedule_change_extension_test ) { try {
       // ensure it is accepted (but rejected because it doesn't match expected state)
       BOOST_REQUIRE_EXCEPTION(
          remote.push_block(bad_block), wrong_signing_key,
-         fc_exception_message_is( "block signed by unexpected key" )
+         fc_exception_message_starts_with( "block signed by unexpected key" )
       );
    }
 
@@ -1752,7 +1752,7 @@ BOOST_AUTO_TEST_CASE( producer_schedule_change_extension_test ) { try {
       // ensure it is rejected because it doesn't match expected state (but the extention was accepted)
       BOOST_REQUIRE_EXCEPTION(
          remote.push_block(bad_block), wrong_signing_key,
-         fc_exception_message_is( "block signed by unexpected key" )
+         fc_exception_message_starts_with( "block signed by unexpected key" )
       );
    }
 


### PR DESCRIPTION
- Delay opening fork database until after replay of the block log.
- Change `complete_block` to hold a `block_handle`. This removes update code and allows access to block_handle methods like `id()` without using fork database variant.

Resolves #2141 