### PR TITLE
Perf issue: avoid vector copy at each insertion.

### DIFF
--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -709,7 +709,7 @@ namespace eosio { namespace chain {
    {
       uint32_t new_action_ordinal = trace->action_traces.size() + 1;
 
-      trace->action_traces.reserve( std::bit_ceil(new_action_ordinal) ); // bit_ceil to avoid vector copy on every insertion
+      trace->action_traces.reserve( std::bit_ceil(new_action_ordinal) ); // bit_ceil to avoid vector copy on every reserve call.
 
       const action& provided_action = get_action_trace( action_ordinal ).act;
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -10,6 +10,7 @@
 #include <eosio/chain/deep_mind.hpp>
 
 #include <chrono>
+#include <bit>
 
 namespace eosio { namespace chain {
 
@@ -708,11 +709,12 @@ namespace eosio { namespace chain {
    {
       uint32_t new_action_ordinal = trace->action_traces.size() + 1;
 
-      trace->action_traces.reserve( new_action_ordinal );
+      trace->action_traces.reserve( std::bit_ceil(new_action_ordinal) ); // bit_ceil to avoid vector copy on every insertion
 
       const action& provided_action = get_action_trace( action_ordinal ).act;
 
-      // The reserve above is required so that the emplace_back below does not invalidate the provided_action reference.
+      // The reserve above is required so that the emplace_back below does not invalidate the provided_action reference,
+      // which references an action within the `trace->action_traces` vector we are appending to.
 
       trace->action_traces.emplace_back( *trace, provided_action, receiver, context_free,
                                          new_action_ordinal, creator_action_ordinal,


### PR DESCRIPTION
The `vector::reserve(vector::size() + 1)` call which is updated in this PR, with typical `std::vector` implementations, causes the vector to grow by a single element on every reverve, and therefore a memory allocation and full vector copy on every `reserve` call.

This updates the `reserve()` call so that the vector capacity grows quadrically.