### PR TITLE
[5.0] treat a `end_block_num=0` as "forever" in snapshot scheduler for compatibility with leap 4.0 behavior

### DIFF
--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -105,7 +105,12 @@ void snapshot_scheduler::set_db_path(fs::path db_path) {
       _snapshot_db >> sr;
       // if db read succeeded, clear/load
       _snapshot_requests.get<by_snapshot_id>().clear();
-      _snapshot_requests.insert(sr.begin(), sr.end());
+      for(snapshot_schedule_information& ssi : sr) {
+         //fix up Leap v4's "forever" value of 0 to MAX
+         if(ssi.end_block_num == 0)
+            ssi.end_block_num = std::numeric_limits<uint32_t>::max();
+         _snapshot_requests.insert(ssi);
+      }
    }
 }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1542,6 +1542,9 @@ producer_plugin::schedule_snapshot(const chain::snapshot_scheduler::snapshot_req
       .end_block_num   = srp.end_block_num ? *srp.end_block_num : std::numeric_limits<uint32_t>::max(),
       .snapshot_description = srp.snapshot_description ? *srp.snapshot_description : ""
    };
+   //treat a 0 end_block_num as max for compatibility with leap4 behavior
+   if(sri.end_block_num == 0)
+      sri.end_block_num = std::numeric_limits<uint32_t>::max();
 
    return my->_snapshot_scheduler.schedule_snapshot(sri);
 }


### PR DESCRIPTION
leap 5's snapshot scheduling implementation changed the meaning of  `end_block_num=0` which breaks both requests that previously worked and any previously scheduled snapshots with that value (the scheduled snapshots will effectively be removed upon upgrade to leap5).

In leap4 requests were submitted as
https://github.com/AntelopeIO/leap/blob/01dab51ac00aed6730700b82943c30ccfd854fce/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp#L85-L89
This has the important behavior that if a request does not specify `end_block_num` it remains 0 _and is written out to `snapshot-schedule.json` with `"end_block_num":0`._ I believe what happens then is that `end_block_num=0` gets treated as "forever" by it not being removed from the scheduled list here,
https://github.com/AntelopeIO/leap/blob/01dab51ac00aed6730700b82943c30ccfd854fce/plugins/producer_plugin/include/eosio/producer_plugin/snapshot_scheduler.hpp#L94-L99

But leap5 changes things up. There is an additional indirection on the requests,
https://github.com/AntelopeIO/leap/blob/0242caa61646f1a672d4bfd2799b557a262de3e5/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp#L47-L54
before the similar `snapshot_request_information` is used,
https://github.com/AntelopeIO/leap/blob/0242caa61646f1a672d4bfd2799b557a262de3e5/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp#L40-L45
So, importantly, in 5.0 if the request does not specify the `optional<uint32_t> end_block_num` then it is set to UINT32_MAX,
https://github.com/AntelopeIO/leap/blob/0242caa61646f1a672d4bfd2799b557a262de3e5/plugins/producer_plugin/producer_plugin.cpp#L1538-L1544

And then leap5's schedule pruning does not treat `end_block_num=0` as special because it expects "forever requests" to be `end_block_num=UINT32_MAX`; so any `end_block_num=0` requests (be it new ones arriving on RPC, or old ones read from the JSON file) just get removed immediately.
https://github.com/AntelopeIO/leap/blob/0242caa61646f1a672d4bfd2799b557a262de3e5/libraries/chain/snapshot_scheduler.cpp#L30-L31


So this PR replaces `end_block_num=0` with `end_block_num=UINT32_MAX` both,
* when reading existing `snapshot-schedule.json` entries with `end_block_num=0`, and
* when handling `schedule_snapshot` RPC request, so that behavior with requests that worked in leap4 remain the same in leap5

Resolves #2261 