### PR TITLE
[5.0] Fix issue #2330 by limiting the vector size that can be reserve'd

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -415,7 +415,7 @@ namespace eosio { namespace chain {
             fc::raw::unpack(stream, size);
          } EOS_RETHROW_EXCEPTIONS( unpack_exception, "Unable to unpack size of array '${p}'", ("p", ctx.get_path_string()) )
          vector<fc::variant> vars;
-         vars.reserve(size);
+         vars.reserve(std::min(size.value, 1024u)); // limit the maximum size that can be reserved before data is read
          auto h1 = ctx.push_to_path( impl::array_index_path_item{} );
          for( decltype(size.value) i = 0; i < size; ++i ) {
             ctx.set_array_index_of_path_back(i);


### PR DESCRIPTION
Resolves [#2330](https://github.com/AntelopeIO/leap/issues/2330).

The deserialization of arrays involves reading a size, and then the array elements which are `emplace`'d back into a `std::vector`. For normal vectors, since we know the size in advance, it is beneficial to call `std::vector::reserve()` to prevent quadratic reallocations of the vector's buffer as the values are read. Still, limit the size that can be reserved to `1024` `fc::variant` values, or 16KB since `sizeof(fc::variant) == 16`).