### PR TITLE
IF: net: Add extra logging around async write

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3729,6 +3729,7 @@ namespace eosio {
             close( false ); // do not reconnect after closing
             break;
          case vote_status::unknown_block: // track the failure
+            peer_dlog(this, "vote unknown block #${bn}:${id}..", ("bn", block_header::num_from_id(msg.block_id))("id", msg.block_id.str().substr(8,16)));
             block_status_monitor_.rejected();
             break;
          case vote_status::duplicate: // do nothing


### PR DESCRIPTION
Add additional debug logging around async write.
Make all logs that contain a connection id use a prefix of `- ` so they are easy to grep for in the log.

```
debug 2024-03-28T20:58:09.489 net-2     net_plugin.cpp:2654           operator()           ] socket_is_open true, state connected, syncing false, connection - 4
```
The `- ` matches default output of `peer_*` logging:
```
debug 2024-03-28T20:58:09.489 net-0     net_plugin.cpp:2668           operator()           ] ["localhost:9876 - b648e56" - 4 127.0.0.1:9876] bcast block 7
```

Should help verify issue of #2354 and #2351.