### PR TITLE
IF: Verify bls signature of vote while not holding a mutex

### DIFF
--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -158,6 +158,19 @@ vote_status block_state::aggregate_vote(const vote_message& vote) {
    }
 }
 
+bool block_state::has_voted(const bls_public_key& key) const {
+   const auto& finalizers = active_finalizer_policy->finalizers;
+   auto it = std::find_if(finalizers.begin(),
+                          finalizers.end(),
+                          [&](const auto& finalizer) { return finalizer.public_key == key; });
+
+   if (it != finalizers.end()) {
+      auto index = std::distance(finalizers.begin(), it);
+      return pending_qc.has_voted(index);
+   }
+   return false;
+}
+
 // Called from net threads
 void block_state::verify_qc(const valid_quorum_certificate& qc) const {
    const auto& finalizers = active_finalizer_policy->finalizers;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3498,12 +3498,11 @@ struct controller_impl {
       std::optional<bool> voted = fork_db.apply_s<std::optional<bool>>([&](auto& forkdb) -> std::optional<bool> {
          auto bsp = forkdb.get_block(id);
          if (bsp) {
-            for (auto& f : my_finalizers.finalizers) {
-               if (bsp->has_voted(f.first))
-                  return {true};
-            }
+            return std::ranges::all_of(my_finalizers.finalizers, [&bsp](auto& f) {
+               return bsp->has_voted(f.first);
+            });
          }
-         return {false};
+         return false;
       });
       // empty optional means legacy forkdb
       return !voted || *voted;

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -124,6 +124,7 @@ public:
 
    // vote_status
    vote_status aggregate_vote(const vote_message& vote); // aggregate vote into pending_qc
+   bool has_voted(const bls_public_key& key) const;
    void verify_qc(const valid_quorum_certificate& qc) const; // verify given qc is valid with respect block_state
 
    using bhs_t  = block_header_state;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -326,6 +326,8 @@ namespace eosio::chain {
          void set_proposed_finalizers( const finalizer_policy& fin_set );
          // called from net threads
          vote_status process_vote_message( const vote_message& msg );
+         // thread safe, for testing
+         bool node_has_voted_if_finalizer(const block_id_type& id) const;
 
          bool light_validation_allowed() const;
          bool skip_auth_check()const;

--- a/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
@@ -85,8 +85,7 @@ namespace eosio::chain {
          void resize(size_t num_finalizers) { _bitset.resize(num_finalizers); }
          size_t count() const { return _bitset.count(); }
 
-         vote_status add_vote(std::span<const uint8_t> proposal_digest, size_t index, const bls_public_key& pubkey,
-                              const bls_signature& new_sig);
+         vote_status add_vote(size_t index, const bls_signature& sig);
 
          void reset(size_t num_finalizers);
       };
@@ -126,20 +125,17 @@ namespace eosio::chain {
       votes_t              _strong_votes;
 
       // called by add_vote, already protected by mutex
-      vote_status add_strong_vote(std::span<const uint8_t> proposal_digest,
-                                  size_t index,
-                                  const bls_public_key& pubkey,
+      vote_status add_strong_vote(size_t index,
                                   const bls_signature& sig,
                                   uint64_t weight);
 
       // called by add_vote, already protected by mutex
-      vote_status add_weak_vote(std::span<const uint8_t> proposal_digest,
-                                size_t index,
-                                const bls_public_key& pubkey,
+      vote_status add_weak_vote(size_t index,
                                 const bls_signature& sig,
                                 uint64_t weight);
 
       bool is_quorum_met_no_lock() const;
+      bool is_duplicate_no_lock(bool strong, size_t index) const;
    };
 } //eosio::chain
 

--- a/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
+++ b/libraries/chain/include/eosio/chain/hotstuff/hotstuff.hpp
@@ -109,6 +109,9 @@ namespace eosio::chain {
                            const bls_signature& sig,
                            uint64_t weight);
 
+      // thread safe
+      bool has_voted(size_t index) const;
+
       state_t state() const { std::lock_guard g(*_mtx); return _state; };
       valid_quorum_certificate to_valid_quorum_certificate() const;
 
@@ -135,7 +138,7 @@ namespace eosio::chain {
                                 uint64_t weight);
 
       bool is_quorum_met_no_lock() const;
-      bool is_duplicate_no_lock(bool strong, size_t index) const;
+      bool has_voted_no_lock(bool strong, size_t index) const;
    };
 } //eosio::chain
 

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -458,6 +458,7 @@ namespace eosio { namespace testing {
 
          void             _start_block(fc::time_point block_time);
          signed_block_ptr _finish_block();
+         void             _wait_for_vote_if_needed(controller& c);
 
       // Fields:
       protected:
@@ -626,10 +627,7 @@ namespace eosio { namespace testing {
 
       signed_block_ptr produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms) )override {
          auto sb = _produce_block(skip_time, false);
-         auto btf = validating_node->create_block_handle_future( sb->calculate_id(), sb );
-         controller::block_report br;
-         validating_node->push_block( br, btf.get(), {}, trx_meta_cache_lookup{} );
-
+         validate_push_block(sb);
          return sb;
       }
 
@@ -641,15 +639,13 @@ namespace eosio { namespace testing {
          auto btf = validating_node->create_block_handle_future( sb->calculate_id(), sb );
          controller::block_report br;
          validating_node->push_block( br, btf.get(), {}, trx_meta_cache_lookup{} );
+         _wait_for_vote_if_needed(*validating_node);
       }
 
       signed_block_ptr produce_empty_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms) )override {
          unapplied_transactions.add_aborted( control->abort_block() );
          auto sb = _produce_block(skip_time, true);
-         auto btf = validating_node->create_block_handle_future( sb->calculate_id(), sb );
-         controller::block_report br;
-         validating_node->push_block( br, btf.get(), {}, trx_meta_cache_lookup{} );
-
+         validate_push_block(sb);
          return sb;
       }
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -485,6 +485,15 @@ namespace eosio { namespace testing {
       control->commit_block();
       last_produced_block[producer_name] = control->head_block_id();
 
+      if (control->head_block()->is_proper_svnn_block()) {
+         // wait for this node's vote to be processed
+         size_t retrys = 200;
+         while (!control->node_has_voted_if_finalizer(control->head_block_id()) && --retrys) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+         }
+         FC_ASSERT(retrys, "Never saw this nodes vote processed before timeout");
+      }
+
       return control->head_block();
    }
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -485,16 +485,20 @@ namespace eosio { namespace testing {
       control->commit_block();
       last_produced_block[producer_name] = control->head_block_id();
 
-      if (control->head_block()->is_proper_svnn_block()) {
+      _wait_for_vote_if_needed(*control);
+
+      return control->head_block();
+   }
+
+   void base_tester::_wait_for_vote_if_needed(controller& c) {
+      if (c.head_block()->is_proper_svnn_block()) {
          // wait for this node's vote to be processed
          size_t retrys = 200;
-         while (!control->node_has_voted_if_finalizer(control->head_block_id()) && --retrys) {
+         while (!c.node_has_voted_if_finalizer(c.head_block_id()) && --retrys) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
          }
          FC_ASSERT(retrys, "Never saw this nodes vote processed before timeout");
       }
-
-      return control->head_block();
    }
 
    signed_block_ptr base_tester::produce_block( std::vector<transaction_trace_ptr>& traces ) {


### PR DESCRIPTION
Since bls signature verification can take 6-8ms on ci/cd machines (~2ms on i7 or i9 12th gen), perform the verify while not holding a mutex. This reduces the contention on the `pending_quorum_certificate` mutex.

I believe we still need to do the verify off the `net` thread, but this is a simple improvement we can get in now.

This PR severely aggravated #2289, so added a fix for that issue.

Resolves #2289