### PR TITLE
IF: Test: Verify needed trx processed before continuing

### DIFF
--- a/tests/nodeos_retry_transaction_test.py
+++ b/tests/nodeos_retry_transaction_test.py
@@ -135,9 +135,10 @@ try:
     startTime = time.perf_counter()
     Print("Create new accounts via %s" % (cluster.eosioAccount.name))
     for account in accounts:
-        trans = node.createInitializeAccount(account, cluster.eosioAccount, stakedDeposit=0, waitForTransBlock=(account == accounts[-1]), stakeNet=1000, stakeCPU=1000, buyRAM=1000, exitOnError=True)
+        trans = node.createInitializeAccount(account, cluster.eosioAccount, stakedDeposit=0, waitForTransBlock=False, stakeNet=1000, stakeCPU=1000, buyRAM=1000, exitOnError=True)
         checkTransIds.append(Node.getTransId(trans))
 
+    node.waitForTransactionsInBlock(checkTransIds)
     nextTime = time.perf_counter()
     Print("Create new accounts took %s sec" % (nextTime - startTime))
     startTime = nextTime
@@ -146,18 +147,20 @@ try:
     for account in accounts:
         transferAmount="1000.0000 {0}".format(CORE_SYMBOL)
         Print("Transfer funds %s from account %s to %s" % (transferAmount, cluster.eosioAccount.name, account.name))
-        trans = node.transferFunds(cluster.eosioAccount, account, transferAmount, "test transfer", waitForTransBlock=(account == accounts[-1]), reportStatus=False)
+        trans = node.transferFunds(cluster.eosioAccount, account, transferAmount, "test transfer", waitForTransBlock=False, reportStatus=False)
         checkTransIds.append(Node.getTransId(trans))
 
+    node.waitForTransactionsInBlock(checkTransIds)
     nextTime = time.perf_counter()
     Print("Transfer funds took %s sec" % (nextTime - startTime))
     startTime = nextTime
 
     Print("Delegate Bandwidth to new accounts")
     for account in accounts:
-        trans=node.delegatebw(account, 200.0000, 200.0000, waitForTransBlock=(account == accounts[-1]), exitOnError=True, reportStatus=False)
+        trans=node.delegatebw(account, 200.0000, 200.0000, waitForTransBlock=False, exitOnError=True, reportStatus=False)
         checkTransIds.append(Node.getTransId(trans))
 
+    node.waitForTransactionsInBlock(checkTransIds)
     nextTime = time.perf_counter()
     Print("Delegate Bandwidth took %s sec" % (nextTime - startTime))
     startTime = nextTime


### PR DESCRIPTION
The test would wait on the last trx in a set before continuing. However, there is no guarantee that a previous trx is not retried because it didn't fit into a block. The test now verifies the complete set of trx are complete before continuing to the next step.

Resolves #2364