### PR TITLE
Replace hacky version of `calculate_max_depth` with simpler one.

### DIFF
--- a/libraries/chain/include/eosio/chain/incremental_merkle.hpp
+++ b/libraries/chain/include/eosio/chain/incremental_merkle.hpp
@@ -18,7 +18,7 @@ namespace detail {
 constexpr uint64_t calculate_max_depth(uint64_t node_count) {
    if (node_count == 0)
       return 0;
-   // following is non-floating point equivalent to `std::ceil(std::log2(node_count)) + 1)
+   // following is non-floating point equivalent to `std::ceil(std::log2(node_count)) + 1)` (and about 9x faster)
    return 8*sizeof(node_count) - std::countl_zero(std::bit_ceil(node_count));
 }
 

--- a/libraries/chain/include/eosio/chain/incremental_merkle.hpp
+++ b/libraries/chain/include/eosio/chain/incremental_merkle.hpp
@@ -19,7 +19,7 @@ constexpr uint64_t calculate_max_depth(uint64_t node_count) {
    if (node_count == 0)
       return 0;
    // following is non-floating point equivalent to `std::ceil(std::log2(node_count)) + 1)` (and about 9x faster)
-   return 8*sizeof(node_count) - std::countl_zero(std::bit_ceil(node_count));
+   return std::bit_width(std::bit_ceil(node_count));
 }
 
 template<typename ContainerA, typename ContainerB>

--- a/libraries/chain/include/eosio/chain/incremental_merkle.hpp
+++ b/libraries/chain/include/eosio/chain/incremental_merkle.hpp
@@ -2,6 +2,7 @@
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/merkle.hpp>
 #include <fc/io/raw.hpp>
+#include <bit>
 
 namespace eosio::chain {
 
@@ -17,7 +18,8 @@ namespace detail {
 constexpr uint64_t calculate_max_depth(uint64_t node_count) {
    if (node_count == 0)
       return 0;
-   return std::llround(std::ceil(std::log2(node_count))) + 1;
+   // following is non-floating point equivalent to `std::ceil(std::log2(node_count)) + 1)
+   return 8*sizeof(node_count) - std::countl_zero(std::bit_ceil(node_count));
 }
 
 template<typename ContainerA, typename ContainerB>

--- a/libraries/chain/include/eosio/chain/incremental_merkle.hpp
+++ b/libraries/chain/include/eosio/chain/incremental_merkle.hpp
@@ -3,51 +3,9 @@
 #include <eosio/chain/merkle.hpp>
 #include <fc/io/raw.hpp>
 
-namespace eosio { namespace chain {
+namespace eosio::chain {
 
 namespace detail {
-
-/**
- * given an unsigned integral number return the smallest
- * power-of-2 which is greater than or equal to the given number
- *
- * @param value - an unsigned integral
- * @return - the minimum power-of-2 which is >= value
- */
-constexpr uint64_t next_power_of_2(uint64_t value) {
-   value -= 1;
-   value |= value >> 1;
-   value |= value >> 2;
-   value |= value >> 4;
-   value |= value >> 8;
-   value |= value >> 16;
-   value |= value >> 32;
-   value += 1;
-   return value;
-}
-
-/**
- * Given a power-of-2 (assumed correct) return the number of leading zeros
- *
- * This is a classic count-leading-zeros in parallel without the necessary
- * math to make it safe for anything that is not already a power-of-2
- *
- * @param value - and integral power-of-2
- * @return the number of leading zeros
- */
-constexpr int clz_power_2(uint64_t value) {
-   int lz = 64;
-
-   if (value) lz--;
-   if (value & 0x00000000FFFFFFFFULL) lz -= 32;
-   if (value & 0x0000FFFF0000FFFFULL) lz -= 16;
-   if (value & 0x00FF00FF00FF00FFULL) lz -= 8;
-   if (value & 0x0F0F0F0F0F0F0F0FULL) lz -= 4;
-   if (value & 0x3333333333333333ULL) lz -= 2;
-   if (value & 0x5555555555555555ULL) lz -= 1;
-
-   return lz;
-}
 
 /**
  * Given a number of nodes return the depth required to store them
@@ -56,12 +14,10 @@ constexpr int clz_power_2(uint64_t value) {
  * @param node_count - the number of nodes in the implied tree
  * @return the max depth of the minimal tree that stores them
  */
-constexpr int calcluate_max_depth(uint64_t node_count) {
-   if (node_count == 0) {
+constexpr uint64_t calculate_max_depth(uint64_t node_count) {
+   if (node_count == 0)
       return 0;
-   }
-   auto implied_count = next_power_of_2(node_count);
-   return clz_power_2(implied_count) + 1;
+   return std::llround(std::ceil(std::log2(node_count))) + 1;
 }
 
 template<typename ContainerA, typename ContainerB>
@@ -167,7 +123,7 @@ class incremental_merkle_impl {
        */
       const DigestType& append(const DigestType& digest) {
          bool partial = false;
-         auto max_depth = detail::calcluate_max_depth(_node_count + 1);
+         auto max_depth = detail::calculate_max_depth(_node_count + 1);
          auto current_depth = max_depth - 1;
          auto index = _node_count;
          auto top = digest;
@@ -246,6 +202,6 @@ class incremental_merkle_impl {
 typedef incremental_merkle_impl<digest_type>               incremental_merkle;
 typedef incremental_merkle_impl<digest_type,shared_vector> shared_incremental_merkle;
 
-} } /// eosio::chain
+} /// eosio::chain
 
 FC_REFLECT( eosio::chain::incremental_merkle, (_active_nodes)(_node_count) );


### PR DESCRIPTION
In PR #2314, I asked why we were using overly complex code to do what was basically a log base 2.
Gnome mentioned that the original code was in `incremental_merkle_tree.hpp`.

So I propose this simplification. The replacement provides exactly the same result as the previous implementation, as the following test program demonstrates:

```c++
#include <cmath>
#include <cstdlib>

static uint64_t next_power_of_2(uint64_t value) {
   value -= 1;
   value |= value >> 1;
   value |= value >> 2;
   value |= value >> 4;
   value |= value >> 8;
   value |= value >> 16;
   value |= value >> 32;
   value += 1;   return value;
}

constexpr uint64_t clz_power_2(uint64_t value) {
   int lz = 64;

   if (value) lz--;
   if (value & 0x00000000FFFFFFFFULL) lz -= 32;
   if (value & 0x0000FFFF0000FFFFULL) lz -= 16;
   if (value & 0x00FF00FF00FF00FFULL) lz -= 8;
   if (value & 0x0F0F0F0F0F0F0F0FULL) lz -= 4;
   if (value & 0x3333333333333333ULL) lz -= 2;
   if (value & 0x5555555555555555ULL) lz -= 1;

   return lz;
}

constexpr uint64_t calculate_max_depth(uint64_t node_count) {
   if (node_count == 0) {
      return 0;
   }
   auto implied_count = next_power_of_2(node_count);
   return clz_power_2(implied_count) + 1;
}

static uint64_t calculate_max_depth2(uint64_t node_count) {
   if (node_count == 0)
      return 0;
   return std::llround(std::ceil(std::log2(node_count))) + 1;
}

int main(int argc, char **argv)
{
   for (size_t i=0; i<100'000'000; ++i)
      if (auto a = calculate_max_depth(i), b = calculate_max_depth2(i); a != b) {
         printf("fails for i=%ld (%ld != %ld)\n", i, a, b);
         exit(0);
      }
   printf("success\n");
   return 0;
}
```