### PR TITLE
IF: Test fix: Delay on error to give time for node to launch

### DIFF
--- a/tests/p2p_sync_throttle_test.py
+++ b/tests/p2p_sync_throttle_test.py
@@ -136,6 +136,7 @@ try:
             if len(response) < 100:
                 # tolerate HTTPError as well (method returns only the exception code)
                 errorLimit -= 1
+                time.sleep(0.5)
                 continue
             connPorts = prometheusHostPortPattern.findall(response)
             Print(connPorts)
@@ -180,6 +181,7 @@ try:
             if len(connPorts) < 2:
                 # wait for sending node to be connected
                 errorLimit -= 1
+                time.sleep(0.5)
                 continue
             Print('Throttled Node Start State')
             throttledNodePortMap = {port: id for id, port in connPorts if port != '0'}


### PR DESCRIPTION
See https://github.com/AntelopeIO/leap/actions/runs/8347816731/job/22848869684
Failed because it didn't wait on an error and quickly exhausted error limit.

```
debug 2024-03-19T18:09:31.199 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7638    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 5 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{bl...
debug 2024-03-19T18:09:31.200 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.200 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7638    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 6 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{bl...
debug 2024-03-19T18:09:31.201 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.202 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7638    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 7 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{bl...
debug 2024-03-19T18:09:31.203 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.203 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7638    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 8 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{bl...
debug 2024-03-19T18:09:31.204 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.204 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7638    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 9 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{bl...
debug 2024-03-19T18:09:31.205 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.205 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7639    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 10 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.207 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.207 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7640    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 11 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.208 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.209 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7640    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 12 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.210 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.210 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7640    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 13 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.212 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.212 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7640    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 14 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.213 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.213 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 15 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.215 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.215 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 16 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.217 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.217 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 17 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.218 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.219 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 18 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.220 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.220 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 19 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.222 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.222 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 20 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.224 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.224 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 21 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.225 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.225 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 22 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.226 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.227 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 23 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.228 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.228 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 24 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.229 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.229 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 25 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.230 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.230 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 26 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.231 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.231 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 27 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.232 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.232 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 28 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.233 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.234 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 29 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.235 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.235 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 30 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.237 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.237 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 31 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.238 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.238 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 32 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.240 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.240 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 33 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.241 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.242 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 34 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.243 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.243 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 35 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.244 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.245 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 36 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.246 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.246 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 37 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.248 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.248 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 38 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.249 http-0    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.249 http-0    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 39 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
debug 2024-03-19T18:09:31.250 http-1    beast_http_session.hpp:156    handle_request       ] Request:  localhost:8891 POST /v1/prometheus/metrics HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8891  User-Agent: Python-urllib/3.10  Connection: close    
debug 2024-03-19T18:09:31.251 http-1    beast_http_session.hpp:480    send_response        ] Response: localhost:8891 HTTP/1.1 200 OK  Connection: close  Server: nodeos/v5.1.0-dev  Content-Type: text/plain  Content-Length: 7641    # HELP nodeos_http_requests_total number of HTTP requests # TYPE nodeos_http_requests_total counter nodeos_http_requests_total{handler="/v1/prometheus/metrics"} 40 # HELP nodeos_p2p_failed_connections total number of failed out-going p2p connections # TYPE nodeos_p2p_failed_connections counter nodeos_p2p_failed_connections 2 # HELP nodeos_p2p_dropped_trxs_total total number of dropped transactions by net plugin # TYPE nodeos_p2p_dropped_trxs_total counter nodeos_p2p_dropped_trxs_total 0 # HELP nodeos_cpu_usage_us_total total cpu usage in microseconds for blocks # TYPE nodeos_cpu_usage_us_total counter nodeos_cpu_usage_us_total{block_type="incoming"} 100 nodeos_cpu_usage_us_total{block_type="produced"} 0 # HELP nodeos_net_usage_us_total total net usage in microseconds for blocks # TYPE nodeos_net_usage_us_total counter nodeos_net_usage_us_total{block_type="incoming"} 0 nodeos_net_usage_us_total{b...
```