### PR TITLE
Increment `finalizer_policy`'s `generation` when `set_finalizers` is executed.

### DIFF
--- a/libraries/chain/block_header_state_legacy.cpp
+++ b/libraries/chain/block_header_state_legacy.cpp
@@ -216,7 +216,7 @@ namespace eosio::chain {
       }
 
       if (new_finalizer_policy) {
-         new_finalizer_policy->generation = 1; // only allowed to be set once
+         assert(new_finalizer_policy->generation == 1); // only allowed to be set once
          // set current block_num as qc_claim.last_qc_block_num in the IF extension
          qc_claim_t initial_if_claim { .block_num = block_num,
                                        .is_strong_qc = false };

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -323,7 +323,7 @@ namespace eosio::chain {
          int64_t set_proposed_producers( vector<producer_authority> producers );
 
          // called by host function set_finalizers
-         void set_proposed_finalizers( const finalizer_policy& fin_set );
+         void set_proposed_finalizers( finalizer_policy&& fin_pol );
          // called from net threads
          vote_status process_vote_message( const vote_message& msg );
          // thread safe, for testing

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -195,7 +195,7 @@ namespace eosio { namespace chain { namespace webassembly {
 
       EOS_ASSERT( weight_sum >= finpol.threshold && finpol.threshold > weight_sum / 2, wasm_execution_error, "Finalizer policy threshold (${t}) must be greater than half of the sum of the weights (${w}), and less than or equal to the sum of the weights", ("t", finpol.threshold)("w", weight_sum) );
 
-      context.control.set_proposed_finalizers( finpol );
+      context.control.set_proposed_finalizers( std::move(finpol) );
    }
 
    uint32_t interface::get_blockchain_parameters_packed( legacy_span<char> packed_blockchain_parameters ) const {


### PR DESCRIPTION
Resolves #2345 

The `finalizer_policy` struct in contracts does not have a `generation` member.
In this PR, when the `set_finalizers` host function is executed, we increment the generation number of the `finalizer_policy` to the the active policy generation number plus one.