### PR TITLE
Avoid unused warning

### DIFF
--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -23,8 +23,7 @@ using namespace eosio;
 #define CALL_WITH_400(api_name, category, api_handle, call_name, INVOKE, http_response_code) \
 {std::string("/v1/" #api_name "/" #call_name), \
    api_category::category, \
-   [&http, &producer](string&&, string&& body, url_response_callback&& cb) mutable { \
-          (void)&http; (void)&producer; \
+   [&producer](string&&, string&& body, url_response_callback&& cb) mutable { \
           try { \
              INVOKE \
              cb(http_response_code, fc::variant(result)); \
@@ -64,6 +63,7 @@ using namespace eosio;
      auto result = api_handle.call_name(std::move(params));
 
 #define INVOKE_R_R_D(api_handle, call_name, in_param) \
+     auto& http = app().get_plugin<http_plugin>(); \
      const fc::microseconds http_max_response_time = http.get_max_response_time(); \
      auto deadline = http_max_response_time == fc::microseconds::maximum() ? fc::time_point::maximum() \
                                                                            : fc::time_point::now() + http_max_response_time; \
@@ -92,7 +92,6 @@ void producer_api_plugin::plugin_startup() {
    ilog("starting producer_api_plugin");
    // lifetime of plugin is lifetime of application
    auto& producer = app().get_plugin<producer_plugin>();
-   auto& http = app().get_plugin<http_plugin>();
 
    app().get_plugin<http_plugin>().add_api({
        CALL_WITH_400(producer, producer_ro, producer, paused,

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -24,6 +24,7 @@ using namespace eosio;
 {std::string("/v1/" #api_name "/" #call_name), \
    api_category::category, \
    [&http, &producer](string&&, string&& body, url_response_callback&& cb) mutable { \
+          (void)&http; (void)&producer; \
           try { \
              INVOKE \
              cb(http_response_code, fc::variant(result)); \


### PR DESCRIPTION
Workaround unused compiler warning. Note `[[maybe_unused]]` does not work for lambda captures.