### PR TITLE
Use `assert` instead of `FC_ASSERT` for conditions that are not progr…

### DIFF
--- a/libraries/libfc/include/fc/variant_object.hpp
+++ b/libraries/libfc/include/fc/variant_object.hpp
@@ -26,10 +26,10 @@ namespace fc
       public:
          entry();
          entry( std::string k, variant v );
-         entry( entry&& e );
+         entry( entry&& e ) noexcept ;
          entry( const entry& e);
          entry& operator=(const entry&);
-         entry& operator=(entry&&);
+         entry& operator=(entry&&) noexcept ;
 
          const std::string& key()const;
          const variant& value()const;

--- a/libraries/libfc/src/variant_object.cpp
+++ b/libraries/libfc/src/variant_object.cpp
@@ -9,7 +9,7 @@ namespace fc
 
    variant_object::entry::entry() {}
    variant_object::entry::entry( std::string k, variant v ) : _key(fc::move(k)),_value(fc::move(v)) {}
-   variant_object::entry::entry( entry&& e ) : _key(fc::move(e._key)),_value(fc::move(e._value)) {}
+   variant_object::entry::entry( entry&& e )  noexcept : _key(fc::move(e._key)),_value(fc::move(e._value)) {}
    variant_object::entry::entry( const entry& e ) : _key(e._key),_value(e._value) {}
    variant_object::entry& variant_object::entry::operator=( const variant_object::entry& e )
    {
@@ -20,8 +20,7 @@ namespace fc
       }
       return *this;
    }
-   variant_object::entry& variant_object::entry::operator=( variant_object::entry&& e )
-   {
+   variant_object::entry& variant_object::entry::operator=( variant_object::entry&& e ) noexcept    {
       fc_swap( _key, e._key );
       fc_swap( _value, e._value );
       return *this;
@@ -51,7 +50,7 @@ namespace fc
 
    variant_object::iterator variant_object::begin() const
    {
-      FC_ASSERT( _key_value != nullptr );
+      assert( _key_value != nullptr );
       return _key_value->begin();
    }
 
@@ -109,14 +108,14 @@ namespace fc
    variant_object::variant_object( const variant_object& obj )
    :_key_value( obj._key_value )
    {
-      FC_ASSERT( _key_value != nullptr );
+      assert( _key_value != nullptr );
    }
 
    variant_object::variant_object( variant_object&& obj) noexcept:
       _key_value( fc::move(obj._key_value) )
    {
       obj._key_value = std::make_shared<std::vector<entry>>();
-      FC_ASSERT( _key_value != nullptr );
+      assert( _key_value != nullptr );
    }
 
    variant_object::variant_object( const mutable_variant_object& obj )
@@ -127,14 +126,14 @@ namespace fc
    variant_object::variant_object( mutable_variant_object&& obj )
    : _key_value(fc::move(obj._key_value))
    {
-      FC_ASSERT( _key_value != nullptr );
+      assert( _key_value != nullptr );
    }
 
    variant_object& variant_object::operator=( variant_object&& obj ) noexcept {
       if (this != &obj)
       {
          fc_swap(_key_value, obj._key_value );
-         FC_ASSERT( _key_value != nullptr );
+         assert( _key_value != nullptr );
       }
       return *this;
    }

--- a/libraries/libfc/src/variant_object.cpp
+++ b/libraries/libfc/src/variant_object.cpp
@@ -20,7 +20,7 @@ namespace fc
       }
       return *this;
    }
-   variant_object::entry& variant_object::entry::operator=( variant_object::entry&& e ) noexcept    {
+   variant_object::entry& variant_object::entry::operator=( variant_object::entry&& e ) noexcept {
       fc_swap( _key, e._key );
       fc_swap( _value, e._value );
       return *this;


### PR DESCRIPTION
…amatically possible.

In the sense that a user of the class cannot trigger these asserts unless there is a bug in `variant_object.[cpp,hpp]`