### PR TITLE
TraceAPI: Remove sync() to improve performance

### DIFF
--- a/plugins/trace_api_plugin/include/eosio/trace_api/store_provider.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/store_provider.hpp
@@ -66,7 +66,6 @@ namespace eosio::trace_api {
       const auto offset = file.tellp();
       file.write(data.data(), data.size());
       file.flush();
-      file.sync();
       return offset;
    }
 


### PR DESCRIPTION
It has been reported a few times, for example: https://github.com/EOSIO/eos/issues/10690 that the `trace_api_plugin` performance suffers greatly from the `sync()` call in storing to disk. This has recently caused slow down in ci/cd as well causing tests to fail do to taking so long to write to the trace api log.

We do not `sync()` for the block log or SHiP logs. Seems the trade off of performance for small possibility of corrupted trace api logs is worth it.

Resolves #2331 