### PR TITLE
[5.0.3] P2P: Resolve on reconnect

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4474,7 +4474,7 @@ namespace eosio {
 
       connection_ptr c = std::make_shared<connection>( peer_address, listen_address );
       if (c->resolve_and_connect()) {
-         add(c);
+         add(std::move(c));
 
          return "added connection";
       }


### PR DESCRIPTION
Resolve address on reconnect. (Take 2, See #2408)

Instead of:
````
info  2024-09-25T21:50:50.686 net-1     net_plugin.cpp:2797           operator()           ] connection failed to p2p.telos-bad.zenblocks.io:9876, Element not found
info  2024-09-25T21:50:50.686 net-1     net_plugin.cpp:1461           _close               ] ["p2p.telos-bad.zenblocks.io:9876" - 1 <unknown>:<unknown>] closing
````
Now you get:
```
warn  2024-09-25T21:42:48.642 net-0     net_plugin.cpp:4524           operator()           ] Unable to resolve p2p.telos-bad.zenblocks.io:9876 Host not found (authoritative)
```

This takes a different approach than #2408. This approach is closer to Leap 4.0 approach to connection lifetime although it does keep the `connections_manager` added in Leap 5.0.

Backport of https://github.com/AntelopeIO/spring/pull/853