### PR TITLE
[5.0 -> main] Better error reporting on snapshot load exceptions

### DIFF
--- a/libraries/chain/snapshot.cpp
+++ b/libraries/chain/snapshot.cpp
@@ -257,10 +257,7 @@ void istream_snapshot_reader::validate() const {
                  ("expected", expected_version)("actual", actual_version));
 
       while (validate_section()) {}
-   } catch( const std::exception& e ) {  \
-      snapshot_exception fce(FC_LOG_MESSAGE( warn, "Binary snapshot validation threw IO exception (${what})",("what",e.what())));
-      throw fce;
-   }
+   } FC_LOG_AND_RETHROW()
 }
 
 bool istream_snapshot_reader::validate_section() const {


### PR DESCRIPTION
`./nodeos --data-dir dd --config-dir mainconfig --snapshot snapshot-2024-02-08-04-eos-v6-0356339018.bin.zst`

Before:
```
warn  2024-03-08T13:37:03.489 nodeos    chain_plugin.cpp:1102         plugin_initialize    ] 3240000 snapshot_exception: Snapshot exception
Binary snapshot validation threw IO exception (Snapshot exception)
    {"what":"Snapshot exception"}
    nodeos  snapshot.cpp:261 validate

appbase: exception thrown during plugin "" initialization.
Snapshot exception
```

With this PR:
```
warn  2024-03-08T13:39:02.560 nodeos    snapshot.cpp:260              validate             ] 3240000 snapshot_exception: Snapshot exception
Binary snapshot has unexpected magic number!
    {}
    nodeos  snapshot.cpp:249 validate

warn  2024-03-08T13:39:02.561 nodeos    chain_plugin.cpp:1102         plugin_initialize    ] 3240000 snapshot_exception: Snapshot exception
Binary snapshot has unexpected magic number!
    {}
    nodeos  snapshot.cpp:249 validate
rethrow
    {}
    nodeos  snapshot.cpp:260 validate

appbase: exception thrown during plugin "" initialization.
Snapshot exception
```

Merges `release/5.0` into `main` including #2294 

Resolves #2293 