### PR TITLE
custom `chainbase::environment` `to_variant()` to workaround invalid unaligned access

### DIFF
--- a/libraries/chain/include/eosio/chain/chainbase_environment.hpp
+++ b/libraries/chain/include/eosio/chain/chainbase_environment.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <chainbase/environment.hpp>
+
+// reflect chainbase::environment for --print-build-info option
+FC_REFLECT_ENUM(chainbase::environment::os_t,
+                (OS_LINUX) (OS_MACOS) (OS_WINDOWS) (OS_OTHER))
+FC_REFLECT_ENUM(chainbase::environment::arch_t,
+                (ARCH_X86_64) (ARCH_ARM) (ARCH_RISCV) (ARCH_OTHER))
+
+namespace fc {
+
+void to_variant(const chainbase::environment& bi, variant& v) {
+   // the variant conversion ultimately binds a reference to each member, but chainbase::environment is packed making
+   // a reference to an unaligned variable UB. The boost_version is the only offender
+   unsigned aligned_boost_version = bi.boost_version;
+   v = fc::mutable_variant_object()("debug", bi.debug)
+                                   ("os", bi.os)
+                                   ("arch", bi.arch)
+                                   ("boost_version", aligned_boost_version)
+                                   ("compiler", bi.compiler);
+
+}
+
+}

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -16,10 +16,9 @@
 #include <eosio/chain_plugin/trx_finality_status_processing.hpp>
 #include <eosio/chain/permission_link_object.hpp>
 #include <eosio/chain/global_property_object.hpp>
+#include <eosio/chain/chainbase_environment.hpp>
 
 #include <eosio/resource_monitor_plugin/resource_monitor_plugin.hpp>
-
-#include <chainbase/environment.hpp>
 
 #include <boost/signals2/connection.hpp>
 #include <boost/algorithm/string.hpp>
@@ -28,13 +27,6 @@
 #include <fc/io/json.hpp>
 #include <fc/variant.hpp>
 #include <cstdlib>
-
-// reflect chainbase::environment for --print-build-info option
-FC_REFLECT_ENUM( chainbase::environment::os_t,
-                 (OS_LINUX)(OS_MACOS)(OS_WINDOWS)(OS_OTHER) )
-FC_REFLECT_ENUM( chainbase::environment::arch_t,
-                 (ARCH_X86_64)(ARCH_ARM)(ARCH_RISCV)(ARCH_OTHER) )
-FC_REFLECT(chainbase::environment, (debug)(os)(arch)(boost_version)(compiler) )
 
 const std::string deep_mind_logger_name("deep-mind");
 eosio::chain::deep_mind_handler _deep_mind_log;

--- a/programs/leap-util/actions/chain.cpp
+++ b/programs/leap-util/actions/chain.cpp
@@ -10,7 +10,7 @@
 
 #include <eosio/chain/block_log.hpp>
 #include <eosio/chain/exceptions.hpp>
-#include <chainbase/environment.hpp>
+#include <eosio/chain/chainbase_environment.hpp>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -18,15 +18,6 @@
 
 using namespace eosio;
 using namespace eosio::chain;
-
-
-// reflect chainbase::environment for --print-build-info option
-FC_REFLECT_ENUM(chainbase::environment::os_t,
-                (OS_LINUX) (OS_MACOS) (OS_WINDOWS) (OS_OTHER))
-FC_REFLECT_ENUM(chainbase::environment::arch_t,
-                (ARCH_X86_64) (ARCH_ARM) (ARCH_RISCV) (ARCH_OTHER))
-FC_REFLECT(chainbase::environment, (debug) (os) (arch) (boost_version) (compiler))
-
 
 void chain_actions::setup(CLI::App& app) {
    auto* sub = app.add_subcommand("chain-state", "chain utility");


### PR DESCRIPTION
See comment. We should change CB's header to not have this problem next time there is work in area.