### PR TITLE
IF: Set correct proposed producer schedule version

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -479,6 +479,10 @@ struct building_block {
 
       uint32_t get_next_proposer_schedule_version() const {
          if (!parent.proposer_policies.empty()) {
+            block_timestamp_type active_time = detail::get_next_next_round_block_time(timestamp);
+            if (auto itr = parent.proposer_policies.find(active_time); itr != parent.proposer_policies.cend()) {
+               return itr->second->proposer_schedule.version; // will replace so retrun same version
+            }
             return (--parent.proposer_policies.end())->second->proposer_schedule.version + 1;
          }
          assert(active_proposer_policy);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -481,7 +481,7 @@ struct building_block {
          if (!parent.proposer_policies.empty()) {
             block_timestamp_type active_time = detail::get_next_next_round_block_time(timestamp);
             if (auto itr = parent.proposer_policies.find(active_time); itr != parent.proposer_policies.cend()) {
-               return itr->second->proposer_schedule.version; // will replace so retrun same version
+               return itr->second->proposer_schedule.version; // will replace so return same version
             }
             return (--parent.proposer_policies.end())->second->proposer_schedule.version + 1;
          }

--- a/unittests/producer_schedule_if_tests.cpp
+++ b/unittests/producer_schedule_if_tests.cpp
@@ -127,6 +127,7 @@ BOOST_FIXTURE_TEST_CASE( proposer_policy_progression_test, validating_tester ) t
    vector<producer_authority> prev_sch = {
                                  producer_authority{"eosio"_n, block_signing_authority_v0{1, {{get_public_key("eosio"_n, "active"), 1}}}}};
    BOOST_CHECK_EQUAL( true, compare_schedules( prev_sch, control->active_producers() ) );
+   BOOST_CHECK_EQUAL( 0, control->active_producers().version );
 
    // set a new proposer policy sch1
    set_producers( {"alice"_n} );
@@ -138,6 +139,7 @@ BOOST_FIXTURE_TEST_CASE( proposer_policy_progression_test, validating_tester ) t
    produce_blocks(config::producer_repetitions);
 
    // sch1 cannot become active before one round of production
+   BOOST_CHECK_EQUAL( 0, control->active_producers().version );
    BOOST_CHECK_EQUAL( true, compare_schedules( prev_sch, control->active_producers() ) );
 
    // set another ploicy to have multiple pending different active time policies
@@ -146,9 +148,17 @@ BOOST_FIXTURE_TEST_CASE( proposer_policy_progression_test, validating_tester ) t
                                  producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{get_public_key("bob"_n,   "active"),1}}}},
                                  producer_authority{"carol"_n, block_signing_authority_v0{ 1, {{get_public_key("carol"_n, "active"),1}}}}
                                };
+   produce_block();
+
+   // set another ploicy should replace sch2
+   set_producers( {"bob"_n,"alice"_n} );
+   vector<producer_authority> sch3 = {
+      producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{get_public_key("bob"_n,   "active"),1}}}},
+      producer_authority{"alice"_n, block_signing_authority_v0{ 1, {{get_public_key("alice"_n, "active"),1}}}}
+   };
 
    // another round
-   produce_blocks(config::producer_repetitions);
+   produce_blocks(config::producer_repetitions-1); // -1, already produced one of the round above
 
    // sch1  must become active no later than 2 rounds but sch2 cannot become active yet
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
@@ -156,9 +166,9 @@ BOOST_FIXTURE_TEST_CASE( proposer_policy_progression_test, validating_tester ) t
 
    produce_blocks(config::producer_repetitions);
 
-   // sch2 becomes active
-   BOOST_CHECK_EQUAL( control->active_producers().version, 2u );
-   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
+   // sch3 becomes active
+   BOOST_CHECK_EQUAL( 2u, control->active_producers().version ); // should be 2 as sch2 was replaced by sch3
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch3, control->active_producers() ) );
 } FC_LOG_AND_RETHROW()
 
 


### PR DESCRIPTION
When `set_proposed_producers` replaces an existing in-flight producer schedule, use the existing in-flight producer schedule version so that versions are not skipped.

Resolves #2313