### PR TITLE
IF: Use enum to track which action receipt digest to calculate

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -186,9 +186,9 @@ void apply_context::exec_one()
 
    finalize_trace( trace, start );
 
-   if (trx_context.executed_action_receipt_digests_l)
+   if (trx_context.action_digests_to_store == transaction_context::store_action_digests::legacy || trx_context.action_digests_to_store == transaction_context::store_action_digests::both)
       trx_context.executed_action_receipt_digests_l->emplace_back( trace.digest_legacy() );
-   if (trx_context.executed_action_receipt_digests_s)
+   if (trx_context.action_digests_to_store == transaction_context::store_action_digests::savanna || trx_context.action_digests_to_store == transaction_context::store_action_digests::both)
       trx_context.executed_action_receipt_digests_s->emplace_back( trace.digest_savanna() );
 
    if ( control.contracts_console() ) {

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -141,8 +141,11 @@ namespace eosio { namespace chain {
          fc::time_point                published;
 
 
+         enum class store_action_digests { legacy, savanna, both };
+         store_action_digests          action_digests_to_store;
          std::optional<digests_t>      executed_action_receipt_digests_l;
          std::optional<digests_t>      executed_action_receipt_digests_s;
+
          flat_set<account_name>        bill_to_accounts;
          flat_set<account_name>        validate_ram_usage;
 


### PR DESCRIPTION
Suggested alternative for tacking which digest to caculate.
Even better I think would be to create:

```
struct action_receipt_digests {
   enum class store_action_digests { legacy, savanna, both };
   // add() etc
   store_action_digests          action_digests_to_store;
   std::optional<digests_t>      executed_action_receipt_digests_l;
   std::optional<digests_t>      executed_action_receipt_digests_s;
};
```