### PR TITLE
IF: switch variant index of new `get_blocks_request_v1`

### DIFF
--- a/libraries/state_history/abi.cpp
+++ b/libraries/state_history/abi.cpp
@@ -586,7 +586,7 @@ extern const char* const state_history_plugin_abi = R"({
         { "new_type_name": "transaction_id", "type": "checksum256" }
     ],
     "variants": [
-        { "name": "request", "types": ["get_status_request_v0", "get_blocks_request_v0", "get_blocks_request_v1", "get_blocks_ack_request_v0"] },
+        { "name": "request", "types": ["get_status_request_v0", "get_blocks_request_v0", "get_blocks_ack_request_v0", "get_blocks_request_v1"] },
         { "name": "result", "types": ["get_status_result_v0", "get_blocks_result_v0", "get_blocks_result_v1"] },
 
         { "name": "action_receipt", "types": ["action_receipt_v0"] },

--- a/libraries/state_history/include/eosio/state_history/types.hpp
+++ b/libraries/state_history/include/eosio/state_history/types.hpp
@@ -129,7 +129,7 @@ struct get_blocks_result_v1 : get_blocks_result_v0 {
    std::optional<bytes>          finality_data;
 };
 
-using state_request = std::variant<get_status_request_v0, get_blocks_request_v0, get_blocks_request_v1, get_blocks_ack_request_v0>;
+using state_request = std::variant<get_status_request_v0, get_blocks_request_v0, get_blocks_ack_request_v0, get_blocks_request_v1>;
 using state_result  = std::variant<get_status_result_v0, get_blocks_result_v0, get_blocks_result_v1>;
 using get_blocks_request = std::variant<get_blocks_request_v0, get_blocks_request_v1>;
 using get_blocks_result = std::variant<get_blocks_result_v0, get_blocks_result_v1>;


### PR DESCRIPTION
The order of message types in the `state_request` variant is part of the binary protocol. I suggest we add the new `get_blocks_request_v1` to the end. Otherwise, unmodified ship clients that both use `get_blocks_ack_request_v0` and do not consume the ABI from the websocket endpoint (I believe abieos or eos-go based readers) will misbehave.