### PR TITLE
add ASAN CI "platform"

### DIFF
--- a/.cicd/platforms/asan.Dockerfile
+++ b/.cicd/platforms/asan.Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:jammy
+ENV TZ="America/New_York"
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y build-essential      \
+                       cmake                \
+                       git                  \
+                       jq                   \
+                       libcurl4-openssl-dev \
+                       libgmp-dev           \
+                       llvm-11-dev          \
+                       lsb-release          \
+                       ninja-build          \
+                       python3-numpy        \
+                       software-properties-common \
+                       file                 \
+                       wget                 \
+                       zlib1g-dev           \
+                       zstd
+
+RUN yes | bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 18
+
+#make sure no confusion on what llvm library leap's cmake should pick up on
+RUN rm -rf /usr/lib/llvm-18/lib/cmake
+
+ENV LEAP_PLATFORM_HAS_EXTRAS_CMAKE=1
+COPY <<-EOF /extras.cmake
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "" FORCE)
+
+  set(CMAKE_C_COMPILER "clang-18" CACHE STRING "")
+  set(CMAKE_CXX_COMPILER "clang++-18" CACHE STRING "")
+  set(CMAKE_C_FLAGS "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "")
+  set(CMAKE_CXX_FLAGS "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "")
+EOF
+
+ENV ASAN_OPTIONS=detect_leaks=0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -137,6 +137,7 @@ jobs:
           - cfg: {name: 'ubuntu22',      base: 'ubuntu22', builddir: 'ubuntu22'}
           - cfg: {name: 'asserton',      base: 'asserton', builddir: 'asserton'}
           - cfg: {name: 'ubsan',         base: 'ubsan',    builddir: 'ubsan'}
+          - cfg: {name: 'asan',          base: 'asan',     builddir: 'asan'}
           - cfg: {name: 'ubuntu20repro', base: 'ubuntu20', builddir: 'reproducible'}
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-hightier"]


### PR DESCRIPTION
Adds a new "platform" that builds & tests the software with ASAN.

It's possible to enable a single build with UBSAN+ASAN simultaneously, but this further increases both the compile time and run time overhead. So do UBSAN & ASAN separately for now.

And speaking of ASAN build overhead, I was unable to get NP or LR tests to complete in CI without either running out of memory or having some sort of timing problem. I even tried increasing the resources for the run but that still wasn't enough. I think it's likely worthwhile to go ahead with what we've got though as at least we'll still get unit test coverage, and reevaluate whatever the performance problem is later (I was able to complete them successfully locally).

Example run of ASAN failures:
https://github.com/AntelopeIO/leap/actions/runs/8458172328/job/23172568986