### PR TITLE
[5.0] fix eosvmoc_limits_tests on non-x86 and non-Linux (where OC is not supported)

### DIFF
--- a/unittests/eosvmoc_limits_tests.cpp
+++ b/unittests/eosvmoc_limits_tests.cpp
@@ -1,5 +1,3 @@
-#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
-
 #include <eosio/testing/tester.hpp>
 #include <test_contracts.hpp>
 #include <boost/test/unit_test.hpp>
@@ -29,6 +27,7 @@ void limit_violated_test(const eosvmoc::config& eosvmoc_config) {
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
    chain.set_abi("eosio.token"_n, test_contracts::eosio_token_abi());
 
+#ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
    if (chain.control->is_eos_vm_oc_enabled()) {
       BOOST_CHECK_EXCEPTION(
          chain.push_action( "eosio.token"_n, "create"_n, "eosio.token"_n, mvo()
@@ -39,7 +38,9 @@ void limit_violated_test(const eosvmoc::config& eosvmoc_config) {
             return expect_assert_message(e, "failed to compile wasm");
          }
       );
-   } else {
+   } else
+#endif
+   {
       chain.push_action( "eosio.token"_n, "create"_n, "eosio.token"_n, mvo()
          ( "issuer", "eosio.token" )
          ( "maximum_supply", "1000000.00 TOK" )
@@ -140,5 +141,3 @@ BOOST_AUTO_TEST_CASE( generated_code_size_limit ) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()
-
-#endif


### PR DESCRIPTION
Recall that the way `ctest` tests are populated for `unit_test` are by finding all the .cpp files in the `unittests` directory,
https://github.com/AntelopeIO/leap/blob/d47b35ada7b0002a4a0931ffa8c98aadc5498bd2/unittests/CMakeLists.txt#L71
sending those through a `grep` to find the `TEST_SUITE()` for each,
https://github.com/AntelopeIO/leap/blob/d47b35ada7b0002a4a0931ffa8c98aadc5498bd2/unittests/CMakeLists.txt#L91
and then adding a test on what it find, for each WASM runtime enabled,
https://github.com/AntelopeIO/leap/blob/d47b35ada7b0002a4a0931ffa8c98aadc5498bd2/unittests/CMakeLists.txt#L95-L96

Notice how previously the entire `eosvmoc_limits_tests.cpp` is `#ifdef`ed away when OC is not enabled. The glob+grep above has no knowledge of this, so when OC is not enabled the cmake file generates a ctest entry that runs `unit_test --run_test=eosvmoc_limits_tests` but that will always fail because there is no test suite named `eosvmoc_limits_tests`.

Adjust the eosvmoc_limits test suite and tests to be defined no matter OC enabled or not, and just `#ifdef` out the small OC-specific part.

This change still looks strange: why are we running these OC limits tests at all with OC is not enabled for the build? Well, that's actually what is occurring even when OC is enabled normally on our x86 Linux builds. For example this previous run you can see that we run the eosvmoc_limits test even for non-OC runtimes:
https://github.com/AntelopeIO/leap/actions/runs/8634314462/job/23670206127#step:5:76
It's just that when OC isn't enabled `limit_violated_test()` always passes. So arguably this change is more consistent with what already occurs when OC builds are enabled vs, say, stubbing out a no-op test suite and test when OC build is not enabled. Any more complex changes to how tests are populated are probably not reasonably in scope for a release branch.