### PR TITLE
IF: Test: trx_finality_status_forked_test

### DIFF
--- a/tests/trx_finality_status_forked_test.py
+++ b/tests/trx_finality_status_forked_test.py
@@ -116,7 +116,7 @@ try:
     def getState(status):
         assert status is not None, "ERROR: getTransactionStatus failed to return any status"
         assert "state" in status, \
-            f"ERROR: getTransactionStatus returned a status object that didn't have a \"state\" field. state: {json.dumps(status, indent=1)}"
+            f"ERROR: getTransactionStatus returned a status object that didn't have a \"state\" field. status: {json.dumps(status, indent=1)}"
         return status["state"]
 
     def getBlockNum(status):
@@ -124,7 +124,7 @@ try:
         if "block_number" in status:
             return status["block_number"]
         assert "head_number" in status, \
-            f"ERROR: getTransactionStatus returned a status object that didn't have a \"head_number\" field. state: {json.dumps(status, indent=1)}"
+            f"ERROR: getTransactionStatus returned a status object that didn't have a \"head_number\" field. status: {json.dumps(status, indent=1)}"
         return status["head_number"]
 
     def getBlockID(status):
@@ -132,7 +132,7 @@ try:
         if "block_id" in status:
             return status["block_id"]
         assert "head_id" in status, \
-            f"ERROR: getTransactionStatus returned a status object that didn't have a \"head_id\" field. state: {json.dumps(status, indent=1)}"
+            f"ERROR: getTransactionStatus returned a status object that didn't have a \"head_id\" field. status: {json.dumps(status, indent=1)}"
         return status["head_id"]
 
     transferAmount = 10

--- a/tests/trx_finality_status_forked_test.py
+++ b/tests/trx_finality_status_forked_test.py
@@ -121,11 +121,19 @@ try:
 
     def getBlockNum(status):
         assert status is not None, "ERROR: getTransactionStatus failed to return any status"
-        assert "head_number" in status, \
-            f"ERROR: getTransactionStatus returned a status object that didn't have a \"head_number\" field. state: {json.dumps(status, indent=1)}"
         if "block_number" in status:
             return status["block_number"]
+        assert "head_number" in status, \
+            f"ERROR: getTransactionStatus returned a status object that didn't have a \"head_number\" field. state: {json.dumps(status, indent=1)}"
         return status["head_number"]
+
+    def getBlockID(status):
+        assert status is not None, "ERROR: getTransactionStatus failed to return any status"
+        if "block_id" in status:
+            return status["block_id"]
+        assert "head_id" in status, \
+            f"ERROR: getTransactionStatus returned a status object that didn't have a \"head_id\" field. state: {json.dumps(status, indent=1)}"
+        return status["head_id"]
 
     transferAmount = 10
     # Does not use transaction retry (not needed)
@@ -210,18 +218,18 @@ try:
         f"\n\nprod A info: {json.dumps(prodA.getInfo(), indent=1)}\n\nprod D info: {json.dumps(prodD.getInfo(), indent=1)}"
 
     afterForkInBlockState = retStatus
-    afterForkBlockId = retStatus["block_id"]
-    assert afterForkInBlockState["block_number"] > originalInBlockState["block_number"], \
+    afterForkBlockId = getBlockID(retStatus)
+    assert getBlockNum(afterForkInBlockState) > getBlockNum(originalInBlockState), \
         "ERROR: The way the test is designed, the transaction should be added to a block that has a higher number than it was in originally before it was forked out." + \
        f"\n\noriginal in block state: {json.dumps(originalInBlockState, indent=1)}\n\nafter fork in block state: {json.dumps(afterForkInBlockState, indent=1)}"
 
