### PR TITLE
use github provided token for git in submodule regression check

### DIFF
--- a/.github/workflows/submod.yaml
+++ b/.github/workflows/submod.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout
         run: |
-          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git clone https://x-access-token:${{github.token}}@github.com/${GITHUB_REPOSITORY} .
           git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive


### PR DESCRIPTION
This allows for the submodule regression check to run in more environments.