### PR TITLE
[5.0 -> main] fix IPv4 vs IPv6 mismatch in `gelf_test`

### DIFF
--- a/tests/gelf_test.py
+++ b/tests/gelf_test.py
@@ -40,8 +40,8 @@ logging="""{
       "name": "net",
       "type": "gelf",
       "args": {
-        "endpoint": "localhost:GELF_PORT",
-        "host": "localhost",
+        "endpoint": "127.0.0.1:GELF_PORT",
+        "host": "127.0.0.1",
         "_network": "testnet"
       },
       "enabled": true


### PR DESCRIPTION
main merge of #2288

> `gelf_test.py` listens on 127.0.0.1,
> https://github.com/AntelopeIO/leap/blob/aef4329efa9a860b7b46b690876ded088189684e/tests/gelf_test.py#L71-L74
> 
> but then configured its `logging.json` to use `localhost`. In 5.0, gelf will use IPv6 and on by box `localhost` will resolve to `::1` thus this test would fail locally for me since the gelf messages wouldn't arrive on the expected address.
> 
> Explicitly configure `127.0.0.1` in logging.json so it's always IPv4->IPv4