-    assert prodD.waitForBlock(afterForkInBlockState["block_number"], timeout=120, blockType=BlockType.lib), \
+    assert prodD.waitForBlock(getBlockNum(afterForkInBlockState), timeout=120, blockType=BlockType.lib), \
         f"ERROR: Block never finalized.\n\nprod A info: {json.dumps(prodA.getInfo(), indent=1)}\n\nprod C info: {json.dumps(prodD.getInfo(), indent=1)}" + \
         f"\n\nafter fork in block state: {json.dumps(afterForkInBlockState, indent=1)}"
 
     retStatus = prodD.getTransactionStatus(transId)
-    if afterForkBlockId != retStatus["block_id"]: # might have been forked out, if so wait for new block to become LIB
-        assert prodD.waitForBlock(retStatus["block_number"], timeout=120, blockType=BlockType.lib), \
+    if afterForkBlockId != getBlockID(retStatus): # might have been forked out, if so wait for new block to become LIB
+        assert prodD.waitForBlock(getBlockNum(retStatus), timeout=120, blockType=BlockType.lib), \
             f"ERROR: Block never finalized.\n\nprod A info: {json.dumps(prodA.getInfo(), indent=1)}\n\nprod C info: {json.dumps(prodD.getInfo(), indent=1)}" + \
             f"\n\nafter fork in block state: {json.dumps(afterForkInBlockState, indent=1)}"
 


### PR DESCRIPTION
Does not fix issue reported in #2310. This PR is to make reporting of errors better.

Use `getBlockNum()` and `getBlockID()` for accessing `get transaction-status` results. 

`IN_BLOCK` status returns `block_number` and `block_id`.
`LOCALLY_APPLIED` status returns `head_number` and `head_id`.

```
cmd={/__w/leap/leap/build/bin/cleos --url http://localhost:8891 --wallet-url http://localhost:9899 --no-auto-keosd get transaction-status fb2a71ec0e490bf8989f1cfaa9f6a16c0367ec8078f8492477026ff7c5029be4}
cout={b'{\n  "state": "IN_BLOCK",\n  "block_number": 199,\n  "block_id": "000000c7bfc26343def2c691bd7fed57880c320a9cef930fa8f16ffbb86e23c1",\n  "block_timestamp": "2024-03-27T17:12:45.000",\n  "expiration": "2024-03-27T17:14:12.000",\n  "head_number": 200,\n  "head_id": "000000c898855776f59986582451d5db32dea5d9a728b947b2bbc1afab63bb75",\n  "head_timestamp": "2024-03-27T17:12:45.500",\n  "irreversible_number": 195,\n  "irreversible_id": "000000c3d939ef3af111e203cedbb711cf2e56449df8b27d5cee7cef7241677b",\n  "irreversible_timestamp": "2024-03-27T17:12:37.000",\n  "earliest_tracked_block_id": "0000002033fc0440771c1748b11c16aa0d3994e4df53b5c52749677e85726b77",\n  "earliest_tracked_block_number": 32\n}\n'}
```
and 
```
cmd={/__w/leap/leap/build/bin/cleos --url http://localhost:8891 --wallet-url http://localhost:9899 --no-auto-keosd get transaction-status fb2a71ec0e490bf8989f1cfaa9f6a16c0367ec8078f8492477026ff7c5029be4}
cout={b'{\n  "state": "LOCALLY_APPLIED",\n  "expiration": "2024-03-27T17:14:12.000",\n  "head_number": 204,\n  "head_id": "000000cc0772681d58d77c81e61ebf0f71270d539dc8cf8b51e4b24ce5bcd010",\n  "head_timestamp": "2024-03-27T17:12:41.500",\n  "irreversible_number": 201,\n  "irreversible_id": "000000c982efd5f794d1f90c7b4b38e5d495cb52fbf7338ad4fcdd25e57264a9",\n  "irreversible_timestamp": "2024-03-27T17:12:40.000",\n  "earliest_tracked_block_id": "0000002033fc0440771c1748b11c16aa0d3994e4df53b5c52749677e85726b77",\n  "earliest_tracked_block_number": 32\n}\n'}
```