### PR TITLE
IF: Add get_row_by_id to libtester

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -338,6 +338,7 @@ namespace eosio { namespace testing {
                                                              const account_name& account ) const;
 
          vector<char> get_row_by_account( name code, name scope, name table, const account_name& act ) const;
+         vector<char> get_row_by_id( name code, name scope, name table, uint64_t id ) const;
 
          map<account_name, block_id_type> get_last_produced_block_map()const { return last_produced_block; };
          void set_last_produced_block_map( const map<account_name, block_id_type>& lpb ) { last_produced_block = lpb; }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1047,8 +1047,11 @@ namespace eosio { namespace testing {
       return asset(result, asset_symbol);
    }
 
-
    vector<char> base_tester::get_row_by_account( name code, name scope, name table, const account_name& act ) const {
+      return get_row_by_id( code, scope, table, act.to_uint64_t() );
+   }
+
+   vector<char> base_tester::get_row_by_id( name code, name scope, name table, uint64_t id ) const {
       vector<char> data;
       const auto& db = control->db();
       const auto* t_id = db.find<chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( code, scope, table ) );
@@ -1059,8 +1062,8 @@ namespace eosio { namespace testing {
 
       const auto& idx = db.get_index<chain::key_value_index, chain::by_scope_primary>();
 
-      auto itr = idx.lower_bound( boost::make_tuple( t_id->id, act.to_uint64_t() ) );
-      if ( itr == idx.end() || itr->t_id != t_id->id || act.to_uint64_t() != itr->primary_key ) {
+      auto itr = idx.lower_bound( boost::make_tuple( t_id->id, id ) );
+      if ( itr == idx.end() || itr->t_id != t_id->id || id != itr->primary_key ) {
          return data;
       }
 
@@ -1068,7 +1071,6 @@ namespace eosio { namespace testing {
       memcpy( data.data(), itr->value.data(), data.size() );
       return data;
    }
-
 
    vector<uint8_t> base_tester::to_uint8_vector(const string& s) {
       vector<uint8_t> v(s.size());


### PR DESCRIPTION
Currently libtester provides a method get_row_by_account() to return a table row by account name.

This PR adds another convenient method to return a row by id. This is to be used by https://github.com/AntelopeIO/reference-contracts/pull/60.

Resolved https://github.com/AntelopeIO/leap/issues/2367.