### PR TITLE
IF: add get_blocks_result_v1 support to SHiP

### DIFF
--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -57,7 +57,7 @@ struct valid_t {
 struct finality_data_t {
    uint32_t     major_version{light_header_protocol_version_major};
    uint32_t     minor_version{light_header_protocol_version_minor};
-   uint32_t     active_finalizer_policy_generation{0};
+   uint32_t     active_finalizer_policy_generation{1};
    digest_type  action_mroot{};
    digest_type  base_digest{};
 };

--- a/libraries/state_history/abi.cpp
+++ b/libraries/state_history/abi.cpp
@@ -59,6 +59,17 @@ extern const char* const state_history_plugin_abi = R"({
                 { "name": "prev_block", "type": "block_position?" },
                 { "name": "block", "type": "bytes?" },
                 { "name": "traces", "type": "bytes?" },
+                { "name": "deltas", "type": "bytes?" }
+            ]
+        },
+        {
+            "name": "get_blocks_result_v1", "fields": [
+                { "name": "head", "type": "block_position" },
+                { "name": "last_irreversible", "type": "block_position" },
+                { "name": "this_block", "type": "block_position?" },
+                { "name": "prev_block", "type": "block_position?" },
+                { "name": "block", "type": "bytes?" },
+                { "name": "traces", "type": "bytes?" },
                 { "name": "deltas", "type": "bytes?" },
                 { "name": "finality_data", "type": "bytes?" }
             ]
@@ -576,7 +587,7 @@ extern const char* const state_history_plugin_abi = R"({
     ],
     "variants": [
         { "name": "request", "types": ["get_status_request_v0", "get_blocks_request_v0", "get_blocks_request_v1", "get_blocks_ack_request_v0"] },
-        { "name": "result", "types": ["get_status_result_v0", "get_blocks_result_v0"] },
+        { "name": "result", "types": ["get_status_result_v0", "get_blocks_result_v0", "get_blocks_result_v1"] },
 
         { "name": "action_receipt", "types": ["action_receipt_v0"] },
         { "name": "action_trace", "types": ["action_trace_v0", "action_trace_v1"] },

--- a/libraries/state_history/include/eosio/state_history/serialization.hpp
+++ b/libraries/state_history/include/eosio/state_history/serialization.hpp
@@ -709,11 +709,7 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_context_wrapper_sta
 
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const eosio::state_history::get_blocks_result_v0& obj) {
-   fc::raw::pack(ds, obj.head);
-   fc::raw::pack(ds, obj.last_irreversible);
-   fc::raw::pack(ds, obj.this_block);
-   fc::raw::pack(ds, obj.prev_block);
-   history_pack_big_bytes(ds, obj.block);
+   ds << static_cast<const eosio::state_history::get_blocks_result_base&>(obj);
    history_pack_big_bytes(ds, obj.traces);
    history_pack_big_bytes(ds, obj.deltas);
    return ds;
@@ -721,13 +717,7 @@ datastream<ST>& operator<<(datastream<ST>& ds, const eosio::state_history::get_b
 
 template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const eosio::state_history::get_blocks_result_v1& obj) {
-   fc::raw::pack(ds, obj.head);
-   fc::raw::pack(ds, obj.last_irreversible);
-   fc::raw::pack(ds, obj.this_block);
-   fc::raw::pack(ds, obj.prev_block);
-   history_pack_big_bytes(ds, obj.block);
-   history_pack_big_bytes(ds, obj.traces);
-   history_pack_big_bytes(ds, obj.deltas);
+   ds << static_cast<const eosio::state_history::get_blocks_result_v0&>(obj);
    history_pack_big_bytes(ds, obj.finality_data);
    return ds;
 }

--- a/libraries/state_history/include/eosio/state_history/serialization.hpp
+++ b/libraries/state_history/include/eosio/state_history/serialization.hpp
@@ -716,6 +716,18 @@ datastream<ST>& operator<<(datastream<ST>& ds, const eosio::state_history::get_b
    history_pack_big_bytes(ds, obj.block);
    history_pack_big_bytes(ds, obj.traces);
    history_pack_big_bytes(ds, obj.deltas);
+   return ds;
+}
+
+template <typename ST>
+datastream<ST>& operator<<(datastream<ST>& ds, const eosio::state_history::get_blocks_result_v1& obj) {
+   fc::raw::pack(ds, obj.head);
+   fc::raw::pack(ds, obj.last_irreversible);
+   fc::raw::pack(ds, obj.this_block);
+   fc::raw::pack(ds, obj.prev_block);
+   history_pack_big_bytes(ds, obj.block);
+   history_pack_big_bytes(ds, obj.traces);
+   history_pack_big_bytes(ds, obj.deltas);
    history_pack_big_bytes(ds, obj.finality_data);
    return ds;
 }

--- a/libraries/state_history/include/eosio/state_history/types.hpp
+++ b/libraries/state_history/include/eosio/state_history/types.hpp
@@ -123,12 +123,16 @@ struct get_blocks_result_base {
 struct get_blocks_result_v0 : get_blocks_result_base {
    std::optional<bytes>          traces;
    std::optional<bytes>          deltas;
+};
+
+struct get_blocks_result_v1 : get_blocks_result_v0 {
    std::optional<bytes>          finality_data;
 };
 
 using state_request = std::variant<get_status_request_v0, get_blocks_request_v0, get_blocks_request_v1, get_blocks_ack_request_v0>;
+using state_result  = std::variant<get_status_result_v0, get_blocks_result_v0, get_blocks_result_v1>;
 using get_blocks_request = std::variant<get_blocks_request_v0, get_blocks_request_v1>;
-using state_result  = std::variant<get_status_result_v0, get_blocks_result_v0>;
+using get_blocks_result = std::variant<get_blocks_result_v0, get_blocks_result_v1>;
 
 } // namespace state_history
 } // namespace eosio
