### PR TITLE
[5.0] fix `true_lowest()` for `uint128[2]` index; possibly resolving some secondary table row RPC queries

### DIFF
--- a/libraries/chain/include/eosio/chain/contract_table_objects.hpp
+++ b/libraries/chain/include/eosio/chain/contract_table_objects.hpp
@@ -177,7 +177,7 @@ namespace eosio { namespace chain {
       using value_type = std::array<uint128_t, N>;
 
       static value_type true_lowest() {
-         value_type arr;
+         value_type arr = {};
          return arr;
       }
 


### PR DESCRIPTION
Default parameters for the lower bound of a `uint128[2]` ("`checksum256`") index used for the `get_table` RPC call were uninitialized and might cause unexpected results to be returned. Initialize this to zero.