### PR TITLE
split `eosio.system_tests` in two parts to decrease run time

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -88,20 +88,23 @@ target_include_directories( unit_test PUBLIC
 add_test(NAME protocol_feature_digest_unit_test COMMAND unit_test --run_test=protocol_feature_digest_tests --report_level=detailed --color_output)
 set(ctest_tests "protocol_feature_digest_tests")
 foreach(TEST_SUITE ${UNIT_TESTS}) # create an independent target for each test suite
-  execute_process(COMMAND sh -c "grep -E 'BOOST_AUTO_TEST_SUITE\\s*[(]' '${TEST_SUITE}' | grep -vE '//.*BOOST_AUTO_TEST_SUITE\\s*[(]' | cut -d ')' -f 1 | cut -d '(' -f 2" OUTPUT_VARIABLE SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # get the test suite name from the *.cpp file
-  if (NOT "" STREQUAL "${SUITE_NAME}") # ignore empty lines
-    execute_process(COMMAND sh -c "echo ${SUITE_NAME} | sed -e 's/s$//' | sed -e 's/_test$//'" OUTPUT_VARIABLE TRIMMED_SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # trim "_test" or "_tests" from the end of ${SUITE_NAME}
-    # to run unit_test with all log from blockchain displayed, put "--verbose" after "--", i.e. "unit_test -- --verbose"
-    foreach(RUNTIME ${EOSIO_WASM_RUNTIMES})
-      add_test(NAME ${TRIMMED_SUITE_NAME}_unit_test_${RUNTIME} COMMAND unit_test --run_test=${SUITE_NAME} --report_level=detailed --color_output -- --${RUNTIME})
-      # build list of tests to run during coverage testing
-      if(ctest_tests)
-         string(APPEND ctest_tests "|")
-      endif()
-      string(APPEND ctest_tests ${TRIMMED_SUITE_NAME}_unit_test_$RUNTIME)
-    endforeach()
-  endif()
-endforeach(TEST_SUITE)
+  execute_process(COMMAND sh -c "grep -E 'BOOST_AUTO_TEST_SUITE\\s*[(]' '${TEST_SUITE}' | grep -vE '//.*BOOST_AUTO_TEST_SUITE\\s*[(]' | cut -d ')' -f 1 | cut -d '(' -f 2" OUTPUT_VARIABLE SUITE_NAMES OUTPUT_STRIP_TRAILING_WHITESPACE) # get the test suite name from the *.cpp file
+  string(REPLACE "\n" ";" SUITE_NAMES "${SUITE_NAMES}")
+  foreach(SUITE_NAME IN LISTS SUITE_NAMES)
+    if (NOT "" STREQUAL "${SUITE_NAME}") # ignore empty lines
+      execute_process(COMMAND sh -c "echo ${SUITE_NAME} | sed -e 's/s$//' | sed -e 's/_test$//'" OUTPUT_VARIABLE TRIMMED_SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # trim "_test" or "_tests" from the end of ${SUITE_NAME}
+      # to run unit_test with all log from blockchain displayed, put "--verbose" after "--", i.e. "unit_test -- --verbose"
+      foreach(RUNTIME ${EOSIO_WASM_RUNTIMES})
+        add_test(NAME ${TRIMMED_SUITE_NAME}_unit_test_${RUNTIME} COMMAND unit_test --run_test=${SUITE_NAME} --report_level=detailed --color_output -- --${RUNTIME})
+        # build list of tests to run during coverage testing
+        if(ctest_tests)
+          string(APPEND ctest_tests "|")
+        endif()
+        string(APPEND ctest_tests ${TRIMMED_SUITE_NAME}_unit_test_$RUNTIME)
+      endforeach()
+    endif()
+  endforeach()
+endforeach()
 set(ctest_tests "'${ctest_tests}' -j8") # surround test list string in apostrophies
 
 # The following tests are known to take the longest, bump up their cost (priority) so that they'll run first

--- a/unittests/eosio.system_tests.cpp
+++ b/unittests/eosio.system_tests.cpp
@@ -25,10 +25,10 @@ FC_REFLECT( connector, (balance)(weight) );
 
 using namespace eosio_system;
 
-BOOST_AUTO_TEST_SUITE(eosio_system_tests)
-
 bool within_error(int64_t a, int64_t b, int64_t err) { return std::abs(a - b) <= err; };
 bool within_one(int64_t a, int64_t b) { return within_error(a, b, 1); }
+
+BOOST_AUTO_TEST_SUITE(eosio_system_part1_tests)
 
 BOOST_FIXTURE_TEST_CASE( buysell, eosio_system_tester ) try {
    using namespace eosio::chain;
@@ -1239,6 +1239,10 @@ BOOST_FIXTURE_TEST_CASE( proxy_actions_affect_producers, eosio_system_tester, * 
    BOOST_TEST_REQUIRE( stake2votes(core_from_string("180.0003")) == get_producer_info( "defproducer3"_n )["total_votes"].as_double() );
 
 } FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(eosio_system_part2_tests)
 
 BOOST_FIXTURE_TEST_CASE(multiple_producer_votepay_share, eosio_system_tester, * boost::unit_test::tolerance(1e-10)) try {
 


### PR DESCRIPTION
The OC run of `eosio_system_tests` has become the longest running parallelizable test; to the point that sometimes it bumps up against the maximum test run time. How about split it up in two parts so that it runs in parallel faster. Work on #2369