### PR TITLE
restore `get_block_header_state` endpoint for usage both pre and post Savanna activation

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1081,12 +1081,12 @@ struct controller_impl {
                return ret;
             } else if(block_num) {
                //only for savanna: look in reversible blocks for block_num too
-               if(std::optional<signed_block_ptr> sb = blog.read_block_by_num(*block_num)) {
+               if(signed_block_ptr sb = blog.read_block_by_num(*block_num)) {
                   block_header_state_legacy ret;
-                  ret.block_num = (*sb)->block_num();
-                  ret.id = (*sb)->calculate_id();
-                  ret.header = **sb;
-                  ret.additional_signatures = detail::extract_additional_signatures(*sb);
+                  ret.block_num = sb->block_num();
+                  ret.id = sb->calculate_id();
+                  ret.header = *sb;
+                  ret.additional_signatures = detail::extract_additional_signatures(sb);
                   return ret;
                }
             }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1076,15 +1076,17 @@ struct controller_impl {
                block_header_state_legacy ret;
                ret.block_num = p->block_num();
                ret.id = p->id();
-               ret.header.timestamp = p->timestamp();
+               ret.header = *p->block;
+               ret.additional_signatures = detail::extract_additional_signatures(p->block);
                return ret;
             } else if(block_num) {
                //only for savanna: look in reversible blocks for block_num too
-               if(std::optional<signed_block_header> sbh = blog.read_block_header_by_num(*block_num)) {
+               if(std::optional<signed_block_ptr> sb = blog.read_block_by_num(*block_num)) {
                   block_header_state_legacy ret;
-                  ret.block_num = sbh->block_num();
-                  ret.id = sbh->calculate_id();
-                  ret.header.timestamp = sbh->timestamp;
+                  ret.block_num = (*sb)->block_num();
+                  ret.id = (*sb)->calculate_id();
+                  ret.header = **sb;
+                  ret.additional_signatures = detail::extract_additional_signatures(*sb);
                   return ret;
                }
             }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1080,7 +1080,7 @@ struct controller_impl {
                ret.additional_signatures = detail::extract_additional_signatures(p->block);
                return ret;
             } else if(block_num) {
-               //only for savanna: look in reversible blocks for block_num too
+               //only for savanna: look in irreversible blocks for block_num too
                if(signed_block_ptr sb = blog.read_block_by_num(*block_num)) {
                   block_header_state_legacy ret;
                   ret.block_num = sb->block_num();

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -278,6 +278,10 @@ namespace eosio::chain {
          std::optional<signed_block_header> fetch_block_header_by_number( uint32_t block_num )const;
          // thread-safe
          std::optional<signed_block_header> fetch_block_header_by_id( const block_id_type& id )const;
+         // thread-safe; intended for usage of old RPC endpoint: synthesizes skeleton block_header_state_legacy post-savanna activation
+         std::optional<block_header_state_legacy> fetch_bhs_for_legacy_rpc_by_num(uint32_t block_num)const;
+         // thread-safe; intended for usage of old RPC endpoint: synthesizes skeleton block_header_state_legacy post-savanna activation
+         std::optional<block_header_state_legacy> fetch_bhs_for_legacy_rpc_by_id(block_id_type id) const;
          // thread-safe
          block_id_type get_block_id_for_num( uint32_t block_num )const;
          // thread-safe

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -188,7 +188,7 @@ paths:
 
   /get_block_header_state:
     post:
-      description: Retrieves the pre-Savanna block header state; for blocks post-Savanna activation, a fake pre-Savanna block header state is returned with only block_num, id, and header.timestamp filled.
+      description: Retrieves the pre-Savanna block header state; for blocks post-Savanna activation, a fake pre-Savanna block header state is returned with only block_num, id, header, and additional_signatures filled.
       operationId: get_block_header_state
       requestBody:
         content:

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -186,6 +186,30 @@ paths:
               schema:
                 description: Returns Nothing
 
+  /get_block_header_state:
+    post:
+      description: Retrieves the pre-Savanna block header state; for blocks post-Savanna activation, a fake pre-Savanna block header state is returned with only block_num, id, and header.timestamp filled.
+      operationId: get_block_header_state
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - block_num_or_id
+              properties:
+                block_num_or_id:
+                  type: string
+                  description: Provide a block_number or a block_id
+
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "https://docs.eosnetwork.com/openapi/v2.0/BlockHeaderState.yaml"
+
   /get_abi:
     post:
       description: Retrieves the ABI for a contract based on its account name

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -132,6 +132,7 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(get_activated_protocol_features, 200, http_params_types::possible_no_params),
       CHAIN_RO_CALL_POST(get_block, fc::variant, 200, http_params_types::params_required), // _POST because get_block() returns a lambda to be executed on the http thread pool
       CHAIN_RO_CALL(get_block_info, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_block_header_state, 200, http_params_types::params_required),
       CHAIN_RO_CALL_POST(get_account, chain_apis::read_only::get_account_results, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_code, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_code_hash, 200, http_params_types::params_required),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2023,6 +2023,29 @@ fc::variant read_only::get_block_info(const read_only::get_block_info_params& pa
          ("ref_block_prefix", ref_block_prefix);
 }
 
+fc::variant read_only::get_block_header_state(const get_block_header_state_params& params, const fc::time_point&) const {
+   std::optional<block_header_state_legacy> b;
+   std::optional<uint64_t> block_num;
+
+   try {
+      block_num = fc::to_uint64(params.block_num_or_id);
+   } catch( ... ) {}
+
+   if( block_num ) {
+      b = db.fetch_bhs_for_legacy_rpc_by_num(*block_num);
+   } else {
+      try {
+         b = db.fetch_bhs_for_legacy_rpc_by_id(fc::variant(params.block_num_or_id).as<block_id_type>());
+      } EOS_RETHROW_EXCEPTIONS(chain::block_id_type_exception, "Invalid block ID: ${block_num_or_id}", ("block_num_or_id", params.block_num_or_id))
+   }
+
+   EOS_ASSERT( b, unknown_block_exception, "Could not find reversible block: ${block}", ("block", params.block_num_or_id));
+
+   fc::variant vo;
+   fc::to_variant( *b, vo );
+   return vo;
+}
+
 void read_write::push_block(read_write::push_block_params&& params, next_function<read_write::push_block_results> next) {
    try {
       auto b = std::make_shared<signed_block>( std::move(params) );

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -409,6 +409,12 @@ public:
 
    fc::variant get_block_info(const get_block_info_params& params, const fc::time_point& deadline) const;
 
+   struct get_block_header_state_params {
+      string block_num_or_id;
+   };
+
+   fc::variant get_block_header_state(const get_block_header_state_params& params, const fc::time_point& deadline) const;
+
    struct get_table_rows_params {
       bool                 json = false;
       name                 code;
@@ -1022,6 +1028,7 @@ FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params,
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
 FC_REFLECT(eosio::chain_apis::read_only::get_raw_block_params, (block_num_or_id))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_info_params, (block_num))
+FC_REFLECT(eosio::chain_apis::read_only::get_block_header_state_params, (block_num_or_id))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_header_params, (block_num_or_id)(include_extensions))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_header_result, (id)(signed_block_header)(block_extensions))
 

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -33,6 +33,7 @@ namespace eosio { namespace client { namespace http {
    const string get_raw_block_func = chain_func_base + "/get_raw_block";
    const string get_block_header_func = chain_func_base + "/get_block_header";
    const string get_block_info_func = chain_func_base + "/get_block_info";
+   const string get_block_header_state_func = chain_func_base + "/get_block_header_state";
    const string get_account_func = chain_func_base + "/get_account";
    const string get_table_func = chain_func_base + "/get_table_rows";
    const string get_table_by_scope_func = chain_func_base + "/get_table_by_scope";

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -336,6 +336,25 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
         self.assertEqual(ret_json["payload"]["block_num"], 1)
 
+        # get_block_header_state with empty parameter
+        command = "get_block_header_state"
+        ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_block_header_state with empty content parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_block_header_state with invalid parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_block_header_state with valid parameter, the irreversible is not available, unknown block number
+        payload = {"block_num_or_id":1}
+        ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3100002)
+
         # get_account with empty parameter
         command = "get_account"
         ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)


### PR DESCRIPTION
`get_block_header_state` returns the pre-Savanna (legacy) block header state. Parts of this response are incompatible with the internals of the new Savanna block state. Originally the plan was to simply remove the `get_block_header_state`  endpoint, but some versions of eosjs (including the `latest` one, 22.1.0, apparently downloaded some 17k times in the last week) require operation of this endpoint given certain values of `blocksBehind` otherwise eosjs will be unable to push a transaction.

So instead, restore the endpoint with some important restrictions. Prior to Savanna activation the endpoint will continue to -- strictly for reversible blocks -- return the entire legacy block header state as it does today. But after activation of Savanna, it will return a response containing all fields but with only `block_num`, `id`, `header`, and `additional_signatures` filled out. Other fields will still exist but will be empty or zero. Additionally, the endpoint will consider both reversible and irreversible blocks if the request used a block number. This latter tweak helps guard against a race condition in eosjs between calling `get_info` and then `get_block_header_state` when `blocksBehind` is a low number such as 2 or 3.

An example post Savanna activated response with the limited filled fields looks something like,
```json
{
  "block_num": 40660,
  "dpos_proposed_irreversible_blocknum": 0,
  "dpos_irreversible_blocknum": 0,
  "active_schedule": {
    "version": 0,
    "producers": []
  },
  "blockroot_merkle": {
    "_active_nodes": [],
    "_node_count": 0
  },
  "producer_to_last_produced": [],
  "producer_to_last_implied_irb": [],
  "valid_block_signing_authority": [
    0,
    {
      "threshold": 0,
      "keys": []
    }
  ],
  "confirm_count": [],
  "id": "00009ed4aa662f3d7e96d88061e4741692b433fe783befc6c3cb6c6a40c5955a",
  "header": {
    "timestamp": "2024-03-19T02:39:40.000",
    "producer": "inita",
    "confirmed": 0,
    "previous": "00009ed38d8d4c103ce5ced75558d6ac0f4d2ac4b63cf964feeb6d8bce600ade",
    "transaction_mroot": "0000000000000000000000000000000000000000000000000000000000000000",
    "action_mroot": "b179283d2264aa663cb669924bbff2f33e81a7ed71dcb465342673602605a1f1",
    "schedule_version": 2,
    "header_extensions": [
      [
        2,
        "d39e0000010000"
      ]
    ],
    "producer_signature": "SIG_K1_KgufADyFuHdBwT6VGBVdrnhVs6dakZdXp4qr5NgJFU7orfXbFi9eVc7NvjrjvUyL79SXfMjgyzW7cVGfQW8iy1CbjStENZ"
  },
  "pending_schedule": {
    "schedule_lib_num": 0,
    "schedule_hash": "0000000000000000000000000000000000000000000000000000000000000000",
    "schedule": {
      "version": 0,
      "producers": []
    }
  },
  "activated_protocol_features": null,
  "additional_signatures": []
}

```

I've confirmed with eosjs 22.1.0, 21.0.4, and 20.0.3 that operation works as expected. (20.0.3 does not use `get_block_header_state` for `transact()` though, instead just always calling `get_block`)

Resolves #2222