@@ -142,5 +146,6 @@ FC_REFLECT(eosio::state_history::get_blocks_request_v0, (start_block_num)(end_bl
 FC_REFLECT_DERIVED(eosio::state_history::get_blocks_request_v1, (eosio::state_history::get_blocks_request_v0), (fetch_finality_data));
 FC_REFLECT(eosio::state_history::get_blocks_ack_request_v0, (num_messages));
 FC_REFLECT(eosio::state_history::get_blocks_result_base, (head)(last_irreversible)(this_block)(prev_block)(block));
-FC_REFLECT_DERIVED(eosio::state_history::get_blocks_result_v0, (eosio::state_history::get_blocks_result_base), (traces)(deltas)(finality_data));
+FC_REFLECT_DERIVED(eosio::state_history::get_blocks_result_v0, (eosio::state_history::get_blocks_result_base), (traces)(deltas));
+FC_REFLECT_DERIVED(eosio::state_history::get_blocks_result_v1, (eosio::state_history::get_blocks_result_v0), (finality_data));
 // clang-format on

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -320,9 +320,11 @@ public:
       std::visit(
          chain::overloaded{
             [&](state_history::get_blocks_result_v0& r) {
+               static_assert(std::is_same_v<state_history::get_blocks_result_v0, std::variant_alternative_t<1, state_history::state_result>>);
                pack_result_base(r, 1); // 1 for variant index of get_blocks_result_v0 in state_result
             },
             [&](state_history::get_blocks_result_v1& r) {
+               static_assert(std::is_same_v<state_history::get_blocks_result_v1, std::variant_alternative_t<2, state_history::state_result>>);
                pack_result_base(r, 2); // 2 for variant index of get_blocks_result_v1 in state_result
             }
          },

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -194,7 +194,7 @@ public:
 template <typename Session>
 class blocks_result_send_queue_entry : public send_queue_entry_base, public std::enable_shared_from_this<blocks_result_send_queue_entry<Session>> {
    std::shared_ptr<Session>                                        session;
-   state_history::get_blocks_result_v0                             r;
+   state_history::get_blocks_result                                result;
    std::vector<char>                                               data;
    std::optional<locked_decompress_stream>                         stream;
 
@@ -264,46 +264,68 @@ class blocks_result_send_queue_entry : public send_queue_entry_base, public std:
                 });
    }
 
-   // last to be sent
+   // last to be sent if result is get_blocks_result_v1
    void send_finality_data() {
+      assert(std::holds_alternative<state_history::get_blocks_result_v1>(result));
       stream.reset();
-      send_log(session->get_finality_data_log_entry(r, stream), true, [me=this->shared_from_this()]() {
+      send_log(session->get_finality_data_log_entry(std::get<state_history::get_blocks_result_v1>(result), stream), true, [me=this->shared_from_this()]() {
          me->stream.reset();
          me->session->session_mgr.pop_entry();
       });
    }
 
-   // second to be sent
+   // second to be sent if result is get_blocks_result_v1;
+   // last to be sent if result is get_blocks_result_v0
    void send_deltas() {
       stream.reset();
-      send_log(session->get_delta_log_entry(r, stream), false, [me=this->shared_from_this()]() {
-         me->send_finality_data();
-      });
+      std::visit(chain::overloaded{
+                    [&](state_history::get_blocks_result_v0& r) {
+                        send_log(session->get_delta_log_entry(r, stream), true, [me=this->shared_from_this()]() {
+                           me->stream.reset();
+                           me->session->session_mgr.pop_entry();}); },
+                    [&](state_history::get_blocks_result_v1& r) {
+                        send_log(session->get_delta_log_entry(r, stream), false, [me=this->shared_from_this()]() {
+                           me->send_finality_data(); }); }},
+                 result);
    }
 
    // first to be sent
    void send_traces() {
       stream.reset();
-      send_log(session->get_trace_log_entry(r, stream), false, [me=this->shared_from_this()]() {
+      send_log(session->get_trace_log_entry(result, stream), false, [me=this->shared_from_this()]() {
          me->send_deltas();
       });
    }
 
 public:
-   blocks_result_send_queue_entry(std::shared_ptr<Session> s, state_history::get_blocks_result_v0&& r)
+   blocks_result_send_queue_entry(std::shared_ptr<Session> s, state_history::get_blocks_result&& r)
        : session(std::move(s)),
-         r(std::move(r)) {}
+         result(std::move(r)) {}
 
    void send_entry() override {
+      assert(std::holds_alternative<state_history::get_blocks_result_v0>(result) ||
+             std::holds_alternative<state_history::get_blocks_result_v1>(result));
+
       // pack the state_result{get_blocks_result} excluding the fields `traces` and `deltas`
       fc::datastream<size_t> ss;
-      fc::raw::pack(ss, fc::unsigned_int(1)); // pack the variant index of state_result{r}
-      fc::raw::pack(ss, static_cast<const state_history::get_blocks_result_base&>(r));
+      if(std::holds_alternative<state_history::get_blocks_result_v0>(result)) {
+         fc::raw::pack(ss, fc::unsigned_int(1)); // pack the variant index of state_result{r}, 1 for get_blocks_result_v0
+      } else {
+         fc::raw::pack(ss, fc::unsigned_int(2)); // pack the variant index of state_result{r}, 2 for get_blocks_result_v1
+      }
+      std::visit([&](auto& r) {
+                    fc::raw::pack(ss, static_cast<const state_history::get_blocks_result_base&>(r)); },
+                 result);
       data.resize(ss.tellp());
       fc::datastream<char*> ds(data.data(), data.size());
-      fc::raw::pack(ds, fc::unsigned_int(1)); // pack the variant index of state_result{r}
-      fc::raw::pack(ds, static_cast<const state_history::get_blocks_result_base&>(r));
-
+      if(std::holds_alternative<state_history::get_blocks_result_v0>(result)) {
+         fc::raw::pack(ds, fc::unsigned_int(1)); // pack the variant index of state_result{r}, 1 for get_blocks_result_v0
+      } else {
+         fc::raw::pack(ds, fc::unsigned_int(2)); // pack the variant index of state_result{r}, 2 for get_blocks_result_v1
+      }
+      std::visit([&](auto& r) {
+                    fc::raw::pack(ds, static_cast<const state_history::get_blocks_result_base&>(r)); },
+                 result);
       async_send(false, data, [me=this->shared_from_this()]() {
          me->send_traces();
       });
@@ -394,31 +416,31 @@ private:
       }
    }
 
-   uint64_t get_log_entry_impl(const eosio::state_history::get_blocks_result_v0& result,
+   uint64_t get_log_entry_impl(const eosio::state_history::get_blocks_result& result,
                                bool has_value,
                                std::optional<state_history_log>& optional_log,
                                std::optional<locked_decompress_stream>& buf) {
       if (has_value) {
          if( optional_log ) {
             buf.emplace( optional_log->create_locked_decompress_stream() );
-            return optional_log->get_unpacked_entry( result.this_block->block_num, *buf );
+            return std::visit([&](auto& r) { return optional_log->get_unpacked_entry( r.this_block->block_num, *buf ); }, result);
          }
       }
       return 0;
    }
 
-   uint64_t get_trace_log_entry(const eosio::state_history::get_blocks_result_v0& result,
+   uint64_t get_trace_log_entry(const eosio::state_history::get_blocks_result& result,
                                 std::optional<locked_decompress_stream>& buf) {
-      return get_log_entry_impl(result, result.traces.has_value(), plugin.get_trace_log(), buf);
+      return std::visit([&](auto& r) { return get_log_entry_impl(r, r.traces.has_value(), plugin.get_trace_log(), buf); }, result);
    }
 
-   uint64_t get_delta_log_entry(const eosio::state_history::get_blocks_result_v0& result,
+   uint64_t get_delta_log_entry(const eosio::state_history::get_blocks_result& result,
                                 std::optional<locked_decompress_stream>& buf) {
-      return get_log_entry_impl(result, result.deltas.has_value(), plugin.get_chain_state_log(), buf);
+      return std::visit([&](auto& r) { return get_log_entry_impl(r, r.deltas.has_value(), plugin.get_chain_state_log(), buf); }, result);
    }
 
-   uint64_t get_finality_data_log_entry(const eosio::state_history::get_blocks_result_v0& result,
-                                std::optional<locked_decompress_stream>& buf) {
+   uint64_t get_finality_data_log_entry(const eosio::state_history::get_blocks_result_v1& result,
+                                        std::optional<locked_decompress_stream>& buf) {
       return get_log_entry_impl(result, result.finality_data.has_value(), plugin.get_finality_data_log(), buf);
    }
 
@@ -515,7 +537,8 @@ private:
       current_request = std::move(req);
    }
 
-   void send_update(state_history::get_blocks_request_v0& request, bool fetch_finality_data, state_history::get_blocks_result_v0 result, const chain::signed_block_ptr& block, const chain::block_id_type& id) {
+   template<typename T> // get_blocks_result_v0 or get_blocks_result_v1
+   void send_update(state_history::get_blocks_request_v0& request, bool fetch_finality_data, T result, const chain::signed_block_ptr& block, const chain::block_id_type& id) {
       need_to_send_update = true;
 
       result.last_irreversible = plugin.get_last_irreversible();
@@ -565,8 +588,10 @@ private:
             result.traces.emplace();
          if (request.fetch_deltas && plugin.get_chain_state_log())
             result.deltas.emplace();
-         if (fetch_finality_data && plugin.get_finality_data_log()) {
-            result.finality_data.emplace(); // create finality_data (it's an optional field)
+         if constexpr (std::is_same_v<T, state_history::get_blocks_result_v1>) {
+            if (fetch_finality_data && plugin.get_finality_data_log()) {
+               result.finality_data.emplace();
+            }
          }
       }
       ++to_send_block_num;
@@ -601,7 +626,7 @@ private:
       return !max_messages_in_flight;
    }
 
-   void send_update(state_history::get_blocks_result_v0 result, const chain::signed_block_ptr& block, const chain::block_id_type& id) {
+   void send_update(const state_history::block_position& head, const chain::signed_block_ptr& block, const chain::block_id_type& id) {
       if (no_request_or_not_max_messages_in_flight()) {
          session_mgr.pop_entry(false);
          return;
@@ -613,9 +638,13 @@ private:
 
       std::visit(eosio::chain::overloaded{
                     [&](eosio::state_history::get_blocks_request_v0& request) {
-                       send_update(request, false, result, block, id); },
+                       state_history::get_blocks_result_v0 result;
+                       result.head = head;
+                       send_update(request, false, std::move(result), block, id); },
                     [&](eosio::state_history::get_blocks_request_v1& request) {
-                       send_update(request, request.fetch_finality_data, result, block, id); } },
+                       state_history::get_blocks_result_v1 result;
+                       result.head = head;
+                       send_update(request, request.fetch_finality_data, std::move(result), block, id); } },
                  *current_request);
    }
 
@@ -626,17 +655,13 @@ private:
       }
 
       auto block_num = block->block_num();
-      state_history::get_blocks_result_v0 result;
-      result.head = {block_num, id};
       to_send_block_num = std::min(block_num, to_send_block_num);
-      send_update(std::move(result), block, id);
+      send_update(state_history::block_position{block_num, id}, block, id);
    }
 
    void send_update(bool changed) override {
       if (changed || need_to_send_update) {
-         state_history::get_blocks_result_v0 result;
-         result.head = plugin.get_block_head();
-         send_update(std::move(result), nullptr, chain::block_id_type{});
+         send_update(plugin.get_block_head(), nullptr, chain::block_id_type{});
       } else {
          session_mgr.pop_entry(false);
       }

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -541,7 +541,7 @@ private:
    }
 
    template<typename T> // get_blocks_result_v0 or get_blocks_result_v1
-   void send_update(state_history::get_blocks_request_v0& request, bool fetch_finality_data, T result, const chain::signed_block_ptr& block, const chain::block_id_type& id) {
+   void send_update(state_history::get_blocks_request_v0& request, bool fetch_finality_data, T&& result, const chain::signed_block_ptr& block, const chain::block_id_type& id) {
       need_to_send_update = true;
 
       result.last_irreversible = plugin.get_last_irreversible();

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -598,11 +598,11 @@ try:
         block_num = start_block_num
         for i in data:
             # fork can cause block numbers to be repeated
-            this_block_num = i['get_blocks_result_v0']['this_block']['block_num']
+            this_block_num = i['get_blocks_result_v1']['this_block']['block_num']
             if this_block_num < block_num:
                 block_num = this_block_num
             assert block_num == this_block_num, f"{block_num} != {this_block_num}"
-            assert isinstance(i['get_blocks_result_v0']['block'], str) # verify block in result
+            assert isinstance(i['get_blocks_result_v1']['block'], str) # verify block in result
             block_num += 1
         assert block_num-1 == end_block_num, f"{block_num-1} != {end_block_num}"
 

--- a/tests/ship_streamer.cpp
+++ b/tests/ship_streamer.cpp
@@ -142,7 +142,11 @@ int main(int argc, char* argv[]) {
          eosio::check(!result_document.HasParseError(),                                      "Failed to parse result JSON from abieos");
          eosio::check(result_document.IsArray(),                                             "result should have been an array (variant) but it's not");
          eosio::check(result_document.Size() == 2,                                           "result was an array but did not contain 2 items like a variant should");
-         eosio::check(std::string(result_document[0].GetString()) == "get_blocks_result_v0", "result type doesn't look like get_blocks_result_v0");
+         if( fetch_finality_data ) {
+            eosio::check(std::string(result_document[0].GetString()) == "get_blocks_result_v1", "result type doesn't look like get_blocks_result_v1");
+         } else {
+            eosio::check(std::string(result_document[0].GetString()) == "get_blocks_result_v0", "result type doesn't look like get_blocks_result_v0");
+         }
          eosio::check(result_document[1].IsObject(),                                         "second item in result array is not an object");
          eosio::check(result_document[1].HasMember("head"),                                  "cannot find 'head' in result");
          eosio::check(result_document[1]["head"].IsObject(),                                 "'head' is not an object");
@@ -158,7 +162,11 @@ int main(int argc, char* argv[]) {
          } else {
            std::cout << "," << std::endl;
          }
-         std::cout << "{ \"get_blocks_result_v0\":" << std::endl;
+         if( fetch_finality_data ) {
+            std::cout << "{ \"get_blocks_result_v1\":" << std::endl;
+         } else {
+            std::cout << "{ \"get_blocks_result_v0\":" << std::endl;
+         }
 
          rapidjson::StringBuffer result_sb;
          rapidjson::PrettyWriter<rapidjson::StringBuffer> result_writer(result_sb);

--- a/tests/ship_streamer.cpp
+++ b/tests/ship_streamer.cpp
@@ -138,9 +138,7 @@ int main(int argc, char* argv[]) {
          eosio::check(!result_document.HasParseError(),                                      "Failed to parse result JSON from abieos");
          eosio::check(result_document.IsArray(),                                             "result should have been an array (variant) but it's not");
          eosio::check(result_document.Size() == 2,                                           "result was an array but did not contain 2 items like a variant should");
-         if( fetch_finality_data ) {
-            eosio::check(std::string(result_document[0].GetString()) == "get_blocks_result_v1", "result type doesn't look like get_blocks_result_v1");
-         }
+         eosio::check(std::string(result_document[0].GetString()) == "get_blocks_result_v1", "result type doesn't look like get_blocks_result_v1");
          eosio::check(result_document[1].IsObject(),                                         "second item in result array is not an object");
          eosio::check(result_document[1].HasMember("head"),                                  "cannot find 'head' in result");
          eosio::check(result_document[1]["head"].IsObject(),                                 "'head' is not an object");

--- a/tests/ship_streamer.cpp
+++ b/tests/ship_streamer.cpp
@@ -93,11 +93,7 @@ int main(int argc, char* argv[]) {
       //};
       request_writer.StartArray();
 
-         if( fetch_finality_data ) {
-            request_writer.String("get_blocks_request_v1");
-         } else {
-            request_writer.String("get_blocks_request_v0");
-         }
+         request_writer.String("get_blocks_request_v1"); // always send out latest version of request
          request_writer.StartObject();
          request_writer.Key("start_block_num");
          request_writer.Uint(start_block_num);
@@ -144,8 +140,6 @@ int main(int argc, char* argv[]) {
          eosio::check(result_document.Size() == 2,                                           "result was an array but did not contain 2 items like a variant should");
          if( fetch_finality_data ) {
             eosio::check(std::string(result_document[0].GetString()) == "get_blocks_result_v1", "result type doesn't look like get_blocks_result_v1");
-         } else {
-            eosio::check(std::string(result_document[0].GetString()) == "get_blocks_result_v0", "result type doesn't look like get_blocks_result_v0");
          }
          eosio::check(result_document[1].IsObject(),                                         "second item in result array is not an object");
          eosio::check(result_document[1].HasMember("head"),                                  "cannot find 'head' in result");
@@ -162,11 +156,7 @@ int main(int argc, char* argv[]) {
          } else {
            std::cout << "," << std::endl;
          }
-         if( fetch_finality_data ) {
-            std::cout << "{ \"get_blocks_result_v1\":" << std::endl;
-         } else {
-            std::cout << "{ \"get_blocks_result_v0\":" << std::endl;
-         }
+         std::cout << "{ \"get_blocks_result_v1\":" << std::endl;
 
          rapidjson::StringBuffer result_sb;
          rapidjson::PrettyWriter<rapidjson::StringBuffer> result_writer(result_sb);

--- a/tests/ship_streamer.cpp
+++ b/tests/ship_streamer.cpp
@@ -112,10 +112,8 @@ int main(int argc, char* argv[]) {
          request_writer.Bool(fetch_traces);
          request_writer.Key("fetch_deltas");
          request_writer.Bool(fetch_deltas);
-         if( fetch_finality_data ) {
-            request_writer.Key("fetch_finality_data");
-            request_writer.Bool(fetch_finality_data);
-         }
+         request_writer.Key("fetch_finality_data");
+         request_writer.Bool(fetch_finality_data);
          request_writer.EndObject();
       request_writer.EndArray();
 

--- a/tests/ship_streamer_test.py
+++ b/tests/ship_streamer_test.py
@@ -211,11 +211,14 @@ try:
         block_num = start_block_num
         for i in data:
             # fork can cause block numbers to be repeated
-            this_block_num = i['get_blocks_result_v0']['this_block']['block_num']
+            this_block_num = i['get_blocks_result_v1']['this_block']['block_num'] if args.finality_data_history else i['get_blocks_result_v0']['this_block']['block_num']
             if this_block_num < block_num:
                 block_num = this_block_num
             assert block_num == this_block_num, f"{block_num} != {this_block_num}"
-            assert isinstance(i['get_blocks_result_v0']['block'], str) # verify block in result
+            if args.finality_data_history:
+                assert isinstance(i['get_blocks_result_v1']['block'], str) # verify block in result
+            else:
+                assert isinstance(i['get_blocks_result_v0']['block'], str) # verify block in result
             block_num += 1
         assert block_num-1 == end_block_num, f"{block_num-1} != {end_block_num}"
 
@@ -268,11 +271,14 @@ try:
         block_num = start_block_num
         for i in data:
             # fork can cause block numbers to be repeated
-            this_block_num = i['get_blocks_result_v0']['this_block']['block_num']
+            this_block_num = i['get_blocks_result_v1']['this_block']['block_num'] if args.finality_data_history else i['get_blocks_result_v0']['this_block']['block_num']
             if this_block_num < block_num:
                 block_num = this_block_num
             assert block_num == this_block_num, f"{block_num} != {this_block_num}"
-            assert isinstance(i['get_blocks_result_v0']['deltas'], str) # verify deltas in result
+            if args.finality_data_history:
+                assert isinstance(i['get_blocks_result_v1']['deltas'], str) # verify deltas in result
+            else:
+                assert isinstance(i['get_blocks_result_v0']['deltas'], str) # verify deltas in result
             block_num += 1
         assert block_num-1 == end_block_num, f"{block_num-1} != {end_block_num}"
 

--- a/tests/ship_streamer_test.py
+++ b/tests/ship_streamer_test.py
@@ -211,14 +211,11 @@ try:
         block_num = start_block_num
         for i in data:
             # fork can cause block numbers to be repeated
-            this_block_num = i['get_blocks_result_v1']['this_block']['block_num'] if args.finality_data_history else i['get_blocks_result_v0']['this_block']['block_num']
+            this_block_num = i['get_blocks_result_v1']['this_block']['block_num']
             if this_block_num < block_num:
                 block_num = this_block_num
             assert block_num == this_block_num, f"{block_num} != {this_block_num}"
-            if args.finality_data_history:
-                assert isinstance(i['get_blocks_result_v1']['block'], str) # verify block in result
-            else:
-                assert isinstance(i['get_blocks_result_v0']['block'], str) # verify block in result
+            assert isinstance(i['get_blocks_result_v1']['block'], str) # verify block in result
             block_num += 1
         assert block_num-1 == end_block_num, f"{block_num-1} != {end_block_num}"
 
@@ -271,14 +268,11 @@ try:
         block_num = start_block_num
         for i in data:
             # fork can cause block numbers to be repeated
-            this_block_num = i['get_blocks_result_v1']['this_block']['block_num'] if args.finality_data_history else i['get_blocks_result_v0']['this_block']['block_num']
+            this_block_num = i['get_blocks_result_v1']['this_block']['block_num']
             if this_block_num < block_num:
                 block_num = this_block_num
             assert block_num == this_block_num, f"{block_num} != {this_block_num}"
-            if args.finality_data_history:
-                assert isinstance(i['get_blocks_result_v1']['deltas'], str) # verify deltas in result
-            else:
-                assert isinstance(i['get_blocks_result_v0']['deltas'], str) # verify deltas in result
+            assert isinstance(i['get_blocks_result_v1']['deltas'], str) # verify deltas in result
             block_num += 1
         assert block_num-1 == end_block_num, f"{block_num-1} != {end_block_num}"
 


### PR DESCRIPTION
https://github.com/AntelopeIO/leap/pull/2321 added SHiP support for IBC. A new `get_blocks_request_v1` was introduced to include a field `fetch_finality_data`, but existing `get_blocks_result_v0` was reused to return the result of `get_blocks_request_v1`. That can cause confusions to the users, and a client's ABI `bin_to_json()` would add an extra `"finality_data": null` to the JSON output in Legacy (as `finality_data` does not exist).

This PR adds `get_blocks_result_v1` which stores the result of `get_blocks_request_v1`; `get_blocks_result_v0` is restored to its original use: only storing the result of `get_blocks_result_v0`.

`get_blocks_request_v1` adds extra `get_blocks_request_v1` to `get_blocks_request_v0`; `get_blocks_result_v1` adds extra `finality_data` to `get_blocks_result_v0`.

```
struct get_blocks_request_v1 : get_blocks_request_v0 {
   bool                        fetch_finality_data    = false;
};

struct get_blocks_result_v1 : get_blocks_result_v0 {
   std::optional<bytes>        finality_data;
};
```

Tests are updated to check both `get_blocks_result_v0` and `get_blocks_result_v1` work.

Resolved https://github.com/AntelopeIO/leap/issues/2340