### PR TITLE
add CI "platform" running UBSAN

### DIFF
--- a/.cicd/platforms/ubsan.Dockerfile
+++ b/.cicd/platforms/ubsan.Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:jammy
+ENV TZ="America/New_York"
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y build-essential      \
+                       cmake                \
+                       git                  \
+                       jq                   \
+                       libcurl4-openssl-dev \
+                       libgmp-dev           \
+                       llvm-11-dev          \
+                       lsb-release          \
+                       ninja-build          \
+                       python3-numpy        \
+                       software-properties-common \
+                       file                 \
+                       wget                 \
+                       zlib1g-dev           \
+                       zstd
+
+RUN yes | bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 18
+
+#make sure no confusion on what llvm library leap's cmake should pick up on
+RUN rm -rf /usr/lib/llvm-18/lib/cmake
+
+COPY <<-EOF /ubsan.supp
+  vptr:wasm_eosio_validation.hpp
+  vptr:wasm_eosio_injection.hpp
+EOF
+
+ENV LEAP_PLATFORM_HAS_EXTRAS_CMAKE=1
+COPY <<-EOF /extras.cmake
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "" FORCE)
+
+  set(CMAKE_C_COMPILER "clang-18" CACHE STRING "")
+  set(CMAKE_CXX_COMPILER "clang++-18" CACHE STRING "")
+  set(CMAKE_C_FLAGS "-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" CACHE STRING "")
+  set(CMAKE_CXX_FLAGS "-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" CACHE STRING "")
+EOF
+
+ENV UBSAN_OPTIONS=print_stacktrace=1,suppressions=/ubsan.supp

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -136,6 +136,7 @@ jobs:
           - cfg: {name: 'ubuntu20',      base: 'ubuntu20', builddir: 'ubuntu20'}
           - cfg: {name: 'ubuntu22',      base: 'ubuntu22', builddir: 'ubuntu22'}
           - cfg: {name: 'asserton',      base: 'asserton', builddir: 'asserton'}
+          - cfg: {name: 'ubsan',         base: 'ubsan',    builddir: 'ubsan'}
           - cfg: {name: 'ubuntu20repro', base: 'ubuntu20', builddir: 'reproducible'}
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-hightier"]
@@ -176,6 +177,7 @@ jobs:
           - cfg: {name: 'ubuntu20',      base: 'ubuntu20', builddir: 'ubuntu20'}
           - cfg: {name: 'ubuntu22',      base: 'ubuntu22', builddir: 'ubuntu22'}
           - cfg: {name: 'asserton',      base: 'asserton', builddir: 'asserton'}
+          - cfg: {name: 'ubsan',         base: 'ubsan',    builddir: 'ubsan'}
           - cfg: {name: 'ubuntu20repro', base: 'ubuntu20', builddir: 'reproducible'}
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-midtier"]
@@ -216,6 +218,7 @@ jobs:
           - cfg: {name: 'ubuntu20',      base: 'ubuntu20', builddir: 'ubuntu20'}
           - cfg: {name: 'ubuntu22',      base: 'ubuntu22', builddir: 'ubuntu22'}
           - cfg: {name: 'asserton',      base: 'asserton', builddir: 'asserton'}
+          - cfg: {name: 'ubsan',         base: 'ubsan',    builddir: 'ubsan'}
           - cfg: {name: 'ubuntu20repro', base: 'ubuntu20', builddir: 'reproducible'}
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-lowtier"]


### PR DESCRIPTION
While there are still a few remaining violations (see comments below), I think we're in a good spot to enable UBSAN in CI builds. UBSAN is expected to generate no false positives so requiring it to pass is reasonable.

An example run with failures is here,
https://github.com/AntelopeIO/leap/actions/runs/8252261490