### PR TITLE
IF: set active finalizer policy generation in finality_data for SHiP correctly

### DIFF
--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -317,6 +317,7 @@ finality_data_t block_state::get_finality_data() {
    }
    return {
       // other fields take the default values set by finality_data_t definition
+      .active_finalizer_policy_generation = active_finalizer_policy->generation,
       .action_mroot = action_mroot,
       .base_digest  = *base_digest
    };

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -57,7 +57,7 @@ struct valid_t {
 struct finality_data_t {
    uint32_t     major_version{light_header_protocol_version_major};
    uint32_t     minor_version{light_header_protocol_version_minor};
-   uint32_t     active_finalizer_policy_generation{1};
+   uint32_t     active_finalizer_policy_generation{0};
    digest_type  action_mroot{};
    digest_type  base_digest{};
 };


### PR DESCRIPTION
We can set active finalizer policy generation in finality_data without waiting for the completion of finalizer policy change feature.

Resolved https://github.com/AntelopeIO/leap/issues/2352